### PR TITLE
feat: meter MCP gateway bandwidth

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -10,3 +10,5 @@
 # [stripe]
 # price_id_tum = "..."
 # meter_event_name = "tum"
+# meter_event_name_mcp_bandwidth_ingress = "mcp_bandwidth_ingress"
+# meter_event_name_mcp_bandwidth_egress = "mcp_bandwidth_egress"

--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -46,6 +46,7 @@ import (
 
 	jose "github.com/go-jose/go-jose/v4"
 	"github.com/speakeasy-api/gram/infra/gen"
+	meteringv1 "github.com/speakeasy-api/gram/infra/gen/gram/metering/v1"
 	otelv1 "github.com/speakeasy-api/gram/infra/gen/gram/otel/v1"
 	riskv1 "github.com/speakeasy-api/gram/infra/gen/gram/risk/v1"
 	telemetryv1 "github.com/speakeasy-api/gram/infra/gen/gram/telemetry/v1"
@@ -603,7 +604,7 @@ func newStripeMeterEventClient(
 	guardianPolicy *guardian.Policy,
 	c *cli.Context,
 ) (stripeclient.V2MeterEventClient, error) {
-	if !c.Bool(stripeTUMMeterStreamingFlagName) {
+	if !c.Bool(stripeTUMMeterStreamingFlagName) && !c.Bool(stripeMeterEventExportFlagName) {
 		return stripeclient.NewNoopV2MeterEventClient(), nil
 	}
 
@@ -621,6 +622,7 @@ func newStripeMeterEventClient(
 func newStripeCatalog(c *cli.Context) metering.StripeCatalog {
 	tumMeterEventName := c.String("stripe-meter-event-name")
 	tumMeterStreamingEnabled := c.Bool(stripeTUMMeterStreamingFlagName)
+	meterExportEnabled := c.Bool(stripeMeterEventExportFlagName)
 	return metering.StripeCatalogFunc(func(definition metering.Definition) (string, error) {
 		switch definition {
 		case metering.AgentSessionStorage():
@@ -631,6 +633,16 @@ func newStripeCatalog(c *cli.Context) metering.StripeCatalog {
 				return "", errors.New("stripe TUM meter event name is not configured")
 			}
 			return tumMeterEventName, nil
+		case metering.MCPBandwidthIngress():
+			if !meterExportEnabled {
+				return "", nil
+			}
+			return c.String("stripe-meter-event-name-mcp-bandwidth-ingress"), nil
+		case metering.MCPBandwidthEgress():
+			if !meterExportEnabled {
+				return "", nil
+			}
+			return c.String("stripe-meter-event-name-mcp-bandwidth-egress"), nil
 		default:
 			return "", errors.New("meter definition is not mapped to Stripe")
 		}
@@ -1227,9 +1239,9 @@ func newPublishers(ctx context.Context, psbroker pubSubBroker) (*background.Publ
 	}
 	pubs = append(pubs, labelledStop{label: "riskFindings", pub: riskFindings})
 
-	// The telemetry shadow dual-write is best-effort and must stay bounded
-	// during a Pub/Sub outage: cap how long a publish may take and fail fast
-	// at enqueue once the buffer fills, instead of buffering unboundedly.
+	// Request-path telemetry and meter publishing must stay bounded during a
+	// Pub/Sub outage: cap how long a publish may take and fail fast at enqueue
+	// once the buffer fills instead of buffering unboundedly.
 	telemetryPublishSettings := pubsub.DefaultPublishSettings
 	telemetryPublishSettings.Timeout = 10 * time.Second
 	telemetryPublishSettings.FlowControlSettings.MaxOutstandingMessages = 10_000
@@ -1243,6 +1255,14 @@ func newPublishers(ctx context.Context, psbroker pubSubBroker) (*background.Publ
 		return nil, noopShutdown, fmt.Errorf("failed to create pubsub publisher for telemetry logs: %w", err)
 	}
 	pubs = append(pubs, labelledStop{label: "telemetryLogs", pub: telemetryLogs})
+
+	meterReadings, err := gcp.PubSubPublisherForMessage(ctx, psbroker, &meteringv1.MeterReading{},
+		gcp.WithPubSubPublishSettings(&telemetryPublishSettings),
+	)
+	if err != nil {
+		return nil, noopShutdown, fmt.Errorf("failed to create pubsub publisher for meter readings: %w", err)
+	}
+	pubs = append(pubs, labelledStop{label: "meterReadings", pub: meterReadings})
 
 	// OTLP ingest publishes on the request path and waits for the result before
 	// answering the exporter. Bound buffering so Pub/Sub stalls reject exports
@@ -1317,6 +1337,7 @@ func newPublishers(ctx context.Context, psbroker pubSubBroker) (*background.Publ
 		PromptPolicyAnalysis:    promptPolicyAnalysis,
 		CustomRulesAnalysis:     customRulesAnalysis,
 		RiskFindings:            riskFindings,
+		MeterReadings:           meterReadings,
 		TelemetryLogs:           telemetryLogs,
 		OTELLogs:                otelLogs,
 		OTELMetrics:             otelMetrics,

--- a/server/cmd/gram/deps_stripe_test.go
+++ b/server/cmd/gram/deps_stripe_test.go
@@ -235,6 +235,72 @@ func TestNewStripeCatalogRejectsMissingTUMEventName(t *testing.T) {
 	require.ErrorContains(t, err, "stripe TUM meter event name is not configured")
 }
 
+func TestNewStripeCatalogMapsMCPBandwidthMeters(t *testing.T) {
+	t.Parallel()
+
+	catalog := newStripeCatalog(newStripeCLIContext(t, map[string]string{
+		"stripe-meter-event-name-mcp-bandwidth-ingress": "mcp_bandwidth_ingress",
+		"stripe-meter-event-name-mcp-bandwidth-egress":  "mcp_bandwidth_egress",
+		stripeMeterEventExportFlagName:                  "true",
+	}))
+
+	ingressName, err := catalog.MeterEventName(metering.MCPBandwidthIngress())
+	require.NoError(t, err)
+	require.Equal(t, "mcp_bandwidth_ingress", ingressName)
+
+	egressName, err := catalog.MeterEventName(metering.MCPBandwidthEgress())
+	require.NoError(t, err)
+	require.Equal(t, "mcp_bandwidth_egress", egressName)
+}
+
+func TestNewStripeCatalogLeavesBandwidthMetersUnmappedWithoutNames(t *testing.T) {
+	t.Parallel()
+
+	catalog := newStripeCatalog(newStripeCLIContext(t, map[string]string{
+		stripeMeterEventExportFlagName: "true",
+	}))
+
+	ingressName, err := catalog.MeterEventName(metering.MCPBandwidthIngress())
+	require.NoError(t, err)
+	require.Empty(t, ingressName)
+
+	egressName, err := catalog.MeterEventName(metering.MCPBandwidthEgress())
+	require.NoError(t, err)
+	require.Empty(t, egressName)
+}
+
+func TestNewStripeCatalogDropsMCPBandwidthMetersWhenExportDisabled(t *testing.T) {
+	t.Parallel()
+
+	catalog := newStripeCatalog(newStripeCLIContext(t, map[string]string{
+		"stripe-meter-event-name-mcp-bandwidth-ingress": "mcp_bandwidth_ingress",
+		"stripe-meter-event-name-mcp-bandwidth-egress":  "mcp_bandwidth_egress",
+	}))
+
+	ingressName, err := catalog.MeterEventName(metering.MCPBandwidthIngress())
+	require.NoError(t, err)
+	require.Empty(t, ingressName)
+
+	egressName, err := catalog.MeterEventName(metering.MCPBandwidthEgress())
+	require.NoError(t, err)
+	require.Empty(t, egressName)
+}
+
+func TestNewStripeMeterEventClientAllowsMissingBandwidthNamesWhenExportEnabled(t *testing.T) {
+	t.Parallel()
+
+	client, err := newStripeMeterEventClient(
+		guardian.NewDefaultPolicy(testenv.NewTracerProvider(t)),
+		newStripeCLIContext(t, map[string]string{
+			"environment":                  "prod",
+			"stripe-api-key":               "sk_test_placeholder",
+			stripeMeterEventExportFlagName: "true",
+		}),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+}
+
 func TestNewBillingProviderAcceptsStripeWithoutPolar(t *testing.T) {
 	t.Parallel()
 
@@ -288,8 +354,11 @@ func newStripeCLIContext(t *testing.T, values map[string]string) *cli.Context {
 	set.String("stripe-price-id-tum", "", "")
 	set.String("stripe-meter-id-tum", "", "")
 	set.String("stripe-meter-event-name", "", "")
+	set.String("stripe-meter-event-name-mcp-bandwidth-ingress", "", "")
+	set.String("stripe-meter-event-name-mcp-bandwidth-egress", "", "")
 	set.String("stripe-portal-configuration-id", "", "")
 	set.Bool(stripeTUMMeterStreamingFlagName, false, "")
+	set.Bool(stripeMeterEventExportFlagName, false, "")
 	set.String("polar-api-key", "", "")
 	for key, value := range values {
 		require.NoError(t, set.Set(key, value))

--- a/server/cmd/gram/flags_stripe.go
+++ b/server/cmd/gram/flags_stripe.go
@@ -38,7 +38,19 @@ func stripeFlags() []cli.Flag {
 			Name:    "stripe-meter-event-name",
 			Aliases: []string{"stripe.meter_event_name"},
 			Usage:   "The Stripe TUM meter event name",
-			EnvVars: []string{"STRIPE_METER_EVENT_NAME"},
+			EnvVars: []string{"STRIPE_METER_EVENT_NAME", "STRIPE_METER_EVENT_NAME_TUM"},
+		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:    "stripe-meter-event-name-mcp-bandwidth-ingress",
+			Aliases: []string{"stripe.meter_event_name_mcp_bandwidth_ingress"},
+			Usage:   "The Stripe MCP bandwidth ingress meter event name",
+			EnvVars: []string{"STRIPE_METER_EVENT_NAME_MCP_BANDWIDTH_INGRESS"},
+		}),
+		altsrc.NewStringFlag(&cli.StringFlag{
+			Name:    "stripe-meter-event-name-mcp-bandwidth-egress",
+			Aliases: []string{"stripe.meter_event_name_mcp_bandwidth_egress"},
+			Usage:   "The Stripe MCP bandwidth egress meter event name",
+			EnvVars: []string{"STRIPE_METER_EVENT_NAME_MCP_BANDWIDTH_EGRESS"},
 		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:    "stripe-portal-configuration-id",

--- a/server/cmd/gram/flags_stripe_test.go
+++ b/server/cmd/gram/flags_stripe_test.go
@@ -45,6 +45,19 @@ func TestStripeFlagsAreAvailableInEveryServerProcess(t *testing.T) {
 			_, tomlSourceable = meterEventName.(altsrc.FlagInputSourceExtension)
 			require.True(t, tomlSourceable, "Stripe catalog must be TOML-sourceable")
 			require.Contains(t, meterEventName.Names(), "stripe.meter_event_name")
+			meterEventNameFlag, ok := meterEventName.(*altsrc.StringFlag)
+			require.True(t, ok)
+			require.Contains(t, meterEventNameFlag.EnvVars, "STRIPE_METER_EVENT_NAME_TUM")
+
+			ingressMeterEventName := requireFlag(t, command.Flags, "stripe-meter-event-name-mcp-bandwidth-ingress")
+			_, tomlSourceable = ingressMeterEventName.(altsrc.FlagInputSourceExtension)
+			require.True(t, tomlSourceable, "Stripe catalog must be TOML-sourceable")
+			require.Contains(t, ingressMeterEventName.Names(), "stripe.meter_event_name_mcp_bandwidth_ingress")
+
+			egressMeterEventName := requireFlag(t, command.Flags, "stripe-meter-event-name-mcp-bandwidth-egress")
+			_, tomlSourceable = egressMeterEventName.(altsrc.FlagInputSourceExtension)
+			require.True(t, tomlSourceable, "Stripe catalog must be TOML-sourceable")
+			require.Contains(t, egressMeterEventName.Names(), "stripe.meter_event_name_mcp_bandwidth_egress")
 
 			portalConfigurationID := requireFlag(t, command.Flags, "stripe-portal-configuration-id")
 			_, tomlSourceable = portalConfigurationID.(altsrc.FlagInputSourceExtension)

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -97,6 +97,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mcpservers"
 	"github.com/speakeasy-api/gram/server/internal/memory"
 	"github.com/speakeasy-api/gram/server/internal/metamcp"
+	"github.com/speakeasy-api/gram/server/internal/metering"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/modelkeys"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
@@ -1311,6 +1312,12 @@ func newStartCommand() *cli.Command {
 			}
 			mux.Use(mcpSecurity)
 			mux.Use(customdomains.Middleware(logger, db, c.String("environment"), serverURL))
+			// Ordering invariant: recovery and context-enrichment middleware stay
+			// outside bandwidth metering so panics and pre-handler rejections are
+			// not billable and validated custom-domain context is available.
+			// Middleware outside this boundary must not consume request bodies or
+			// transform successful response bodies; those bytes would not be counted.
+			mux.Use(metering.NewMCPBandwidthMiddleware(logger, publishers.MeterReadings))
 			mux.Use(middleware.SessionMiddleware)
 			mux.Use(middleware.RBACOverrideMiddleware())
 			// LiteLLM dispatch must run before canonical OTLP ingest because

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.temporal.io/sdk/temporal"
 
+	meteringv1 "github.com/speakeasy-api/gram/infra/gen/gram/metering/v1"
 	otelv1 "github.com/speakeasy-api/gram/infra/gen/gram/otel/v1"
 	riskv1 "github.com/speakeasy-api/gram/infra/gen/gram/risk/v1"
 	telemetryv1 "github.com/speakeasy-api/gram/infra/gen/gram/telemetry/v1"
@@ -91,6 +92,7 @@ type Publishers struct {
 	PromptPolicyAnalysis    gcp.Publisher[*riskv1.PromptPolicyAnalysis]
 	CustomRulesAnalysis     gcp.Publisher[*riskv1.CustomRulesAnalysis]
 	RiskFindings            gcp.Publisher[*riskv1.Finding]
+	MeterReadings           gcp.Publisher[*meteringv1.MeterReading]
 	TelemetryLogs           gcp.Publisher[*telemetryv1.LogRecord]
 	OTELLogs                gcp.Publisher[*otelv1.InboundLogRecord]
 	OTELMetrics             gcp.Publisher[*otelv1.InboundMetric]

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -19,6 +19,7 @@ import (
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
 
+	meteringv1 "github.com/speakeasy-api/gram/infra/gen/gram/metering/v1"
 	otelv1 "github.com/speakeasy-api/gram/infra/gen/gram/otel/v1"
 	riskv1 "github.com/speakeasy-api/gram/infra/gen/gram/risk/v1"
 	telemetryv1 "github.com/speakeasy-api/gram/infra/gen/gram/telemetry/v1"
@@ -200,6 +201,7 @@ func ForDeploymentProcessing(
 			PromptPolicyAnalysis:    gcp.NewNoopPublisher[*riskv1.PromptPolicyAnalysis](),
 			CustomRulesAnalysis:     gcp.NewNoopPublisher[*riskv1.CustomRulesAnalysis](),
 			RiskFindings:            gcp.NewNoopPublisher[*riskv1.Finding](),
+			MeterReadings:           gcp.NewNoopPublisher[*meteringv1.MeterReading](),
 			TelemetryLogs:           gcp.NewNoopPublisher[*telemetryv1.LogRecord](),
 			OTELLogs:                gcp.NewNoopPublisher[*otelv1.InboundLogRecord](),
 			OTELMetrics:             gcp.NewNoopPublisher[*otelv1.InboundMetric](),

--- a/server/internal/mcp/bandwidth_metering_test.go
+++ b/server/internal/mcp/bandwidth_metering_test.go
@@ -1,0 +1,149 @@
+package mcp_test
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	meteringv1 "github.com/speakeasy-api/gram/infra/gen/gram/metering/v1"
+	"github.com/speakeasy-api/gram/infra/pkg/gcp"
+	assistantsrepo "github.com/speakeasy-api/gram/server/internal/assistants/repo"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/metering"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/platformtools"
+	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+)
+
+type mcpBandwidthPublisher struct {
+	mu       sync.Mutex
+	messages []*meteringv1.MeterReading
+}
+
+func (p *mcpBandwidthPublisher) Publish(_ context.Context, message *meteringv1.MeterReading, _ ...gcp.PublishOption) gcp.PublishResult {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.messages = append(p.messages, message)
+	return immediatePublishResult{}
+}
+
+func (p *mcpBandwidthPublisher) Stop(context.Context) error { return nil }
+
+func (p *mcpBandwidthPublisher) snapshot() []*meteringv1.MeterReading {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]*meteringv1.MeterReading(nil), p.messages...)
+}
+
+type immediatePublishResult struct{}
+
+func (immediatePublishResult) Ready() <-chan struct{} {
+	ready := make(chan struct{})
+	close(ready)
+	return ready
+}
+
+func (immediatePublishResult) Get(context.Context) (string, error) { return "published", nil }
+
+func TestMCPBandwidthAttributionForResolvedHostedEndpoint(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsetsrepo.New(ti.conn), authCtx, "bandwidth-hosted-"+uuid.NewString()[:8])
+	slug := "bandwidth-hosted-" + uuid.NewString()[:8]
+	mcpServer := createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, toolset.ID, slug, "public", uuid.NullUUID{}, uuid.Nil)
+	body := makeInitializeBody()
+	publisher := &mcpBandwidthPublisher{}
+	handler := metering.NewMCPBandwidthMiddleware(ti.logger, publisher)(oops.MCPErrHandle(ti.logger, ti.service.ServePublic))
+	recorder := httptest.NewRecorder()
+	req := newMCPBandwidthRequest(ctx, "/mcp/"+slug, "mcpSlug", slug, body, "")
+
+	handler.ServeHTTP(recorder, req)
+
+	messages := publisher.snapshot()
+	require.Len(t, messages, 2, recorder.Body.String())
+	requireBandwidthMessage(t, messages[0], metering.MeterMCPBandwidthIngress, int64(len(body)), authCtx, "/mcp/"+slug, metering.MCPServerTypeHosted, mcpServer.ID.String(), mcpServer.Slug.String)
+	requireBandwidthMessage(t, messages[1], metering.MeterMCPBandwidthEgress, int64(recorder.Body.Len()), authCtx, "/mcp/"+slug, metering.MCPServerTypeHosted, mcpServer.ID.String(), mcpServer.Slug.String)
+}
+
+func TestMCPBandwidthAttributionForAuthorizedPlatformToolset(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	managedID := createAssistant(t, ti, authCtx, "Bandwidth managed assistant")
+	require.NoError(t, assistantsrepo.New(ti.conn).CreateProjectManagedAssistant(t.Context(), assistantsrepo.CreateProjectManagedAssistantParams{
+		ProjectID:   *authCtx.ProjectID,
+		AssistantID: managedID,
+	}))
+	token := mintAssistantToken(t, ti, authCtx, managedID)
+	body := toolsListBody()
+	slug := platformtools.ManagedAssistantPlatformToolsetSlug
+	requestPath := "/platform/mcp/" + slug
+	publisher := &mcpBandwidthPublisher{}
+	handler := metering.NewMCPBandwidthMiddleware(ti.logger, publisher)(oops.MCPErrHandle(ti.logger, ti.service.ServePlatformToolset))
+	recorder := httptest.NewRecorder()
+	req := newMCPBandwidthRequest(t.Context(), requestPath, "toolsetSlug", slug, body, token)
+
+	handler.ServeHTTP(recorder, req)
+
+	messages := publisher.snapshot()
+	require.Len(t, messages, 2, recorder.Body.String())
+	requireBandwidthMessage(t, messages[0], metering.MeterMCPBandwidthIngress, int64(len(body)), authCtx, requestPath, metering.MCPServerTypePlatformToolset, slug, slug)
+	requireBandwidthMessage(t, messages[1], metering.MeterMCPBandwidthEgress, int64(recorder.Body.Len()), authCtx, requestPath, metering.MCPServerTypePlatformToolset, slug, slug)
+}
+
+func TestMCPBandwidthDoesNotAttributeUnknownEndpoint(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestMCPService(t)
+	slug := "unknown-" + uuid.NewString()
+	publisher := &mcpBandwidthPublisher{}
+	handler := metering.NewMCPBandwidthMiddleware(ti.logger, publisher)(oops.MCPErrHandle(ti.logger, ti.service.ServePublic))
+	recorder := httptest.NewRecorder()
+	req := newMCPBandwidthRequest(ctx, "/mcp/"+slug, "mcpSlug", slug, makeInitializeBody(), "")
+
+	handler.ServeHTTP(recorder, req)
+
+	require.Empty(t, publisher.snapshot())
+	require.Equal(t, http.StatusNotFound, recorder.Code)
+}
+
+func newMCPBandwidthRequest(ctx context.Context, path, routeParam, routeValue string, body []byte, bearerToken string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	if bearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+bearerToken)
+	}
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add(routeParam, routeValue)
+	return req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
+}
+
+func requireBandwidthMessage(t *testing.T, message *meteringv1.MeterReading, meterID metering.MeterID, value int64, authCtx *contextvalues.AuthContext, requestPath string, serverType metering.MCPServerType, serverID, serverSlug string) {
+	t.Helper()
+	require.Equal(t, string(meterID), message.GetMeterId())
+	require.Equal(t, value, message.GetValue())
+	require.Equal(t, authCtx.ActiveOrganizationID, message.GetOrganizationId())
+	require.Equal(t, authCtx.ProjectID.String(), message.GetProjectId())
+	require.Equal(t, string(metering.UnitBytes), message.GetUnit())
+	require.Equal(t, string(metering.MeasurementHTTPBodyBytes), message.GetMeasurementMethod())
+	require.Equal(t, requestPath, message.GetAttributes()[metering.AttributeRequestPath])
+	require.Equal(t, string(serverType), message.GetAttributes()[metering.AttributeMCPServerType])
+	require.Equal(t, serverID, message.GetAttributes()[metering.AttributeMCPServerID])
+	require.Equal(t, serverSlug, message.GetAttributes()[metering.AttributeMCPServerSlug])
+}
+
+var _ gcp.Publisher[*meteringv1.MeterReading] = (*mcpBandwidthPublisher)(nil)

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -69,6 +69,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
 	"github.com/speakeasy-api/gram/server/internal/mcpmetadata"
 	metadata_repo "github.com/speakeasy-api/gram/server/internal/mcpmetadata/repo"
+	"github.com/speakeasy-api/gram/server/internal/metering"
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	oauth_repo "github.com/speakeasy-api/gram/server/internal/oauth/repo"
@@ -700,6 +701,7 @@ func (s *Service) serveProxyBackedEndpoint(w http.ResponseWriter, r *http.Reques
 		// Unavailable addresses are terminal, never the legacy behavior.
 		return true, err
 	}
+	attributeMCPBandwidthServer(ctx, mcpServer, metaServer, mcpSlug)
 
 	// Meta-backed endpoints hold no upstream session and no proxied GET/SSE
 	// stream; the caller's legacy behavior (install page or 405) applies.
@@ -789,6 +791,7 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 	mcpEndpoint, mcpServer, metaServer, err := s.ResolveMCPEndpointAndServer(ctx, logger, mcpSlug)
 	switch {
 	case err == nil:
+		attributeMCPBandwidthServer(ctx, mcpServer, metaServer, mcpSlug)
 		if err := s.enforceCustomDomainLockdown(ctx, logger, mcpEndpoint.ProjectID); err != nil {
 			return err
 		}
@@ -813,6 +816,7 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 	case err != nil:
 		return oops.E(oops.CodeUnexpected, err, "failed to load MCP server").LogError(ctx, s.logger)
 	}
+	metering.AttributeMCPBandwidthServer(ctx, metering.MCPServerTypeDirectToolset, toolset.ID.String(), mcpSlug)
 	s.metrics.RecordToolsetSlugFallback(ctx, mcpmetrics.LegacyFallbackServePublic)
 
 	if err := s.enforceCustomDomainLockdown(ctx, logger, toolset.ProjectID); err != nil {

--- a/server/internal/mcp/serve_platform.go
+++ b/server/internal/mcp/serve_platform.go
@@ -25,6 +25,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcprequests"
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
+	"github.com/speakeasy-api/gram/server/internal/metering"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/platformtools"
@@ -71,6 +72,8 @@ func (s *Service) ServePlatformToolset(w http.ResponseWriter, r *http.Request) e
 	if !ok || authCtx == nil || authCtx.ProjectID == nil {
 		return oops.E(oops.CodeUnauthorized, nil, "no project auth context").LogError(ctx, s.logger)
 	}
+	metering.AttributeMCPBandwidth(ctx, authCtx.ActiveOrganizationID, *authCtx.ProjectID)
+	metering.AttributeMCPBandwidthServer(ctx, metering.MCPServerTypePlatformToolset, slug, slug)
 
 	if err := s.authorizePlatformToolset(ctx, slug, authCtx); err != nil {
 		return err

--- a/server/internal/mcp/serveendpoint.go
+++ b/server/internal/mcp/serveendpoint.go
@@ -26,6 +26,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mcpservers"
 	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	metamcprepo "github.com/speakeasy-api/gram/server/internal/metamcp/repo"
+	"github.com/speakeasy-api/gram/server/internal/metering"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp"
@@ -45,6 +46,7 @@ func (s *Service) ServeMCPEndpoint(w http.ResponseWriter, r *http.Request, slug,
 	if err != nil {
 		return err
 	}
+	attributeMCPBandwidthServer(ctx, mcpServer, metaServer, slug)
 
 	if metaServer != nil {
 		// Meta-backed endpoints are served only on the canonical /mcp
@@ -64,6 +66,24 @@ func (s *Service) ServeMCPEndpoint(w http.ResponseWriter, r *http.Request, slug,
 	}
 
 	return s.serveResolvedMCPEndpoint(w, r, logger, mcpEndpoint, mcpServer, slug, mcpRouteBase)
+}
+
+func attributeMCPBandwidthServer(ctx context.Context, mcpServer *mcpserversrepo.McpServer, metaServer *metamcprepo.MetaMcpServer, serverSlug string) {
+	if mcpServer != nil && mcpServer.Slug.Valid && mcpServer.Slug.String != "" {
+		serverSlug = mcpServer.Slug.String
+	}
+	switch {
+	case metaServer != nil:
+		metering.AttributeMCPBandwidthServer(ctx, metering.MCPServerTypeMeta, metaServer.ID.String(), serverSlug)
+	case mcpServer == nil:
+		return
+	case mcpServer.RemoteMcpServerID.Valid:
+		metering.AttributeMCPBandwidthServer(ctx, metering.MCPServerTypeRemote, mcpServer.ID.String(), serverSlug)
+	case mcpServer.TunneledMcpServerID.Valid:
+		metering.AttributeMCPBandwidthServer(ctx, metering.MCPServerTypeTunneled, mcpServer.ID.String(), serverSlug)
+	case mcpServer.ToolsetID.Valid:
+		metering.AttributeMCPBandwidthServer(ctx, metering.MCPServerTypeHosted, mcpServer.ID.String(), serverSlug)
+	}
 }
 
 // enforceCustomDomainLockdown 403s a public-host MCP request when the owning
@@ -93,11 +113,13 @@ func (s *Service) enforceCustomDomainLockdown(ctx context.Context, logger *slog.
 }
 
 // customDomainLockdownApplies reports whether a platform-origin request must
-// be kept away from runtime-like MCP surfaces. Requests already carrying a
-// custom-domain context passed through the ingress allowlist and are never
-// locked down here.
+// be kept away from runtime-like MCP surfaces. Once project ownership is known,
+// it also attributes an active bandwidth exchange; calls from non-runtime
+// surfaces are no-ops. Requests already carrying a custom-domain context passed
+// through the ingress allowlist and are never locked down here.
 func (s *Service) customDomainLockdownApplies(ctx context.Context, logger *slog.Logger, projectID uuid.UUID) (bool, error) {
-	if customdomains.FromContext(ctx) != nil {
+	if domainCtx := customdomains.FromContext(ctx); domainCtx != nil {
+		metering.AttributeMCPBandwidth(ctx, domainCtx.OrganizationID, projectID)
 		return false, nil
 	}
 
@@ -108,6 +130,7 @@ func (s *Service) customDomainLockdownApplies(ctx context.Context, logger *slog.
 	case err != nil:
 		return false, oops.E(oops.CodeUnexpected, err, "load project for custom domain lockdown").LogError(ctx, logger)
 	}
+	metering.AttributeMCPBandwidth(ctx, project.OrganizationID, projectID)
 
 	domain, err := customdomainsrepo.New(s.db).GetCustomDomainByOrganization(ctx, project.OrganizationID)
 	switch {

--- a/server/internal/metering/attributes.go
+++ b/server/internal/metering/attributes.go
@@ -10,6 +10,22 @@ const (
 	// AttributeWorkloadSource identifies the product path responsible for the workload.
 	AttributeWorkloadSource = "workload_source"
 
+	// AttributeRequestPath identifies the HTTP request path that carried the workload.
+	AttributeRequestPath = "request_path"
+
+	// AttributeCustomDomain identifies the validated custom domain carrying the workload.
+	AttributeCustomDomain = "custom_domain"
+
+	// AttributeMCPServerType identifies the resolved MCP server implementation.
+	AttributeMCPServerType = "mcp_server_type"
+
+	// AttributeMCPServerID identifies the resolved server within its type-specific namespace.
+	AttributeMCPServerID = "mcp_server_id"
+
+	// AttributeMCPServerSlug identifies the resolved server's canonical slug,
+	// or its stable route slug when the server type has no persisted slug.
+	AttributeMCPServerSlug = "mcp_server_slug"
+
 	// AttributeModel identifies the model that produced or received the message.
 	AttributeModel = "model"
 

--- a/server/internal/metering/bandwidth.go
+++ b/server/internal/metering/bandwidth.go
@@ -1,0 +1,255 @@
+package metering
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"mime"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+	meteringv1 "github.com/speakeasy-api/gram/infra/gen/gram/metering/v1"
+	"github.com/speakeasy-api/gram/infra/pkg/gcp"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/customdomains"
+)
+
+const (
+	mcpBandwidthPublishTimeout = 10 * time.Second
+	mcpBandwidthSource         = "mcp_bandwidth_middleware"
+)
+
+// MCPServerType is a stable classification of a resolved MCP runtime server.
+type MCPServerType string
+
+const (
+	MCPServerTypeHosted          MCPServerType = "hosted"
+	MCPServerTypeRemote          MCPServerType = "remote"
+	MCPServerTypeTunneled        MCPServerType = "tunneled"
+	MCPServerTypeMeta            MCPServerType = "meta"
+	MCPServerTypeDirectToolset   MCPServerType = "direct_toolset"
+	MCPServerTypePlatformToolset MCPServerType = "platform_toolset"
+)
+
+type mcpBandwidthContextKey struct{}
+
+type mcpBandwidthExchange struct {
+	mu               sync.Mutex
+	scope            Scope
+	serverType       MCPServerType
+	serverID         string
+	serverSlug       string
+	attributed       bool
+	serverAttributed bool
+	ingress          atomic.Int64
+	egress           atomic.Int64
+}
+
+// AttributeMCPBandwidth assigns an MCP HTTP exchange to a resolved project.
+// It is a no-op outside NewMCPBandwidthMiddleware and keeps the first trusted
+// attribution if a handler crosses multiple internal dispatch layers.
+func AttributeMCPBandwidth(ctx context.Context, organizationID string, projectID uuid.UUID) {
+	exchange, ok := ctx.Value(mcpBandwidthContextKey{}).(*mcpBandwidthExchange)
+	if !ok || exchange == nil {
+		return
+	}
+
+	exchange.mu.Lock()
+	defer exchange.mu.Unlock()
+	if exchange.attributed {
+		return
+	}
+	exchange.scope = ProjectScope(organizationID, projectID)
+	exchange.attributed = true
+}
+
+// AttributeMCPBandwidthServer assigns resolved server provenance to an MCP HTTP
+// exchange. The server ID's namespace is determined by serverType: mcp_servers
+// for hosted, remote, and tunneled servers; meta_mcp_servers for meta servers;
+// toolsets for direct toolsets; and the stable slug for platform toolsets.
+// serverSlug is the canonical or stable route slug for the resolved server.
+func AttributeMCPBandwidthServer(ctx context.Context, serverType MCPServerType, serverID, serverSlug string) {
+	exchange, ok := ctx.Value(mcpBandwidthContextKey{}).(*mcpBandwidthExchange)
+	if !ok || exchange == nil || serverType == "" || serverID == "" {
+		return
+	}
+
+	exchange.mu.Lock()
+	defer exchange.mu.Unlock()
+	if exchange.serverAttributed {
+		return
+	}
+	exchange.serverType = serverType
+	exchange.serverID = serverID
+	exchange.serverSlug = serverSlug
+	exchange.serverAttributed = true
+}
+
+// NewMCPBandwidthMiddleware meters application-visible request and response
+// body bytes for MCP and Platform MCP runtime routes. It deliberately ignores
+// headers, HTTP framing, unread request bytes, and nested gateway fan-out.
+//
+// Ordering invariant: install this inside recovery and after middleware that
+// enriches the request context without consuming request bodies or transforming
+// successful response bodies. Panics and outer-middleware rejections are
+// intentionally outside the billable exchange.
+func NewMCPBandwidthMiddleware(logger *slog.Logger, publisher gcp.Publisher[*meteringv1.MeterReading]) func(http.Handler) http.Handler {
+	logger = logger.With(attr.SlogComponent("mcp-bandwidth-meter"))
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestPath := r.URL.Path
+			if !isMCPRuntimePath(requestPath) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			customDomain := ""
+			if domainCtx := customdomains.FromContext(r.Context()); domainCtx != nil {
+				customDomain = domainCtx.Domain
+			}
+
+			exchange := new(mcpBandwidthExchange)
+			if r.Body != nil {
+				r.Body = &countingReadCloser{ReadCloser: r.Body, bytes: &exchange.ingress}
+			}
+			meteredWriter := &countingResponseWriter{ResponseWriter: w, bytes: &exchange.egress}
+			ctx := context.WithValue(r.Context(), mcpBandwidthContextKey{}, exchange)
+			next.ServeHTTP(meteredWriter, r.WithContext(ctx))
+
+			if isHTMLResponse(meteredWriter.Header()) {
+				// Browser-facing install pages share runtime route shapes but are
+				// product UI, not MCP traffic, so their bodies are not billable.
+				return
+			}
+
+			exchange.mu.Lock()
+			scope := exchange.scope
+			attributed := exchange.attributed
+			serverType := exchange.serverType
+			serverID := exchange.serverID
+			serverSlug := exchange.serverSlug
+			serverAttributed := exchange.serverAttributed
+			exchange.mu.Unlock()
+			if !attributed {
+				return
+			}
+
+			occurredAt := time.Now().UTC()
+			operationID := uuid.NewString()
+			attributes := map[string]string{AttributeRequestPath: requestPath}
+			if customDomain != "" {
+				attributes[AttributeCustomDomain] = customDomain
+			}
+			if serverAttributed {
+				attributes[AttributeMCPServerType] = string(serverType)
+				attributes[AttributeMCPServerID] = serverID
+				if serverSlug != "" {
+					attributes[AttributeMCPServerSlug] = serverSlug
+				}
+			}
+			readings := make([]Reading, 0, 2)
+			for _, measured := range []struct {
+				definition Definition
+				value      int64
+			}{
+				{definition: MCPBandwidthIngress(), value: exchange.ingress.Load()},
+				{definition: MCPBandwidthEgress(), value: exchange.egress.Load()},
+			} {
+				if measured.value == 0 {
+					continue
+				}
+				reading, err := NewUsage(UsageInput{
+					Meter:       measured.definition,
+					Scope:       scope,
+					OperationID: operationID,
+					Value:       measured.value,
+					OccurredAt:  occurredAt,
+					ProducedAt:  occurredAt,
+					Source:      mcpBandwidthSource,
+					Attributes:  attributes,
+				})
+				if err != nil {
+					logger.ErrorContext(ctx, "build MCP bandwidth reading", attr.SlogError(err))
+					return
+				}
+				readings = append(readings, reading)
+			}
+			if len(readings) == 0 {
+				return
+			}
+
+			publishCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), mcpBandwidthPublishTimeout)
+			defer cancel()
+			if err := publishReadings(publishCtx, publisher, readings); err != nil {
+				logger.ErrorContext(publishCtx, "publish MCP bandwidth readings", attr.SlogError(err))
+			}
+		})
+	}
+}
+
+func publishReadings(ctx context.Context, publisher gcp.Publisher[*meteringv1.MeterReading], readings []Reading) error {
+	results := make([]gcp.PublishResult, len(readings))
+	for i, reading := range readings {
+		results[i] = publisher.Publish(ctx, toProto(reading, reading.ID()))
+	}
+
+	var errs []error
+	for i, result := range results {
+		if _, err := result.Get(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("publish meter reading %d: %w", i, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func isMCPRuntimePath(path string) bool {
+	for _, prefix := range [...]string{"/mcp/", "/platform/mcp/"} {
+		if remainder, ok := strings.CutPrefix(path, prefix); ok {
+			return remainder != "" && !strings.ContainsRune(remainder, '/')
+		}
+	}
+	return false
+}
+
+func isHTMLResponse(header http.Header) bool {
+	mediaType, _, err := mime.ParseMediaType(header.Get("Content-Type"))
+	return err == nil && (mediaType == "text/html" || mediaType == "application/xhtml+xml")
+}
+
+type countingReadCloser struct {
+	io.ReadCloser
+	bytes *atomic.Int64
+}
+
+func (r *countingReadCloser) Read(p []byte) (int, error) {
+	n, err := r.ReadCloser.Read(p)
+	r.bytes.Add(int64(n))
+	return n, err //nolint:wrapcheck // An io.Reader wrapper must preserve sentinel error identity.
+}
+
+type countingResponseWriter struct {
+	http.ResponseWriter
+	bytes *atomic.Int64
+}
+
+func (w *countingResponseWriter) Write(p []byte) (int, error) {
+	n, err := w.ResponseWriter.Write(p)
+	w.bytes.Add(int64(n))
+	return n, err //nolint:wrapcheck // A ResponseWriter wrapper must preserve the underlying write error.
+}
+
+// Flush preserves streaming through response-writer wrapper chains.
+func (w *countingResponseWriter) Flush() {
+	_ = http.NewResponseController(w.ResponseWriter).Flush()
+}
+
+// Unwrap exposes the underlying writer to http.ResponseController.
+func (w *countingResponseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}

--- a/server/internal/metering/bandwidth_test.go
+++ b/server/internal/metering/bandwidth_test.go
@@ -1,0 +1,328 @@
+package metering_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	meteringv1 "github.com/speakeasy-api/gram/infra/gen/gram/metering/v1"
+	"github.com/speakeasy-api/gram/infra/pkg/gcp"
+	"github.com/speakeasy-api/gram/server/internal/customdomains"
+	"github.com/speakeasy-api/gram/server/internal/metering"
+	"github.com/speakeasy-api/gram/server/internal/middleware"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+type bandwidthCapturePublisher struct {
+	mu                  sync.Mutex
+	messages            []*meteringv1.MeterReading
+	publishContextError []error
+	requireBatchSize    int
+}
+
+func (p *bandwidthCapturePublisher) Publish(ctx context.Context, message *meteringv1.MeterReading, _ ...gcp.PublishOption) gcp.PublishResult {
+	p.mu.Lock()
+	p.messages = append(p.messages, message)
+	p.publishContextError = append(p.publishContextError, ctx.Err())
+	p.mu.Unlock()
+	return bandwidthPublishResult{publisher: p}
+}
+
+func (p *bandwidthCapturePublisher) Stop(context.Context) error { return nil }
+
+func (p *bandwidthCapturePublisher) published() ([]*meteringv1.MeterReading, []error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]*meteringv1.MeterReading(nil), p.messages...), append([]error(nil), p.publishContextError...)
+}
+
+type bandwidthPublishResult struct {
+	publisher *bandwidthCapturePublisher
+}
+
+func (r bandwidthPublishResult) Ready() <-chan struct{} {
+	ready := make(chan struct{})
+	close(ready)
+	return ready
+}
+
+func (r bandwidthPublishResult) Get(context.Context) (string, error) {
+	r.publisher.mu.Lock()
+	defer r.publisher.mu.Unlock()
+	if r.publisher.requireBatchSize > 0 && len(r.publisher.messages) != r.publisher.requireBatchSize {
+		return "", errors.New("publisher result awaited before the whole exchange batch was published")
+	}
+	return "published", nil
+}
+
+func TestMCPBandwidthMiddlewareMetersHostedRemoteTunneledMetaAndPlatformBodies(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		requestPath string
+		serverType  metering.MCPServerType
+	}{
+		{requestPath: "/mcp/hosted", serverType: metering.MCPServerTypeHosted},
+		{requestPath: "/mcp/remote", serverType: metering.MCPServerTypeRemote},
+		{requestPath: "/mcp/tunneled", serverType: metering.MCPServerTypeTunneled},
+		{requestPath: "/mcp/meta", serverType: metering.MCPServerTypeMeta},
+		{requestPath: "/mcp/direct", serverType: metering.MCPServerTypeDirectToolset},
+		{requestPath: "/platform/mcp/platform-toolset", serverType: metering.MCPServerTypePlatformToolset},
+	}
+	for _, tt := range tests {
+		requestPath := tt.requestPath
+		publisher := &bandwidthCapturePublisher{requireBatchSize: 2}
+		projectID := uuid.New()
+		var gotBody string
+		var readErr, writeErr error
+		handler := metering.NewMCPBandwidthMiddleware(testenv.NewLogger(t), publisher)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			metering.AttributeMCPBandwidth(r.Context(), "org-test", projectID)
+			metering.AttributeMCPBandwidthServer(r.Context(), tt.serverType, "server-id", "server-slug")
+			body, err := io.ReadAll(r.Body)
+			readErr = err
+			gotBody = string(body)
+			_, writeErr = io.WriteString(w, "response-body")
+		}))
+
+		request := httptest.NewRequest(http.MethodPost, requestPath+"?query=omitted", strings.NewReader("request-body"))
+		request = request.WithContext(customdomains.WithContext(request.Context(), &customdomains.Context{
+			OrganizationID: "org-test",
+			Domain:         "mcp.example.test",
+			DomainID:       uuid.New(),
+		}))
+		request.URL.Fragment = "omitted"
+		handler.ServeHTTP(httptest.NewRecorder(), request)
+		require.NoError(t, readErr, requestPath)
+		require.Equal(t, "request-body", gotBody, requestPath)
+		require.NoError(t, writeErr, requestPath)
+		messages, contextErrors := publisher.published()
+		require.Len(t, messages, 2, requestPath)
+		require.Equal(t, string(metering.MeterMCPBandwidthIngress), messages[0].GetMeterId(), requestPath)
+		require.Equal(t, int64(len("request-body")), messages[0].GetValue(), requestPath)
+		require.Equal(t, string(metering.MeterMCPBandwidthEgress), messages[1].GetMeterId(), requestPath)
+		require.Equal(t, int64(len("response-body")), messages[1].GetValue(), requestPath)
+		require.Equal(t, messages[0].GetOperationId(), messages[1].GetOperationId(), requestPath)
+		require.NotEmpty(t, messages[0].GetOperationId(), requestPath)
+		_, err := uuid.Parse(messages[0].GetOperationId())
+		require.NoError(t, err, requestPath)
+		require.Equal(t, messages[0].GetOccurredAt(), messages[1].GetOccurredAt(), requestPath)
+		require.Equal(t, messages[0].GetProducedAt(), messages[1].GetProducedAt(), requestPath)
+		require.Equal(t, messages[0].GetOccurredAt(), messages[0].GetProducedAt(), requestPath)
+		require.Equal(t, "mcp_bandwidth_middleware", messages[0].GetSource(), requestPath)
+		require.Equal(t, "org-test", messages[0].GetOrganizationId(), requestPath)
+		require.Equal(t, projectID.String(), messages[0].GetProjectId(), requestPath)
+		require.Equal(t, string(metering.UnitBytes), messages[0].GetUnit(), requestPath)
+		require.Equal(t, string(metering.MeasurementHTTPBodyBytes), messages[0].GetMeasurementMethod(), requestPath)
+		require.Equal(t, requestPath, messages[0].GetAttributes()[metering.AttributeRequestPath], requestPath)
+		require.Equal(t, requestPath, messages[1].GetAttributes()[metering.AttributeRequestPath], requestPath)
+		require.Equal(t, string(tt.serverType), messages[0].GetAttributes()[metering.AttributeMCPServerType], requestPath)
+		require.Equal(t, "server-id", messages[0].GetAttributes()[metering.AttributeMCPServerID], requestPath)
+		require.Equal(t, string(tt.serverType), messages[1].GetAttributes()[metering.AttributeMCPServerType], requestPath)
+		require.Equal(t, "server-id", messages[1].GetAttributes()[metering.AttributeMCPServerID], requestPath)
+		require.Equal(t, "server-slug", messages[0].GetAttributes()[metering.AttributeMCPServerSlug], requestPath)
+		require.Equal(t, "server-slug", messages[1].GetAttributes()[metering.AttributeMCPServerSlug], requestPath)
+		require.Equal(t, "mcp.example.test", messages[0].GetAttributes()[metering.AttributeCustomDomain], requestPath)
+		require.Equal(t, "mcp.example.test", messages[1].GetAttributes()[metering.AttributeCustomDomain], requestPath)
+		require.Equal(t, []error{nil, nil}, contextErrors, requestPath)
+	}
+}
+
+func TestMCPBandwidthMiddlewareCountsGeneratedErrorsAndPartialWrites(t *testing.T) {
+	t.Parallel()
+
+	publisher := &bandwidthCapturePublisher{}
+	partial := &partialResponseWriter{header: make(http.Header), limit: 7}
+	handler := metering.NewMCPBandwidthMiddleware(testenv.NewLogger(t), publisher)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		metering.AttributeMCPBandwidth(r.Context(), "org-test", uuid.New())
+		_, _ = io.ReadAll(r.Body)
+		http.Error(w, "generated error", http.StatusBadGateway)
+	}))
+
+	handler.ServeHTTP(partial, httptest.NewRequest(http.MethodPost, "/mcp/generated-error", strings.NewReader("read-me")))
+	messages, _ := publisher.published()
+	require.Len(t, messages, 2)
+	require.Equal(t, int64(len("read-me")), messages[0].GetValue())
+	require.Equal(t, int64(7), messages[1].GetValue())
+}
+
+func TestMCPBandwidthMiddlewareSkipsPanicsRecoveredOutsideMeter(t *testing.T) {
+	t.Parallel()
+
+	publisher := &bandwidthCapturePublisher{}
+	handler := middleware.NewRecovery(testenv.NewLogger(t))(
+		metering.NewMCPBandwidthMiddleware(testenv.NewLogger(t), publisher)(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				metering.AttributeMCPBandwidth(r.Context(), "org-test", uuid.New())
+				_, _ = io.ReadAll(r.Body)
+				_, _ = io.WriteString(w, "partial response")
+				panic("boom")
+			}),
+		),
+	)
+
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/mcp/panic", strings.NewReader("request")))
+	messages, _ := publisher.published()
+	require.Empty(t, messages)
+}
+
+func TestMCPBandwidthMiddlewarePublishesStreamBytesOnlyAfterClose(t *testing.T) {
+	t.Parallel()
+
+	publisher := &bandwidthCapturePublisher{}
+	inner := &flushResponseRecorder{ResponseRecorder: httptest.NewRecorder()}
+	var firstWriteErr, secondWriteErr error
+	var flusherOK, unwrapperOK bool
+	var unwrapped http.ResponseWriter
+	var messagesDuringHandler int
+	handler := metering.NewMCPBandwidthMiddleware(testenv.NewLogger(t), publisher)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		metering.AttributeMCPBandwidth(r.Context(), "org-test", uuid.New())
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, firstWriteErr = io.WriteString(w, "data: one\n\n")
+		flusher, ok := w.(http.Flusher)
+		flusherOK = ok
+		if flusherOK {
+			flusher.Flush()
+		}
+		messages, _ := publisher.published()
+		messagesDuringHandler = len(messages)
+		_, secondWriteErr = io.WriteString(w, "data: two\n\n")
+		unwrapper, ok := w.(interface{ Unwrap() http.ResponseWriter })
+		unwrapperOK = ok
+		if unwrapperOK {
+			unwrapped = unwrapper.Unwrap()
+		}
+	}))
+
+	handler.ServeHTTP(inner, httptest.NewRequest(http.MethodGet, "/mcp/stream", nil))
+	require.NoError(t, firstWriteErr)
+	require.NoError(t, secondWriteErr)
+	require.True(t, flusherOK)
+	require.True(t, unwrapperOK)
+	require.Equal(t, http.ResponseWriter(inner), unwrapped)
+	require.Zero(t, messagesDuringHandler)
+	messages, _ := publisher.published()
+	require.Len(t, messages, 1)
+	require.Equal(t, string(metering.MeterMCPBandwidthEgress), messages[0].GetMeterId())
+	require.Equal(t, int64(len("data: one\n\ndata: two\n\n")), messages[0].GetValue())
+	require.True(t, inner.flushed)
+}
+
+func TestMCPBandwidthMiddlewareDetachesPublicationFromRequestCancellation(t *testing.T) {
+	t.Parallel()
+
+	publisher := &bandwidthCapturePublisher{requireBatchSize: 2}
+	ctx, cancel := context.WithCancel(t.Context())
+	handler := metering.NewMCPBandwidthMiddleware(testenv.NewLogger(t), publisher)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		metering.AttributeMCPBandwidth(r.Context(), "org-test", uuid.New())
+		_, _ = io.ReadAll(r.Body)
+		_, _ = io.WriteString(w, "response")
+		cancel()
+	}))
+
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/mcp/cancelled", strings.NewReader("request")).WithContext(ctx))
+	messages, contextErrors := publisher.published()
+	require.Len(t, messages, 2)
+	require.Equal(t, []error{nil, nil}, contextErrors)
+}
+
+func TestMCPBandwidthMiddlewareSkipsHTMLInstallAndNonMCPExchanges(t *testing.T) {
+	t.Parallel()
+
+	paths := []string{
+		"/rpc/projects.list",
+		"/mcp/server/install",
+		"/platform-mcp",
+		"/platform/mcp",
+	}
+	for _, requestPath := range paths {
+		publisher := &bandwidthCapturePublisher{}
+		handler := metering.NewMCPBandwidthMiddleware(testenv.NewLogger(t), publisher)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			metering.AttributeMCPBandwidth(r.Context(), "org-test", uuid.New())
+			_, _ = io.ReadAll(r.Body)
+			_, _ = io.WriteString(w, "response")
+		}))
+		handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, requestPath, strings.NewReader("request")))
+		messages, _ := publisher.published()
+		require.Empty(t, messages, requestPath)
+	}
+
+	publisher := &bandwidthCapturePublisher{}
+	htmlInstall := metering.NewMCPBandwidthMiddleware(testenv.NewLogger(t), publisher)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		metering.AttributeMCPBandwidth(r.Context(), "org-test", uuid.New())
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = io.WriteString(w, "<html>install</html>")
+	}))
+	htmlInstall.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/mcp/hosted", nil))
+	messages, _ := publisher.published()
+	require.Empty(t, messages)
+}
+
+func TestMCPBandwidthMiddlewareSkipsUnknownTenantsAndZeroByteDirections(t *testing.T) {
+	t.Parallel()
+
+	unknownPublisher := &bandwidthCapturePublisher{}
+	unknownTenant := metering.NewMCPBandwidthMiddleware(testenv.NewLogger(t), unknownPublisher)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		_, _ = io.WriteString(w, "not found")
+	}))
+	unknownTenant.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/mcp/unknown", strings.NewReader("request")))
+	unknownMessages, _ := unknownPublisher.published()
+	require.Empty(t, unknownMessages)
+
+	zeroPublisher := &bandwidthCapturePublisher{}
+	zero := metering.NewMCPBandwidthMiddleware(testenv.NewLogger(t), zeroPublisher)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		metering.AttributeMCPBandwidth(r.Context(), "org-test", uuid.New())
+	}))
+	zero.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/mcp/zero", nil))
+	zeroMessages, _ := zeroPublisher.published()
+	require.Empty(t, zeroMessages)
+
+	egressOnlyPublisher := &bandwidthCapturePublisher{}
+	egressOnly := metering.NewMCPBandwidthMiddleware(testenv.NewLogger(t), egressOnlyPublisher)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		metering.AttributeMCPBandwidth(r.Context(), "org-test", uuid.New())
+		_, _ = io.WriteString(w, "response")
+	}))
+	egressOnly.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/mcp/egress-only", nil))
+	egressOnlyMessages, _ := egressOnlyPublisher.published()
+	require.Len(t, egressOnlyMessages, 1)
+	require.Equal(t, string(metering.MeterMCPBandwidthEgress), egressOnlyMessages[0].GetMeterId())
+
+	ingressOnlyPublisher := &bandwidthCapturePublisher{}
+	ingressOnly := metering.NewMCPBandwidthMiddleware(testenv.NewLogger(t), ingressOnlyPublisher)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		metering.AttributeMCPBandwidth(r.Context(), "org-test", uuid.New())
+		_, _ = io.ReadAll(r.Body)
+	}))
+	ingressOnly.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/mcp/ingress-only", strings.NewReader("request")))
+	ingressOnlyMessages, _ := ingressOnlyPublisher.published()
+	require.Len(t, ingressOnlyMessages, 1)
+	require.Equal(t, string(metering.MeterMCPBandwidthIngress), ingressOnlyMessages[0].GetMeterId())
+}
+
+type partialResponseWriter struct {
+	header http.Header
+	limit  int
+}
+
+func (w *partialResponseWriter) Header() http.Header { return w.header }
+func (w *partialResponseWriter) WriteHeader(int)     {}
+func (w *partialResponseWriter) Write(p []byte) (int, error) {
+	return min(w.limit, len(p)), io.ErrShortWrite
+}
+
+type flushResponseRecorder struct {
+	*httptest.ResponseRecorder
+	flushed bool
+}
+
+func (w *flushResponseRecorder) Flush() {
+	w.flushed = true
+	w.ResponseRecorder.Flush()
+}

