### PR TITLE
fix: treat 2xx token responses carrying an OAuth error as refresh failures

### DIFF
--- a/.changeset/refresh-success-status-error-body.md
+++ b/.changeset/refresh-success-status-error-body.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Read OAuth error bodies on 2xx upstream token responses so a dead refresh grant reported that way (GitHub's `bad_refresh_token`) clears the stored refresh token instead of being retried indefinitely.

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -367,7 +367,9 @@ const (
 	OAuthClientSecretGeneratedKey = attribute.Key("gram.oauth.client_secret_generated")
 	// OAuthErrorKey / OAuthErrorDescriptionKey carry the `error` /
 	// `error_description` parameters from RFC 6749 / RFC 7591 error responses
-	// — used across DCR registration, /authorize, /token, and /revoke.
+	// — the ones Gram emits across DCR registration, /authorize, /token, and
+	// /revoke, and the ones an upstream authorization server answers Gram
+	// with (IdP and remote-login callbacks, token refresh).
 	OAuthErrorKey            = attribute.Key("gram.oauth.error")
 	OAuthErrorDescriptionKey = attribute.Key("gram.oauth.error_description")
 	OAuthFailureReasonKey    = attribute.Key("gram.oauth.failure_reason")

--- a/server/internal/background/activities/remote_session_refresh.go
+++ b/server/internal/background/activities/remote_session_refresh.go
@@ -128,15 +128,21 @@ func (r *RemoteSessionRefresh) Do(ctx context.Context, input RefreshRemoteSessio
 	result, err := r.refresher.RefreshNow(ctx, sess, "", remotesessionmetrics.RefreshTriggerScheduled)
 	if err != nil {
 		// The issuer URL and outcome are the ones the upstream-refresh metric
-		// recorded, so these lines join to its series; the user id is what
-		// lets "how many users are affected" be answered, since a client id is
-		// one row per provider connection, not per user.
+		// recorded, so these lines join to its series; the error code is the
+		// one the upstream answered with when its body carried one; the user
+		// id is what lets "how many users are affected" be answered, since a
+		// client id is one row per provider connection, not per user.
 		args := []any{
 			attr.SlogRemoteSessionClientID(sess.RemoteSessionClientID.String()),
 			attr.SlogUserSessionIssuerID(sess.UserSessionIssuerID.String()),
 		}
 		if failure, ok := errors.AsType[*remotesessions.RefreshError](err); ok {
 			args = append(args, attr.SlogOAuthIssuer(failure.IssuerURL), attr.SlogOutcome(string(failure.Outcome)))
+		}
+		if tokenErr, ok := errors.AsType[*remotesessions.TokenRefreshError](err); ok {
+			if code := tokenErr.UpstreamCode(); code != "" {
+				args = append(args, attr.SlogOAuthError(code))
+			}
 		}
 		if sess.SubjectUrn.Kind == urn.SessionSubjectKindUser {
 			args = append(args, attr.SlogUserID(sess.SubjectUrn.ID))

--- a/server/internal/oautherr/vendor_error.go
+++ b/server/internal/oautherr/vendor_error.go
@@ -104,16 +104,20 @@ func (v vendorCodeMessage) normalized() vendorCodeMessage {
 }
 
 // vendorDeadGrantCodes maps RFC-shaped extension codes that a provider sends
-// only when a refresh grant can never succeed again onto CodeInvalidGrant.
-// GitHub's token endpoint (https://github.com/login/oauth/access_token)
-// answers a revoked or expired refresh token with "bad_refresh_token" under
-// HTTP 200. Matching is exact: any other extension code is returned as is.
+// only when a grant can never succeed again onto CodeInvalidGrant, which RFC
+// 6749 §5.2 defines for an invalid, expired or revoked authorization code or
+// refresh token alike. GitHub's token endpoint
+// (https://github.com/login/oauth/access_token) answers a revoked or expired
+// refresh token with "bad_refresh_token" and a spent or unknown authorization
+// code with "bad_verification_code", both under HTTP 200. Matching is exact:
+// any other extension code is returned as is.
 var vendorDeadGrantCodes = map[string]string{
-	"bad_refresh_token": CodeInvalidGrant,
+	"bad_refresh_token":     CodeInvalidGrant,
+	"bad_verification_code": CodeInvalidGrant,
 }
 
 // CanonicalTokenErrorCode maps a vendor extension code that means a dead
-// refresh grant onto CodeInvalidGrant and returns every other code unchanged.
+// grant onto CodeInvalidGrant and returns every other code unchanged.
 // ParseTokenError keeps extension codes verbatim, so callers that act on
 // invalid_grant apply this before deciding.
 func CanonicalTokenErrorCode(code string) string {

--- a/server/internal/oautherr/vendor_error.go
+++ b/server/internal/oautherr/vendor_error.go
@@ -11,7 +11,8 @@ import (
 // shape; the decode error itself is ignored because encoding/json fills every
 // member it can, so an RFC-shaped or foreign body simply leaves the shape's
 // required members empty. Adding a shape means adding a struct, a parser, and
-// an entry here.
+// an entry here; a provider that keeps the RFC shape but invents its own
+// dead-grant code belongs in vendorDeadGrantCodes instead.
 var vendorTokenErrorParsers = []func(body []byte) (RFC6749Error, bool){
 	parseVendorErrorsStringArray,
 	parseVendorErrorCodeMessageObject,
@@ -100,6 +101,26 @@ func (v vendorCodeMessage) normalized() vendorCodeMessage {
 		Code:    strings.TrimSpace(v.Code),
 		Message: strings.TrimSpace(strings.TrimRight(message, ".")),
 	}
+}
+
+// vendorDeadGrantCodes maps RFC-shaped extension codes that a provider sends
+// only when a refresh grant can never succeed again onto CodeInvalidGrant.
+// GitHub's token endpoint (https://github.com/login/oauth/access_token)
+// answers a revoked or expired refresh token with "bad_refresh_token" under
+// HTTP 200. Matching is exact: any other extension code is returned as is.
+var vendorDeadGrantCodes = map[string]string{
+	"bad_refresh_token": CodeInvalidGrant,
+}
+
+// CanonicalTokenErrorCode maps a vendor extension code that means a dead
+// refresh grant onto CodeInvalidGrant and returns every other code unchanged.
+// ParseTokenError keeps extension codes verbatim, so callers that act on
+// invalid_grant apply this before deciding.
+func CanonicalTokenErrorCode(code string) string {
+	if canonical, ok := vendorDeadGrantCodes[code]; ok {
+		return canonical
+	}
+	return code
 }
 
 // vendorDeadGrantErrors is the last-chance fallback for token endpoints that

--- a/server/internal/oautherr/vendor_error_test.go
+++ b/server/internal/oautherr/vendor_error_test.go
@@ -147,12 +147,13 @@ func TestSplitFlattenedError(t *testing.T) {
 	require.False(t, ok)
 }
 
-// Only the exact vendor code is canonicalized; every other code, registered or
-// extension, passes through untouched.
+// Only the exact vendor codes are canonicalized; every other code, registered
+// or extension, passes through untouched.
 func TestCanonicalTokenErrorCode(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t, CodeInvalidGrant, CanonicalTokenErrorCode("bad_refresh_token"))
+	require.Equal(t, CodeInvalidGrant, CanonicalTokenErrorCode("bad_verification_code"))
 	require.Equal(t, CodeInvalidGrant, CanonicalTokenErrorCode(CodeInvalidGrant))
 	require.Equal(t, CodeInvalidClient, CanonicalTokenErrorCode(CodeInvalidClient))
 	require.Equal(t, "bad_refresh_token_format", CanonicalTokenErrorCode("bad_refresh_token_format"))

--- a/server/internal/oautherr/vendor_error_test.go
+++ b/server/internal/oautherr/vendor_error_test.go
@@ -146,3 +146,15 @@ func TestSplitFlattenedError(t *testing.T) {
 	_, _, ok = splitFlattenedError("")
 	require.False(t, ok)
 }
+
+// Only the exact vendor code is canonicalized; every other code, registered or
+// extension, passes through untouched.
+func TestCanonicalTokenErrorCode(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, CodeInvalidGrant, CanonicalTokenErrorCode("bad_refresh_token"))
+	require.Equal(t, CodeInvalidGrant, CanonicalTokenErrorCode(CodeInvalidGrant))
+	require.Equal(t, CodeInvalidClient, CanonicalTokenErrorCode(CodeInvalidClient))
+	require.Equal(t, "bad_refresh_token_format", CanonicalTokenErrorCode("bad_refresh_token_format"))
+	require.Empty(t, CanonicalTokenErrorCode(""))
+}

--- a/server/internal/remotesessions/refreshservice_invalid_grant_test.go
+++ b/server/internal/remotesessions/refreshservice_invalid_grant_test.go
@@ -119,6 +119,44 @@ func TestRefreshNow_InvalidGrant_DubRefreshTokenNotFound_ClearsRefreshGrant(t *t
 	require.False(t, active.RefreshExpiresAt.Valid)
 }
 
+// GitHub answers a revoked or expired refresh token with HTTP 200 and
+// {"error":"bad_refresh_token"}. The 2xx status must not hide the dead grant:
+// the body is read as invalid_grant and the refresh grant is cleared.
+func TestRefreshNow_InvalidGrant_GitHubSuccessStatusErrorBody_ClearsRefreshGrant(t *testing.T) {
+	t.Parallel()
+
+	active, tokenErr := refreshNowAgainstUpstreamError(
+		t,
+		"refreshnow-github-200-error",
+		http.StatusOK,
+		`{"error":"bad_refresh_token","error_description":"The refresh token passed is incorrect or expired.","error_uri":"https://docs.github.com/apps/oauth-apps/troubleshooting"}`,
+	)
+
+	require.Equal(t, "invalid_grant: The refresh token passed is incorrect or expired.", tokenErr.Reason)
+	require.Equal(t, "bad_refresh_token", tokenErr.UpstreamCode(), "the code is logged as the provider sent it")
+	require.NotContains(t, tokenErr.Error(), "docs.github.com", "the raw body never reaches the cause")
+	require.False(t, active.RefreshTokenEncrypted.Valid)
+	require.False(t, active.RefreshExpiresAt.Valid)
+}
+
+// A 2xx body that carries neither a token set nor an OAuth error says nothing
+// about the grant, so it stays a transient failure and the refresh grant
+// survives for the next attempt.
+func TestRefreshNow_EmptySuccessBody_KeepsRefreshGrant(t *testing.T) {
+	t.Parallel()
+
+	active, tokenErr := refreshNowAgainstUpstreamError(
+		t,
+		"refreshnow-empty-200",
+		http.StatusOK,
+		`{}`,
+	)
+
+	require.Equal(t, "the identity provider returned no access token", tokenErr.Reason)
+	require.Empty(t, tokenErr.UpstreamCode())
+	require.True(t, active.RefreshTokenEncrypted.Valid, "an empty success body must not clear the grant")
+}
+
 // A client authentication failure under the same vendor code is fixed by
 // correcting the client configuration, so the still-valid refresh grant must
 // survive it.

--- a/server/internal/remotesessions/refreshservice_invalid_grant_test.go
+++ b/server/internal/remotesessions/refreshservice_invalid_grant_test.go
@@ -90,13 +90,14 @@ func TestRefreshNow_InvalidGrant_ClearsRefreshGrantWhenCacheUnavailable(t *testi
 func TestRefreshNow_InvalidGrant_DatadogErrorsArray_ClearsRefreshGrant(t *testing.T) {
 	t.Parallel()
 
-	active, tokenErr := refreshNowAgainstUpstreamError(
+	active, failure, tokenErr := refreshNowAgainstUpstreamError(
 		t,
 		"refreshnow-datadog-errors",
 		http.StatusBadRequest,
 		`{"errors": ["invalid_grant - Invalid or expired refresh token or code verifier."]}`,
 	)
 
+	require.Equal(t, remotesessionmetrics.RefreshOutcomeInvalidGrant, failure.Outcome)
 	require.Equal(t, "invalid_grant: Invalid or expired refresh token or code verifier.", tokenErr.Reason)
 	require.False(t, active.RefreshTokenEncrypted.Valid)
 	require.False(t, active.RefreshExpiresAt.Valid)
@@ -107,13 +108,14 @@ func TestRefreshNow_InvalidGrant_DatadogErrorsArray_ClearsRefreshGrant(t *testin
 func TestRefreshNow_InvalidGrant_DubRefreshTokenNotFound_ClearsRefreshGrant(t *testing.T) {
 	t.Parallel()
 
-	active, tokenErr := refreshNowAgainstUpstreamError(
+	active, failure, tokenErr := refreshNowAgainstUpstreamError(
 		t,
 		"refreshnow-dub-dead-grant",
 		http.StatusUnauthorized,
 		`{"error":{"code":"unauthorized","message":"Refresh token not found.","doc_url":"https://dub.co/docs/api-reference/errors#unauthorized"}}`,
 	)
 
+	require.Equal(t, remotesessionmetrics.RefreshOutcomeInvalidGrant, failure.Outcome)
 	require.Equal(t, "invalid_grant: Refresh token not found.", tokenErr.Reason)
 	require.False(t, active.RefreshTokenEncrypted.Valid)
 	require.False(t, active.RefreshExpiresAt.Valid)
@@ -121,17 +123,20 @@ func TestRefreshNow_InvalidGrant_DubRefreshTokenNotFound_ClearsRefreshGrant(t *t
 
 // GitHub answers a revoked or expired refresh token with HTTP 200 and
 // {"error":"bad_refresh_token"}. The 2xx status must not hide the dead grant:
-// the body is read as invalid_grant and the refresh grant is cleared.
+// the body is read as invalid_grant, the attempt is filed as an upstream
+// invalid_grant rather than an internal error, and the refresh grant is
+// cleared.
 func TestRefreshNow_InvalidGrant_GitHubSuccessStatusErrorBody_ClearsRefreshGrant(t *testing.T) {
 	t.Parallel()
 
-	active, tokenErr := refreshNowAgainstUpstreamError(
+	active, failure, tokenErr := refreshNowAgainstUpstreamError(
 		t,
 		"refreshnow-github-200-error",
 		http.StatusOK,
 		`{"error":"bad_refresh_token","error_description":"The refresh token passed is incorrect or expired.","error_uri":"https://docs.github.com/apps/oauth-apps/troubleshooting"}`,
 	)
 
+	require.Equal(t, remotesessionmetrics.RefreshOutcomeInvalidGrant, failure.Outcome, "the 2xx status is carried so the attempt is not filed as internal_error")
 	require.Equal(t, "invalid_grant: The refresh token passed is incorrect or expired.", tokenErr.Reason)
 	require.Equal(t, "bad_refresh_token", tokenErr.UpstreamCode(), "the code is logged as the provider sent it")
 	require.NotContains(t, tokenErr.Error(), "docs.github.com", "the raw body never reaches the cause")
@@ -145,13 +150,14 @@ func TestRefreshNow_InvalidGrant_GitHubSuccessStatusErrorBody_ClearsRefreshGrant
 func TestRefreshNow_EmptySuccessBody_KeepsRefreshGrant(t *testing.T) {
 	t.Parallel()
 
-	active, tokenErr := refreshNowAgainstUpstreamError(
+	active, failure, tokenErr := refreshNowAgainstUpstreamError(
 		t,
 		"refreshnow-empty-200",
 		http.StatusOK,
 		`{}`,
 	)
 
+	require.Equal(t, remotesessionmetrics.RefreshOutcomeInternalError, failure.Outcome)
 	require.Equal(t, "the identity provider returned no access token", tokenErr.Reason)
 	require.Empty(t, tokenErr.UpstreamCode())
 	require.True(t, active.RefreshTokenEncrypted.Valid, "an empty success body must not clear the grant")
@@ -163,13 +169,14 @@ func TestRefreshNow_EmptySuccessBody_KeepsRefreshGrant(t *testing.T) {
 func TestRefreshNow_DubClientAuthFailure_KeepsRefreshGrant(t *testing.T) {
 	t.Parallel()
 
-	active, tokenErr := refreshNowAgainstUpstreamError(
+	active, failure, tokenErr := refreshNowAgainstUpstreamError(
 		t,
 		"refreshnow-dub-client-auth",
 		http.StatusUnauthorized,
 		`{"error":{"code":"unauthorized","message":"Invalid client_secret"}}`,
 	)
 
+	require.Equal(t, remotesessionmetrics.RefreshOutcomeRejected, failure.Outcome)
 	require.Equal(t, "unauthorized: Invalid client_secret", tokenErr.Reason)
 	require.True(t, active.RefreshTokenEncrypted.Valid, "a recoverable failure must not clear the grant")
 }
@@ -177,8 +184,9 @@ func TestRefreshNow_DubClientAuthFailure_KeepsRefreshGrant(t *testing.T) {
 // refreshNowAgainstUpstreamError links a session whose access token has
 // expired, makes the upstream token endpoint answer every refresh with the
 // given status and body, runs RefreshNow once, and returns the session row as
-// persisted afterwards together with the operator-actionable refresh error.
-func refreshNowAgainstUpstreamError(t *testing.T, slugSuffix string, status int, body string) (repo.RemoteSession, *remotesessions.TokenRefreshError) {
+// persisted afterwards together with the classified refresh failure and the
+// operator-actionable refresh error inside it.
+func refreshNowAgainstUpstreamError(t *testing.T, slugSuffix string, status int, body string) (repo.RemoteSession, *remotesessions.RefreshError, *remotesessions.TokenRefreshError) {
 	t.Helper()
 
 	ctx, env := newSyntheticExpiryEnv(t, slugSuffix, func(w http.ResponseWriter, r *http.Request) {
@@ -205,6 +213,8 @@ func refreshNowAgainstUpstreamError(t *testing.T, slugSuffix string, status int,
 	require.Error(t, refreshErr)
 	require.Empty(t, result.Outcome)
 	require.Empty(t, result.AccessToken)
+	var failure *remotesessions.RefreshError
+	require.ErrorAs(t, refreshErr, &failure)
 	var tokenErr *remotesessions.TokenRefreshError
 	require.ErrorAs(t, refreshErr, &tokenErr)
 
@@ -213,5 +223,5 @@ func refreshNowAgainstUpstreamError(t *testing.T, slugSuffix string, status int,
 		RemoteSessionClientID: env.clientID,
 	})
 	require.NoError(t, err)
-	return active, tokenErr
+	return active, failure, tokenErr
 }

--- a/server/internal/remotesessions/refreshservice_outcome_internal_test.go
+++ b/server/internal/remotesessions/refreshservice_outcome_internal_test.go
@@ -125,6 +125,21 @@ func TestRefreshOutcomeForError(t *testing.T) {
 			want: remotesessionmetrics.RefreshOutcomeRejectedUnparsed,
 		},
 		{
+			name: "2xx body carrying a vendor dead-grant code (GitHub)",
+			err:  mustSuccessBodyError(t, http.StatusOK, "200 OK", []byte(`{"error":"bad_refresh_token","error_description":"The refresh token passed is incorrect or expired."}`)),
+			want: remotesessionmetrics.RefreshOutcomeInvalidGrant,
+		},
+		{
+			name: "2xx body carrying another code",
+			err:  mustSuccessBodyError(t, http.StatusOK, "200 OK", []byte(`{"error":"invalid_client"}`)),
+			want: remotesessionmetrics.RefreshOutcomeRejected,
+		},
+		{
+			name: "2xx fallback with no status code",
+			err:  newTokenRefreshError("the identity provider returned no access token", nil),
+			want: remotesessionmetrics.RefreshOutcomeInternalError,
+		},
+		{
 			name: "wrapped in context",
 			err:  fmt.Errorf("resolve access token: %w", newTokenRefreshErrorFromHTTP(http.StatusBadRequest, "400 Bad Request", []byte(`{"error":"invalid_grant"}`))),
 			want: remotesessionmetrics.RefreshOutcomeInvalidGrant,
@@ -138,4 +153,13 @@ func TestRefreshOutcomeForError(t *testing.T) {
 		}
 		require.Equal(t, tc.want, refreshOutcomeForError(ctx, tc.err), tc.name)
 	}
+}
+
+// mustSuccessBodyError builds the error refreshSessionTokens returns for a 2xx
+// token response whose body carries an OAuth error; the body must parse.
+func mustSuccessBodyError(t *testing.T, statusCode int, status string, body []byte) error {
+	t.Helper()
+	err, ok := newTokenRefreshErrorFromSuccessBody(statusCode, status, body)
+	require.True(t, ok, "body carries no recognizable OAuth error")
+	return err
 }

--- a/server/internal/remotesessions/token_refresh_error.go
+++ b/server/internal/remotesessions/token_refresh_error.go
@@ -23,12 +23,16 @@ var errRefreshUpstreamUnreachable = errors.New("remotesessions: upstream token e
 // operator in a UI toast; cause carries the private detail for logs. An
 // explicit, user-facing refresh maps these to a client error with the Reason
 // shown; the lazy MCP path treats them like any other "no valid token" outcome
-// and re-challenges, ignoring the Reason.
+// and re-challenges, ignoring the Reason. When the upstream answered with an
+// OAuth error body, upstreamCode is the code exactly as sent and code is its
+// canonical RFC 6749 §5.2 form, which is what the grant-clearing decision
+// reads.
 type TokenRefreshError struct {
-	Reason     string
-	cause      error
-	code       string
-	statusCode int
+	Reason       string
+	cause        error
+	code         string
+	upstreamCode string
+	statusCode   int
 }
 
 // Error returns the full detail (the public-safe Reason plus the private cause)
@@ -44,8 +48,13 @@ func (e *TokenRefreshError) Error() string {
 
 func (e *TokenRefreshError) Unwrap() error { return e.cause }
 
+// UpstreamCode returns the error code the upstream token endpoint answered
+// with, exactly as sent and before any canonicalization, or "" when the
+// failure did not come from a recognizable OAuth error body.
+func (e *TokenRefreshError) UpstreamCode() string { return e.upstreamCode }
+
 func newTokenRefreshError(reason string, cause error) *TokenRefreshError {
-	return &TokenRefreshError{Reason: reason, cause: cause, code: "", statusCode: 0}
+	return &TokenRefreshError{Reason: reason, cause: cause, code: "", upstreamCode: "", statusCode: 0}
 }
 
 // invalidGrant reports whether the upstream answered with RFC 6749 §5.2
@@ -64,6 +73,31 @@ func IsTokenRefreshRateLimited(err error) bool {
 	return errors.As(err, &refreshErr) && refreshErr.statusCode == http.StatusTooManyRequests
 }
 
+// newTokenRefreshErrorFromSuccessBody builds a TokenRefreshError for a 2xx
+// token response whose body carries an RFC 6749 §5.2 error instead of a token
+// set. GitHub answers a dead refresh token this way (HTTP 200 with
+// bad_refresh_token). The status code is kept so the refresh outcome
+// classifier files it as an upstream rejection, and an invalid_grant code
+// clears the stored refresh grant exactly as a 4xx would. ok is false when the
+// body carries no recognizable error.
+func newTokenRefreshErrorFromSuccessBody(statusCode int, status string, body []byte) (*TokenRefreshError, bool) {
+	parsed, ok := oautherr.ParseTokenError(body)
+	if !ok {
+		return nil, false
+	}
+	upstreamCode := parsed.Code
+	parsed.Code = oautherr.CanonicalTokenErrorCode(parsed.Code)
+	// The body is never embedded: a success-status response may still carry
+	// token material next to the error member.
+	return &TokenRefreshError{
+		Reason:       parsed.Error(),
+		cause:        fmt.Errorf("refresh endpoint %s carried error %q", status, upstreamCode),
+		code:         parsed.Code,
+		upstreamCode: upstreamCode,
+		statusCode:   statusCode,
+	}, true
+}
+
 // newTokenRefreshErrorFromHTTP builds a TokenRefreshError from a non-2xx response
 // from the upstream token endpoint. The public Reason is the error body
 // normalized onto its RFC 6749 §5.2 members ("invalid_grant: ..."), or "HTTP
@@ -72,14 +106,18 @@ func IsTokenRefreshRateLimited(err error) bool {
 func newTokenRefreshErrorFromHTTP(statusCode int, status string, body []byte) *TokenRefreshError {
 	reason := "HTTP " + status
 	code := ""
+	upstreamCode := ""
 	if parsed, ok := oautherr.ParseTokenError(body); ok {
+		upstreamCode = parsed.Code
+		parsed.Code = oautherr.CanonicalTokenErrorCode(parsed.Code)
 		reason = parsed.Error()
 		code = parsed.Code
 	}
 	return &TokenRefreshError{
-		Reason:     reason,
-		cause:      fmt.Errorf("refresh endpoint %s: %s", status, string(body)),
-		code:       code,
-		statusCode: statusCode,
+		Reason:       reason,
+		cause:        fmt.Errorf("refresh endpoint %s: %s", status, string(body)),
+		code:         code,
+		upstreamCode: upstreamCode,
+		statusCode:   statusCode,
 	}
 }

--- a/server/internal/remotesessions/tokenservice.go
+++ b/server/internal/remotesessions/tokenservice.go
@@ -495,20 +495,27 @@ func (m *ChallengeManager) validateAndRefresh(
 
 // refreshFailureAttrs is the attribute set a failed request-path refresh is
 // logged with. The reason is the public-safe TokenRefreshError.Reason when
-// there is one. The issuer URL and outcome are the ones the upstream-refresh
-// metric recorded for the attempt, so the log line joins to its series; the
-// user id is what lets "how many users are affected" be answered, since a
-// client id is one row per provider connection, not per user.
+// there is one, joined by the error code the upstream answered with when its
+// body carried one. The issuer URL and outcome are the ones the
+// upstream-refresh metric recorded for the attempt, so the log line joins to
+// its series; the user id is what lets "how many users are affected" be
+// answered, since a client id is one row per provider connection, not per
+// user.
 func refreshFailureAttrs(sess remotesessions_repo.RemoteSession, err error) []any {
 	reason := "upstream token refresh failed"
+	code := ""
 	if refreshErr, ok := errors.AsType[*TokenRefreshError](err); ok {
 		reason = refreshErr.Reason
+		code = refreshErr.UpstreamCode()
 	}
 	args := []any{
 		attr.SlogRemoteSessionClientID(sess.RemoteSessionClientID.String()),
 		attr.SlogUserSessionIssuerID(sess.UserSessionIssuerID.String()),
 		attr.SlogOAuthFailureReason(reason),
 		attr.SlogError(err),
+	}
+	if code != "" {
+		args = append(args, attr.SlogOAuthError(code))
 	}
 	if failure, ok := errors.AsType[*RefreshError](err); ok {
 		args = append(args, attr.SlogOAuthIssuer(failure.IssuerURL), attr.SlogOutcome(string(failure.Outcome)))
@@ -604,6 +611,9 @@ func refreshSessionTokens(
 		return zero, "", fmt.Errorf("decode refresh response: %w", err)
 	}
 	if tok.AccessToken == "" {
+		if refreshErr, ok := newTokenRefreshErrorFromSuccessBody(resp.StatusCode, resp.Status, body); ok {
+			return zero, "", refreshErr
+		}
 		return zero, "", newTokenRefreshError("the identity provider returned no access token", nil)
 	}
 


### PR DESCRIPTION
AIM-201

## Summary

- `refreshSessionTokens` now parses the body of a 2xx token response that carries no `access_token`. If it holds an OAuth error, the refresh fails with a `TokenRefreshError` that carries the error code and the real HTTP status, so `refreshOutcomeForError` files it as an upstream rejection and an `invalid_grant` clears the stored refresh grant exactly as a 4xx would. A 2xx body with neither a token nor an error is unchanged and stays transient.
- `oautherr.CanonicalTokenErrorCode` maps GitHub's `bad_refresh_token` and `bad_verification_code` onto `invalid_grant` by exact match. `ParseTokenError` still returns extension codes verbatim; both `TokenRefreshError` constructors canonicalise after parsing and keep the original in `UpstreamCode()`.
- Both refresh-failure log lines (request path and scheduled keepalive) record the upstream's error code as `gram.oauth.error`. The success-body cause names only the code, never the body, since a success-status response can still carry token material.
- Tests: canonicalisation, three new outcome-classifier rows, and two end-to-end `RefreshNow` cases against a fake token endpoint (200 with `bad_refresh_token` clears the grant; empty 200 body keeps it).

## Motivation

GitHub's token endpoint answers a revoked or expired refresh token with HTTP 200 and `{"error":"bad_refresh_token"}`. The refresh path only classified non-2xx bodies, so this became a code-less "returned no access token" error: never `invalid_grant`, refresh token never cleared, and the same dead grant retried on every proxied request and every keepalive sweep, while the session kept reading as connected. Over the last 30 days this produced roughly 1,500 failed refreshes from a single connection.

The authorization-code exchange has the same blind spot; it does not parse error bodies yet, so the `bad_verification_code` alias only takes effect once it does. That is left as a follow-up because no session exists there to clear, only the error message improves.

Temporal actions/month ≈ 0, scales with fixed (no workflow, activity, schedule, or signal is added or changed; the keepalive activity only gains a log attribute).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C555wgLmfbVWf4oxK7FvwB
