### PR TITLE
fix: name the execute_tool argument keys in gateway descriptions

### DIFF
--- a/.changeset/gateway-execute-tool-name.md
+++ b/.changeset/gateway-execute-tool-name.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Name the `name` and `arguments` keys in the execute_tool description, gateway instructions, and missing-name error so clients stop guessing a `tool` key.

--- a/server/internal/mcp/dynamic_tool_calling.go
+++ b/server/internal/mcp/dynamic_tool_calling.go
@@ -70,7 +70,7 @@ func buildDynamicSessionTools(
 	}
 
 	findDescription := "Search through the available tools in this MCP server using a search query. The result will be a list of tools that could help you complete your task."
-	executeDescription := "Execute a specific tool by name, passing through the correct arguments for that tool's schema. Do not call a tool without first describing it to get the input schema."
+	executeDescription := "Execute one tool. Pass its exact name as `name` and its JSON payload, matching the schema from describe_tools, as `arguments`. Do not call a tool without first describing it to get the input schema."
 
 	availableTags, _ := vectorToolStore.GetToolsetAvailableTags(ctx, *toolset)
 	if len(availableTags) > 0 {

--- a/server/internal/mcp/metamcp/initialize.go
+++ b/server/internal/mcp/metamcp/initialize.go
@@ -14,7 +14,7 @@ Work from the outside in:
 1. list_servers — what is reachable, what each system is for, and each member's status: "available", "unavailable" when the member's tunnel is down, or "unknown" when the gateway cannot observe the member's health.
 2. describe_server — that server's tools, as qualified names (server--tool) with descriptions but no input schemas.
 3. describe_tools — input schemas for the specific tools you intend to call.
-4. execute_tool — run one, by qualified name.
+4. execute_tool — run one: the qualified name goes in "name", its JSON payload in "arguments".
 
 Never execute a name you have not described: arguments guessed from a tool name will fail validation.
 

--- a/server/internal/mcp/metamcp/tools_list.go
+++ b/server/internal/mcp/metamcp/tools_list.go
@@ -66,7 +66,7 @@ func Tools(executeToolSchema json.RawMessage) []Tool {
 		},
 		{
 			Name:        ToolExecuteTool,
-			Description: "Execute a specific tool by qualified name (serverslug--toolname), passing arguments that match that tool's schema.",
+			Description: "Execute one tool. Pass its qualified name (serverslug--toolname) as `name` and its JSON payload, matching the schema from describe_tools, as `arguments`.",
 			InputSchema: executeToolSchema,
 		},
 	}

--- a/server/internal/mcp/rpc_tools_call.go
+++ b/server/internal/mcp/rpc_tools_call.go
@@ -635,7 +635,7 @@ var dynamicExecuteToolSchema = json.RawMessage(`{
 		"properties": {
 			"name": {
 				"type": "string",
-				"description": "Exact name of the tool to execute."
+				"description": "Exact name of the tool to execute. The key is name, not tool."
 			},
 			"arguments": {
 				"description": "JSON payload to forward to the tool as its arguments."
@@ -661,7 +661,7 @@ func processExecuteToolCall(ctx context.Context, logger *slog.Logger, argsRaw js
 
 	name := strings.TrimSpace(args.Name)
 	if name == "" {
-		return "", nil, oops.E(oops.CodeInvalid, errors.New("missing tool name"), "name is required for execute_tool").LogError(ctx, logger)
+		return "", nil, oops.E(oops.CodeInvalid, errors.New("missing tool name"), "name is required for execute_tool: pass the tool's exact name as \"name\"").LogError(ctx, logger)
 	}
 
 	payload := args.Arguments


### PR DESCRIPTION
## Summary

Wording-only change across the gateway (meta-MCP) and dynamic toolset surfaces so an agent knows which JSON keys `execute_tool` takes without reading the schema:

- The `execute_tool` description on both surfaces now says: qualified name in `name`, payload in `arguments`, schema from `describe_tools`.
- Step 4 of the gateway handshake instructions names both keys the same way.
- The `name` property description in the shared execute schema states the key is `name`, not `tool`.
- The missing-name error now tells the caller to pass the tool's exact name as `"name"`.

No schema or behavior change. `additionalProperties: false` and `required: ["name"]` stay as they are.

## Motivation

Exercising a gateway endpoint from Claude Code, a first batch of six `execute_tool` calls all failed with `name is required for execute_tool`. Every call had passed the qualified name under a `tool` key. Nothing the agent reads before executing (instructions, tool description, error text) said the key is `name`, so the natural guess from "execute a tool by name" went wrong and the error gave no hint about the right key.

Fixing the prose is preferable to accepting `tool` as an alias: the published schema is strict, and loosening the parser would make server behavior diverge from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6YAEsSK4gcez8BoS6Ttqm


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `execute_tool` descriptions so agents stop passing the tool name under a `tool` key and failing with `name is required for execute_tool`.

- Descriptions on the gateway (meta-MCP) and dynamic toolset surfaces now say the qualified name goes in `name` and the payload in `arguments`.
- The missing-name error now tells callers to pass the exact name as `"name"`.
- No schema or behavior change; `additionalProperties: false` and `required: ["name"]` stay as-is.

<sup>Written for commit a22c093eaf05f29e847ff752d0ddad3f6f4f79df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