--- a/server/internal/metering/ch_writer.go
+++ b/server/internal/metering/ch_writer.go
@@ -288,6 +288,7 @@ func meterReadingRow(message *meteringv1.MeterReading, insertedAt time.Time) (ch
 		MeterID:           string(definition.id),
 		OperationID:       message.GetOperationId(),
 		Unit:              string(definition.unit),
+		MeasurementMethod: string(definition.measurementMethod),
 		Value:             message.GetValue(),
 		OccurredAt:        occurredAt,
 		ProducedAt:        producedAt,

--- a/server/internal/metering/ch_writer_test.go
+++ b/server/internal/metering/ch_writer_test.go
@@ -48,7 +48,7 @@ func usageMessage(t *testing.T, input metering.UsageInput) (*meteringv1.MeterRea
 	t.Helper()
 	reading, err := metering.NewUsage(input)
 	require.NoError(t, err)
-	message := commonMessage(reading.ID(), input.Scope, input.OperationID, input.Value, input.OccurredAt, input.ProducedAt, input.Source, input.Attributes)
+	message := commonMessage(t, reading.ID(), input.Meter, input.Scope, input.OperationID, input.Value, input.OccurredAt, input.ProducedAt, input.Source, input.Attributes)
 	message.SetKind(meteringv1.MeterReading_KIND_USAGE)
 	return message, reading
 }
@@ -57,7 +57,7 @@ func adjustmentMessage(t *testing.T, input metering.AdjustmentInput) (*meteringv
 	t.Helper()
 	reading, err := metering.NewAdjustment(input)
 	require.NoError(t, err)
-	message := commonMessage(reading.ID(), input.Scope, input.OperationID, input.Value, input.OccurredAt, input.ProducedAt, input.Source, input.Attributes)
+	message := commonMessage(t, reading.ID(), input.Meter, input.Scope, input.OperationID, input.Value, input.OccurredAt, input.ProducedAt, input.Source, input.Attributes)
 	message.SetKind(meteringv1.MeterReading_KIND_ADJUSTMENT)
 	message.SetCorrectsReadingId(input.CorrectsReadingID.String())
 	message.SetAdjustmentReason(input.Reason)
@@ -65,7 +65,9 @@ func adjustmentMessage(t *testing.T, input metering.AdjustmentInput) (*meteringv
 }
 
 func commonMessage(
+	t *testing.T,
 	id uuid.UUID,
+	definition metering.Definition,
 	scope metering.Scope,
 	operationID string,
 	value int64,
@@ -74,23 +76,65 @@ func commonMessage(
 	source string,
 	attributes map[string]string,
 ) *meteringv1.MeterReading {
+	t.Helper()
+	meterID, unit, measurementMethod := definitionProtoFields(t, definition)
 	message := &meteringv1.MeterReading{}
 	message.SetId(id.String())
 	message.SetOrganizationId(scope.OrganizationID())
 	if projectID, ok := scope.ProjectID(); ok {
 		message.SetProjectId(projectID.String())
 	}
-	message.SetMeterId(string(metering.MeterAgentSessionStorage))
+	message.SetMeterId(string(meterID))
 	message.SetOperationId(operationID)
-	message.SetUnit(string(metering.UnitSTokens))
+	message.SetUnit(string(unit))
 	message.SetValue(value)
 	message.SetOccurredAt(occurredAt.Format(time.RFC3339Nano))
 	message.SetAttributes(attributes)
 	message.SetMeterVersion(1)
 	message.SetProducedAt(producedAt.Format(time.RFC3339Nano))
-	message.SetMeasurementMethod(string(metering.MeasurementTiktokenO200kBase))
+	message.SetMeasurementMethod(string(measurementMethod))
 	message.SetSource(source)
 	return message
+}
+func definitionProtoFields(t *testing.T, definition metering.Definition) (metering.MeterID, metering.Unit, metering.MeasurementMethod) {
+	t.Helper()
+	switch definition {
+	case metering.AgentSessionStorage():
+		return metering.MeterAgentSessionStorage, metering.UnitSTokens, metering.MeasurementTiktokenO200kBase
+	case metering.MCPBandwidthIngress():
+		return metering.MeterMCPBandwidthIngress, metering.UnitBytes, metering.MeasurementHTTPBodyBytes
+	case metering.MCPBandwidthEgress():
+		return metering.MeterMCPBandwidthEgress, metering.UnitBytes, metering.MeasurementHTTPBodyBytes
+	default:
+		require.FailNow(t, "unknown meter definition")
+		return "", "", ""
+	}
+}
+
+func TestMeterReadingCHWriterPersistsBandwidthMeasurementMethod(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	message, reading := usageMessage(t, metering.UsageInput{
+		Meter:       metering.MCPBandwidthIngress(),
+		Scope:       metering.ProjectScope("org-"+uuid.NewString(), uuid.New()),
+		OperationID: "mcp-http-exchange:" + uuid.NewString(),
+		Value:       4096,
+		OccurredAt:  now,
+		ProducedAt:  now,
+		Source:      "test",
+		Attributes:  nil,
+	})
+	capture := &captureReadingInserter{}
+	writer := metering.NewMeterReadingCHWriter(testenv.NewLogger(t), nil, capture)
+
+	require.NoError(t, writer.HandleBatch(t.Context(), []*meteringv1.MeterReading{message}, nil))
+	require.Len(t, capture.rows, 1)
+	require.Equal(t, reading.ID(), capture.rows[0].ID)
+	require.Equal(t, string(metering.MeterMCPBandwidthIngress), capture.rows[0].MeterID)
+	require.Equal(t, string(metering.UnitBytes), capture.rows[0].Unit)
+	require.Equal(t, string(metering.MeasurementHTTPBodyBytes), capture.rows[0].MeasurementMethod)
+	require.Equal(t, int64(4096), capture.rows[0].Value)
+	require.NotContains(t, capture.rows[0].Attributes, "codec")
 }
 
 func TestMeterReadingCHWriterSkipsPoisonAndDeduplicatesBatch(t *testing.T) {
@@ -128,6 +172,32 @@ func TestMeterReadingCHWriterSkipsPoisonAndDeduplicatesBatch(t *testing.T) {
 	require.Equal(t, string(metering.MeasurementTiktokenO200kBase), capture.rows[0].Attributes["codec"])
 	require.Equal(t, "refreshed", capture.rows[0].Attributes["revision"])
 	require.Equal(t, updatedInput.ProducedAt, capture.rows[0].ProducedAt)
+}
+
+func TestMeterReadingCHWriterRejectsUnregisteredMeasurementContracts(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	valid, _ := usageMessage(t, metering.UsageInput{
+		Meter:       metering.MCPBandwidthIngress(),
+		Scope:       metering.ProjectScope("org-"+uuid.NewString(), uuid.New()),
+		OperationID: "mcp-http-exchange:" + uuid.NewString(),
+		Value:       1024,
+		OccurredAt:  now,
+		ProducedAt:  now,
+		Source:      "test",
+		Attributes:  nil,
+	})
+	invalidUnit, ok := proto.Clone(valid).(*meteringv1.MeterReading)
+	require.True(t, ok)
+	invalidUnit.SetUnit("kilobytes")
+	invalidMethod, ok := proto.Clone(valid).(*meteringv1.MeterReading)
+	require.True(t, ok)
+	invalidMethod.SetMeasurementMethod("estimated_bytes")
+	capture := &captureReadingInserter{}
+	writer := metering.NewMeterReadingCHWriter(testenv.NewLogger(t), nil, capture)
+
+	require.NoError(t, writer.HandleBatch(t.Context(), []*meteringv1.MeterReading{invalidUnit, invalidMethod}, nil))
+	require.Empty(t, capture.rows)
 }
 
 func TestMeterReadingCHWriterPropagatesInsertFailure(t *testing.T) {

--- a/server/internal/metering/chrepo/queries.go
+++ b/server/internal/metering/chrepo/queries.go
@@ -33,6 +33,9 @@ type ReadingRow struct {
 	// Unit is the workload measurement unit.
 	Unit string `ch:"unit"`
 
+	// MeasurementMethod identifies how the workload quantity was measured.
+	MeasurementMethod string `ch:"measurement_method"`
+
 	// Value is the signed workload value.
 	Value int64 `ch:"value"`
 
@@ -75,6 +78,7 @@ func (q *Queries) InsertReadings(ctx context.Context, rows []ReadingRow) error {
 		"meter_id",
 		"operation_id",
 		"unit",
+		"measurement_method",
 		"value",
 		"occurred_at",
 		"produced_at",
@@ -94,6 +98,7 @@ func (q *Queries) InsertReadings(ctx context.Context, rows []ReadingRow) error {
 			row.MeterID,
 			row.OperationID,
 			row.Unit,
+			row.MeasurementMethod,
 			row.Value,
 			row.OccurredAt.Format("2006-01-02 15:04:05.999999999"),
 			row.ProducedAt.Format("2006-01-02 15:04:05.999999999"),

--- a/server/internal/metering/chrepo/queries_test.go
+++ b/server/internal/metering/chrepo/queries_test.go
@@ -32,6 +32,7 @@ func TestInsertReadingsPersistsAndDeduplicatesStableIDs(t *testing.T) {
 		MeterID:           "gram.agent_session.storage",
 		OperationID:       "chat_message:" + uuid.NewString(),
 		Unit:              "stokens",
+		MeasurementMethod: "tiktoken_o200k_base",
 		Value:             10,
 		OccurredAt:        firstOccurredAt,
 		ProducedAt:        producedAt,
@@ -50,6 +51,7 @@ func TestInsertReadingsPersistsAndDeduplicatesStableIDs(t *testing.T) {
 		MeterID:           "gram.agent_session.storage",
 		OperationID:       first.OperationID + ":correction",
 		Unit:              "stokens",
+		MeasurementMethod: "tiktoken_o200k_base",
 		Value:             -4,
 		OccurredAt:        secondOccurredAt,
 		ProducedAt:        adjustmentProducedAt,
@@ -63,20 +65,21 @@ func TestInsertReadingsPersistsAndDeduplicatesStableIDs(t *testing.T) {
 	require.NoError(t, queries.InsertReadings(t.Context(), []chrepo.ReadingRow{redelivery, correction}))
 
 	var (
-		operationID, unit, corrects  string
-		value                        int64
-		occurredAt, storedProducedAt time.Time
-		storedInsertedAt             time.Time
-		attributes                   map[string]string
+		operationID, unit, measurementMethod, corrects string
+		value                                          int64
+		occurredAt, storedProducedAt                   time.Time
+		storedInsertedAt                               time.Time
+		attributes                                     map[string]string
 	)
 	err := conn.QueryRow(t.Context(), `
-		SELECT operation_id, toString(unit), value, occurred_at, produced_at, inserted_at,
-		       ifNull(toString(corrects_reading_id), ''), attributes
+		SELECT operation_id, toString(unit), toString(measurement_method), value,
+		       occurred_at, produced_at, inserted_at, ifNull(toString(corrects_reading_id), ''), attributes
 		FROM billing_meter_readings FINAL
 		WHERE organization_id = ? AND project_id = ? AND meter_id = ? AND id = ?
 	`, organizationID, projectID, first.MeterID, readingID).Scan(
 		&operationID,
 		&unit,
+		&measurementMethod,
 		&value,
 		&occurredAt,
 		&storedProducedAt,
@@ -87,6 +90,7 @@ func TestInsertReadingsPersistsAndDeduplicatesStableIDs(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, first.OperationID, operationID)
 	require.Equal(t, "stokens", unit)
+	require.Equal(t, "tiktoken_o200k_base", measurementMethod)
 	require.Equal(t, int64(10), value)
 	require.Equal(t, secondOccurredAt, occurredAt)
 	require.Equal(t, producedAt, storedProducedAt)
@@ -121,4 +125,37 @@ func TestInsertReadingsPersistsAndDeduplicatesStableIDs(t *testing.T) {
 	`, organizationID, projectID, correctionID).Scan(&storedCorrectionID, &storedCorrectionValue))
 	require.Equal(t, readingID.String(), storedCorrectionID)
 	require.Equal(t, int64(-4), storedCorrectionValue)
+}
+
+func TestInsertReadingsAcceptsBandwidthMeasurements(t *testing.T) {
+	t.Parallel()
+	conn := newTestClickhouse(t)
+	queries := chrepo.New(conn)
+	row := chrepo.ReadingRow{
+		ID:                uuid.New(),
+		OrganizationID:    "org-" + uuid.NewString(),
+		ProjectID:         uuid.New(),
+		MeterID:           "gram.mcp.bandwidth.egress",
+		OperationID:       "mcp-http-exchange:" + uuid.NewString(),
+		Unit:              "bytes",
+		MeasurementMethod: "http_body_bytes",
+		Value:             8192,
+		OccurredAt:        time.Now().UTC(),
+		ProducedAt:        time.Now().UTC(),
+		InsertedAt:        time.Now().UTC(),
+		Attributes:        map[string]string{},
+	}
+
+	require.NoError(t, queries.InsertReadings(t.Context(), []chrepo.ReadingRow{row}))
+
+	var unit, measurementMethod string
+	var value int64
+	require.NoError(t, conn.QueryRow(t.Context(), `
+		SELECT toString(unit), toString(measurement_method), value
+		FROM billing_meter_readings FINAL
+		WHERE organization_id = ? AND project_id = ? AND id = ?
+	`, row.OrganizationID, row.ProjectID, row.ID).Scan(&unit, &measurementMethod, &value))
+	require.Equal(t, "bytes", unit)
+	require.Equal(t, "http_body_bytes", measurementMethod)
+	require.Equal(t, int64(8192), value)
 }

--- a/server/internal/metering/definition.go
+++ b/server/internal/metering/definition.go
@@ -24,11 +24,23 @@ const (
 	// MeterAgentSessionStorage measures durable agent-session message storage.
 	MeterAgentSessionStorage MeterID = "gram.agent_session.storage"
 
+	// MeterMCPBandwidthIngress measures application-visible MCP request body bytes.
+	MeterMCPBandwidthIngress MeterID = "gram.mcp.bandwidth.ingress"
+
+	// MeterMCPBandwidthEgress measures application-visible MCP response body bytes.
+	MeterMCPBandwidthEgress MeterID = "gram.mcp.bandwidth.egress"
+
 	// UnitSTokens is the Gram-owned Speakeasy token workload unit.
 	UnitSTokens Unit = "stokens"
 
+	// UnitBytes is the byte workload unit.
+	UnitBytes Unit = "bytes"
+
 	// MeasurementTiktokenO200kBase is the canonical s-token measurement method.
 	MeasurementTiktokenO200kBase MeasurementMethod = "tiktoken_o200k_base" //nolint:gosec // tokenizer identifier, not a credential
+
+	// MeasurementHTTPBodyBytes counts bytes returned by HTTP body reads and writes.
+	MeasurementHTTPBodyBytes MeasurementMethod = "http_body_bytes"
 )
 
 // AgentSessionStorage returns the current durable message-storage definition.
@@ -42,11 +54,38 @@ func AgentSessionStorage() Definition {
 	}
 }
 
+// MCPBandwidthIngress returns the current MCP request-bandwidth definition.
+func MCPBandwidthIngress() Definition {
+	return Definition{
+		id:                MeterMCPBandwidthIngress,
+		version:           1,
+		unit:              UnitBytes,
+		measurementMethod: MeasurementHTTPBodyBytes,
+		scopeKind:         scopeKindProject,
+	}
+}
+
+// MCPBandwidthEgress returns the current MCP response-bandwidth definition.
+func MCPBandwidthEgress() Definition {
+	return Definition{
+		id:                MeterMCPBandwidthEgress,
+		version:           1,
+		unit:              UnitBytes,
+		measurementMethod: MeasurementHTTPBodyBytes,
+		scopeKind:         scopeKindProject,
+	}
+}
+
 // LookupDefinition returns a registered meter definition by identity.
 func LookupDefinition(id MeterID, version uint32) (Definition, bool) {
-	definition := AgentSessionStorage()
-	if id == definition.id && version == definition.version {
-		return definition, true
+	for _, definition := range [...]Definition{
+		AgentSessionStorage(),
+		MCPBandwidthIngress(),
+		MCPBandwidthEgress(),
+	} {
+		if id == definition.id && version == definition.version {
+			return definition, true
+		}
 	}
 	var zero Definition
 	return zero, false


### PR DESCRIPTION
## Summary

- Add project-scoped ingress and egress meters for raw HTTP body bytes on resolved `/mcp/{slug}` and `/platform/mcp/{slug}` exchanges.
- Attach query-free request paths, validated custom domains, and resolved server type, identifier, and canonical slug provenance to each reading. Server types distinguish hosted, remote, tunneled, meta, direct toolset, and platform toolset traffic.
- Install metering inside recovery and custom-domain middleware: panics and pre-handler rejections are not billable, while accepted handler errors and completed streams remain measurable.
- Publish paired readings directly to the existing metering Pub/Sub pipeline after each exchange, including completed streaming responses and generated errors.
- Validate each reading's unit and measurement method against its registered definition before persisting it, then expose separate Stripe meter-event configuration under the existing generic export gate.
- Allow missing bandwidth Stripe mappings to be acknowledged and dropped until configured, support `STRIPE_METER_EVENT_NAME_TUM`, and preserve the independent TUM export gate.
- Exclude unknown tenants, zero-byte directions, install pages, and HTML renders.

Temporal actions/month: 0 (direct Pub/Sub publishing, no Temporal workflows, activities, timers, or signals).

## Motivation

Gateway bandwidth needs direction-specific, project-attributed usage records without counting HTTP framing, headers, unread request data, or upstream fan-out. Measuring at the HTTP middleware boundary gives exact application-visible byte counts while keeping unresolved tenant traffic out of billing and reusing the current metering ingestion and Stripe export paths.
