### PR TITLE
mig: add ClickHouse tenant dimension tables

### DIFF
--- a/server/clickhouse/local/golang_migrate/20260904141331_tenant-reporting-dimensions.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260904141331_tenant-reporting-dimensions.down.sql
@@ -1,0 +1,8 @@
+-- reverse: create "projects_staging" table
+DROP TABLE `projects_staging`;
+-- reverse: create "projects" table
+DROP TABLE `projects`;
+-- reverse: create "organization_metadata_staging" table
+DROP TABLE `organization_metadata_staging`;
+-- reverse: create "organization_metadata" table
+DROP TABLE `organization_metadata`;

--- a/server/clickhouse/local/golang_migrate/20260904141331_tenant-reporting-dimensions.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260904141331_tenant-reporting-dimensions.up.sql
@@ -1,0 +1,68 @@
+-- create "organization_metadata" table
+CREATE TABLE `organization_metadata` (
+  `id` String COMMENT 'Gram organization identifier.',
+  `slug` String COMMENT 'Current Gram organization slug.',
+  `account_type` LowCardinality(String) COMMENT 'Gram account type, sourced from Postgres gram_account_type.',
+  `workos_id` Nullable(String) COMMENT 'WorkOS organization identifier used for cross-system reporting.',
+  `workos_updated_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'Timestamp of the latest applied WorkOS organization update.',
+  `webhooks_enabled` Nullable(Bool) COMMENT 'Whether outbound organization webhooks are enabled. Null means not recorded.',
+  `scim_enabled` Nullable(Bool) COMMENT 'Whether SCIM directory sync is enabled. Null means not recorded.',
+  `sso_enabled` Nullable(Bool) COMMENT 'Whether SSO is enabled. Null means not recorded.',
+  `whitelisted` Bool COMMENT 'Whether the organization is allowed to use Gram.',
+  `free_trial_started_at` DateTime64(6, 'UTC') COMMENT 'Start of the organization metadata free-trial window.',
+  `free_trial_ends_at` DateTime64(6, 'UTC') COMMENT 'End of the organization metadata free-trial window.',
+  `trial_tier` Nullable(String) COMMENT 'Enterprise trial tier from the trials lifecycle table.',
+  `trial_ends_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'Current enterprise trial end time.',
+  `trial_converted_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'When the enterprise trial converted.',
+  `trial_demoted_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'When the enterprise trial was demoted.',
+  `trial_created_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'When the enterprise trial lifecycle was created.',
+  `trial_updated_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'When the enterprise trial lifecycle was last updated.',
+  `created_at` DateTime64(6, 'UTC') COMMENT 'When the organization was created in Gram.',
+  `updated_at` DateTime64(6, 'UTC') COMMENT 'When the organization metadata was last updated in Gram.',
+  `disabled_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'When the organization was disabled.'
+) ENGINE = MergeTree
+PRIMARY KEY (`id`) ORDER BY (`id`) SETTINGS index_granularity = 8192 COMMENT 'Current organization reporting dimensions synced from Postgres.';
+-- create "organization_metadata_staging" table
+CREATE TABLE `organization_metadata_staging` (
+  `id` String COMMENT 'Gram organization identifier.',
+  `slug` String COMMENT 'Current Gram organization slug.',
+  `account_type` LowCardinality(String) COMMENT 'Gram account type, sourced from Postgres gram_account_type.',
+  `workos_id` Nullable(String) COMMENT 'WorkOS organization identifier used for cross-system reporting.',
+  `workos_updated_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'Timestamp of the latest applied WorkOS organization update.',
+  `webhooks_enabled` Nullable(Bool) COMMENT 'Whether outbound organization webhooks are enabled. Null means not recorded.',
+  `scim_enabled` Nullable(Bool) COMMENT 'Whether SCIM directory sync is enabled. Null means not recorded.',
+  `sso_enabled` Nullable(Bool) COMMENT 'Whether SSO is enabled. Null means not recorded.',
+  `whitelisted` Bool COMMENT 'Whether the organization is allowed to use Gram.',
+  `free_trial_started_at` DateTime64(6, 'UTC') COMMENT 'Start of the organization metadata free-trial window.',
+  `free_trial_ends_at` DateTime64(6, 'UTC') COMMENT 'End of the organization metadata free-trial window.',
+  `trial_tier` Nullable(String) COMMENT 'Enterprise trial tier from the trials lifecycle table.',
+  `trial_ends_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'Current enterprise trial end time.',
+  `trial_converted_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'When the enterprise trial converted.',
+  `trial_demoted_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'When the enterprise trial was demoted.',
+  `trial_created_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'When the enterprise trial lifecycle was created.',
+  `trial_updated_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'When the enterprise trial lifecycle was last updated.',
+  `created_at` DateTime64(6, 'UTC') COMMENT 'When the organization was created in Gram.',
+  `updated_at` DateTime64(6, 'UTC') COMMENT 'When the organization metadata was last updated in Gram.',
+  `disabled_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'When the organization was disabled.'
+) ENGINE = MergeTree
+PRIMARY KEY (`id`) ORDER BY (`id`) SETTINGS index_granularity = 8192 COMMENT 'Staging generation for the organization reporting dimensions.';
+-- create "projects" table
+CREATE TABLE `projects` (
+  `id` UUID COMMENT 'Gram project identifier.',
+  `organization_id` String COMMENT 'Organization that owns the project.',
+  `slug` String COMMENT 'Current project slug within its organization.',
+  `created_at` DateTime64(6, 'UTC') COMMENT 'When the project was created.',
+  `updated_at` DateTime64(6, 'UTC') COMMENT 'When the project was last updated.',
+  `deleted_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'When the project was soft-deleted.'
+) ENGINE = MergeTree
+PRIMARY KEY (`organization_id`, `id`) ORDER BY (`organization_id`, `id`) SETTINGS index_granularity = 8192 COMMENT 'Current project reporting dimensions synced from Postgres.';
+-- create "projects_staging" table
+CREATE TABLE `projects_staging` (
+  `id` UUID COMMENT 'Gram project identifier.',
+  `organization_id` String COMMENT 'Organization that owns the project.',
+  `slug` String COMMENT 'Current project slug within its organization.',
+  `created_at` DateTime64(6, 'UTC') COMMENT 'When the project was created.',
+  `updated_at` DateTime64(6, 'UTC') COMMENT 'When the project was last updated.',
+  `deleted_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'When the project was soft-deleted.'
+) ENGINE = MergeTree
+PRIMARY KEY (`organization_id`, `id`) ORDER BY (`organization_id`, `id`) SETTINGS index_granularity = 8192 COMMENT 'Staging generation for the project reporting dimensions.';

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:g42IScMHCC68uMHryNId66emdM9MwpjhcXbJP1iJ1y8=
+h1:++5d1TmQtcj+EIeBo9Zcem9PguM+jWiKmLhT12RdSng=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -97,3 +97,4 @@ h1:g42IScMHCC68uMHryNId66emdM9MwpjhcXbJP1iJ1y8=
 20260831143540_shadow-ai-detections.up.sql h1:uRzttx9/L+w1DU0E1aPuphygN67rLIztDf48CVrT8NI=
 20260902165937_meta-mcp-attribution.up.sql h1:7NTw1iTmV1otLjK+FhDNsLM3DqJtl5qKdewT8g0JuvI=
 20260902193942_openclaw-usage-rows.up.sql h1:FLrJnV85T8U/HUgIeHFhfyTFEKaRBMwxudBpFNu+RG8=
