### PR TITLE
fix: Use project slug override for Inspect tab link in RBAC tool picker

### DIFF
--- a/client/dashboard/src/pages/access/GrantRuleDrawerContent.tsx
+++ b/client/dashboard/src/pages/access/GrantRuleDrawerContent.tsx
@@ -690,6 +690,35 @@ function remoteServerStatus(
 }
 
 /**
+ * Link to the MCP server's Inspect tab, correctly scoped to the server's
+ * project. Uses useRoutes with the project slug override so the link works
+ * when rendered from org-level pages (where the ambient projectSlug is
+ * undefined).
+ */
+function InspectTabLink({
+  serverId,
+  serverSlug,
+  projectSlug,
+}: {
+  serverId: string;
+  serverSlug: string;
+  projectSlug?: string;
+}) {
+  const routes = useRoutes({ projectSlug });
+  return (
+    <Link
+      to={routes.mcp.x.inspect.href(
+        mcpServerRouteParam({ id: serverId, slug: serverSlug }),
+      )}
+      className="text-primary inline-flex items-center gap-1 hover:underline"
+    >
+      Connect it on the Inspect tab
+      <ArrowUpRight className="h-3 w-3" />
+    </Link>
+  );
+}
+
+/**
  * Dashboard adapter around the shared ToolSelectionPanel: converts server
  * groups and selectors into the panel's normalized types, lazily loads remote
  * tool metadata, and replays panel toggles as the legacy selector/annotation
@@ -722,8 +751,6 @@ function RoleToolSelectionPanel({
   isDeny?: boolean;
   className?: string;
 }): JSX.Element {
-  const routes = useRoutes();
-
   const allServers = useMemo(
     () =>
       mcpServers
@@ -796,15 +823,11 @@ function RoleToolSelectionPanel({
               <div className="text-muted-foreground space-y-1 px-8 py-3 text-sm">
                 <p>This server&apos;s tools haven&apos;t been synced yet.</p>
                 <p>
-                  <Link
-                    to={routes.mcp.x.inspect.href(
-                      mcpServerRouteParam({ id: server.id, slug: server.slug }),
-                    )}
-                    className="text-primary inline-flex items-center gap-1 hover:underline"
-                  >
-                    Connect it on the Inspect tab
-                    <ArrowUpRight className="h-3 w-3" />
-                  </Link>{" "}
+                  <InspectTabLink
+                    serverId={server.id}
+                    serverSlug={server.slug}
+                    projectSlug={server.projectSlug}
+                  />{" "}
                   to permission its tools individually.
                 </p>
               </div>
@@ -820,7 +843,7 @@ function RoleToolSelectionPanel({
           status: "ready",
         };
       }),
-    [allServers, remoteTools, routes],
+    [allServers, remoteTools],
   );
 
   // Annotation counts stay pinned to deploy-time tools: lazily loaded remote


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the broken "Connect it on the Inspect tab" link in the RBAC tool picker.

## Problem

When on an org-level page (like Roles & Permissions at `/:orgSlug/access`), the `projectSlug` from `useSlugs()` returns `undefined`. The Inspect tab link in the RBAC tool picker was using `useRoutes()` without a project slug override, causing the generated URL to contain "undefined" instead of the actual project slug.

For example, the link would generate:
```
/speakeasy/projects/undefined/mcp/x/server-slug/inspect
```

instead of:
```
/speakeasy/projects/default/mcp/x/server-slug/inspect
```

## Solution

Created a new `InspectTabLink` component that:
1. Accepts the server's `projectSlug` as a prop
2. Uses `useRoutes({ projectSlug })` with the override to properly scope the route
3. Generates the correct URL regardless of the current page's project context

## Testing

- TypeScript type check passes
- ESLint/formatting passes
- Verified the Roles & Permissions page loads correctly

## Fixes

AGE-3395
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3395](https://linear.app/speakeasy/issue/AGE-3395/bug-fix-broken-inspect-page-link-in-rbac-tool-view)

<div><a href="https://cursor.com/agents/bc-1fa02be0-a5ae-44c2-852a-4f33a5a2d40f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fa02be0-a5ae-44c2-852a-4f33a5a2d40f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Inspect tab link in the RBAC tool picker so it no longer generates URLs with `undefined` as the project slug when rendered from org-level pages like Roles & Permissions.

**Bug Fixes**
- Added an `InspectTabLink` component that scopes the route with the server's `projectSlug` override.
- Removed the now-unused `useRoutes()` call from the parent panel.

Fixes AGE-3395.

<sup>Written for commit e11934e31c64cdadaa909e6535c91c51ad404547. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

