### PR TITLE
mig: add judge_temperature and judge_fail_open to risk_policies

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -5538,10 +5538,18 @@ CREATE TABLE IF NOT EXISTS risk_policies (
   -- For policy_type = 'prompt_based': the prompt-based guardrail the LLM judge
   -- evaluates each in-scope message against. NULL for standard policies.
   prompt TEXT,
-  -- For policy_type = 'prompt_based': per-policy judge model configuration
-  -- (model id, temperature, fail-mode, etc.) as a JSON object. NULL for
-  -- standard policies.
+  -- For policy_type = 'prompt_based': per-policy judge model configuration as a
+  -- JSON object. Superseded by judge_temperature and judge_fail_open below;
+  -- retained until those are backfilled and the readers are cut over, then
+  -- dropped in a contract migration. NULL for standard policies.
   model_config JSONB,
+  -- For policy_type = 'prompt_based': sampling temperature for the LLM judge.
+  -- NULL means the judge default (a low value, for deterministic verdicts).
+  judge_temperature DOUBLE PRECISION,
+  -- For policy_type = 'prompt_based': behavior when the LLM judge errors or
+  -- times out. TRUE allows the message, FALSE blocks it. NULL means the judge
+  -- default (fail-open).
+  judge_fail_open BOOLEAN,
   -- CVSS-style severity (0.1-10) the policy author assigns to findings this
   -- policy produces. Purely descriptive; changing it does NOT bump `version`
   -- or re-scan messages. Bounds are validated in the application layer.

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -2317,6 +2317,8 @@ type RiskPolicy struct {
 	UserMessage          pgtype.Text
 	Prompt               pgtype.Text
 	ModelConfig          []byte
+	JudgeTemperature     pgtype.Float8
+	JudgeFailOpen        pgtype.Bool
 	Score                float64
 	Version              int64
 	CreatedAt            pgtype.Timestamptz

--- a/server/internal/risk/repo/models.go
+++ b/server/internal/risk/repo/models.go
@@ -65,6 +65,8 @@ type RiskPolicy struct {
 	UserMessage          pgtype.Text
 	Prompt               pgtype.Text
 	ModelConfig          []byte
+	JudgeTemperature     pgtype.Float8
+	JudgeFailOpen        pgtype.Bool
 	Score                float64
 	Version              int64
 	CreatedAt            pgtype.Timestamptz

--- a/server/internal/risk/repo/queries.sql.go
+++ b/server/internal/risk/repo/queries.sql.go
@@ -257,7 +257,7 @@ SET version = version + 1
 WHERE id = $1
   AND project_id = $2
   AND deleted IS FALSE
-RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, judge_temperature, judge_fail_open, score, version, created_at, updated_at, deleted_at, deleted
 `
 
 type BumpRiskPolicyVersionParams struct {
@@ -291,6 +291,8 @@ func (q *Queries) BumpRiskPolicyVersion(ctx context.Context, arg BumpRiskPolicyV
 		&i.UserMessage,
 		&i.Prompt,
 		&i.ModelConfig,
+		&i.JudgeTemperature,
+		&i.JudgeFailOpen,
 		&i.Score,
 		&i.Version,
 		&i.CreatedAt,
@@ -802,7 +804,7 @@ VALUES (
   , COALESCE($23::double precision, 5.0)
   , 1
 )
-RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, judge_temperature, judge_fail_open, score, version, created_at, updated_at, deleted_at, deleted
 `
 
 type CreateRiskPolicyParams struct {
@@ -881,6 +883,8 @@ func (q *Queries) CreateRiskPolicy(ctx context.Context, arg CreateRiskPolicyPara
 		&i.UserMessage,
 		&i.Prompt,
 		&i.ModelConfig,
+		&i.JudgeTemperature,
+		&i.JudgeFailOpen,
 		&i.Score,
 		&i.Version,
 		&i.CreatedAt,
@@ -2137,7 +2141,7 @@ func (q *Queries) GetRiskOverviewScanCounts(ctx context.Context, arg GetRiskOver
 }
 
 const getRiskPolicy = `-- name: GetRiskPolicy :one
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, judge_temperature, judge_fail_open, score, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE id = $1
   AND project_id = $2
@@ -2175,6 +2179,8 @@ func (q *Queries) GetRiskPolicy(ctx context.Context, arg GetRiskPolicyParams) (R
 		&i.UserMessage,
 		&i.Prompt,
 		&i.ModelConfig,
+		&i.JudgeTemperature,
+		&i.JudgeFailOpen,
 		&i.Score,
 		&i.Version,
 		&i.CreatedAt,
@@ -2226,7 +2232,7 @@ func (q *Queries) GetRiskPolicyBypassRequest(ctx context.Context, arg GetRiskPol
 }
 
 const getRiskPolicyForUpdate = `-- name: GetRiskPolicyForUpdate :one
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, judge_temperature, judge_fail_open, score, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE id = $1
   AND project_id = $2
@@ -2265,6 +2271,8 @@ func (q *Queries) GetRiskPolicyForUpdate(ctx context.Context, arg GetRiskPolicyF
 		&i.UserMessage,
 		&i.Prompt,
 		&i.ModelConfig,
+		&i.JudgeTemperature,
+		&i.JudgeFailOpen,
 		&i.Score,
 		&i.Version,
 		&i.CreatedAt,
@@ -2729,7 +2737,7 @@ func (q *Queries) ListCustomDetectionRules(ctx context.Context, projectID uuid.U
 }
 
 const listEnabledEnforcingPoliciesByProject = `-- name: ListEnabledEnforcingPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, judge_temperature, judge_fail_open, score, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -2772,6 +2780,8 @@ func (q *Queries) ListEnabledEnforcingPoliciesByProject(ctx context.Context, pro
 			&i.UserMessage,
 			&i.Prompt,
 			&i.ModelConfig,
+			&i.JudgeTemperature,
+			&i.JudgeFailOpen,
 			&i.Score,
 			&i.Version,
 			&i.CreatedAt,
@@ -2841,7 +2851,7 @@ func (q *Queries) ListEnabledExclusionsForPolicy(ctx context.Context, arg ListEn
 }
 
 const listEnabledRiskPoliciesByProject = `-- name: ListEnabledRiskPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, judge_temperature, judge_fail_open, score, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -2880,6 +2890,8 @@ func (q *Queries) ListEnabledRiskPoliciesByProject(ctx context.Context, projectI
 			&i.UserMessage,
 			&i.Prompt,
 			&i.ModelConfig,
+			&i.JudgeTemperature,
+			&i.JudgeFailOpen,
 			&i.Score,
 			&i.Version,
 			&i.CreatedAt,
@@ -2898,7 +2910,7 @@ func (q *Queries) ListEnabledRiskPoliciesByProject(ctx context.Context, projectI
 }
 
 const listEnabledShadowMCPPoliciesByProject = `-- name: ListEnabledShadowMCPPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, judge_temperature, judge_fail_open, score, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -2939,6 +2951,8 @@ func (q *Queries) ListEnabledShadowMCPPoliciesByProject(ctx context.Context, pro
 			&i.UserMessage,
 			&i.Prompt,
 			&i.ModelConfig,
+			&i.JudgeTemperature,
+			&i.JudgeFailOpen,
 			&i.Score,
 			&i.Version,
 			&i.CreatedAt,
@@ -2957,7 +2971,7 @@ func (q *Queries) ListEnabledShadowMCPPoliciesByProject(ctx context.Context, pro
 }
 
 const listEnabledToolIdentityPoliciesByProject = `-- name: ListEnabledToolIdentityPoliciesByProject :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, judge_temperature, judge_fail_open, score, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND enabled IS TRUE
@@ -3001,6 +3015,8 @@ func (q *Queries) ListEnabledToolIdentityPoliciesByProject(ctx context.Context, 
 			&i.UserMessage,
 			&i.Prompt,
 			&i.ModelConfig,
+			&i.JudgeTemperature,
+			&i.JudgeFailOpen,
 			&i.Score,
 			&i.Version,
 			&i.CreatedAt,
@@ -3521,7 +3537,7 @@ func (q *Queries) ListRiskOverviewTopUsers(ctx context.Context, arg ListRiskOver
 }
 
 const listRiskPolicies = `-- name: ListRiskPolicies :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, judge_temperature, judge_fail_open, score, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND deleted IS FALSE
@@ -3560,6 +3576,8 @@ func (q *Queries) ListRiskPolicies(ctx context.Context, projectID uuid.UUID) ([]
 			&i.UserMessage,
 			&i.Prompt,
 			&i.ModelConfig,
+			&i.JudgeTemperature,
+			&i.JudgeFailOpen,
 			&i.Score,
 			&i.Version,
 			&i.CreatedAt,
@@ -3578,7 +3596,7 @@ func (q *Queries) ListRiskPolicies(ctx context.Context, projectID uuid.UUID) ([]
 }
 
 const listRiskPoliciesPage = `-- name: ListRiskPoliciesPage :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, judge_temperature, judge_fail_open, score, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND deleted IS FALSE
@@ -3639,6 +3657,8 @@ func (q *Queries) ListRiskPoliciesPage(ctx context.Context, arg ListRiskPolicies
 			&i.UserMessage,
 			&i.Prompt,
 			&i.ModelConfig,
+			&i.JudgeTemperature,
+			&i.JudgeFailOpen,
 			&i.Score,
 			&i.Version,
 			&i.CreatedAt,
@@ -3719,7 +3739,7 @@ func (q *Queries) ListRiskPolicyBypassRequests(ctx context.Context, arg ListRisk
 }
 
 const listRiskPolicyCreateCandidates = `-- name: ListRiskPolicyCreateCandidates :many
-SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+SELECT id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, judge_temperature, judge_fail_open, score, version, created_at, updated_at, deleted_at, deleted
 FROM risk_policies
 WHERE project_id = $1
   AND name = $2
@@ -3768,6 +3788,8 @@ func (q *Queries) ListRiskPolicyCreateCandidates(ctx context.Context, arg ListRi
 			&i.UserMessage,
 			&i.Prompt,
 			&i.ModelConfig,
+			&i.JudgeTemperature,
+			&i.JudgeFailOpen,
 			&i.Score,
 			&i.Version,
 			&i.CreatedAt,
@@ -5638,7 +5660,7 @@ SET name = $1
 WHERE id = $19
   AND project_id = $20
   AND deleted IS FALSE
-RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, score, version, created_at, updated_at, deleted_at, deleted
+RETURNING id, project_id, organization_id, enabled, name, policy_type, sources, presidio_entities, analyzer_config, prompt_injection_rules, disabled_rules, custom_rule_ids, message_types, scope_include, scope_exempt, action, audience_type, shadow_mcp_disposition, auto_name, user_message, prompt, model_config, judge_temperature, judge_fail_open, score, version, created_at, updated_at, deleted_at, deleted
 `
 
 type UpdateRiskPolicyParams struct {
@@ -5711,6 +5733,8 @@ func (q *Queries) UpdateRiskPolicy(ctx context.Context, arg UpdateRiskPolicyPara
 		&i.UserMessage,
 		&i.Prompt,
 		&i.ModelConfig,
+		&i.JudgeTemperature,
+		&i.JudgeFailOpen,
 		&i.Score,
 		&i.Version,
 		&i.CreatedAt,

--- a/server/migrations/20260904163601_risk-policies-add-judge-settings-columns.sql
+++ b/server/migrations/20260904163601_risk-policies-add-judge-settings-columns.sql
@@ -1,0 +1,2 @@
+-- Modify "risk_policies" table
+ALTER TABLE "risk_policies" ADD COLUMN "judge_temperature" double precision NULL, ADD COLUMN "judge_fail_open" boolean NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:lWgwEDKhJmswhQSNNUz+XbbEegPtMm7g5WD2Dt8vHzk=
+h1:zaTvXPw/xDKXZEmCzG2E/gGRl5nWB9nbZbI5CUfgUgo=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -387,3 +387,4 @@ h1:lWgwEDKhJmswhQSNNUz+XbbEegPtMm7g5WD2Dt8vHzk=
 20260903214520_organization-setup-tasks.sql h1:VOA01E6IifoXX5dkmwFgU3gskEG6LeSeuP7N9E7eZWo=
 20260903215231_aim-183-agent-principals.sql h1:l7hdBwam2aqT3pIjK2eBBje7J1z8ow8+/gZ7YpRyp7U=
 20260904130247_aim-191-delegated-agent-credential-columns.sql h1:ai8nyCt3GN33WzGoe8iMil/GP1Zw9xSI5ReYhdbM2Fk=
+20260904163601_risk-policies-add-judge-settings-columns.sql h1:7c9QP8Qume9cuW4iP39gVP6EH3ajJGveqDZoOVaxVjs=


### PR DESCRIPTION
Stacked on #6089 (which is stacked on #6024). Review those first; this diff is only the last commit.

Expand step for moving prompt-policy judge settings out of the `model_config` JSONB blob into typed columns.

```sql
ALTER TABLE "risk_policies"
  ADD COLUMN "judge_temperature" double precision NULL,
  ADD COLUMN "judge_fail_open"   boolean NULL;
```

Both nullable, so existing rows are untouched and `NULL` keeps meaning "use the judge default".

## Migration only

Nothing reads or writes these columns yet — this PR is the migration plus the sqlc row structs that regenerate from it. Per the `postgresql` skill, migrations ship without application logic so the schema can roll out ahead of the code and stay trivially revertible.

That splits the storage work into more PRs than the two we planned:

1. this PR: add the columns
2. next: cut readers/writers over, backfilling each policy's values on write
3. later, once backfilled: contract migration dropping `model_config`

Step 3 stays deferred deliberately — expand-contract means the blob sticks around until nothing reads it.

## Locking

Two nullable `ADD COLUMN`s with no default take a catalog-only update: no table rewrite, no scan, no `ACCESS EXCLUSIVE` held for any meaningful time. No `CHECK` or `FOREIGN KEY`, so no PG305/PG306 and no `NOT VALID` two-step needed. `mise run lint:migrations` is clean and the timestamp is in order.

## Testing

`mise run db:migrate` applies cleanly locally, `gen:sqlc-server` regenerates without drift, `test:server ./internal/risk/` (378) passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `judge_temperature` and `judge_fail_open` as nullable columns on `risk_policies`, the expand step for moving prompt-policy judge settings out of the `model_config` JSONB blob into typed columns. NULL keeps meaning "use the judge default", so existing rows are untouched.

**Migration**
- Nothing reads or writes these columns yet; this ships the schema and regenerated sqlc row structs only.
- The two `ADD COLUMN`s need no table scan and no lock beyond the catalog update, so no PG305/PG306.
- Readers/writers get cut over and values backfilled in a follow-up; dropping `model_config` waits until nothing reads it.

<sup>Written for commit 281755e3d1f0dc51273f95ae5e7e885aa8a8ed19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

