### PR TITLE
mig: persist meter measurement methods

### DIFF
--- a/server/clickhouse/local/golang_migrate/20260904165443_mcp-bandwidth-meter-readings.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260904165443_mcp-bandwidth-meter-readings.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `billing_meter_readings` DROP COLUMN `measurement_method`;
+ALTER TABLE `billing_meter_readings` COMMENT COLUMN `unit` 'Measurement unit, currently stokens.';
+ALTER TABLE `billing_meter_readings` ADD CONSTRAINT `measurement_valid` CHECK ((unit = 'stokens') AND (tokenizer_codec = 'tiktoken_o200k_base'));
+ALTER TABLE `billing_meter_readings` MODIFY COMMENT 'Raw s-token usage ledger with producer-time stable-id convergence and billing reads requiring FINAL or equivalent id deduplication';

--- a/server/clickhouse/local/golang_migrate/20260904165443_mcp-bandwidth-meter-readings.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260904165443_mcp-bandwidth-meter-readings.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `billing_meter_readings` MODIFY COMMENT 'Raw usage ledger with producer-time stable-id convergence and billing reads requiring FINAL or equivalent id deduplication';
+ALTER TABLE `billing_meter_readings` DROP CONSTRAINT `measurement_valid`;
+ALTER TABLE `billing_meter_readings` COMMENT COLUMN `unit` 'Measurement unit.';
+ALTER TABLE `billing_meter_readings` ADD COLUMN `measurement_method` LowCardinality(String) DEFAULT if(unit = 'stokens', 'tiktoken_o200k_base', '') COMMENT 'Rating-critical measurement implementation.';

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:++5d1TmQtcj+EIeBo9Zcem9PguM+jWiKmLhT12RdSng=
+h1:MhpqfJ7zpqJFHj8tTSuf/LSR4G8nAb1BhTzjluF9PCM=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -98,3 +98,4 @@ h1:++5d1TmQtcj+EIeBo9Zcem9PguM+jWiKmLhT12RdSng=
 20260902165937_meta-mcp-attribution.up.sql h1:7NTw1iTmV1otLjK+FhDNsLM3DqJtl5qKdewT8g0JuvI=
 20260902193942_openclaw-usage-rows.up.sql h1:FLrJnV85T8U/HUgIeHFhfyTFEKaRBMwxudBpFNu+RG8=
 20260904141331_tenant-reporting-dimensions.up.sql h1:M529LrMZ0R04erQuo/ftTFMQostnvNFJpN50HZToSFE=
+20260904165443_mcp-bandwidth-meter-readings.up.sql h1:ve0lzIwI6dz2YM9yXqEwdvHKGX0TLvfk2OyzY7VFR5A=

--- a/server/clickhouse/migrations/20260904165434_mcp-bandwidth-meter-readings.sql
+++ b/server/clickhouse/migrations/20260904165434_mcp-bandwidth-meter-readings.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `billing_meter_readings` MODIFY COMMENT 'Raw usage ledger with producer-time stable-id convergence and billing reads requiring FINAL or equivalent id deduplication';
+ALTER TABLE `billing_meter_readings` DROP CONSTRAINT `measurement_valid`;
+ALTER TABLE `billing_meter_readings` COMMENT COLUMN `unit` 'Measurement unit.';
+ALTER TABLE `billing_meter_readings` ADD COLUMN `measurement_method` LowCardinality(String) DEFAULT if(unit = 'stokens', 'tiktoken_o200k_base', '') COMMENT 'Rating-critical measurement implementation.';

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:qbKpSL2nvj4WT8TifYFAUk3KvToVcm0iZhIG2jgidOA=
+h1:TuCj3KjRfAfJmSonve6uhSIZtL2tZyiMwly2WWJLZVw=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -103,3 +103,4 @@ h1:qbKpSL2nvj4WT8TifYFAUk3KvToVcm0iZhIG2jgidOA=
 20260902165930_meta-mcp-attribution.sql h1:DqvRFSad+IKXmH+pZzFTzzsD4gKIGl+4cnXb2buvTEA=
 20260902193935_openclaw-usage-rows.sql h1:EqmJwX/4Tf1aQVEvIT2viHC3vWV0/iKonGRY8RXP2qc=
 20260904141320_tenant-reporting-dimensions.sql h1:mPYeUlsGTFGV/rJg3SdOP/CUI3gkbMJc/j6Z/OJFO64=
