### PR TITLE
chore: sync tenant dimensions into ClickHouse

### DIFF
--- a/.changeset/clickhouse-tenant-dimensions.md
+++ b/.changeset/clickhouse-tenant-dimensions.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Expose synchronized organization and project dimensions in ClickHouse so internal reporting can group tenant activity by current slugs, account lifecycle, trial state, and integration flags.

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -586,30 +586,33 @@ const (
 	// HookBlockReasonKey is set on hook telemetry entries when the Gram hook
 	// denied the tool call (e.g. shadow-MCP guard). Its presence (non-empty)
 	// signals the trace should render as "blocked" in dashboards.
-	HookBlockReasonKey             = attribute.Key("gram.hook.block_reason")
-	IdentityFoldCanonicalGroupsKey = attribute.Key("gram.identity_fold.canonical_groups")
-	IdentityFoldCostDeltaKey       = attribute.Key("gram.identity_fold.cost_delta")
-	IdentityFoldLiteralGroupsKey   = attribute.Key("gram.identity_fold.literal_groups")
-	IdentityFoldNewKeysKey         = attribute.Key("gram.identity_fold.new_keys")
-	IdentityFoldOrderChangedKey    = attribute.Key("gram.identity_fold.order_changed")
-	IdentityFoldTruncatedKey       = attribute.Key("gram.identity_fold.truncated")
-	IdentityFoldTokenDeltaKey      = attribute.Key("gram.identity_fold.token_delta")
-	IdentityMapEntryCountKey       = attribute.Key("gram.identity_map.entry_count")
-	LiteLLMInstanceIDKey           = attribute.Key("gram.litellm.instance_id")
-	LiteLLMCallIDKey               = attribute.Key("gram.litellm.call_id")
-	LiteLLMTraceIDKey              = attribute.Key("gram.litellm.trace_id")
-	LiteLLMUserIDKey               = attribute.Key("gram.litellm.user_id")
-	LiteLLMUserEmailKey            = attribute.Key("gram.litellm.user_email")
-	LiteLLMTeamIDKey               = attribute.Key("gram.litellm.team_id")
-	LiteLLMTeamAliasKey            = attribute.Key("gram.litellm.team_alias")
-	LiteLLMEndUserIDKey            = attribute.Key("gram.litellm.end_user_id")
-	LiteLLMOrganizationIDKey       = attribute.Key("gram.litellm.org_id")
-	LiteLLMAPIKeyHashKey           = attribute.Key("gram.litellm.api_key_hash")
-	LiteLLMAPIKeyAliasKey          = attribute.Key("gram.litellm.api_key_alias")
-	LiteLLMInputCostKey            = attribute.Key("litellm.cost.input")
-	LiteLLMOutputCostKey           = attribute.Key("litellm.cost.output")
-	LiteLLMCacheReadCostKey        = attribute.Key("litellm.cost.cache_read")
-	LiteLLMCacheWriteCostKey       = attribute.Key("litellm.cost.cache_creation")
+	HookBlockReasonKey                   = attribute.Key("gram.hook.block_reason")
+	IdentityFoldCanonicalGroupsKey       = attribute.Key("gram.identity_fold.canonical_groups")
+	IdentityFoldCostDeltaKey             = attribute.Key("gram.identity_fold.cost_delta")
+	IdentityFoldLiteralGroupsKey         = attribute.Key("gram.identity_fold.literal_groups")
+	IdentityFoldNewKeysKey               = attribute.Key("gram.identity_fold.new_keys")
+	IdentityFoldOrderChangedKey          = attribute.Key("gram.identity_fold.order_changed")
+	IdentityFoldTruncatedKey             = attribute.Key("gram.identity_fold.truncated")
+	IdentityFoldTokenDeltaKey            = attribute.Key("gram.identity_fold.token_delta")
+	IdentityMapEntryCountKey             = attribute.Key("gram.identity_map.entry_count")
+	TenantDimensionOrganizationCountKey  = attribute.Key("gram.tenant_dimensions.organization_count")
+	TenantDimensionProjectCountKey       = attribute.Key("gram.tenant_dimensions.project_count")
+	TenantDimensionOrphanProjectCountKey = attribute.Key("gram.tenant_dimensions.orphan_project_count")
+	LiteLLMInstanceIDKey                 = attribute.Key("gram.litellm.instance_id")
+	LiteLLMCallIDKey                     = attribute.Key("gram.litellm.call_id")
+	LiteLLMTraceIDKey                    = attribute.Key("gram.litellm.trace_id")
+	LiteLLMUserIDKey                     = attribute.Key("gram.litellm.user_id")
+	LiteLLMUserEmailKey                  = attribute.Key("gram.litellm.user_email")
+	LiteLLMTeamIDKey                     = attribute.Key("gram.litellm.team_id")
+	LiteLLMTeamAliasKey                  = attribute.Key("gram.litellm.team_alias")
+	LiteLLMEndUserIDKey                  = attribute.Key("gram.litellm.end_user_id")
+	LiteLLMOrganizationIDKey             = attribute.Key("gram.litellm.org_id")
+	LiteLLMAPIKeyHashKey                 = attribute.Key("gram.litellm.api_key_hash")
+	LiteLLMAPIKeyAliasKey                = attribute.Key("gram.litellm.api_key_alias")
+	LiteLLMInputCostKey                  = attribute.Key("litellm.cost.input")
+	LiteLLMOutputCostKey                 = attribute.Key("litellm.cost.output")
+	LiteLLMCacheReadCostKey              = attribute.Key("litellm.cost.cache_read")
+	LiteLLMCacheWriteCostKey             = attribute.Key("litellm.cost.cache_creation")
 	// MCPMatchKey carries the server-level identifier the matcher resolved
 	// for a hook-time MCP tool call — an HTTP/SSE URL, a stdio command, or
 	// (as fallback) the `mcp__<server>__` prefix from the tool name. Set on
@@ -1003,6 +1006,27 @@ func SlogIdentityFoldTokenDelta(v int64) slog.Attr {
 
 func IdentityMapEntryCount(v int) attribute.KeyValue { return IdentityMapEntryCountKey.Int(v) }
 func SlogIdentityMapEntryCount(v int) slog.Attr      { return slog.Int(string(IdentityMapEntryCountKey), v) }
+
+func TenantDimensionOrganizationCount(v int) attribute.KeyValue {
+	return TenantDimensionOrganizationCountKey.Int(v)
+}
+func SlogTenantDimensionOrganizationCount(v int) slog.Attr {
+	return slog.Int(string(TenantDimensionOrganizationCountKey), v)
+}
+
+func TenantDimensionProjectCount(v int) attribute.KeyValue {
+	return TenantDimensionProjectCountKey.Int(v)
+}
+func SlogTenantDimensionProjectCount(v int) slog.Attr {
+	return slog.Int(string(TenantDimensionProjectCountKey), v)
+}
+
+func TenantDimensionOrphanProjectCount(v int) attribute.KeyValue {
+	return TenantDimensionOrphanProjectCountKey.Int(v)
+}
+func SlogTenantDimensionOrphanProjectCount(v int) slog.Attr {
+	return slog.Int(string(TenantDimensionOrphanProjectCountKey), v)
+}
 
 func HookHasPluginAuth(v bool) attribute.KeyValue { return HookHasPluginAuthKey.Bool(v) }
 func SlogHookHasPluginAuth(v bool) slog.Attr      { return slog.Bool(string(HookHasPluginAuthKey), v) }

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -120,6 +120,7 @@ type Activities struct {
 	sendOpenRouterCreditsAlerts     *activities.MaybeSendOpenRouterCreditsAlerts
 	firePlatformUsageMetrics        *activities.FirePlatformUsageMetrics
 	syncIdentityMap                 *activities.SyncIdentityMap
+	syncTenantDimensions            *activities.SyncTenantDimensions
 	promoteStagedTelemetry          *activities.PromoteStagedTelemetry
 	listStagedTelemetryProjects     *activities.ListStagedTelemetryProjects
 	generateChatTitle               *activities.GenerateChatTitle
@@ -389,6 +390,7 @@ func NewActivities(
 		sendOpenRouterCreditsAlerts:     activities.NewMaybeSendOpenRouterCreditsAlerts(logger, db, cacheAdapter, emailService, meterProvider),
 		firePlatformUsageMetrics:        activities.NewFirePlatformUsageMetrics(logger, billingTracker),
 		syncIdentityMap:                 activities.NewSyncIdentityMap(logger, db, chConn, cacheAdapter),
+		syncTenantDimensions:            activities.NewSyncTenantDimensions(logger, db, chConn, cacheAdapter),
 		promoteStagedTelemetry:          activities.NewPromoteStagedTelemetry(logger, chConn, cacheAdapter, telemetryLogPublisher),
 		listStagedTelemetryProjects:     activities.NewListStagedTelemetryProjects(logger, chConn),
 		generateChatTitle:               activities.NewGenerateChatTitle(logger, db, chatClient),
@@ -757,6 +759,10 @@ func (a *Activities) GenerateChatTitle(ctx context.Context, input activities.Gen
 
 func (a *Activities) SyncIdentityMap(ctx context.Context) (*activities.SyncIdentityMapResult, error) {
 	return a.syncIdentityMap.Do(ctx)
+}
+
+func (a *Activities) SyncTenantDimensions(ctx context.Context) (*activities.SyncTenantDimensionsResult, error) {
+	return a.syncTenantDimensions.Do(ctx)
 }
 
 func (a *Activities) PromoteStagedTelemetry(ctx context.Context, input activities.PromoteStagedTelemetryArgs) (*activities.PromoteStagedTelemetryResult, error) {

--- a/server/internal/background/activities/queries.sql
+++ b/server/internal/background/activities/queries.sql
@@ -1032,3 +1032,51 @@ WHERE NOT EXISTS (
       AND dd.email_lower = uao.email_lower
 )
 ORDER BY organization_id, email_lower;
+
+-- name: ListTenantDimensionOrganizations :many
+-- Full reporting projection for ClickHouse organizations that own at least
+-- one project. The caller runs this and ListTenantDimensionProjects in one
+-- repeatable-read transaction so both generations come from one source
+-- snapshot.
+SELECT
+    om.id,
+    om.slug,
+    om.gram_account_type AS account_type,
+    om.workos_id,
+    om.workos_updated_at,
+    om.webhooks_enabled,
+    om.scim_enabled,
+    om.sso_enabled,
+    om.whitelisted,
+    om.free_trial_started_at,
+    om.free_trial_ends_at,
+    t.tier AS trial_tier,
+    t.ends_at AS trial_ends_at,
+    t.converted_at AS trial_converted_at,
+    t.demoted_at AS trial_demoted_at,
+    t.created_at AS trial_created_at,
+    t.updated_at AS trial_updated_at,
+    om.created_at,
+    om.updated_at,
+    om.disabled_at
+FROM organization_metadata om
+LEFT JOIN trials t ON t.organization_id = om.id
+WHERE EXISTS (
+    SELECT 1
+    FROM projects p
+    WHERE p.organization_id = om.id
+)
+ORDER BY om.id;
+
+-- name: ListTenantDimensionProjects :many
+-- Includes soft-deleted projects so retained ClickHouse facts keep their
+-- human-readable dimension and reports can choose lifecycle semantics.
+SELECT
+    id,
+    organization_id,
+    slug,
+    created_at,
+    updated_at,
+    deleted_at
+FROM projects
+ORDER BY organization_id, id;

--- a/server/internal/background/activities/repo/queries.sql.go
+++ b/server/internal/background/activities/repo/queries.sql.go
@@ -1794,6 +1794,156 @@ func (q *Queries) ListStripeInvoicesForOpenRouterBilling(ctx context.Context, ar
 	return items, nil
 }
 
+const listTenantDimensionOrganizations = `-- name: ListTenantDimensionOrganizations :many
+SELECT
+    om.id,
+    om.slug,
+    om.gram_account_type AS account_type,
+    om.workos_id,
+    om.workos_updated_at,
+    om.webhooks_enabled,
+    om.scim_enabled,
+    om.sso_enabled,
+    om.whitelisted,
+    om.free_trial_started_at,
+    om.free_trial_ends_at,
+    t.tier AS trial_tier,
+    t.ends_at AS trial_ends_at,
+    t.converted_at AS trial_converted_at,
+    t.demoted_at AS trial_demoted_at,
+    t.created_at AS trial_created_at,
+    t.updated_at AS trial_updated_at,
+    om.created_at,
+    om.updated_at,
+    om.disabled_at
+FROM organization_metadata om
+LEFT JOIN trials t ON t.organization_id = om.id
+WHERE EXISTS (
+    SELECT 1
+    FROM projects p
+    WHERE p.organization_id = om.id
+)
+ORDER BY om.id
+`
+
+type ListTenantDimensionOrganizationsRow struct {
+	ID                 string
+	Slug               string
+	AccountType        string
+	WorkosID           pgtype.Text
+	WorkosUpdatedAt    pgtype.Timestamptz
+	WebhooksEnabled    pgtype.Bool
+	ScimEnabled        pgtype.Bool
+	SsoEnabled         pgtype.Bool
+	Whitelisted        bool
+	FreeTrialStartedAt pgtype.Timestamptz
+	FreeTrialEndsAt    pgtype.Timestamptz
+	TrialTier          pgtype.Text
+	TrialEndsAt        pgtype.Timestamptz
+	TrialConvertedAt   pgtype.Timestamptz
+	TrialDemotedAt     pgtype.Timestamptz
+	TrialCreatedAt     pgtype.Timestamptz
+	TrialUpdatedAt     pgtype.Timestamptz
+	CreatedAt          pgtype.Timestamptz
+	UpdatedAt          pgtype.Timestamptz
+	DisabledAt         pgtype.Timestamptz
+}
+
+// Full reporting projection for ClickHouse organizations that own at least
+// one project. The caller runs this and ListTenantDimensionProjects in one
+// repeatable-read transaction so both generations come from one source
+// snapshot.
+func (q *Queries) ListTenantDimensionOrganizations(ctx context.Context) ([]ListTenantDimensionOrganizationsRow, error) {
+	rows, err := q.db.Query(ctx, listTenantDimensionOrganizations)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListTenantDimensionOrganizationsRow
+	for rows.Next() {
+		var i ListTenantDimensionOrganizationsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Slug,
+			&i.AccountType,
+			&i.WorkosID,
+			&i.WorkosUpdatedAt,
+			&i.WebhooksEnabled,
+			&i.ScimEnabled,
+			&i.SsoEnabled,
+			&i.Whitelisted,
+			&i.FreeTrialStartedAt,
+			&i.FreeTrialEndsAt,
+			&i.TrialTier,
+			&i.TrialEndsAt,
+			&i.TrialConvertedAt,
+			&i.TrialDemotedAt,
+			&i.TrialCreatedAt,
+			&i.TrialUpdatedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.DisabledAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listTenantDimensionProjects = `-- name: ListTenantDimensionProjects :many
+SELECT
+    id,
+    organization_id,
+    slug,
+    created_at,
+    updated_at,
+    deleted_at
+FROM projects
+ORDER BY organization_id, id
+`
+
+type ListTenantDimensionProjectsRow struct {
+	ID             uuid.UUID
+	OrganizationID string
+	Slug           string
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+	DeletedAt      pgtype.Timestamptz
+}
+
+// Includes soft-deleted projects so retained ClickHouse facts keep their
+// human-readable dimension and reports can choose lifecycle semantics.
+func (q *Queries) ListTenantDimensionProjects(ctx context.Context) ([]ListTenantDimensionProjectsRow, error) {
+	rows, err := q.db.Query(ctx, listTenantDimensionProjects)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListTenantDimensionProjectsRow
+	for rows.Next() {
+		var i ListTenantDimensionProjectsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrganizationID,
+			&i.Slug,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.DeletedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listWeeklyUsageSummaryTargets = `-- name: ListWeeklyUsageSummaryTargets :many
 SELECT
     om.id AS organization_id,

--- a/server/internal/background/activities/sync_tenant_dimensions.go
+++ b/server/internal/background/activities/sync_tenant_dimensions.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -19,8 +20,11 @@ import (
 	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 )
 
-// tenantDimensionsReplaceLockTTL outlives one activity attempt and the longest
-// ClickHouse statement that can still complete after its caller times out.
+// tenantDimensionsReplaceLockTTL outlives one activity attempt (2m
+// StartToClose) plus the longest ClickHouse statement that can still land
+// afterwards: SELECT and INSERT pipelines are bounded by the connection's 60s
+// max_execution_time, while DDL lock acquisition is bounded by the server's
+// 120s lock_acquire_timeout. Revisit this TTL if either bound is raised.
 const tenantDimensionsReplaceLockTTL = 5 * time.Minute
 
 const tenantDimensionsReplaceLockKey = "tenant-dimensions:replace-lock"
@@ -63,6 +67,35 @@ type SyncTenantDimensionsResult struct {
 
 // Do reads and publishes one complete tenant dimension generation.
 func (s *SyncTenantDimensions) Do(ctx context.Context) (*SyncTenantDimensionsResult, error) {
+	leases, ok := s.cache.(cache.LeaseCache)
+	if !ok {
+		return nil, fmt.Errorf("tenant dimension cache does not support ownership-aware leases")
+	}
+
+	leaseOwner := uuid.NewString()
+	claimed, err := leases.AcquireLease(ctx, tenantDimensionsReplaceLockKey, leaseOwner, tenantDimensionsReplaceLockTTL)
+	if err != nil {
+		return nil, fmt.Errorf("claim tenant dimension replacement lease: %w", err)
+	}
+	if !claimed {
+		return nil, fmt.Errorf("tenant dimension replacement already in progress")
+	}
+
+	keepLeaseUntilExpiry := false
+	defer func() {
+		if keepLeaseUntilExpiry {
+			return
+		}
+
+		released, err := leases.ReleaseLeaseIfOwner(context.WithoutCancel(ctx), tenantDimensionsReplaceLockKey, leaseOwner)
+		switch {
+		case err != nil:
+			s.logger.WarnContext(ctx, "failed to release tenant dimension replacement lease", attr.SlogError(err))
+		case !released:
+			s.logger.WarnContext(ctx, "tenant dimension replacement lease expired before release")
+		}
+	}()
+
 	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{
 		IsoLevel:       pgx.RepeatableRead,
 		AccessMode:     pgx.ReadOnly,
@@ -112,23 +145,14 @@ func (s *SyncTenantDimensions) Do(ctx context.Context) (*SyncTenantDimensionsRes
 		}
 	}
 
-	claimed, err := s.cache.Add(ctx, tenantDimensionsReplaceLockKey, tenantDimensionsReplaceLockTTL)
-	if err != nil {
-		return nil, fmt.Errorf("claim tenant dimension replacement lock: %w", err)
-	}
-	if !claimed {
-		return nil, fmt.Errorf("tenant dimension replacement already in progress")
-	}
+	keepLeaseUntilExpiry = true
 
 	if err := s.telemetry.ReplaceTenantDimensions(ctx, organizations, projects); err != nil {
-		// Keep the claim until its TTL after a failed or ambiguous ClickHouse
+		// Keep the lease until its TTL after a failed or ambiguous ClickHouse
 		// statement so a delayed predecessor cannot overwrite a newer generation.
 		return nil, fmt.Errorf("replace tenant dimensions: %w", err)
 	}
-
-	if err := s.cache.Delete(context.WithoutCancel(ctx), tenantDimensionsReplaceLockKey); err != nil {
-		s.logger.WarnContext(ctx, "failed to release tenant dimension replacement lock", attr.SlogError(err))
-	}
+	keepLeaseUntilExpiry = false
 
 	result := &SyncTenantDimensionsResult{
 		Organizations:  len(organizations),

--- a/server/internal/background/activities/sync_tenant_dimensions.go
+++ b/server/internal/background/activities/sync_tenant_dimensions.go
@@ -1,0 +1,221 @@
+package activities
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	activitiesrepo "github.com/speakeasy-api/gram/server/internal/background/activities/repo"
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+)
+
+// tenantDimensionsReplaceLockTTL outlives one activity attempt and the longest
+// ClickHouse statement that can still complete after its caller times out.
+const tenantDimensionsReplaceLockTTL = 5 * time.Minute
+
+const tenantDimensionsReplaceLockKey = "tenant-dimensions:replace-lock"
+
+type tenantDimensionsTelemetry interface {
+	ReplaceTenantDimensions(ctx context.Context, organizations []telemetryrepo.OrganizationMetadataDimension, projects []telemetryrepo.ProjectDimension) error
+}
+
+// SyncTenantDimensions publishes current organization and project reporting
+// dimensions from one repeatable-read Postgres snapshot into ClickHouse.
+type SyncTenantDimensions struct {
+	logger    *slog.Logger
+	db        *pgxpool.Pool
+	telemetry tenantDimensionsTelemetry
+	cache     cache.Cache
+}
+
+// NewSyncTenantDimensions creates a tenant dimension synchronization activity.
+func NewSyncTenantDimensions(logger *slog.Logger, db *pgxpool.Pool, chConn clickhouse.Conn, cacheAdapter cache.Cache) *SyncTenantDimensions {
+	return &SyncTenantDimensions{
+		logger:    logger.With(attr.SlogComponent("sync_tenant_dimensions")),
+		db:        db,
+		telemetry: telemetryrepo.New(chConn),
+		cache:     cacheAdapter,
+	}
+}
+
+// SyncTenantDimensionsResult describes one published ClickHouse generation.
+type SyncTenantDimensionsResult struct {
+	// Organizations is the number of organization dimension rows published.
+	Organizations int
+
+	// Projects is the number of project dimension rows published.
+	Projects int
+
+	// OrphanProjects is the number of projects whose organization was absent
+	// from the same Postgres snapshot.
+	OrphanProjects int
+}
+
+// Do reads and publishes one complete tenant dimension generation.
+func (s *SyncTenantDimensions) Do(ctx context.Context) (*SyncTenantDimensionsResult, error) {
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel:       pgx.RepeatableRead,
+		AccessMode:     pgx.ReadOnly,
+		DeferrableMode: "",
+		BeginQuery:     "",
+		CommitQuery:    "",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("begin tenant dimension snapshot: %w", err)
+	}
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
+
+	queries := activitiesrepo.New(tx)
+	organizationRows, err := queries.ListTenantDimensionOrganizations(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list tenant dimension organizations: %w", err)
+	}
+	projectRows, err := queries.ListTenantDimensionProjects(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list tenant dimension projects: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit tenant dimension snapshot: %w", err)
+	}
+
+	organizations := make([]telemetryrepo.OrganizationMetadataDimension, 0, len(organizationRows))
+	organizationIDs := make(map[string]struct{}, len(organizationRows))
+	for _, row := range organizationRows {
+		organization, err := organizationDimension(row)
+		if err != nil {
+			return nil, err
+		}
+		organizations = append(organizations, organization)
+		organizationIDs[row.ID] = struct{}{}
+	}
+
+	projects := make([]telemetryrepo.ProjectDimension, 0, len(projectRows))
+	orphanProjects := 0
+	for _, row := range projectRows {
+		project, err := projectDimension(row)
+		if err != nil {
+			return nil, err
+		}
+		projects = append(projects, project)
+		if _, exists := organizationIDs[row.OrganizationID]; !exists {
+			orphanProjects++
+		}
+	}
+
+	claimed, err := s.cache.Add(ctx, tenantDimensionsReplaceLockKey, tenantDimensionsReplaceLockTTL)
+	if err != nil {
+		return nil, fmt.Errorf("claim tenant dimension replacement lock: %w", err)
+	}
+	if !claimed {
+		return nil, fmt.Errorf("tenant dimension replacement already in progress")
+	}
+
+	if err := s.telemetry.ReplaceTenantDimensions(ctx, organizations, projects); err != nil {
+		// Keep the claim until its TTL after a failed or ambiguous ClickHouse
+		// statement so a delayed predecessor cannot overwrite a newer generation.
+		return nil, fmt.Errorf("replace tenant dimensions: %w", err)
+	}
+
+	if err := s.cache.Delete(context.WithoutCancel(ctx), tenantDimensionsReplaceLockKey); err != nil {
+		s.logger.WarnContext(ctx, "failed to release tenant dimension replacement lock", attr.SlogError(err))
+	}
+
+	result := &SyncTenantDimensionsResult{
+		Organizations:  len(organizations),
+		Projects:       len(projects),
+		OrphanProjects: orphanProjects,
+	}
+	s.logger.InfoContext(ctx, "tenant dimensions synced",
+		attr.SlogTenantDimensionOrganizationCount(result.Organizations),
+		attr.SlogTenantDimensionProjectCount(result.Projects),
+		attr.SlogTenantDimensionOrphanProjectCount(result.OrphanProjects),
+	)
+	return result, nil
+}
+
+func organizationDimension(row activitiesrepo.ListTenantDimensionOrganizationsRow) (telemetryrepo.OrganizationMetadataDimension, error) {
+	freeTrialStartedAt, err := requiredTenantDimensionTime(row.FreeTrialStartedAt, "free_trial_started_at", row.ID)
+	if err != nil {
+		return telemetryrepo.OrganizationMetadataDimension{}, err
+	}
+	freeTrialEndsAt, err := requiredTenantDimensionTime(row.FreeTrialEndsAt, "free_trial_ends_at", row.ID)
+	if err != nil {
+		return telemetryrepo.OrganizationMetadataDimension{}, err
+	}
+	createdAt, err := requiredTenantDimensionTime(row.CreatedAt, "created_at", row.ID)
+	if err != nil {
+		return telemetryrepo.OrganizationMetadataDimension{}, err
+	}
+	updatedAt, err := requiredTenantDimensionTime(row.UpdatedAt, "updated_at", row.ID)
+	if err != nil {
+		return telemetryrepo.OrganizationMetadataDimension{}, err
+	}
+
+	return telemetryrepo.OrganizationMetadataDimension{
+		ID:                 row.ID,
+		Slug:               row.Slug,
+		AccountType:        row.AccountType,
+		WorkOSID:           conv.FromPGText[string](row.WorkosID),
+		WorkOSUpdatedAt:    nullableTenantDimensionTime(row.WorkosUpdatedAt),
+		WebhooksEnabled:    conv.FromPGBool[bool](row.WebhooksEnabled),
+		SCIMEnabled:        conv.FromPGBool[bool](row.ScimEnabled),
+		SSOEnabled:         conv.FromPGBool[bool](row.SsoEnabled),
+		Whitelisted:        row.Whitelisted,
+		FreeTrialStartedAt: freeTrialStartedAt,
+		FreeTrialEndsAt:    freeTrialEndsAt,
+		TrialTier:          conv.FromPGText[string](row.TrialTier),
+		TrialEndsAt:        nullableTenantDimensionTime(row.TrialEndsAt),
+		TrialConvertedAt:   nullableTenantDimensionTime(row.TrialConvertedAt),
+		TrialDemotedAt:     nullableTenantDimensionTime(row.TrialDemotedAt),
+		TrialCreatedAt:     nullableTenantDimensionTime(row.TrialCreatedAt),
+		TrialUpdatedAt:     nullableTenantDimensionTime(row.TrialUpdatedAt),
+		CreatedAt:          createdAt,
+		UpdatedAt:          updatedAt,
+		DisabledAt:         nullableTenantDimensionTime(row.DisabledAt),
+	}, nil
+}
+
+func projectDimension(row activitiesrepo.ListTenantDimensionProjectsRow) (telemetryrepo.ProjectDimension, error) {
+	createdAt, err := requiredTenantDimensionTime(row.CreatedAt, "created_at", row.ID.String())
+	if err != nil {
+		return telemetryrepo.ProjectDimension{}, err
+	}
+	updatedAt, err := requiredTenantDimensionTime(row.UpdatedAt, "updated_at", row.ID.String())
+	if err != nil {
+		return telemetryrepo.ProjectDimension{}, err
+	}
+
+	return telemetryrepo.ProjectDimension{
+		ID:             row.ID,
+		OrganizationID: row.OrganizationID,
+		Slug:           row.Slug,
+		CreatedAt:      createdAt,
+		UpdatedAt:      updatedAt,
+		DeletedAt:      nullableTenantDimensionTime(row.DeletedAt),
+	}, nil
+}
+
+func requiredTenantDimensionTime(value pgtype.Timestamptz, field, id string) (time.Time, error) {
+	if !value.Valid || value.InfinityModifier != pgtype.Finite {
+		return time.Time{}, fmt.Errorf("tenant dimension %s has invalid %s", id, field)
+	}
+	return value.Time.UTC(), nil
+}
+
+func nullableTenantDimensionTime(value pgtype.Timestamptz) *time.Time {
+	if !value.Valid || value.InfinityModifier != pgtype.Finite {
+		return nil
+	}
+	result := value.Time.UTC()
+	return &result
+}

--- a/server/internal/background/activities/sync_tenant_dimensions_test.go
+++ b/server/internal/background/activities/sync_tenant_dimensions_test.go
@@ -1,0 +1,224 @@
+package activities_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
+)
+
+// This test replaces package-global ClickHouse dimension tables and therefore
+// must not overlap another tenant-dimension generation swap.
+func TestSyncTenantDimensions_PublishesReportingProjectionAndLifecycleChanges(t *testing.T) { //nolint:paralleltest // Swaps package-global ClickHouse tables.
+	ctx := t.Context()
+	conn, err := infra.CloneTestDatabase(t, "sync_tenant_dimensions")
+	require.NoError(t, err)
+	chConn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+	redisClient, err := infra.NewRedisClient(t, 0)
+	require.NoError(t, err)
+
+	orgID := "org-tenant-dimensions"
+	emptyOrgID := "org-tenant-dimensions-empty"
+	workosID := "workos-tenant-dimensions"
+	freeTrialStartedAt := time.Date(2026, 1, 2, 3, 4, 5, 123456000, time.UTC)
+	freeTrialEndsAt := freeTrialStartedAt.Add(14 * 24 * time.Hour)
+	organizationCreatedAt := freeTrialStartedAt.Add(-24 * time.Hour)
+	workosUpdatedAt := freeTrialStartedAt.Add(2 * time.Hour)
+	trialCreatedAt := freeTrialStartedAt.Add(3 * time.Hour)
+	trialEndsAt := trialCreatedAt.Add(30 * 24 * time.Hour)
+	trialConvertedAt := trialCreatedAt.Add(7 * 24 * time.Hour)
+	enabled := true
+	disabled := false
+
+	fixtures := testrepo.New(conn)
+	require.NoError(t, fixtures.CreateOrganizationMetadataFixture(ctx, testrepo.CreateOrganizationMetadataFixtureParams{
+		ID:                 orgID,
+		Name:               "Tenant Dimensions Org",
+		Slug:               "tenant-dimensions-org",
+		GramAccountType:    "enterprise",
+		WorkosID:           conv.ToPGText(workosID),
+		Whitelisted:        false,
+		FreeTrialStartedAt: conv.ToPGTimestamptz(freeTrialStartedAt),
+		FreeTrialEndsAt:    conv.ToPGTimestamptz(freeTrialEndsAt),
+		DisabledAt:         pgtype.Timestamptz{},
+		CreatedAt:          conv.ToPGTimestamptz(organizationCreatedAt),
+	}))
+	require.NoError(t, fixtures.CreateOrganizationMetadataFixture(ctx, testrepo.CreateOrganizationMetadataFixtureParams{
+		ID:                 emptyOrgID,
+		Name:               "Empty Tenant Dimensions Org",
+		Slug:               "empty-tenant-dimensions-org",
+		GramAccountType:    "free",
+		WorkosID:           pgtype.Text{},
+		Whitelisted:        false,
+		FreeTrialStartedAt: conv.ToPGTimestamptz(freeTrialStartedAt),
+		FreeTrialEndsAt:    conv.ToPGTimestamptz(freeTrialEndsAt),
+		DisabledAt:         pgtype.Timestamptz{},
+		CreatedAt:          conv.ToPGTimestamptz(organizationCreatedAt),
+	}))
+
+	organizations := orgrepo.New(conn)
+	_, err = organizations.UpdateOrganizationMetadataFromWorkOS(ctx, orgrepo.UpdateOrganizationMetadataFromWorkOSParams{
+		Name:              "Tenant Dimensions Org",
+		WorkosID:          conv.ToPGText(workosID),
+		WorkosUpdatedAt:   conv.ToPGTimestamptz(workosUpdatedAt),
+		WorkosLastEventID: conv.ToPGText("event-tenant-dimensions"),
+		ID:                orgID,
+	})
+	require.NoError(t, err)
+	_, err = organizations.SetWebhooksEnabled(ctx, orgrepo.SetWebhooksEnabledParams{
+		Enabled: conv.PtrToPGBool(&enabled),
+		ID:      orgID,
+	})
+	require.NoError(t, err)
+	require.NoError(t, organizations.SetSCIMEnabled(ctx, orgrepo.SetSCIMEnabledParams{
+		Enabled:           conv.PtrToPGBool(&enabled),
+		WorkosLastEventID: conv.ToPGText("event-scim-enabled"),
+		WorkosID:          conv.ToPGText(workosID),
+	}))
+	require.NoError(t, organizations.SetSSOEnabled(ctx, orgrepo.SetSSOEnabledParams{
+		Enabled:           conv.PtrToPGBool(&disabled),
+		WorkosLastEventID: conv.ToPGText("event-sso-disabled"),
+		WorkosID:          conv.ToPGText(workosID),
+	}))
+
+	require.NoError(t, trialsrepo.New(conn).InsertTrialFixture(ctx, trialsrepo.InsertTrialFixtureParams{
+		OrganizationID: orgID,
+		Tier:           "enterprise",
+		CreatedAt:      conv.ToPGTimestamptz(trialCreatedAt),
+		EndsAt:         conv.ToPGTimestamptz(trialEndsAt),
+		ConvertedAt:    conv.ToPGTimestamptz(trialConvertedAt),
+		DemotedAt:      pgtype.Timestamptz{},
+	}))
+
+	project, err := projectsrepo.New(conn).CreateProject(ctx, projectsrepo.CreateProjectParams{
+		Name:           "Tenant Dimensions Project",
+		Slug:           "tenant-dimensions-project",
+		OrganizationID: orgID,
+	})
+	require.NoError(t, err)
+
+	activity := activities.NewSyncTenantDimensions(testenv.NewLogger(t), conn, chConn, cache.NewRedisCacheAdapter(redisClient))
+	result, err := activity.Do(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Organizations)
+	require.Equal(t, 1, result.Projects)
+	require.Zero(t, result.OrphanProjects)
+
+	var emptyOrganizationCount uint64
+	require.NoError(t, chConn.QueryRow(ctx, `
+		SELECT count()
+		FROM organization_metadata
+		WHERE id = ?`, emptyOrgID).Scan(&emptyOrganizationCount))
+	require.Zero(t, emptyOrganizationCount)
+
+	var (
+		organizationSlug string
+		accountType      string
+		gotWorkosID      *string
+		gotWorkosUpdated *time.Time
+		webhooksEnabled  *bool
+		scimEnabled      *bool
+		ssoEnabled       *bool
+		whitelisted      bool
+		gotFreeStart     time.Time
+		gotFreeEnd       time.Time
+		trialTier        *string
+		gotTrialEnd      *time.Time
+		gotConvertedAt   *time.Time
+		gotDemotedAt     *time.Time
+		gotTrialCreated  *time.Time
+		gotTrialUpdated  *time.Time
+		gotOrgCreated    time.Time
+		gotOrgUpdated    time.Time
+		gotDisabledAt    *time.Time
+	)
+	require.NoError(t, chConn.QueryRow(ctx, `
+		SELECT slug, account_type, workos_id, workos_updated_at,
+		       webhooks_enabled, scim_enabled, sso_enabled, whitelisted,
+		       free_trial_started_at, free_trial_ends_at,
+		       trial_tier, trial_ends_at, trial_converted_at, trial_demoted_at,
+		       trial_created_at, trial_updated_at, created_at, updated_at, disabled_at
+		FROM organization_metadata
+		WHERE id = ?`, orgID).Scan(
+		&organizationSlug, &accountType, &gotWorkosID, &gotWorkosUpdated,
+		&webhooksEnabled, &scimEnabled, &ssoEnabled, &whitelisted,
+		&gotFreeStart, &gotFreeEnd, &trialTier, &gotTrialEnd, &gotConvertedAt,
+		&gotDemotedAt, &gotTrialCreated, &gotTrialUpdated, &gotOrgCreated,
+		&gotOrgUpdated, &gotDisabledAt,
+	))
+	require.Equal(t, "tenant-dimensions-org", organizationSlug)
+	require.Equal(t, "enterprise", accountType)
+	require.Equal(t, workosID, *gotWorkosID)
+	require.Equal(t, workosUpdatedAt, *gotWorkosUpdated)
+	require.True(t, *webhooksEnabled)
+	require.True(t, *scimEnabled)
+	require.False(t, *ssoEnabled)
+	require.False(t, whitelisted)
+	require.Equal(t, freeTrialStartedAt, gotFreeStart)
+	require.Equal(t, freeTrialEndsAt, gotFreeEnd)
+	require.Equal(t, "enterprise", *trialTier)
+	require.Equal(t, trialEndsAt, *gotTrialEnd)
+	require.Equal(t, trialConvertedAt, *gotConvertedAt)
+	require.Nil(t, gotDemotedAt)
+	require.Equal(t, trialCreatedAt, *gotTrialCreated)
+	require.NotNil(t, gotTrialUpdated)
+	require.Equal(t, organizationCreatedAt, gotOrgCreated)
+	require.False(t, gotOrgUpdated.IsZero())
+	require.Nil(t, gotDisabledAt)
+
+	var projectSlug, joinedOrganizationSlug string
+	var projectCreatedAt, projectUpdatedAt time.Time
+	var projectDeletedAt *time.Time
+	require.NoError(t, chConn.QueryRow(ctx, `
+		SELECT p.slug, p.created_at, p.updated_at, p.deleted_at, o.slug
+		FROM projects p
+		LEFT ANY JOIN organization_metadata o ON p.organization_id = o.id
+		WHERE p.id = ?`, project.ID).Scan(
+		&projectSlug, &projectCreatedAt, &projectUpdatedAt, &projectDeletedAt, &joinedOrganizationSlug,
+	))
+	require.Equal(t, "tenant-dimensions-project", projectSlug)
+	require.Equal(t, "tenant-dimensions-org", joinedOrganizationSlug)
+	require.Equal(t, project.CreatedAt.Time.UTC(), projectCreatedAt)
+	require.Equal(t, project.UpdatedAt.Time.UTC(), projectUpdatedAt)
+	require.Nil(t, projectDeletedAt)
+
+	require.NoError(t, fixtures.SetProjectSlugFixture(ctx, testrepo.SetProjectSlugFixtureParams{
+		Slug: "renamed-project",
+		ID:   project.ID,
+	}))
+	_, err = projectsrepo.New(conn).DeleteProject(ctx, project.ID)
+	require.NoError(t, err)
+	_, err = organizations.UpsertOrganizationMetadata(ctx, orgrepo.UpsertOrganizationMetadataParams{
+		ID:          orgID,
+		Name:        "Tenant Dimensions Org",
+		Slug:        "renamed-org",
+		WorkosID:    conv.ToPGText(workosID),
+		Whitelisted: conv.PtrToPGBool(&disabled),
+	})
+	require.NoError(t, err)
+
+	result, err = activity.Do(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Organizations)
+	require.Equal(t, 1, result.Projects)
+
+	require.NoError(t, chConn.QueryRow(ctx, `
+		SELECT p.slug, p.deleted_at, o.slug
+		FROM projects p
+		LEFT ANY JOIN organization_metadata o ON p.organization_id = o.id
+		WHERE p.id = ?`, project.ID).Scan(&projectSlug, &projectDeletedAt, &joinedOrganizationSlug))
+	require.Equal(t, "renamed-project", projectSlug)
+	require.NotNil(t, projectDeletedAt)
+	require.Equal(t, "renamed-org", joinedOrganizationSlug)
+}

--- a/server/internal/background/activities/sync_tenant_dimensions_test.go
+++ b/server/internal/background/activities/sync_tenant_dimensions_test.go
@@ -1,6 +1,7 @@
 package activities_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -17,6 +18,30 @@ import (
 	trialsrepo "github.com/speakeasy-api/gram/server/internal/trials/repo"
 )
 
+type tenantDimensionLeaseCache struct {
+	cache.Cache
+	beforeAcquire func(context.Context) error
+	acquiredOwner string
+	releasedOwner string
+}
+
+func (c *tenantDimensionLeaseCache) AcquireLease(ctx context.Context, _ string, owner string, _ time.Duration) (bool, error) {
+	c.acquiredOwner = owner
+	beforeAcquire := c.beforeAcquire
+	c.beforeAcquire = nil
+	if beforeAcquire != nil {
+		if err := beforeAcquire(ctx); err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+func (c *tenantDimensionLeaseCache) ReleaseLeaseIfOwner(_ context.Context, _ string, owner string) (bool, error) {
+	c.releasedOwner = owner
+	return owner == c.acquiredOwner, nil
+}
+
 // This test replaces package-global ClickHouse dimension tables and therefore
 // must not overlap another tenant-dimension generation swap.
 func TestSyncTenantDimensions_PublishesReportingProjectionAndLifecycleChanges(t *testing.T) { //nolint:paralleltest // Swaps package-global ClickHouse tables.
@@ -24,8 +49,6 @@ func TestSyncTenantDimensions_PublishesReportingProjectionAndLifecycleChanges(t 
 	conn, err := infra.CloneTestDatabase(t, "sync_tenant_dimensions")
 	require.NoError(t, err)
 	chConn, err := infra.NewClickhouseClient(t)
-	require.NoError(t, err)
-	redisClient, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)
 
 	orgID := "org-tenant-dimensions"
@@ -108,12 +131,25 @@ func TestSyncTenantDimensions_PublishesReportingProjectionAndLifecycleChanges(t 
 	})
 	require.NoError(t, err)
 
-	activity := activities.NewSyncTenantDimensions(testenv.NewLogger(t), conn, chConn, cache.NewRedisCacheAdapter(redisClient))
+	leaseCache := &tenantDimensionLeaseCache{
+		Cache: cache.NoopCache,
+		beforeAcquire: func(ctx context.Context) error {
+			return fixtures.SetProjectSlugFixture(ctx, testrepo.SetProjectSlugFixtureParams{
+				Slug: "lease-snapshot-project",
+				ID:   project.ID,
+			})
+		},
+		acquiredOwner: "",
+		releasedOwner: "",
+	}
+	activity := activities.NewSyncTenantDimensions(testenv.NewLogger(t), conn, chConn, leaseCache)
 	result, err := activity.Do(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 1, result.Organizations)
 	require.Equal(t, 1, result.Projects)
 	require.Zero(t, result.OrphanProjects)
+	require.NotEmpty(t, leaseCache.acquiredOwner)
+	require.Equal(t, leaseCache.acquiredOwner, leaseCache.releasedOwner)
 
 	var emptyOrganizationCount uint64
 	require.NoError(t, chConn.QueryRow(ctx, `
@@ -187,7 +223,7 @@ func TestSyncTenantDimensions_PublishesReportingProjectionAndLifecycleChanges(t 
 		WHERE p.id = ?`, project.ID).Scan(
 		&projectSlug, &projectCreatedAt, &projectUpdatedAt, &projectDeletedAt, &joinedOrganizationSlug,
 	))
-	require.Equal(t, "tenant-dimensions-project", projectSlug)
+	require.Equal(t, "lease-snapshot-project", projectSlug)
 	require.Equal(t, "tenant-dimensions-org", joinedOrganizationSlug)
 	require.Equal(t, project.CreatedAt.Time.UTC(), projectCreatedAt)
 	require.Equal(t, project.UpdatedAt.Time.UTC(), projectUpdatedAt)

--- a/server/internal/background/sync_tenant_dimensions.go
+++ b/server/internal/background/sync_tenant_dimensions.go
@@ -1,0 +1,83 @@
+package background
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+
+	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
+)
+
+const tenantDimensionsSyncInterval = 15 * time.Minute
+
+// SyncTenantDimensionsWorkflow refreshes the ClickHouse organization and
+// project reporting dimensions from one consistent Postgres snapshot.
+func SyncTenantDimensionsWorkflow(ctx workflow.Context) error {
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout:    2 * time.Minute,
+		ScheduleToCloseTimeout: 8 * time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts:    3,
+			InitialInterval:    5 * time.Second,
+			BackoffCoefficient: 2,
+			MaximumInterval:    30 * time.Second,
+		},
+	})
+
+	var a *Activities
+	if err := workflow.ExecuteActivity(ctx, a.SyncTenantDimensions).Get(ctx, nil); err != nil {
+		return fmt.Errorf("sync tenant dimensions: %w", err)
+	}
+	return nil
+}
+
+// AddTenantDimensionsSyncSchedule installs the queue-scoped periodic dimension
+// refresh. Queue scoping prevents preview workers sharing one namespace from
+// repointing or deleting another worktree's schedule.
+func AddTenantDimensionsSyncSchedule(ctx context.Context, temporalEnv *tenv.Environment) error {
+	queue := string(temporalEnv.Queue())
+	scheduleID := fmt.Sprintf("v1:tenant-dimensions-sync:%s", queue)
+	workflowID := scheduleID + "/scheduled"
+	scheduleClient := temporalEnv.Client().ScheduleClient()
+
+	spec := client.ScheduleSpec{
+		Intervals: []client.ScheduleIntervalSpec{{Every: tenantDimensionsSyncInterval}},
+	}
+	action := &client.ScheduleWorkflowAction{
+		ID:                 workflowID,
+		Workflow:           SyncTenantDimensionsWorkflow,
+		TaskQueue:          queue,
+		WorkflowRunTimeout: 10 * time.Minute,
+	}
+
+	_, err := scheduleClient.Create(ctx, client.ScheduleOptions{
+		ID:      scheduleID,
+		Overlap: enums.SCHEDULE_OVERLAP_POLICY_SKIP,
+		Spec:    spec,
+		Action:  action,
+	})
+	switch {
+	case errors.Is(err, temporal.ErrScheduleAlreadyRunning):
+		if err := scheduleClient.GetHandle(ctx, scheduleID).Update(ctx, client.ScheduleUpdateOptions{
+			DoUpdate: func(input client.ScheduleUpdateInput) (*client.ScheduleUpdate, error) {
+				input.Description.Schedule.Spec = &spec
+				input.Description.Schedule.Action = action
+				return &client.ScheduleUpdate{
+					Schedule:              &input.Description.Schedule,
+					TypedSearchAttributes: nil,
+				}, nil
+			},
+		}); err != nil {
+			return fmt.Errorf("update tenant dimension sync schedule: %w", err)
+		}
+	case err != nil:
+		return fmt.Errorf("create tenant dimension sync schedule: %w", err)
+	}
+	return nil
+}

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -451,6 +451,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterActivity(activities.GenerateToolsetEmbeddings)
 	temporalWorker.RegisterActivity(activities.GenerateChatTitle)
 	temporalWorker.RegisterActivity(activities.SyncIdentityMap)
+	temporalWorker.RegisterActivity(activities.SyncTenantDimensions)
 	temporalWorker.RegisterActivity(activities.PromoteStagedTelemetry)
 	temporalWorker.RegisterActivity(activities.ListStagedTelemetryProjects)
 	temporalWorker.RegisterActivity(activities.SegmentChat)
@@ -576,6 +577,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterWorkflow(IndexToolsetWorkflow)
 	temporalWorker.RegisterWorkflow(GenerateChatTitleWorkflow)
 	temporalWorker.RegisterWorkflow(SyncIdentityMapWorkflow)
+	temporalWorker.RegisterWorkflow(SyncTenantDimensionsWorkflow)
 	temporalWorker.RegisterWorkflow(PromoteStagedTelemetryWorkflow)
 	temporalWorker.RegisterWorkflow(StagedTelemetrySweepWorkflow)
 	temporalWorker.RegisterWorkflow(AnalyzeChatResolutionsWorkflow)
@@ -746,6 +748,10 @@ func (w *Workers) registerSchedules(ctx context.Context) {
 
 	if err := AddIdentityMapSyncSchedule(ctx, env); err != nil {
 		logger.ErrorContext(ctx, "failed to add identity map sync schedule", attr.SlogError(err))
+	}
+
+	if err := AddTenantDimensionsSyncSchedule(ctx, env); err != nil {
+		logger.ErrorContext(ctx, "failed to add tenant dimension sync schedule", attr.SlogError(err))
 	}
 
 	if err := AddSpendRuleEvaluationSchedule(ctx, env); err != nil {

--- a/server/internal/telemetry/repo/tenant_dimensions.go
+++ b/server/internal/telemetry/repo/tenant_dimensions.go
@@ -1,0 +1,212 @@
+package repo
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// TenantDimensionInsertChunk bounds one INSERT's parameter count. Organization
+// rows carry twenty columns, so a smaller chunk than the identity map keeps each
+// statement comfortably below driver and server limits.
+const TenantDimensionInsertChunk = 1000
+
+// OrganizationMetadataDimension is one organization reporting row sourced from
+// Postgres organization_metadata and its optional enterprise trial lifecycle.
+type OrganizationMetadataDimension struct {
+	// ID is the Gram organization identifier.
+	ID string
+
+	// Slug is the organization's current Gram slug.
+	Slug string
+
+	// AccountType is the Gram billing and entitlement tier.
+	AccountType string
+
+	// WorkOSID is the linked WorkOS organization identifier.
+	WorkOSID *string
+
+	// WorkOSUpdatedAt is the timestamp of the latest applied WorkOS update.
+	WorkOSUpdatedAt *time.Time
+
+	// WebhooksEnabled records whether outbound organization webhooks are enabled.
+	WebhooksEnabled *bool
+
+	// SCIMEnabled records whether SCIM directory sync is enabled.
+	SCIMEnabled *bool
+
+	// SSOEnabled records whether SSO is enabled.
+	SSOEnabled *bool
+
+	// Whitelisted records whether the organization is allowed to use Gram.
+	Whitelisted bool
+
+	// FreeTrialStartedAt begins the organization metadata free-trial window.
+	FreeTrialStartedAt time.Time
+
+	// FreeTrialEndsAt ends the organization metadata free-trial window.
+	FreeTrialEndsAt time.Time
+
+	// TrialTier is the optional enterprise trial tier.
+	TrialTier *string
+
+	// TrialEndsAt is the current enterprise trial end time.
+	TrialEndsAt *time.Time
+
+	// TrialConvertedAt records when the enterprise trial converted.
+	TrialConvertedAt *time.Time
+
+	// TrialDemotedAt records when the enterprise trial was demoted.
+	TrialDemotedAt *time.Time
+
+	// TrialCreatedAt records when the enterprise trial lifecycle was created.
+	TrialCreatedAt *time.Time
+
+	// TrialUpdatedAt records when the enterprise trial lifecycle was updated.
+	TrialUpdatedAt *time.Time
+
+	// CreatedAt records when the organization was created in Gram.
+	CreatedAt time.Time
+
+	// UpdatedAt records when the organization metadata was updated in Gram.
+	UpdatedAt time.Time
+
+	// DisabledAt records when the organization was disabled.
+	DisabledAt *time.Time
+}
+
+// ProjectDimension is one project reporting row sourced from Postgres.
+type ProjectDimension struct {
+	// ID is the Gram project identifier.
+	ID uuid.UUID
+
+	// OrganizationID is the organization that owns the project.
+	OrganizationID string
+
+	// Slug is the project's current slug within its organization.
+	Slug string
+
+	// CreatedAt records when the project was created.
+	CreatedAt time.Time
+
+	// UpdatedAt records when the project was updated.
+	UpdatedAt time.Time
+
+	// DeletedAt records when the project was soft-deleted.
+	DeletedAt *time.Time
+}
+
+// ReplaceTenantDimensions rebuilds both staging tables before publishing their
+// complete generations. Each EXCHANGE is atomic, while the pair is necessarily
+// sequential because ClickHouse does not provide a multi-table atomic exchange.
+func (q *Queries) ReplaceTenantDimensions(ctx context.Context, organizations []OrganizationMetadataDimension, projects []ProjectDimension) error {
+	if err := validateTenantDimensions(organizations, projects); err != nil {
+		return err
+	}
+
+	if err := q.conn.Exec(ctx, "TRUNCATE TABLE organization_metadata_staging"); err != nil {
+		return fmt.Errorf("truncate organization metadata staging: %w", err)
+	}
+	if err := q.conn.Exec(ctx, "TRUNCATE TABLE projects_staging"); err != nil {
+		return fmt.Errorf("truncate projects staging: %w", err)
+	}
+
+	for start := 0; start < len(organizations); start += TenantDimensionInsertChunk {
+		chunk := organizations[start:min(start+TenantDimensionInsertChunk, len(organizations))]
+		args := make([]any, 0, len(chunk)*20)
+		for _, row := range chunk {
+			args = append(args,
+				row.ID,
+				row.Slug,
+				row.AccountType,
+				nullableValue(row.WorkOSID),
+				nullableUnixMicro(row.WorkOSUpdatedAt),
+				nullableValue(row.WebhooksEnabled),
+				nullableValue(row.SCIMEnabled),
+				nullableValue(row.SSOEnabled),
+				row.Whitelisted,
+				row.FreeTrialStartedAt.UnixMicro(),
+				row.FreeTrialEndsAt.UnixMicro(),
+				nullableValue(row.TrialTier),
+				nullableUnixMicro(row.TrialEndsAt),
+				nullableUnixMicro(row.TrialConvertedAt),
+				nullableUnixMicro(row.TrialDemotedAt),
+				nullableUnixMicro(row.TrialCreatedAt),
+				nullableUnixMicro(row.TrialUpdatedAt),
+				row.CreatedAt.UnixMicro(),
+				row.UpdatedAt.UnixMicro(),
+				nullableUnixMicro(row.DisabledAt),
+			)
+		}
+		query := "INSERT INTO organization_metadata_staging (id, slug, account_type, workos_id, workos_updated_at, webhooks_enabled, scim_enabled, sso_enabled, whitelisted, free_trial_started_at, free_trial_ends_at, trial_tier, trial_ends_at, trial_converted_at, trial_demoted_at, trial_created_at, trial_updated_at, created_at, updated_at, disabled_at) VALUES " + tenantDimensionValuesClause(len(chunk), "(?, ?, ?, ?, fromUnixTimestamp64Micro(?), ?, ?, ?, ?, fromUnixTimestamp64Micro(?), fromUnixTimestamp64Micro(?), ?, fromUnixTimestamp64Micro(?), fromUnixTimestamp64Micro(?), fromUnixTimestamp64Micro(?), fromUnixTimestamp64Micro(?), fromUnixTimestamp64Micro(?), fromUnixTimestamp64Micro(?), fromUnixTimestamp64Micro(?), fromUnixTimestamp64Micro(?))")
+		if err := q.conn.Exec(ctx, query, args...); err != nil {
+			return fmt.Errorf("insert organization metadata staging chunk: %w", err)
+		}
+	}
+
+	for start := 0; start < len(projects); start += TenantDimensionInsertChunk {
+		chunk := projects[start:min(start+TenantDimensionInsertChunk, len(projects))]
+		args := make([]any, 0, len(chunk)*6)
+		for _, row := range chunk {
+			args = append(args, row.ID, row.OrganizationID, row.Slug, row.CreatedAt.UnixMicro(), row.UpdatedAt.UnixMicro(), nullableUnixMicro(row.DeletedAt))
+		}
+		query := "INSERT INTO projects_staging (id, organization_id, slug, created_at, updated_at, deleted_at) VALUES " + tenantDimensionValuesClause(len(chunk), "(?, ?, ?, fromUnixTimestamp64Micro(?), fromUnixTimestamp64Micro(?), fromUnixTimestamp64Micro(?))")
+		if err := q.conn.Exec(ctx, query, args...); err != nil {
+			return fmt.Errorf("insert projects staging chunk: %w", err)
+		}
+	}
+
+	if err := q.conn.Exec(ctx, "EXCHANGE TABLES organization_metadata_staging AND organization_metadata"); err != nil {
+		return fmt.Errorf("exchange organization metadata tables: %w", err)
+	}
+	if err := q.conn.Exec(ctx, "EXCHANGE TABLES projects_staging AND projects"); err != nil {
+		return fmt.Errorf("exchange project tables: %w", err)
+	}
+
+	return nil
+}
+
+func validateTenantDimensions(organizations []OrganizationMetadataDimension, projects []ProjectDimension) error {
+	organizationIDs := make(map[string]struct{}, len(organizations))
+	for _, organization := range organizations {
+		if _, exists := organizationIDs[organization.ID]; exists {
+			return fmt.Errorf("duplicate organization dimension id %q", organization.ID)
+		}
+		organizationIDs[organization.ID] = struct{}{}
+	}
+
+	projectIDs := make(map[uuid.UUID]struct{}, len(projects))
+	for _, project := range projects {
+		if _, exists := projectIDs[project.ID]; exists {
+			return fmt.Errorf("duplicate project dimension id %q", project.ID)
+		}
+		projectIDs[project.ID] = struct{}{}
+	}
+
+	return nil
+}
+
+func tenantDimensionValuesClause(rows int, tuple string) string {
+	values := make([]string, rows)
+	for i := range values {
+		values[i] = tuple
+	}
+	return strings.Join(values, ", ")
+}
+
+func nullableValue[T any](value *T) any {
+	if value == nil {
+		return nil
+	}
+	return *value
+}
+
+func nullableUnixMicro(value *time.Time) any {
+	if value == nil {
+		return nil
+	}
+	return value.UnixMicro()
+}


### PR DESCRIPTION
## Summary

- Publish a consistent PostgreSQL snapshot through a scheduled Temporal activity with single-writer protection and staging-table exchanges.
- Include organization lifecycle, trial, integration, and account metadata only for organizations with projects, plus project lifecycle data for reporting joins.
- Register a queue-scoped 15-minute schedule with overlap protection, retries, row-count logging, and orphan-project telemetry.

## Motivation

Telemetry rows contain tenant identifiers but not the current descriptive and lifecycle attributes needed for internal reporting. Synchronizing these dimensions into ClickHouse enables grouping and filtering without querying PostgreSQL from analytical workloads.

Temporal actions/month ≈ 5,760 per namespace, scales with fixed schedule cadence before retries.