+20260904141331_tenant-reporting-dimensions.up.sql h1:M529LrMZ0R04erQuo/ftTFMQostnvNFJpN50HZToSFE=

--- a/server/clickhouse/migrations/20260904141320_tenant-reporting-dimensions.sql
+++ b/server/clickhouse/migrations/20260904141320_tenant-reporting-dimensions.sql
@@ -1,0 +1,68 @@
+-- Create "organization_metadata" table
+CREATE TABLE `organization_metadata` (
+  `id` String COMMENT 'Gram organization identifier.',
+  `slug` String COMMENT 'Current Gram organization slug.',
+  `account_type` LowCardinality(String) COMMENT 'Gram account type, sourced from Postgres gram_account_type.',
+  `workos_id` Nullable(String) COMMENT 'WorkOS organization identifier used for cross-system reporting.',
+  `workos_updated_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'Timestamp of the latest applied WorkOS organization update.',
+  `webhooks_enabled` Nullable(Bool) COMMENT 'Whether outbound organization webhooks are enabled. Null means not recorded.',
+  `scim_enabled` Nullable(Bool) COMMENT 'Whether SCIM directory sync is enabled. Null means not recorded.',
+  `sso_enabled` Nullable(Bool) COMMENT 'Whether SSO is enabled. Null means not recorded.',
+  `whitelisted` Bool COMMENT 'Whether the organization is allowed to use Gram.',
+  `free_trial_started_at` DateTime64(6, 'UTC') COMMENT 'Start of the organization metadata free-trial window.',
+  `free_trial_ends_at` DateTime64(6, 'UTC') COMMENT 'End of the organization metadata free-trial window.',
+  `trial_tier` Nullable(String) COMMENT 'Enterprise trial tier from the trials lifecycle table.',
+  `trial_ends_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'Current enterprise trial end time.',
+  `trial_converted_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'When the enterprise trial converted.',
+  `trial_demoted_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'When the enterprise trial was demoted.',
+  `trial_created_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'When the enterprise trial lifecycle was created.',
+  `trial_updated_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'When the enterprise trial lifecycle was last updated.',
+  `created_at` DateTime64(6, 'UTC') COMMENT 'When the organization was created in Gram.',
+  `updated_at` DateTime64(6, 'UTC') COMMENT 'When the organization metadata was last updated in Gram.',
+  `disabled_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'When the organization was disabled.'
+) ENGINE = MergeTree
+PRIMARY KEY (`id`) ORDER BY (`id`) SETTINGS index_granularity = 8192 COMMENT 'Current organization reporting dimensions synced from Postgres.';
+-- Create "organization_metadata_staging" table
+CREATE TABLE `organization_metadata_staging` (
+  `id` String COMMENT 'Gram organization identifier.',
+  `slug` String COMMENT 'Current Gram organization slug.',
+  `account_type` LowCardinality(String) COMMENT 'Gram account type, sourced from Postgres gram_account_type.',
+  `workos_id` Nullable(String) COMMENT 'WorkOS organization identifier used for cross-system reporting.',
+  `workos_updated_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'Timestamp of the latest applied WorkOS organization update.',
+  `webhooks_enabled` Nullable(Bool) COMMENT 'Whether outbound organization webhooks are enabled. Null means not recorded.',
+  `scim_enabled` Nullable(Bool) COMMENT 'Whether SCIM directory sync is enabled. Null means not recorded.',
+  `sso_enabled` Nullable(Bool) COMMENT 'Whether SSO is enabled. Null means not recorded.',
+  `whitelisted` Bool COMMENT 'Whether the organization is allowed to use Gram.',
+  `free_trial_started_at` DateTime64(6, 'UTC') COMMENT 'Start of the organization metadata free-trial window.',
+  `free_trial_ends_at` DateTime64(6, 'UTC') COMMENT 'End of the organization metadata free-trial window.',
+  `trial_tier` Nullable(String) COMMENT 'Enterprise trial tier from the trials lifecycle table.',
+  `trial_ends_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'Current enterprise trial end time.',
+  `trial_converted_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'When the enterprise trial converted.',
+  `trial_demoted_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'When the enterprise trial was demoted.',
+  `trial_created_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'When the enterprise trial lifecycle was created.',
+  `trial_updated_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'When the enterprise trial lifecycle was last updated.',
+  `created_at` DateTime64(6, 'UTC') COMMENT 'When the organization was created in Gram.',
+  `updated_at` DateTime64(6, 'UTC') COMMENT 'When the organization metadata was last updated in Gram.',
+  `disabled_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'When the organization was disabled.'
+) ENGINE = MergeTree
+PRIMARY KEY (`id`) ORDER BY (`id`) SETTINGS index_granularity = 8192 COMMENT 'Staging generation for the organization reporting dimensions.';
+-- Create "projects" table
+CREATE TABLE `projects` (
+  `id` UUID COMMENT 'Gram project identifier.',
+  `organization_id` String COMMENT 'Organization that owns the project.',
+  `slug` String COMMENT 'Current project slug within its organization.',
+  `created_at` DateTime64(6, 'UTC') COMMENT 'When the project was created.',
+  `updated_at` DateTime64(6, 'UTC') COMMENT 'When the project was last updated.',
+  `deleted_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'When the project was soft-deleted.'
+) ENGINE = MergeTree
+PRIMARY KEY (`organization_id`, `id`) ORDER BY (`organization_id`, `id`) SETTINGS index_granularity = 8192 COMMENT 'Current project reporting dimensions synced from Postgres.';
+-- Create "projects_staging" table
+CREATE TABLE `projects_staging` (
+  `id` UUID COMMENT 'Gram project identifier.',
+  `organization_id` String COMMENT 'Organization that owns the project.',
+  `slug` String COMMENT 'Current project slug within its organization.',
+  `created_at` DateTime64(6, 'UTC') COMMENT 'When the project was created.',
+  `updated_at` DateTime64(6, 'UTC') COMMENT 'When the project was last updated.',
+  `deleted_at` Nullable(DateTime64(6, 'UTC')) COMMENT 'When the project was soft-deleted.'
+) ENGINE = MergeTree
+PRIMARY KEY (`organization_id`, `id`) ORDER BY (`organization_id`, `id`) SETTINGS index_granularity = 8192 COMMENT 'Staging generation for the project reporting dimensions.';

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:uxfP6/iL0fT3LU/W4Ozs6f/ye8pipkW2S5V0Z9DILzg=
+h1:qbKpSL2nvj4WT8TifYFAUk3KvToVcm0iZhIG2jgidOA=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -102,3 +102,4 @@ h1:uxfP6/iL0fT3LU/W4Ozs6f/ye8pipkW2S5V0Z9DILzg=
 20260831143534_shadow-ai-detections.sql h1:tM9NOsGhFltm02XO0vYZiko2F6z7q5rERNq7jaKC4CY=
 20260902165930_meta-mcp-attribution.sql h1:DqvRFSad+IKXmH+pZzFTzzsD4gKIGl+4cnXb2buvTEA=
 20260902193935_openclaw-usage-rows.sql h1:EqmJwX/4Tf1aQVEvIT2viHC3vWV0/iKonGRY8RXP2qc=
+20260904141320_tenant-reporting-dimensions.sql h1:mPYeUlsGTFGV/rJg3SdOP/CUI3gkbMJc/j6Z/OJFO64=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -1589,6 +1589,78 @@ TTL toDateTime(created_at) + INTERVAL 730 DAY
 SETTINGS index_granularity = 8192
 COMMENT 'Chat session analysis verdicts produced by the chat analysis judges.';
 
+CREATE TABLE IF NOT EXISTS organization_metadata (
+    id String COMMENT 'Gram organization identifier.',
+    slug String COMMENT 'Current Gram organization slug.',
+    account_type LowCardinality(String) COMMENT 'Gram account type, sourced from Postgres gram_account_type.',
+    workos_id Nullable(String) COMMENT 'WorkOS organization identifier used for cross-system reporting.',
+    workos_updated_at Nullable(DateTime64(6, 'UTC')) COMMENT 'Timestamp of the latest applied WorkOS organization update.',
+    webhooks_enabled Nullable(Bool) COMMENT 'Whether outbound organization webhooks are enabled. Null means not recorded.',
+    scim_enabled Nullable(Bool) COMMENT 'Whether SCIM directory sync is enabled. Null means not recorded.',
+    sso_enabled Nullable(Bool) COMMENT 'Whether SSO is enabled. Null means not recorded.',
+    whitelisted Bool COMMENT 'Whether the organization is allowed to use Gram.',
+    free_trial_started_at DateTime64(6, 'UTC') COMMENT 'Start of the organization metadata free-trial window.',
+    free_trial_ends_at DateTime64(6, 'UTC') COMMENT 'End of the organization metadata free-trial window.',
+    trial_tier Nullable(String) COMMENT 'Enterprise trial tier from the trials lifecycle table.',
+    trial_ends_at Nullable(DateTime64(6, 'UTC')) COMMENT 'Current enterprise trial end time.',
+    trial_converted_at Nullable(DateTime64(6, 'UTC')) COMMENT 'When the enterprise trial converted.',
+    trial_demoted_at Nullable(DateTime64(6, 'UTC')) COMMENT 'When the enterprise trial was demoted.',
+    trial_created_at Nullable(DateTime64(6, 'UTC')) COMMENT 'When the enterprise trial lifecycle was created.',
+    trial_updated_at Nullable(DateTime64(6, 'UTC')) COMMENT 'When the enterprise trial lifecycle was last updated.',
+    created_at DateTime64(6, 'UTC') COMMENT 'When the organization was created in Gram.',
+    updated_at DateTime64(6, 'UTC') COMMENT 'When the organization metadata was last updated in Gram.',
+    disabled_at Nullable(DateTime64(6, 'UTC')) COMMENT 'When the organization was disabled.'
+) ENGINE = MergeTree
+ORDER BY id
+COMMENT 'Current organization reporting dimensions synced from Postgres.';
+
+CREATE TABLE IF NOT EXISTS organization_metadata_staging (
+    id String COMMENT 'Gram organization identifier.',
+    slug String COMMENT 'Current Gram organization slug.',
+    account_type LowCardinality(String) COMMENT 'Gram account type, sourced from Postgres gram_account_type.',
+    workos_id Nullable(String) COMMENT 'WorkOS organization identifier used for cross-system reporting.',
+    workos_updated_at Nullable(DateTime64(6, 'UTC')) COMMENT 'Timestamp of the latest applied WorkOS organization update.',
+    webhooks_enabled Nullable(Bool) COMMENT 'Whether outbound organization webhooks are enabled. Null means not recorded.',
+    scim_enabled Nullable(Bool) COMMENT 'Whether SCIM directory sync is enabled. Null means not recorded.',
+    sso_enabled Nullable(Bool) COMMENT 'Whether SSO is enabled. Null means not recorded.',
+    whitelisted Bool COMMENT 'Whether the organization is allowed to use Gram.',
+    free_trial_started_at DateTime64(6, 'UTC') COMMENT 'Start of the organization metadata free-trial window.',
+    free_trial_ends_at DateTime64(6, 'UTC') COMMENT 'End of the organization metadata free-trial window.',
+    trial_tier Nullable(String) COMMENT 'Enterprise trial tier from the trials lifecycle table.',
+    trial_ends_at Nullable(DateTime64(6, 'UTC')) COMMENT 'Current enterprise trial end time.',
+    trial_converted_at Nullable(DateTime64(6, 'UTC')) COMMENT 'When the enterprise trial converted.',
+    trial_demoted_at Nullable(DateTime64(6, 'UTC')) COMMENT 'When the enterprise trial was demoted.',
+    trial_created_at Nullable(DateTime64(6, 'UTC')) COMMENT 'When the enterprise trial lifecycle was created.',
+    trial_updated_at Nullable(DateTime64(6, 'UTC')) COMMENT 'When the enterprise trial lifecycle was last updated.',
+    created_at DateTime64(6, 'UTC') COMMENT 'When the organization was created in Gram.',
+    updated_at DateTime64(6, 'UTC') COMMENT 'When the organization metadata was last updated in Gram.',
+    disabled_at Nullable(DateTime64(6, 'UTC')) COMMENT 'When the organization was disabled.'
+) ENGINE = MergeTree
+ORDER BY id
+COMMENT 'Staging generation for the organization reporting dimensions.';
+
+CREATE TABLE IF NOT EXISTS projects (
+    id UUID COMMENT 'Gram project identifier.',
+    organization_id String COMMENT 'Organization that owns the project.',
+    slug String COMMENT 'Current project slug within its organization.',
+    created_at DateTime64(6, 'UTC') COMMENT 'When the project was created.',
+    updated_at DateTime64(6, 'UTC') COMMENT 'When the project was last updated.',
+    deleted_at Nullable(DateTime64(6, 'UTC')) COMMENT 'When the project was soft-deleted.'
+) ENGINE = MergeTree
+ORDER BY (organization_id, id)
+COMMENT 'Current project reporting dimensions synced from Postgres.';
+
+CREATE TABLE IF NOT EXISTS projects_staging (
+    id UUID COMMENT 'Gram project identifier.',
+    organization_id String COMMENT 'Organization that owns the project.',
+    slug String COMMENT 'Current project slug within its organization.',
+    created_at DateTime64(6, 'UTC') COMMENT 'When the project was created.',
+    updated_at DateTime64(6, 'UTC') COMMENT 'When the project was last updated.',
+    deleted_at Nullable(DateTime64(6, 'UTC')) COMMENT 'When the project was soft-deleted.'
+) ENGINE = MergeTree
+ORDER BY (organization_id, id)
+COMMENT 'Staging generation for the project reporting dimensions.';
+
 -- Join engine (not a dictionary) so joinGet lookups need no source connection:
 -- a CLICKHOUSE-source dictionary authenticates its loopback load as the
 -- 'default' user, which does not exist in our deployments and would require


### PR DESCRIPTION
## Summary

- Add production and staging ClickHouse tables for organization and project reporting dimensions.
- Generate synchronized Atlas and local golang-migrate migrations, including rollback definitions and updated checksums.
- Model account, integration, trial, and tenant lifecycle fields with microsecond UTC timestamps.

## Motivation

ClickHouse reporting needs stable tenant dimension tables before the synchronization runtime can publish PostgreSQL metadata for analytical joins.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces the ClickHouse schema needed to sync organization and project reporting dimensions from Postgres.

- Adds `organization_metadata` and `organization_metadata_staging` with account type, WorkOS, SSO/SCIM, trial, and lifecycle fields.
- Adds `projects` and `projects_staging` with project slug and soft-delete state, keyed by organization.
- Registers the migration in both `server/clickhouse/migrations` and `server/clickhouse/local/golang_migrate`, and updates `server/clickhouse/schema.sql`.

<sup>Written for commit 8697c00865bbb8121a97ca5aaba653b4aeda9fc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