+20260904165434_mcp-bandwidth-meter-readings.sql h1:aQJUsNzu7EHoldJZ7IZt+yiiqO9Lz5QihNjYvcY2Oxw=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -1235,7 +1235,8 @@ CREATE TABLE IF NOT EXISTS billing_meter_readings (
     project_id UUID COMMENT 'Project that owns the workload.',
     meter_id LowCardinality(String) COMMENT 'Registered workload meter identifier.',
     operation_id String COMMENT 'Domain operation that produced the reading.',
-    unit LowCardinality(String) COMMENT 'Measurement unit, currently stokens.',
+    unit LowCardinality(String) COMMENT 'Measurement unit.',
+    measurement_method LowCardinality(String) DEFAULT if(unit = 'stokens', 'tiktoken_o200k_base', '') COMMENT 'Rating-critical measurement implementation.',
     value Int64 COMMENT 'Signed workload value where usage is positive and adjustments may be positive or negative.',
     occurred_at DateTime64(9, 'UTC') COMMENT 'Usage-effective UTC time when the metered work executed and the timestamp used for billing periods.',
     produced_at DateTime64(9, 'UTC') COMMENT 'UTC time when the producer created this reading variant and the ReplacingMergeTree version.',
@@ -1247,14 +1248,13 @@ CREATE TABLE IF NOT EXISTS billing_meter_readings (
     CONSTRAINT identity_valid CHECK id != toUUID('00000000-0000-0000-0000-000000000000') AND project_id != toUUID('00000000-0000-0000-0000-000000000000') AND notEmpty(trimBoth(organization_id)) AND notEmpty(trimBoth(meter_id)) AND notEmpty(trimBoth(operation_id)),
     CONSTRAINT value_kind_valid CHECK (corrects_reading_id IS NULL AND value > 0) OR (corrects_reading_id IS NOT NULL AND value != 0),
     CONSTRAINT correction_id_valid CHECK corrects_reading_id IS NULL OR (corrects_reading_id != toUUID('00000000-0000-0000-0000-000000000000') AND corrects_reading_id != id),
-    CONSTRAINT measurement_valid CHECK unit = 'stokens' AND tokenizer_codec = 'tiktoken_o200k_base',
     INDEX idx_billing_meter_readings_occurred_at occurred_at TYPE minmax GRANULARITY 1
 ) ENGINE = ReplacingMergeTree(produced_at)
 PARTITION BY cityHash64(toString(id)) % 64
 PRIMARY KEY (organization_id, meter_id, project_id)
 ORDER BY (organization_id, meter_id, project_id, id)
 SETTINGS index_granularity = 8192
-COMMENT 'Raw s-token usage ledger with producer-time stable-id convergence and billing reads requiring FINAL or equivalent id deduplication';
+COMMENT 'Raw usage ledger with producer-time stable-id convergence and billing reads requiring FINAL or equivalent id deduplication';
 
 CREATE TABLE IF NOT EXISTS authz_challenges (
     -- Identity


### PR DESCRIPTION
## Summary

- Add `measurement_method` to the ClickHouse billing meter readings schema.
- Give legacy s-token readings and rollout-gap writers a safe `tiktoken_o200k_base` default.
- Remove the meter-specific measurement check constraint from ClickHouse.
- Generate both Atlas and golang-migrate outputs with `mise run clickhouse:diff mcp-bandwidth-meter-readings`.

## Motivation

A reading's unit is not sufficient to reproduce how usage was measured. Persisting the rating-critical measurement method keeps that provenance queryable, while application-side meter-definition validation allows new units and methods without another ClickHouse constraint change.

## Rollout

The schema layer lands first. ClickHouse evaluates the default for existing parts and legacy writes that omit the new column; the value matches the only method allowed by the old constraint. Dependent PR #6080 persists each validated meter definition's method explicitly for new readings.

## Verification

- `mise run clickhouse:diff mcp-bandwidth-meter-readings`
- `mise run lint:migrations`
- Full golang-migrate replay against an isolated ClickHouse database
- Legacy-row migration smoke test: a pre-migration `stokens` / `tiktoken_o200k_base` row resolves `measurement_method=tiktoken_o200k_base`
- `mise run test:server -count=1 ./internal/metering/...`