### PR TITLE
feat: add Platform MCP data export management and tool call reads

### DIFF
--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -313,6 +313,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 	skillAuthoring := platformmcp.NewSkillsService(config.Skills, platformmcp.NewPostgresSkillTargets(config.DB), store, config.Authz, registrationGate, budgets.Skills)
 	platformReader := platformmcp.NewPostgresReader(config.Logger, config.DB).
 		WithDataExports(config.Encryption, config.DashboardURL).
+		WithDataExportMutations(config.AuditLogger, config.DashboardURL).
 		WithRecentToolCalls(config.RecentToolCalls, config.DashboardURL)
 	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, config.SessionCapture, platformReader, readiness, budgets.Diagnostics).
 		WithDrilldown(config.TelemetryDrilldown, config.JWTSigningKey, budgets.SensitiveDiagnostics, budgets.DrilldownVolume, platformmcp.NewPostgresDrilldownAuditor(config.DB))
@@ -641,6 +642,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 	skillAuthoring := platformmcp.NewSkillsService(config.Skills, platformmcp.NewPostgresSkillTargets(config.DB), store, config.Authz, registrationGate, budgets.Skills)
 	platformReader := platformmcp.NewPostgresReader(config.Logger, config.DB).
 		WithDataExports(config.Encryption, config.DashboardURL).
+		WithDataExportMutations(config.AuditLogger, config.DashboardURL).
 		WithRecentToolCalls(config.RecentToolCalls, config.DashboardURL)
 	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, config.SessionCapture, platformReader, readiness, budgets.Diagnostics).
 		WithDrilldown(config.TelemetryDrilldown, config.JWTSigningKey, budgets.SensitiveDiagnostics, budgets.DrilldownVolume, platformmcp.NewPostgresDrilldownAuditor(config.DB))

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -92,7 +92,10 @@ type platformMCPConfig struct {
 	// withholds the drill-down tools while leaving the overview-first entry
 	// points serving.
 	TelemetryDrilldown platformmcp.DrilldownTelemetryReader
-	LocalFixture       *platformMCPLocalFixtureConfig
+	// RecentToolCalls reads only the bounded Tool Logs summary path.
+	// Nil keeps the tool visible as unavailable rather than returning an empty list.
+	RecentToolCalls platformmcp.RecentToolCallReader
+	LocalFixture    *platformMCPLocalFixtureConfig
 }
 
 var platformMCPLocalFixtureLoopbackCIDRBlocks = []string{"127.0.0.0/8", "::1/128"}
@@ -308,7 +311,9 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 	config.Mux.Handle(http.MethodPost, "/platform-mcp/local-fixture/mcp", fixtureMCP.Handler().ServeHTTP)
 
 	skillAuthoring := platformmcp.NewSkillsService(config.Skills, platformmcp.NewPostgresSkillTargets(config.DB), store, config.Authz, registrationGate, budgets.Skills)
-	platformReader := platformmcp.NewPostgresReader(config.Logger, config.DB)
+	platformReader := platformmcp.NewPostgresReader(config.Logger, config.DB).
+		WithDataExports(config.Encryption, config.DashboardURL).
+		WithRecentToolCalls(config.RecentToolCalls, config.DashboardURL)
 	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, config.SessionCapture, platformReader, readiness, budgets.Diagnostics).
 		WithDrilldown(config.TelemetryDrilldown, config.JWTSigningKey, budgets.SensitiveDiagnostics, budgets.DrilldownVolume, platformmcp.NewPostgresDrilldownAuditor(config.DB))
 	sessionRecall := platformmcp.NewSessionRecallService(config.Logger, config.DB, platformrepo.New(config.DB), audit.NewLogger(), config.SessionPortability, budgets.SensitiveSessionRecall)
@@ -634,7 +639,9 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 	pluginInventory := platformmcp.NewPluginsService(config.DB, budgets.Plugins, config.JWTSigningKey)
 	distributions := newPlatformMCPDistributionService(config, pluginInventory)
 	skillAuthoring := platformmcp.NewSkillsService(config.Skills, platformmcp.NewPostgresSkillTargets(config.DB), store, config.Authz, registrationGate, budgets.Skills)
-	platformReader := platformmcp.NewPostgresReader(config.Logger, config.DB)
+	platformReader := platformmcp.NewPostgresReader(config.Logger, config.DB).
+		WithDataExports(config.Encryption, config.DashboardURL).
+		WithRecentToolCalls(config.RecentToolCalls, config.DashboardURL)
 	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, config.SessionCapture, platformReader, readiness, budgets.Diagnostics).
 		WithDrilldown(config.TelemetryDrilldown, config.JWTSigningKey, budgets.SensitiveDiagnostics, budgets.DrilldownVolume, platformmcp.NewPostgresDrilldownAuditor(config.DB))
 	sessionRecall := platformmcp.NewSessionRecallService(config.Logger, config.DB, platformrepo.New(config.DB), audit.NewLogger(), config.SessionPortability, budgets.SensitiveSessionRecall)

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1649,6 +1649,7 @@ func newStartCommand() *cli.Command {
 				RiskExclusionReconciler: &background.TemporalRiskExclusionReconciler{TemporalEnv: temporalEnv, Logger: logger},
 				Telemetry:               telemetryrepo.New(chDB),
 				TelemetryDrilldown:      telemetryrepo.New(chDB),
+				RecentToolCalls:         telemetryrepo.New(chDB),
 				SessionCapture:          platformmcp.FeatureChecker(sessionCaptureEnabled),
 				SessionPortability:      platformmcp.FeatureChecker(sessionPortabilityEnabled),
 				LocalFixture:            platformFixture,

--- a/server/internal/dataexports/destinations.go
+++ b/server/internal/dataexports/destinations.go
@@ -15,6 +15,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/dataexports/repo"
+	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
@@ -143,11 +144,18 @@ func (s *Service) encryptHeaders(headers map[string]string) (pgtype.Text, error)
 }
 
 func (s *Service) decryptHeaders(stored pgtype.Text) (map[string]string, error) {
+	return decryptHeaders(s.encryption, stored)
+}
+
+func decryptHeaders(encryptionClient *encryption.Client, stored pgtype.Text) (map[string]string, error) {
 	if !stored.Valid || stored.String == "" {
 		return map[string]string{}, nil
 	}
+	if encryptionClient == nil {
+		return nil, fmt.Errorf("decrypt destination headers: encryption is unavailable")
+	}
 
-	plaintext, err := s.encryption.Decrypt(stored.String)
+	plaintext, err := encryptionClient.Decrypt(stored.String)
 	if err != nil {
 		return nil, fmt.Errorf("decrypt destination headers: %w", err)
 	}
@@ -160,6 +168,39 @@ func (s *Service) decryptHeaders(stored pgtype.Text) (map[string]string, error) 
 		return map[string]string{}, nil
 	}
 	return headers, nil
+}
+
+// DestinationHeaderMetadata is the safe, write-only projection of one
+// destination header. Values never leave the data exports package.
+type DestinationHeaderMetadata struct {
+	Name     string
+	HasValue bool
+}
+
+// DecodeDestinationHeaderMetadata decrypts stored headers and returns only
+// their names and whether a value is configured.
+func DecodeDestinationHeaderMetadata(encryptionClient *encryption.Client, stored pgtype.Text) ([]DestinationHeaderMetadata, error) {
+	headers, err := decryptHeaders(encryptionClient, stored)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(headers))
+	for name := range headers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	metadata := make([]DestinationHeaderMetadata, 0, len(names))
+	for _, name := range names {
+		metadata = append(metadata, DestinationHeaderMetadata{Name: name, HasValue: headers[name] != ""})
+	}
+	return metadata, nil
+}
+
+// DestinationSensitiveDataPolicy returns the effective persisted policy.
+func DestinationSensitiveDataPolicy(stored pgtype.Text) (string, error) {
+	policy, err := sensitiveDataFromRow(stored)
+	return string(policy), err
 }
 
 func destinationSnapshot(name, endpointURL string, headers map[string]string, policy sensitiveData) *audit.OtelDestinationSnapshot {

--- a/server/internal/dataexports/destinations.go
+++ b/server/internal/dataexports/destinations.go
@@ -80,6 +80,32 @@ func validateDestinationURL(raw string) (string, error) {
 	return parsed.String(), nil
 }
 
+// DestinationConfiguration is a validated OTEL destination without secret
+// headers. It is shared by management and agentic mutation surfaces.
+type DestinationConfiguration struct {
+	Name          string
+	EndpointURL   string
+	SensitiveData string
+}
+
+// NormalizeDestinationConfiguration applies the canonical destination
+// validation used by the management API.
+func NormalizeDestinationConfiguration(rawName, rawEndpointURL, rawSensitiveData string) (DestinationConfiguration, error) {
+	name, err := validateDestinationName(rawName)
+	if err != nil {
+		return DestinationConfiguration{}, err
+	}
+	endpointURL, err := validateDestinationURL(rawEndpointURL)
+	if err != nil {
+		return DestinationConfiguration{}, err
+	}
+	policy, err := parseSensitiveData(rawSensitiveData)
+	if err != nil {
+		return DestinationConfiguration{}, oops.E(oops.CodeInvalid, err, "invalid sensitive_data")
+	}
+	return DestinationConfiguration{Name: name, EndpointURL: endpointURL, SensitiveData: string(policy)}, nil
+}
+
 type destinationHeaderInput struct {
 	name     string
 	value    string

--- a/server/internal/dataexports/impl.go
+++ b/server/internal/dataexports/impl.go
@@ -196,17 +196,9 @@ func (s *Service) createOtelDestination(ctx context.Context, authCtx *contextval
 		return nil, oops.E(oops.CodeInvalid, errors.New("missing OTEL configuration"), "otel configuration is required")
 	}
 
-	name, err := validateDestinationName(payload.Name)
+	configuration, err := NormalizeDestinationConfiguration(payload.Name, payload.Otel.EndpointURL, payload.SensitiveData)
 	if err != nil {
 		return nil, err
-	}
-	endpointURL, err := validateDestinationURL(payload.Otel.EndpointURL)
-	if err != nil {
-		return nil, err
-	}
-	policy, err := parseSensitiveData(payload.SensitiveData)
-	if err != nil {
-		return nil, oops.E(oops.CodeInvalid, err, "invalid sensitive_data")
 	}
 	headerInputs := make([]destinationHeaderInput, len(payload.Otel.Headers))
 	for i, input := range payload.Otel.Headers {
@@ -238,10 +230,10 @@ func (s *Service) createOtelDestination(ctx context.Context, authCtx *contextval
 	row, err := repo.New(dbtx).CreateOtelDestination(ctx, repo.CreateOtelDestinationParams{
 		OrganizationID:   authCtx.ActiveOrganizationID,
 		ProjectID:        *authCtx.ProjectID,
-		Name:             name,
-		EndpointUrl:      endpointURL,
+		Name:             configuration.Name,
+		EndpointUrl:      configuration.EndpointURL,
 		HeadersEncrypted: headersEncrypted,
-		SensitiveData:    conv.ToPGText(string(policy)),
+		SensitiveData:    conv.ToPGText(configuration.SensitiveData),
 	})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "create OTEL destination").LogError(ctx, logger)
@@ -262,7 +254,7 @@ func (s *Service) createOtelDestination(ctx context.Context, authCtx *contextval
 		return nil, oops.E(oops.CodeUnexpected, err, "commit OTEL destination creation").LogError(ctx, logger)
 	}
 
-	return buildOtelDestinationView(row, headers, string(policy)), nil
+	return buildOtelDestinationView(row, headers, configuration.SensitiveData), nil
 }
 
 func (s *Service) UpdateDestination(ctx context.Context, payload *gen.UpdateDestinationPayload) (*gen.Destination, error) {
@@ -295,18 +287,11 @@ func (s *Service) updateOtelDestination(ctx context.Context, authCtx *contextval
 	if err != nil {
 		return nil, oops.E(oops.CodeInvalid, err, "invalid destination id")
 	}
-	name, err := validateDestinationName(payload.Name)
+	configuration, err := NormalizeDestinationConfiguration(payload.Name, payload.Otel.EndpointURL, payload.SensitiveData)
 	if err != nil {
 		return nil, err
 	}
-	endpointURL, err := validateDestinationURL(payload.Otel.EndpointURL)
-	if err != nil {
-		return nil, err
-	}
-	policy, err := parseSensitiveData(payload.SensitiveData)
-	if err != nil {
-		return nil, oops.E(oops.CodeInvalid, err, "invalid sensitive_data")
-	}
+	policy := sensitiveData(configuration.SensitiveData)
 
 	logger := s.logger.With(attr.SlogOrganizationID(authCtx.ActiveOrganizationID), attr.SlogProjectID(authCtx.ProjectID.String()))
 	dbtx, err := s.db.Begin(ctx)
@@ -362,10 +347,10 @@ func (s *Service) updateOtelDestination(ctx context.Context, authCtx *contextval
 	beforeSnapshot := destinationSnapshot(before.Name, before.EndpointUrl, existingHeaders, beforePolicy)
 
 	after, err := queries.UpdateOtelDestination(ctx, repo.UpdateOtelDestinationParams{
-		Name:             name,
-		EndpointUrl:      endpointURL,
+		Name:             configuration.Name,
+		EndpointUrl:      configuration.EndpointURL,
 		HeadersEncrypted: headersEncrypted,
-		SensitiveData:    conv.ToPGText(string(policy)),
+		SensitiveData:    conv.ToPGText(configuration.SensitiveData),
 		OrganizationID:   authCtx.ActiveOrganizationID,
 		ProjectID:        *authCtx.ProjectID,
 		ID:               destinationID,
@@ -392,7 +377,7 @@ func (s *Service) updateOtelDestination(ctx context.Context, authCtx *contextval
 		return nil, oops.E(oops.CodeUnexpected, err, "commit OTEL destination update").LogError(ctx, logger)
 	}
 
-	return buildOtelDestinationView(after, headers, string(policy)), nil
+	return buildOtelDestinationView(after, headers, configuration.SensitiveData), nil
 }
 
 func (s *Service) DeleteDestination(ctx context.Context, payload *gen.DeleteDestinationPayload) error {
@@ -536,7 +521,7 @@ func (s *Service) CreateRoute(ctx context.Context, payload *gen.CreateRoutePaylo
 		return nil, err
 	}
 
-	source, err := parseDataSource(payload.DataSource)
+	source, err := NormalizeDataSource(payload.DataSource)
 	if err != nil {
 		return nil, oops.E(oops.CodeInvalid, err, "invalid data_source")
 	}
@@ -555,7 +540,7 @@ func (s *Service) CreateRoute(ctx context.Context, payload *gen.CreateRoutePaylo
 	row, err := queries.CreateDataExportRoute(ctx, repo.CreateDataExportRouteParams{
 		OrganizationID:    authCtx.ActiveOrganizationID,
 		ProjectID:         *authCtx.ProjectID,
-		DataSource:        string(source),
+		DataSource:        source,
 		Enabled:           payload.Enabled,
 		OtelDestinationID: destinationID,
 	})
@@ -597,7 +582,7 @@ func (s *Service) UpdateRoute(ctx context.Context, payload *gen.UpdateRoutePaylo
 	if err != nil {
 		return nil, oops.E(oops.CodeInvalid, err, "invalid route id")
 	}
-	source, err := parseDataSource(payload.DataSource)
+	source, err := NormalizeDataSource(payload.DataSource)
 	if err != nil {
 		return nil, oops.E(oops.CodeInvalid, err, "invalid data_source")
 	}
@@ -626,7 +611,7 @@ func (s *Service) UpdateRoute(ctx context.Context, payload *gen.UpdateRoutePaylo
 		return nil, err
 	}
 	after, err := queries.UpdateDataExportRoute(ctx, repo.UpdateDataExportRouteParams{
-		DataSource:        string(source),
+		DataSource:        source,
 		Enabled:           payload.Enabled,
 		OtelDestinationID: destinationID,
 		OrganizationID:    authCtx.ActiveOrganizationID,

--- a/server/internal/dataexports/queries.sql
+++ b/server/internal/dataexports/queries.sql
@@ -41,6 +41,20 @@ WHERE project.organization_id = @organization_id
   AND destination.deleted IS FALSE
 ORDER BY destination.created_at, destination.id;
 
+-- List a bounded destination inventory with project metadata in one snapshot.
+-- name: ListOtelDestinationsWithProjectMetadata :many
+SELECT destination.*, project.name AS project_name, project.slug AS project_slug
+FROM otel_destinations AS destination
+JOIN projects AS project
+  ON project.id = destination.project_id
+ AND project.organization_id = destination.organization_id
+WHERE project.organization_id = @organization_id
+  AND project.deleted IS FALSE
+  AND destination.deleted IS FALSE
+  AND (sqlc.narg('project_id')::uuid IS NULL OR destination.project_id = sqlc.narg('project_id')::uuid)
+ORDER BY destination.created_at, destination.id
+LIMIT @result_limit;
+
 
 -- Lock a destination before merging preserved header secrets or deleting it.
 -- The lock keeps the before snapshot and subsequent mutation on one row version.
@@ -141,6 +155,20 @@ WHERE project.organization_id = @organization_id
   AND project.deleted IS FALSE
   AND route.deleted IS FALSE
 ORDER BY route.created_at, route.id;
+
+-- List a bounded route inventory with project metadata in one snapshot.
+-- name: ListDataExportRoutesWithProjectMetadata :many
+SELECT route.*, project.name AS project_name, project.slug AS project_slug
+FROM data_export_routes AS route
+JOIN projects AS project
+  ON project.id = route.project_id
+ AND project.organization_id = route.organization_id
+WHERE project.organization_id = @organization_id
+  AND project.deleted IS FALSE
+  AND route.deleted IS FALSE
+  AND (sqlc.narg('project_id')::uuid IS NULL OR route.project_id = sqlc.narg('project_id')::uuid)
+ORDER BY route.created_at, route.id
+LIMIT @result_limit;
 
 -- Serialize route update/delete transitions so audit snapshots describe the
 -- exact row version mutated by the transaction.

--- a/server/internal/dataexports/repo/queries.sql.go
+++ b/server/internal/dataexports/repo/queries.sql.go
@@ -361,6 +361,75 @@ func (q *Queries) ListDataExportRoutesByOrganizationID(ctx context.Context, orga
 	return items, nil
 }
 
+const listDataExportRoutesWithProjectMetadata = `-- name: ListDataExportRoutesWithProjectMetadata :many
+SELECT route.id, route.organization_id, route.project_id, route.data_source, route.enabled, route.otel_destination_id, route.created_at, route.updated_at, route.deleted_at, route.deleted, project.name AS project_name, project.slug AS project_slug
+FROM data_export_routes AS route
+JOIN projects AS project
+  ON project.id = route.project_id
+ AND project.organization_id = route.organization_id
+WHERE project.organization_id = $1
+  AND project.deleted IS FALSE
+  AND route.deleted IS FALSE
+  AND ($2::uuid IS NULL OR route.project_id = $2::uuid)
+ORDER BY route.created_at, route.id
+LIMIT $3
+`
+
+type ListDataExportRoutesWithProjectMetadataParams struct {
+	OrganizationID string
+	ProjectID      uuid.NullUUID
+	ResultLimit    int32
+}
+
+type ListDataExportRoutesWithProjectMetadataRow struct {
+	ID                uuid.UUID
+	OrganizationID    string
+	ProjectID         uuid.UUID
+	DataSource        string
+	Enabled           bool
+	OtelDestinationID uuid.NullUUID
+	CreatedAt         pgtype.Timestamptz
+	UpdatedAt         pgtype.Timestamptz
+	DeletedAt         pgtype.Timestamptz
+	Deleted           bool
+	ProjectName       string
+	ProjectSlug       string
+}
+
+// List a bounded route inventory with project metadata in one snapshot.
+func (q *Queries) ListDataExportRoutesWithProjectMetadata(ctx context.Context, arg ListDataExportRoutesWithProjectMetadataParams) ([]ListDataExportRoutesWithProjectMetadataRow, error) {
+	rows, err := q.db.Query(ctx, listDataExportRoutesWithProjectMetadata, arg.OrganizationID, arg.ProjectID, arg.ResultLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListDataExportRoutesWithProjectMetadataRow
+	for rows.Next() {
+		var i ListDataExportRoutesWithProjectMetadataRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrganizationID,
+			&i.ProjectID,
+			&i.DataSource,
+			&i.Enabled,
+			&i.OtelDestinationID,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.DeletedAt,
+			&i.Deleted,
+			&i.ProjectName,
+			&i.ProjectSlug,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listOtelDestinations = `-- name: ListOtelDestinations :many
 SELECT id, organization_id, project_id, name, endpoint_url, headers_encrypted, sensitive_data, created_at, updated_at, deleted_at, deleted
 FROM otel_destinations
@@ -442,6 +511,77 @@ func (q *Queries) ListOtelDestinationsByOrganizationID(ctx context.Context, orga
 			&i.UpdatedAt,
 			&i.DeletedAt,
 			&i.Deleted,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listOtelDestinationsWithProjectMetadata = `-- name: ListOtelDestinationsWithProjectMetadata :many
+SELECT destination.id, destination.organization_id, destination.project_id, destination.name, destination.endpoint_url, destination.headers_encrypted, destination.sensitive_data, destination.created_at, destination.updated_at, destination.deleted_at, destination.deleted, project.name AS project_name, project.slug AS project_slug
+FROM otel_destinations AS destination
+JOIN projects AS project
+  ON project.id = destination.project_id
+ AND project.organization_id = destination.organization_id
+WHERE project.organization_id = $1
+  AND project.deleted IS FALSE
+  AND destination.deleted IS FALSE
+  AND ($2::uuid IS NULL OR destination.project_id = $2::uuid)
+ORDER BY destination.created_at, destination.id
+LIMIT $3
+`
+
+type ListOtelDestinationsWithProjectMetadataParams struct {
+	OrganizationID string
+	ProjectID      uuid.NullUUID
+	ResultLimit    int32
+}
+
+type ListOtelDestinationsWithProjectMetadataRow struct {
+	ID               uuid.UUID
+	OrganizationID   string
+	ProjectID        uuid.UUID
+	Name             string
+	EndpointUrl      string
+	HeadersEncrypted pgtype.Text
+	SensitiveData    pgtype.Text
+	CreatedAt        pgtype.Timestamptz
+	UpdatedAt        pgtype.Timestamptz
+	DeletedAt        pgtype.Timestamptz
+	Deleted          bool
+	ProjectName      string
+	ProjectSlug      string
+}
+
+// List a bounded destination inventory with project metadata in one snapshot.
+func (q *Queries) ListOtelDestinationsWithProjectMetadata(ctx context.Context, arg ListOtelDestinationsWithProjectMetadataParams) ([]ListOtelDestinationsWithProjectMetadataRow, error) {
+	rows, err := q.db.Query(ctx, listOtelDestinationsWithProjectMetadata, arg.OrganizationID, arg.ProjectID, arg.ResultLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListOtelDestinationsWithProjectMetadataRow
+	for rows.Next() {
+		var i ListOtelDestinationsWithProjectMetadataRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.OrganizationID,
+			&i.ProjectID,
+			&i.Name,
+			&i.EndpointUrl,
+			&i.HeadersEncrypted,
+			&i.SensitiveData,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.DeletedAt,
+			&i.Deleted,
+			&i.ProjectName,
+			&i.ProjectSlug,
 		); err != nil {
 			return nil, err
 		}

--- a/server/internal/dataexports/sources.go
+++ b/server/internal/dataexports/sources.go
@@ -7,17 +7,15 @@ const (
 	DataSourceRiskFindings     = "risk_findings"
 )
 
-type dataSource string
-
-var validDataSources = map[dataSource]struct{}{
+var validDataSources = map[string]struct{}{
 	DataSourceProductTelemetry: {},
 	DataSourceRiskFindings:     {},
 }
 
-func parseDataSource(value string) (dataSource, error) {
-	source := dataSource(value)
-	if _, ok := validDataSources[source]; !ok {
+// NormalizeDataSource validates and returns a supported data export source.
+func NormalizeDataSource(value string) (string, error) {
+	if _, ok := validDataSources[value]; !ok {
 		return "", fmt.Errorf("unsupported data source %q", value)
 	}
-	return source, nil
+	return value, nil
 }

--- a/server/internal/platformmcp/adapters.go
+++ b/server/internal/platformmcp/adapters.go
@@ -285,28 +285,30 @@ func (r *PostgresReadinessRecorder) RecordReady(ctx context.Context, principal P
 }
 
 type PostgresReader struct {
-	logger             *slog.Logger
-	db                 *pgxpool.Pool
-	reader             *readmodel.Reader
-	inventory          *platformrepo.Queries
-	inventoryCursor    *inventoryCursorCodec
-	metadataVersionKey []byte
-	riskReads          *RiskReadService
-	dataExports        *DataExportReadService
-	recentToolCalls    *RecentToolCallReadService
+	logger              *slog.Logger
+	db                  *pgxpool.Pool
+	reader              *readmodel.Reader
+	inventory           *platformrepo.Queries
+	inventoryCursor     *inventoryCursorCodec
+	metadataVersionKey  []byte
+	riskReads           *RiskReadService
+	dataExports         *DataExportReadService
+	dataExportMutations *dataExportMutationService
+	recentToolCalls     *RecentToolCallReadService
 }
 
 func NewPostgresReader(logger *slog.Logger, db *pgxpool.Pool) *PostgresReader {
 	return &PostgresReader{
-		logger:             logger.With(attr.SlogComponent("platformmcp")),
-		db:                 db,
-		reader:             readmodel.New(db),
-		inventory:          platformrepo.New(db),
-		inventoryCursor:    nil,
-		metadataVersionKey: nil,
-		riskReads:          nil,
-		dataExports:        nil,
-		recentToolCalls:    nil,
+		logger:              logger.With(attr.SlogComponent("platformmcp")),
+		db:                  db,
+		reader:              readmodel.New(db),
+		inventory:           platformrepo.New(db),
+		inventoryCursor:     nil,
+		metadataVersionKey:  nil,
+		riskReads:           nil,
+		dataExports:         nil,
+		dataExportMutations: nil,
+		recentToolCalls:     nil,
 	}
 }
 

--- a/server/internal/platformmcp/adapters.go
+++ b/server/internal/platformmcp/adapters.go
@@ -292,6 +292,8 @@ type PostgresReader struct {
 	inventoryCursor    *inventoryCursorCodec
 	metadataVersionKey []byte
 	riskReads          *RiskReadService
+	dataExports        *DataExportReadService
+	recentToolCalls    *RecentToolCallReadService
 }
 
 func NewPostgresReader(logger *slog.Logger, db *pgxpool.Pool) *PostgresReader {
@@ -303,6 +305,8 @@ func NewPostgresReader(logger *slog.Logger, db *pgxpool.Pool) *PostgresReader {
 		inventoryCursor:    nil,
 		metadataVersionKey: nil,
 		riskReads:          nil,
+		dataExports:        nil,
+		recentToolCalls:    nil,
 	}
 }
 

--- a/server/internal/platformmcp/descriptor_test.go
+++ b/server/internal/platformmcp/descriptor_test.go
@@ -178,9 +178,9 @@ func TestAssistantAudienceExcludesConnectionScopedTools(t *testing.T) {
 	}
 
 	// Named-plugin distribution is intentionally unavailable until
-	// compatibility deployment. Session recall is external-only in v1: the
-	// shared project-assistant surface must not serve user-personal
-	// cross-project transcripts.
+	// compatibility deployment. Session recall stays external-only because it
+	// contains user-personal cross-project transcripts. Data exports stay
+	// external-only because creation can send future project data off-platform.
 	for _, name := range []string{
 		"distribute_mcp_to_plugin",
 		"remove_mcp_from_plugin",
@@ -189,8 +189,9 @@ func TestAssistantAudienceExcludesConnectionScopedTools(t *testing.T) {
 		"list_my_sessions",
 		"continue_session",
 		"list_data_exports",
+		"create_data_export",
 	} {
-		require.False(t, admitted[name], "tool %q needs a connection or is rollout-gated and must not be admitted to the assistant", name)
+		require.False(t, admitted[name], "tool %q must not be admitted to the assistant", name)
 	}
 
 	// The reads, registration paths, and persisted readiness projections are

--- a/server/internal/platformmcp/descriptor_test.go
+++ b/server/internal/platformmcp/descriptor_test.go
@@ -188,6 +188,7 @@ func TestAssistantAudienceExcludesConnectionScopedTools(t *testing.T) {
 		"get_plugin",
 		"list_my_sessions",
 		"continue_session",
+		"list_data_exports",
 	} {
 		require.False(t, admitted[name], "tool %q needs a connection or is rollout-gated and must not be admitted to the assistant", name)
 	}
@@ -201,6 +202,7 @@ func TestAssistantAudienceExcludesConnectionScopedTools(t *testing.T) {
 		"list_projects",
 		"find_mcp",
 		"get_mcp",
+		"list_recent_tool_calls",
 		"update_mcp_metadata",
 		"register_catalog_mcp",
 		"register_remote_mcp",

--- a/server/internal/platformmcp/feedback.go
+++ b/server/internal/platformmcp/feedback.go
@@ -387,6 +387,7 @@ var knownPlatformMCPToolNames = map[string]struct{}{
 	"find_mcp":                              {},
 	"get_mcp":                               {},
 	"list_data_exports":                     {},
+	"create_data_export":                    {},
 	"list_recent_tool_calls":                {},
 	"search_mcp_catalog":                    {},
 	"inspect_mcp_candidate":                 {},

--- a/server/internal/platformmcp/feedback.go
+++ b/server/internal/platformmcp/feedback.go
@@ -386,6 +386,8 @@ var knownPlatformMCPToolNames = map[string]struct{}{
 	"list_projects":                         {},
 	"find_mcp":                              {},
 	"get_mcp":                               {},
+	"list_data_exports":                     {},
+	"list_recent_tool_calls":                {},
 	"search_mcp_catalog":                    {},
 	"inspect_mcp_candidate":                 {},
 	"register_catalog_mcp":                  {},

--- a/server/internal/platformmcp/operational_reads_integration_test.go
+++ b/server/internal/platformmcp/operational_reads_integration_test.go
@@ -37,6 +37,15 @@ func TestOperationalReadersRequireHTTPSDashboardURL(t *testing.T) {
 	require.False(t, validDashboardURL(mustParseURL(t, "https://user@app.getgram.test")))
 }
 
+func TestRecentToolCallsRequirePostgres(t *testing.T) {
+	t.Parallel()
+
+	reader := NewPostgresReader(testenv.NewLogger(t), nil).
+		WithRecentToolCalls(&recordingRecentToolCallReader{}, mustParseURL(t, "https://app.getgram.test"))
+	_, err := reader.ListRecentToolCalls(t.Context(), Principal{OrganizationID: "organization"}, ListRecentToolCallsInput{ProjectSlug: "project"})
+	require.ErrorIs(t, err, ErrUnavailable)
+}
+
 func TestListDataExportsReturnsSafeStructuredConfiguration(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/platformmcp/operational_reads_integration_test.go
+++ b/server/internal/platformmcp/operational_reads_integration_test.go
@@ -1,0 +1,161 @@
+package platformmcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	dataexportsrepo "github.com/speakeasy-api/gram/server/internal/dataexports/repo"
+	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	parsed, err := url.Parse(raw)
+	require.NoError(t, err)
+	return parsed
+}
+
+func TestListDataExportsReturnsSafeStructuredConfiguration(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_data_exports")
+	require.NoError(t, err)
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	encryptionClient := testenv.NewEncryptionClient(t)
+
+	const secret = "Bearer test-secret-that-must-not-leave-storage"
+	ciphertext, err := encryptionClient.Encrypt([]byte(`{"Authorization":"` + secret + `","X-Empty":""}`))
+	require.NoError(t, err)
+	queries := dataexportsrepo.New(conn)
+	destination, err := queries.CreateOtelDestination(ctx, dataexportsrepo.CreateOtelDestinationParams{
+		OrganizationID:   principal.OrganizationID,
+		ProjectID:        project.ID,
+		Name:             "Primary collector",
+		EndpointUrl:      "https://otel.example.test/v1",
+		HeadersEncrypted: pgtype.Text{String: ciphertext, Valid: true},
+		SensitiveData:    pgtype.Text{String: "exclude", Valid: true},
+	})
+	require.NoError(t, err)
+	route, err := queries.CreateDataExportRoute(ctx, dataexportsrepo.CreateDataExportRouteParams{
+		OrganizationID:    principal.OrganizationID,
+		ProjectID:         project.ID,
+		DataSource:        "product_telemetry",
+		Enabled:           true,
+		OtelDestinationID: uuid.NullUUID{UUID: destination.ID, Valid: true},
+	})
+	require.NoError(t, err)
+
+	reader := NewPostgresReader(testenv.NewLogger(t), conn).
+		WithDataExports(encryptionClient, mustParseURL(t, "https://app.getgram.test"))
+	output, err := reader.ListDataExports(ctx, principal, ListDataExportsInput{ProjectID: project.ID.String()})
+	require.NoError(t, err)
+	require.False(t, output.Truncated)
+	require.Len(t, output.Destinations, 1)
+	require.Len(t, output.Routes, 1)
+	require.Equal(t, destination.ID.String(), output.Destinations[0].ID)
+	require.Equal(t, project.Slug, output.Destinations[0].ProjectSlug)
+	require.Equal(t, "https://otel.example.test/v1", output.Destinations[0].EndpointURL)
+	require.Equal(t, []DataExportHeader{{Name: "Authorization", HasValue: true}, {Name: "X-Empty", HasValue: false}}, output.Destinations[0].Headers)
+	require.Equal(t, route.ID.String(), output.Routes[0].ID)
+	require.Equal(t, destination.ID.String(), output.Routes[0].DestinationID)
+	require.True(t, output.Routes[0].Enabled)
+	require.True(t, strings.HasSuffix(output.ManagementURL, "/data/exports"))
+
+	encoded, err := json.Marshal(output)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), secret)
+}
+
+type recordingRecentToolCallReader struct {
+	params telemetryrepo.ListToolUsageTracesParams
+	rows   []telemetryrepo.ToolUsageTraceSummary
+	err    error
+}
+
+func (r *recordingRecentToolCallReader) ListToolUsageTraces(_ context.Context, params telemetryrepo.ListToolUsageTracesParams) ([]telemetryrepo.ToolUsageTraceSummary, error) {
+	r.params = params
+	return r.rows, r.err
+}
+
+func TestListRecentToolCallsUsesBoundedSafeSummaryProjection(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_recent_tool_calls")
+	require.NoError(t, err)
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	fixedNow := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	statusCode := int32(500)
+	client := "claude-code"
+	telemetry := &recordingRecentToolCallReader{rows: []telemetryrepo.ToolUsageTraceSummary{{
+		ID:                "summary-row",
+		TraceID:           "trace-id",
+		LogGroupKind:      "trace_id",
+		LogGroupValue:     "trace-id",
+		StartTimeUnixNano: fixedNow.Add(-time.Minute).UnixNano(),
+		LogCount:          2,
+		GramURN:           "tools:payments:refund",
+		ToolName:          "refund",
+		TargetType:        "hosted_mcp",
+		TargetKind:        "server",
+		TargetID:          "payments",
+		TargetLabel:       "Payments",
+		UserKey:           "private-user-key",
+		UserLabel:         "person@example.test",
+		UserKind:          "email",
+		HookSource:        &client,
+		EventSource:       "tool_call",
+		HTTPStatusCode:    &statusCode,
+		HookStatus:        nil,
+		BlockReason:       nil,
+		AccountType:       nil,
+	}}}
+	reader := NewPostgresReader(testenv.NewLogger(t), conn).
+		WithRecentToolCalls(telemetry, mustParseURL(t, "https://app.getgram.test"))
+	reader.recentToolCalls.now = func() time.Time { return fixedNow }
+
+	output, err := reader.ListRecentToolCalls(ctx, principal, ListRecentToolCallsInput{ProjectSlug: project.Slug})
+	require.NoError(t, err)
+	require.Equal(t, project.ID.String(), output.ProjectID)
+	require.Equal(t, DiagnosticWindowLastHour, output.Window.Window)
+	require.False(t, output.More)
+	require.Len(t, output.Calls, 1)
+	require.Equal(t, "error", output.Calls[0].Outcome)
+	require.Equal(t, "refund", output.Calls[0].ToolName)
+	require.Equal(t, "claude-code", output.Calls[0].Client)
+	require.True(t, strings.HasSuffix(output.ToolLogsURL, "/projects/"+project.Slug+"/logs"))
+
+	require.Equal(t, project.ID.String(), telemetry.params.GramProjectID)
+	require.Equal(t, fixedNow.Add(-time.Hour).UnixNano(), telemetry.params.TimeStart)
+	require.Equal(t, fixedNow.UnixNano(), telemetry.params.TimeEnd)
+	require.Equal(t, "desc", telemetry.params.SortOrder)
+	require.Equal(t, defaultRecentToolCallLimit+1, telemetry.params.Limit)
+	require.Empty(t, telemetry.params.Query)
+	require.Empty(t, telemetry.params.Filters)
+
+	encoded, err := json.Marshal(output)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), "private-user-key")
+	require.NotContains(t, string(encoded), "person@example.test")
+	require.NotContains(t, string(encoded), "trace-id")
+}
+
+func TestRecentToolCallTargetOmitsUnclassifiedShadowSource(t *testing.T) {
+	t.Parallel()
+
+	target := recentToolCallTarget(telemetryrepo.ToolUsageTraceSummary{
+		TargetType:  telemetryrepo.ToolUsageTargetTypeShadowMCP,
+		TargetLabel: "npx --yes package --token private",
+	})
+	require.Empty(t, target)
+}

--- a/server/internal/platformmcp/operational_reads_integration_test.go
+++ b/server/internal/platformmcp/operational_reads_integration_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	dataexportsrepo "github.com/speakeasy-api/gram/server/internal/dataexports/repo"
 	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -74,6 +76,118 @@ func TestListDataExportsReturnsSafeStructuredConfiguration(t *testing.T) {
 	encoded, err := json.Marshal(output)
 	require.NoError(t, err)
 	require.NotContains(t, string(encoded), secret)
+}
+
+func TestCreateDataExportRequiresExplicitConfirmation(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_create_export_confirmation")
+	require.NoError(t, err)
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	reader := NewPostgresReader(testenv.NewLogger(t), conn).
+		WithDataExportMutations(audit.NewLogger(), mustParseURL(t, "https://app.getgram.test"))
+
+	_, err = reader.CreateDataExport(ctx, principal, CreateDataExportInput{
+		ProjectID:     project.ID.String(),
+		Name:          "Confirmed collector",
+		EndpointURL:   "https://otel.example.test/v1",
+		DataSource:    "product_telemetry",
+		SensitiveData: "exclude",
+		Enabled:       nil,
+		Confirmed:     false,
+	})
+	require.ErrorIs(t, err, ErrDataExportConfirmationRequired)
+
+	queries := dataexportsrepo.New(conn)
+	destinations, err := queries.ListOtelDestinations(ctx, dataexportsrepo.ListOtelDestinationsParams{
+		OrganizationID: principal.OrganizationID,
+		ProjectID:      project.ID,
+	})
+	require.NoError(t, err)
+	routes, err := queries.ListDataExportRoutes(ctx, dataexportsrepo.ListDataExportRoutesParams{
+		OrganizationID: principal.OrganizationID,
+		ProjectID:      project.ID,
+	})
+	require.NoError(t, err)
+	require.Empty(t, destinations)
+	require.Empty(t, routes)
+}
+
+func TestCreateDataExportCommitsDestinationRouteAndAuditAtomically(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_create_export")
+	require.NoError(t, err)
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	reader := NewPostgresReader(testenv.NewLogger(t), conn).
+		WithDataExportMutations(audit.NewLogger(), mustParseURL(t, "https://app.getgram.test"))
+
+	destinationAuditBefore, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOtelDestinationCreate)
+	require.NoError(t, err)
+	routeAuditBefore, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionDataExportRouteCreate)
+	require.NoError(t, err)
+
+	enabled := false
+	output, err := reader.CreateDataExport(ctx, principal, CreateDataExportInput{
+		ProjectSlug:   project.Slug,
+		Name:          "  Platform MCP collector  ",
+		EndpointURL:   "https://otel.example.test/v1",
+		DataSource:    "risk_findings",
+		SensitiveData: "include",
+		Enabled:       &enabled,
+		Confirmed:     true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "Platform MCP collector", output.Destination.Name)
+	require.Equal(t, "https://otel.example.test/v1", output.Destination.EndpointURL)
+	require.Equal(t, "include", output.Destination.SensitiveData)
+	require.Empty(t, output.Destination.Headers)
+	require.Equal(t, output.Destination.ID, output.Route.DestinationID)
+	require.Equal(t, "risk_findings", output.Route.DataSource)
+	require.False(t, output.Route.Enabled)
+	require.True(t, strings.HasSuffix(output.ManagementURL, "/data/exports"))
+
+	queries := dataexportsrepo.New(conn)
+	destinations, err := queries.ListOtelDestinations(ctx, dataexportsrepo.ListOtelDestinationsParams{
+		OrganizationID: principal.OrganizationID,
+		ProjectID:      project.ID,
+	})
+	require.NoError(t, err)
+	require.Len(t, destinations, 1)
+	require.False(t, destinations[0].HeadersEncrypted.Valid)
+	routes, err := queries.ListDataExportRoutes(ctx, dataexportsrepo.ListDataExportRoutesParams{
+		OrganizationID: principal.OrganizationID,
+		ProjectID:      project.ID,
+	})
+	require.NoError(t, err)
+	require.Len(t, routes, 1)
+
+	destinationAuditAfter, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOtelDestinationCreate)
+	require.NoError(t, err)
+	require.Equal(t, destinationAuditBefore+1, destinationAuditAfter)
+	routeAuditAfter, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionDataExportRouteCreate)
+	require.NoError(t, err)
+	require.Equal(t, routeAuditBefore+1, routeAuditAfter)
+	destinationAudit, err := audittest.LatestAuditLogByAction(ctx, conn, audit.ActionOtelDestinationCreate)
+	require.NoError(t, err)
+	require.Equal(t, principal.UserID, destinationAudit.ActorID)
+
+	_, err = reader.CreateDataExport(ctx, principal, CreateDataExportInput{
+		ProjectID:   project.ID.String(),
+		Name:        "Duplicate route destination",
+		EndpointURL: "https://other.example.test/v1",
+		DataSource:  "risk_findings",
+		Confirmed:   true,
+	})
+	require.ErrorIs(t, err, ErrDataExportRouteConflict)
+	destinations, err = queries.ListOtelDestinations(ctx, dataexportsrepo.ListOtelDestinationsParams{
+		OrganizationID: principal.OrganizationID,
+		ProjectID:      project.ID,
+	})
+	require.NoError(t, err)
+	require.Len(t, destinations, 1, "the conflicting destination must roll back with its route")
 }
 
 type recordingRecentToolCallReader struct {

--- a/server/internal/platformmcp/operational_reads_integration_test.go
+++ b/server/internal/platformmcp/operational_reads_integration_test.go
@@ -3,6 +3,7 @@ package platformmcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/url"
 	"strings"
 	"testing"
@@ -10,11 +11,13 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	dataexportsrepo "github.com/speakeasy-api/gram/server/internal/dataexports/repo"
+	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
@@ -24,6 +27,14 @@ func mustParseURL(t *testing.T, raw string) *url.URL {
 	parsed, err := url.Parse(raw)
 	require.NoError(t, err)
 	return parsed
+}
+
+func TestOperationalReadersRequireHTTPSDashboardURL(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, validDashboardURL(mustParseURL(t, "https://app.getgram.test")))
+	require.False(t, validDashboardURL(mustParseURL(t, "http://localhost:5173")))
+	require.False(t, validDashboardURL(mustParseURL(t, "https://user@app.getgram.test")))
 }
 
 func TestListDataExportsReturnsSafeStructuredConfiguration(t *testing.T) {
@@ -76,6 +87,67 @@ func TestListDataExportsReturnsSafeStructuredConfiguration(t *testing.T) {
 	encoded, err := json.Marshal(output)
 	require.NoError(t, err)
 	require.NotContains(t, string(encoded), secret)
+}
+
+func TestListDataExportsBoundsReadsAndUsesJoinedProjectMetadata(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_bounded_data_exports")
+	require.NoError(t, err)
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	queries := dataexportsrepo.New(conn)
+	dataSources := []string{"product_telemetry", "risk_findings"}
+	names := []string{"First collector", "Second collector"}
+	endpoints := []string{"https://first.example.test/v1", "https://second.example.test/v1"}
+	for i, dataSource := range dataSources {
+		destination, createErr := queries.CreateOtelDestination(ctx, dataexportsrepo.CreateOtelDestinationParams{
+			OrganizationID:   principal.OrganizationID,
+			ProjectID:        project.ID,
+			Name:             names[i],
+			EndpointUrl:      endpoints[i],
+			HeadersEncrypted: pgtype.Text{},
+			SensitiveData:    pgtype.Text{String: "exclude", Valid: true},
+		})
+		require.NoError(t, createErr)
+		_, createErr = queries.CreateDataExportRoute(ctx, dataexportsrepo.CreateDataExportRouteParams{
+			OrganizationID:    principal.OrganizationID,
+			ProjectID:         project.ID,
+			DataSource:        dataSource,
+			Enabled:           true,
+			OtelDestinationID: uuid.NullUUID{UUID: destination.ID, Valid: true},
+		})
+		require.NoError(t, createErr)
+	}
+
+	destinationRows, err := queries.ListOtelDestinationsWithProjectMetadata(ctx, dataexportsrepo.ListOtelDestinationsWithProjectMetadataParams{
+		OrganizationID: principal.OrganizationID,
+		ProjectID:      uuid.NullUUID{},
+		ResultLimit:    1,
+	})
+	require.NoError(t, err)
+	require.Len(t, destinationRows, 1)
+	require.Equal(t, project.Name, destinationRows[0].ProjectName)
+	require.Equal(t, project.Slug, destinationRows[0].ProjectSlug)
+	routeRows, err := queries.ListDataExportRoutesWithProjectMetadata(ctx, dataexportsrepo.ListDataExportRoutesWithProjectMetadataParams{
+		OrganizationID: principal.OrganizationID,
+		ProjectID:      uuid.NullUUID{},
+		ResultLimit:    1,
+	})
+	require.NoError(t, err)
+	require.Len(t, routeRows, 1)
+	require.Equal(t, project.Name, routeRows[0].ProjectName)
+	require.Equal(t, project.Slug, routeRows[0].ProjectSlug)
+
+	reader := NewPostgresReader(testenv.NewLogger(t), conn).
+		WithDataExports(testenv.NewEncryptionClient(t), mustParseURL(t, "https://app.getgram.test"))
+	output, err := reader.ListDataExports(ctx, principal, ListDataExportsInput{Limit: 1})
+	require.NoError(t, err)
+	require.True(t, output.Truncated)
+	require.Len(t, output.Destinations, 1)
+	require.Len(t, output.Routes, 1)
+	require.Equal(t, project.Name, output.Destinations[0].ProjectName)
+	require.Equal(t, project.Slug, output.Routes[0].ProjectSlug)
 }
 
 func TestCreateDataExportRequiresExplicitConfirmation(t *testing.T) {
@@ -190,6 +262,64 @@ func TestCreateDataExportCommitsDestinationRouteAndAuditAtomically(t *testing.T)
 	require.Len(t, destinations, 1, "the conflicting destination must roll back with its route")
 }
 
+func TestCreateDataExportReturnsStructuredRecoverableRefusals(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_create_export_refusals")
+	require.NoError(t, err)
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	reader := NewPostgresReader(testenv.NewLogger(t), conn).
+		WithDataExportMutations(audit.NewLogger(), mustParseURL(t, "https://app.getgram.test"))
+
+	base := CreateDataExportInput{
+		ProjectID:     project.ID.String(),
+		Name:          "Collector",
+		EndpointURL:   "https://otel.example.test/v1",
+		DataSource:    "product_telemetry",
+		SensitiveData: "exclude",
+		Enabled:       nil,
+		Confirmed:     true,
+	}
+	invalidEndpoint := base
+	invalidEndpoint.EndpointURL = "https://otel.example.test/v1?token=secret"
+	_, err = reader.CreateDataExport(ctx, principal, invalidEndpoint)
+	require.ErrorIs(t, err, ErrDataExportInvalidInput)
+	require.Equal(t, "invalid_input", requireDataExportRefusal(t, err).Code)
+
+	invalidSource := base
+	invalidSource.DataSource = "unknown"
+	_, err = reader.CreateDataExport(ctx, principal, invalidSource)
+	require.ErrorIs(t, err, ErrDataExportInvalidInput)
+	require.Equal(t, "invalid_input", requireDataExportRefusal(t, err).Code)
+
+	missingProject := base
+	missingProject.ProjectID = ""
+	missingProject.ProjectSlug = "missing-project"
+	_, err = reader.CreateDataExport(ctx, principal, missingProject)
+	require.ErrorIs(t, err, ErrForbidden)
+	require.Equal(t, "project_not_found", requireDataExportRefusal(t, err).Code)
+
+	result, ok := dataExportMutationToolResult(errors.New("database unavailable"))
+	require.False(t, ok)
+	require.Nil(t, result)
+}
+
+func requireDataExportRefusal(t *testing.T, err error) dataExportMutationRefusal {
+	t.Helper()
+
+	result, ok := dataExportMutationToolResult(err)
+	require.True(t, ok)
+	require.NotNil(t, result)
+	require.True(t, result.IsError)
+	require.Len(t, result.Content, 1)
+	text, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	var refusal dataExportMutationRefusal
+	require.NoError(t, json.Unmarshal([]byte(text.Text), &refusal))
+	return refusal
+}
+
 type recordingRecentToolCallReader struct {
 	params telemetryrepo.ListToolUsageTracesParams
 	rows   []telemetryrepo.ToolUsageTraceSummary
@@ -208,6 +338,12 @@ func TestListRecentToolCallsUsesBoundedSafeSummaryProjection(t *testing.T) {
 	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_recent_tool_calls")
 	require.NoError(t, err)
 	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	servers, err := mcpserversrepo.New(conn).ListMCPServersForTelemetryByProjectID(ctx, project.ID)
+	require.NoError(t, err)
+	require.Len(t, servers, 1)
+	require.True(t, servers[0].RemoteMcpServerID.Valid)
+	require.True(t, servers[0].Name.Valid)
+	require.True(t, servers[0].Slug.Valid)
 	fixedNow := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
 	statusCode := int32(500)
 	client := "claude-code"
@@ -256,6 +392,13 @@ func TestListRecentToolCallsUsesBoundedSafeSummaryProjection(t *testing.T) {
 	require.Equal(t, defaultRecentToolCallLimit+1, telemetry.params.Limit)
 	require.Empty(t, telemetry.params.Query)
 	require.Empty(t, telemetry.params.Filters)
+	require.Empty(t, telemetry.params.HostedMCPMatchers)
+	require.Equal(t, []telemetryrepo.MCPServerMatcher{{
+		SourceID:    servers[0].RemoteMcpServerID.UUID.String(),
+		TargetType:  telemetryrepo.ToolUsageTargetTypeHostedMCP,
+		TargetID:    servers[0].Slug.String,
+		TargetLabel: servers[0].Name.String,
+	}}, telemetry.params.MCPServerMatchers)
 
 	encoded, err := json.Marshal(output)
 	require.NoError(t, err)

--- a/server/internal/platformmcp/tool_create_data_export.go
+++ b/server/internal/platformmcp/tool_create_data_export.go
@@ -25,6 +25,7 @@ import (
 
 var (
 	ErrDataExportConfirmationRequired = errors.New("data export creation requires confirmation")
+	ErrDataExportInvalidInput         = errors.New("invalid data export input")
 	ErrDataExportRouteConflict        = errors.New("a data export route already exists for this source")
 )
 
@@ -69,7 +70,12 @@ func (r *PostgresReader) CreateDataExport(ctx context.Context, principal Princip
 		return CreateDataExportOutput{}, ErrDataExportConfirmationRequired
 	}
 	if (input.ProjectID == "") == (input.ProjectSlug == "") {
-		return CreateDataExportOutput{}, fmt.Errorf("exactly one of project_id or project_slug is required")
+		return CreateDataExportOutput{}, fmt.Errorf("%w: exactly one of project_id or project_slug is required", ErrDataExportInvalidInput)
+	}
+	if input.ProjectID != "" {
+		if _, parseErr := uuid.Parse(input.ProjectID); parseErr != nil {
+			return CreateDataExportOutput{}, fmt.Errorf("%w: invalid project_id: %w", ErrDataExportInvalidInput, parseErr)
+		}
 	}
 	project, err := r.resolveInventoryProject(ctx, principal.OrganizationID, FindMCPInput{ProjectID: input.ProjectID, ProjectSlug: input.ProjectSlug})
 	if err != nil {
@@ -86,11 +92,11 @@ func (r *PostgresReader) CreateDataExport(ctx context.Context, principal Princip
 	}
 	configuration, err := dataexports.NormalizeDestinationConfiguration(input.Name, input.EndpointURL, sensitiveData)
 	if err != nil {
-		return CreateDataExportOutput{}, fmt.Errorf("validate data export destination: %w", err)
+		return CreateDataExportOutput{}, fmt.Errorf("%w: validate data export destination: %w", ErrDataExportInvalidInput, err)
 	}
-	dataSource := input.DataSource
-	if dataSource != dataexports.DataSourceProductTelemetry && dataSource != dataexports.DataSourceRiskFindings {
-		return CreateDataExportOutput{}, fmt.Errorf("data_source must be one of product_telemetry, risk_findings")
+	dataSource, err := dataexports.NormalizeDataSource(input.DataSource)
+	if err != nil {
+		return CreateDataExportOutput{}, fmt.Errorf("%w: validate data_source: %w", ErrDataExportInvalidInput, err)
 	}
 	enabled := true
 	if input.Enabled != nil {
@@ -222,6 +228,10 @@ func dataExportMutationToolResult(err error) (*mcp.CallToolResult, bool) {
 		refusal = dataExportMutationRefusal{Code: "confirmation_required", Message: "Show the exact project, endpoint, data source, enabled state, and sensitive-data policy, then ask the user to confirm before creating the export."}
 	case errors.Is(err, ErrDataExportRouteConflict):
 		refusal = dataExportMutationRefusal{Code: "conflict", Message: "This project already has an export route for that data source. Read the current exports and manage the existing route instead."}
+	case errors.Is(err, ErrDataExportInvalidInput):
+		refusal = dataExportMutationRefusal{Code: "invalid_input", Message: "Choose exactly one existing project, provide a valid HTTP or HTTPS endpoint without credentials, query parameters, or fragments, and use a supported data source and sensitive-data policy."}
+	case errors.Is(err, ErrForbidden):
+		refusal = dataExportMutationRefusal{Code: "project_not_found", Message: "No accessible project matched that project ID or slug. Read the project inventory and choose one of the returned projects."}
 	default:
 		return nil, false
 	}

--- a/server/internal/platformmcp/tool_create_data_export.go
+++ b/server/internal/platformmcp/tool_create_data_export.go
@@ -1,0 +1,233 @@
+//nolint:exhaustruct // MCP SDK manifests intentionally rely on documented zero-value optional fields.
+package platformmcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/dataexports"
+	dataexportsrepo "github.com/speakeasy-api/gram/server/internal/dataexports/repo"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+	organizationsrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+var (
+	ErrDataExportConfirmationRequired = errors.New("data export creation requires confirmation")
+	ErrDataExportRouteConflict        = errors.New("a data export route already exists for this source")
+)
+
+type dataExportMutationService struct {
+	db           *pgxpool.Pool
+	audit        *audit.Logger
+	dashboardURL *url.URL
+}
+
+// WithDataExportMutations enables creation after the read dependencies have
+// been configured. Secret headers remain dashboard-only.
+func (r *PostgresReader) WithDataExportMutations(auditLogger *audit.Logger, dashboardURL *url.URL) *PostgresReader {
+	if r != nil && r.db != nil && auditLogger != nil && validDashboardURL(dashboardURL) {
+		copyURL := *dashboardURL
+		r.dataExportMutations = &dataExportMutationService{db: r.db, audit: auditLogger, dashboardURL: &copyURL}
+	}
+	return r
+}
+
+type CreateDataExportInput struct {
+	ProjectID     string `json:"project_id,omitempty" jsonschema:"project ID that will export telemetry; supply exactly one project selector"`
+	ProjectSlug   string `json:"project_slug,omitempty" jsonschema:"project slug that will export telemetry; supply exactly one project selector"`
+	Name          string `json:"name" jsonschema:"display name for the OTEL destination"`
+	EndpointURL   string `json:"endpoint_url" jsonschema:"HTTP or HTTPS OTEL collector endpoint without credentials, query parameters, or fragments"`
+	DataSource    string `json:"data_source" jsonschema:"data to export: product_telemetry or risk_findings"`
+	SensitiveData string `json:"sensitive_data,omitempty" jsonschema:"whether sensitive fields are included: exclude (default) or include"`
+	Enabled       *bool  `json:"enabled,omitempty" jsonschema:"whether delivery starts immediately; defaults to true"`
+	Confirmed     bool   `json:"confirmed" jsonschema:"true only after the user explicitly confirms the project, endpoint, data source, enabled state, and sensitive-data policy"`
+}
+
+type CreateDataExportOutput struct {
+	Destination   DataExportDestination `json:"destination"`
+	Route         DataExportRoute       `json:"route"`
+	ManagementURL string                `json:"management_url"`
+}
+
+func (r *PostgresReader) CreateDataExport(ctx context.Context, principal Principal, input CreateDataExportInput) (CreateDataExportOutput, error) {
+	if r == nil || r.reader == nil || r.dataExportMutations == nil {
+		return CreateDataExportOutput{}, ErrUnavailable
+	}
+	if !input.Confirmed {
+		return CreateDataExportOutput{}, ErrDataExportConfirmationRequired
+	}
+	if (input.ProjectID == "") == (input.ProjectSlug == "") {
+		return CreateDataExportOutput{}, fmt.Errorf("exactly one of project_id or project_slug is required")
+	}
+	project, err := r.resolveInventoryProject(ctx, principal.OrganizationID, FindMCPInput{ProjectID: input.ProjectID, ProjectSlug: input.ProjectSlug})
+	if err != nil {
+		return CreateDataExportOutput{}, err
+	}
+	organization, err := organizationsrepo.New(r.dataExportMutations.db).GetOrganizationMetadata(ctx, principal.OrganizationID)
+	if err != nil {
+		return CreateDataExportOutput{}, fmt.Errorf("resolve data export organization: %w", err)
+	}
+
+	sensitiveData := input.SensitiveData
+	if sensitiveData == "" {
+		sensitiveData = "exclude"
+	}
+	configuration, err := dataexports.NormalizeDestinationConfiguration(input.Name, input.EndpointURL, sensitiveData)
+	if err != nil {
+		return CreateDataExportOutput{}, fmt.Errorf("validate data export destination: %w", err)
+	}
+	dataSource := input.DataSource
+	if dataSource != dataexports.DataSourceProductTelemetry && dataSource != dataexports.DataSourceRiskFindings {
+		return CreateDataExportOutput{}, fmt.Errorf("data_source must be one of product_telemetry, risk_findings")
+	}
+	enabled := true
+	if input.Enabled != nil {
+		enabled = *input.Enabled
+	}
+
+	tx, err := r.dataExportMutations.db.Begin(ctx)
+	if err != nil {
+		return CreateDataExportOutput{}, fmt.Errorf("begin data export creation: %w", err)
+	}
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
+	queries := dataexportsrepo.New(tx)
+	destination, err := queries.CreateOtelDestination(ctx, dataexportsrepo.CreateOtelDestinationParams{
+		OrganizationID:   principal.OrganizationID,
+		ProjectID:        project.ID,
+		Name:             configuration.Name,
+		EndpointUrl:      configuration.EndpointURL,
+		HeadersEncrypted: pgtype.Text{},
+		SensitiveData:    pgtype.Text{String: configuration.SensitiveData, Valid: true},
+	})
+	if err != nil {
+		return CreateDataExportOutput{}, fmt.Errorf("create data export destination: %w", err)
+	}
+	route, err := queries.CreateDataExportRoute(ctx, dataexportsrepo.CreateDataExportRouteParams{
+		OrganizationID:    principal.OrganizationID,
+		ProjectID:         project.ID,
+		DataSource:        dataSource,
+		Enabled:           enabled,
+		OtelDestinationID: uuid.NullUUID{UUID: destination.ID, Valid: true},
+	})
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation && pgErr.ConstraintName == "data_export_routes_project_source_key" {
+			return CreateDataExportOutput{}, ErrDataExportRouteConflict
+		}
+		return CreateDataExportOutput{}, fmt.Errorf("create data export route: %w", err)
+	}
+	actor := urn.NewPrincipal(urn.PrincipalTypeUser, principal.UserID)
+	if err := r.dataExportMutations.audit.LogOtelDestinationCreate(ctx, tx, audit.LogOtelDestinationCreateEvent{
+		OrganizationID:   principal.OrganizationID,
+		ProjectID:        project.ID,
+		Actor:            actor,
+		ActorDisplayName: nil,
+		ActorSlug:        nil,
+		DestinationURN:   urn.NewOtelDestination(destination.ID),
+		DestinationName:  destination.Name,
+	}); err != nil {
+		return CreateDataExportOutput{}, fmt.Errorf("audit data export destination creation: %w", err)
+	}
+	if err := r.dataExportMutations.audit.LogDataExportRouteCreate(ctx, tx, audit.LogDataExportRouteCreateEvent{
+		OrganizationID:   principal.OrganizationID,
+		ProjectID:        project.ID,
+		Actor:            actor,
+		ActorDisplayName: nil,
+		ActorSlug:        nil,
+		RouteURN:         urn.NewDataExportRoute(route.ID),
+		DataSource:       route.DataSource,
+	}); err != nil {
+		return CreateDataExportOutput{}, fmt.Errorf("audit data export route creation: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return CreateDataExportOutput{}, fmt.Errorf("commit data export creation: %w", err)
+	}
+
+	managementURL := r.dataExportMutations.dashboardURL.JoinPath(organization.Slug, "data", "exports").String()
+	return CreateDataExportOutput{
+		Destination: DataExportDestination{
+			ID:            destination.ID.String(),
+			ProjectID:     project.ID.String(),
+			ProjectName:   project.Name,
+			ProjectSlug:   project.Slug,
+			Name:          destination.Name,
+			Type:          "otel",
+			EndpointURL:   destination.EndpointUrl,
+			SensitiveData: configuration.SensitiveData,
+			Headers:       []DataExportHeader{},
+		},
+		Route: DataExportRoute{
+			ID:            route.ID.String(),
+			ProjectID:     project.ID.String(),
+			ProjectName:   project.Name,
+			ProjectSlug:   project.Slug,
+			DataSource:    route.DataSource,
+			Enabled:       route.Enabled,
+			DestinationID: destination.ID.String(),
+		},
+		ManagementURL: managementURL,
+	}, nil
+}
+
+type dataExportMutationRefusal struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func registerDataExportMutationTool(reg *Registrar, reader *PostgresReader) {
+	addTool(reg, &mcp.Tool{
+		Name:        "create_data_export",
+		Title:       "Create a Data Export",
+		Description: "Create one OTEL destination and connect one project's product telemetry or risk findings to it. Before calling, show the user the exact project, endpoint, data source, enabled state, and whether sensitive fields are included, then obtain explicit confirmation. Constraints: header secrets are never accepted in chat; the destination is created without headers and the returned management URL is where the user securely adds any required authentication. One route per project and data source is allowed.",
+	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input CreateDataExportInput) (*mcp.CallToolResult, CreateDataExportOutput, error) {
+		principal, err := principalFromToolContext(ctx)
+		if err != nil {
+			return nil, CreateDataExportOutput{}, err
+		}
+		output, err := reader.CreateDataExport(ctx, principal, input)
+		if err != nil {
+			if result, ok := dataExportMutationToolResult(err); ok {
+				return result, CreateDataExportOutput{}, nil
+			}
+			return nil, CreateDataExportOutput{}, err
+		}
+		return nil, output, nil
+	})
+}
+
+func registerUnavailableDataExportMutationTool(reg *Registrar) {
+	addTool(reg, &mcp.Tool{
+		Name:        "create_data_export",
+		Title:       "Create a Data Export",
+		Description: "Create an OTEL data export after explicit confirmation. This is not switched on for your organization yet.",
+	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, unavailableTool("data_export_mutations"))
+}
+
+func dataExportMutationToolResult(err error) (*mcp.CallToolResult, bool) {
+	var refusal dataExportMutationRefusal
+	switch {
+	case errors.Is(err, ErrDataExportConfirmationRequired):
+		refusal = dataExportMutationRefusal{Code: "confirmation_required", Message: "Show the exact project, endpoint, data source, enabled state, and sensitive-data policy, then ask the user to confirm before creating the export."}
+	case errors.Is(err, ErrDataExportRouteConflict):
+		refusal = dataExportMutationRefusal{Code: "conflict", Message: "This project already has an export route for that data source. Read the current exports and manage the existing route instead."}
+	default:
+		return nil, false
+	}
+	content, marshalErr := json.Marshal(refusal)
+	if marshalErr != nil {
+		return nil, false
+	}
+	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(content)}}, IsError: true}, true
+}

--- a/server/internal/platformmcp/tool_data_exports.go
+++ b/server/internal/platformmcp/tool_data_exports.go
@@ -1,0 +1,227 @@
+//nolint:exhaustruct // MCP SDK manifests intentionally rely on documented zero-value optional fields.
+package platformmcp
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/speakeasy-api/gram/server/internal/dataexports"
+	dataexportsrepo "github.com/speakeasy-api/gram/server/internal/dataexports/repo"
+	"github.com/speakeasy-api/gram/server/internal/encryption"
+	organizationsrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+)
+
+// DataExportReadService owns the dependencies needed to project data export
+// configuration without exposing stored header values.
+type DataExportReadService struct {
+	db           *pgxpool.Pool
+	encryption   *encryption.Client
+	dashboardURL *url.URL
+}
+
+func newDataExportReadService(db *pgxpool.Pool, encryptionClient *encryption.Client, dashboardURL *url.URL) *DataExportReadService {
+	if db == nil || encryptionClient == nil || !validDashboardURL(dashboardURL) {
+		return nil
+	}
+	copyURL := *dashboardURL
+	return &DataExportReadService{db: db, encryption: encryptionClient, dashboardURL: &copyURL}
+}
+
+func validDashboardURL(value *url.URL) bool {
+	return value != nil && (value.Scheme == "http" || value.Scheme == "https") && value.Host != "" && value.User == nil
+}
+
+// WithDataExports enables the safe data export inventory on this reader.
+func (r *PostgresReader) WithDataExports(encryptionClient *encryption.Client, dashboardURL *url.URL) *PostgresReader {
+	if r != nil {
+		r.dataExports = newDataExportReadService(r.db, encryptionClient, dashboardURL)
+	}
+	return r
+}
+
+type ListDataExportsInput struct {
+	ProjectID   string `json:"project_id,omitempty" jsonschema:"optional project ID; omit both project selectors to list the organization's exports"`
+	ProjectSlug string `json:"project_slug,omitempty" jsonschema:"optional project slug; omit both project selectors to list the organization's exports"`
+	Limit       int    `json:"limit,omitempty" jsonschema:"maximum number of destinations and routes to return in each collection; server clamps this to 100"`
+}
+
+type DataExportHeader struct {
+	Name     string `json:"name"`
+	HasValue bool   `json:"has_value"`
+}
+
+type DataExportDestination struct {
+	ID            string             `json:"id"`
+	ProjectID     string             `json:"project_id"`
+	ProjectName   string             `json:"project_name"`
+	ProjectSlug   string             `json:"project_slug"`
+	Name          string             `json:"name"`
+	Type          string             `json:"type"`
+	EndpointURL   string             `json:"endpoint_url"`
+	SensitiveData string             `json:"sensitive_data"`
+	Headers       []DataExportHeader `json:"headers"`
+}
+
+type DataExportRoute struct {
+	ID            string `json:"id"`
+	ProjectID     string `json:"project_id"`
+	ProjectName   string `json:"project_name"`
+	ProjectSlug   string `json:"project_slug"`
+	DataSource    string `json:"data_source"`
+	Enabled       bool   `json:"enabled"`
+	DestinationID string `json:"destination_id,omitempty"`
+}
+
+type ListDataExportsOutput struct {
+	Destinations  []DataExportDestination `json:"destinations"`
+	Routes        []DataExportRoute       `json:"routes"`
+	ManagementURL string                  `json:"management_url"`
+	Truncated     bool                    `json:"truncated"`
+}
+
+func (r *PostgresReader) ListDataExports(ctx context.Context, principal Principal, input ListDataExportsInput) (ListDataExportsOutput, error) {
+	if r == nil || r.reader == nil || r.dataExports == nil {
+		return ListDataExportsOutput{}, ErrUnavailable
+	}
+	if input.ProjectID != "" && input.ProjectSlug != "" {
+		return ListDataExportsOutput{}, fmt.Errorf("only one of project_id or project_slug may be supplied")
+	}
+
+	projects, selectedProject, err := r.dataExportProjects(ctx, principal, input)
+	if err != nil {
+		return ListDataExportsOutput{}, err
+	}
+
+	query := dataexportsrepo.New(r.dataExports.db)
+	var destinations []dataexportsrepo.OtelDestination
+	var routes []dataexportsrepo.DataExportRoute
+	if selectedProject != nil {
+		destinations, err = query.ListOtelDestinations(ctx, dataexportsrepo.ListOtelDestinationsParams{
+			OrganizationID: principal.OrganizationID,
+			ProjectID:      selectedProject.ID,
+		})
+		if err == nil {
+			routes, err = query.ListDataExportRoutes(ctx, dataexportsrepo.ListDataExportRoutesParams{
+				OrganizationID: principal.OrganizationID,
+				ProjectID:      selectedProject.ID,
+			})
+		}
+	} else {
+		destinations, err = query.ListOtelDestinationsByOrganizationID(ctx, principal.OrganizationID)
+		if err == nil {
+			routes, err = query.ListDataExportRoutesByOrganizationID(ctx, principal.OrganizationID)
+		}
+	}
+	if err != nil {
+		return ListDataExportsOutput{}, fmt.Errorf("list platform data exports: %w", err)
+	}
+
+	limit := boundedLimit(input.Limit)
+	destinations, destinationsTruncated := boundedRows(destinations, limit)
+	routes, routesTruncated := boundedRows(routes, limit)
+	output := ListDataExportsOutput{
+		Destinations:  make([]DataExportDestination, 0, len(destinations)),
+		Routes:        make([]DataExportRoute, 0, len(routes)),
+		ManagementURL: r.dataExports.dashboardURL.JoinPath(projects.organizationSlug, "data", "exports").String(),
+		Truncated:     destinationsTruncated || routesTruncated,
+	}
+	for _, row := range destinations {
+		project := projects.byID[row.ProjectID]
+		headers, decodeErr := dataexports.DecodeDestinationHeaderMetadata(r.dataExports.encryption, row.HeadersEncrypted)
+		if decodeErr != nil {
+			return ListDataExportsOutput{}, fmt.Errorf("decode data export destination headers: %w", decodeErr)
+		}
+		policy, policyErr := dataexports.DestinationSensitiveDataPolicy(row.SensitiveData)
+		if policyErr != nil {
+			return ListDataExportsOutput{}, fmt.Errorf("decode data export sensitive-data policy: %w", policyErr)
+		}
+		headerOutput := make([]DataExportHeader, 0, len(headers))
+		for _, header := range headers {
+			headerOutput = append(headerOutput, DataExportHeader{Name: header.Name, HasValue: header.HasValue})
+		}
+		output.Destinations = append(output.Destinations, DataExportDestination{
+			ID:            row.ID.String(),
+			ProjectID:     row.ProjectID.String(),
+			ProjectName:   project.Name,
+			ProjectSlug:   project.Slug,
+			Name:          row.Name,
+			Type:          "otel",
+			EndpointURL:   row.EndpointUrl,
+			SensitiveData: policy,
+			Headers:       headerOutput,
+		})
+	}
+	for _, row := range routes {
+		project := projects.byID[row.ProjectID]
+		output.Routes = append(output.Routes, DataExportRoute{
+			ID:            row.ID.String(),
+			ProjectID:     row.ProjectID.String(),
+			ProjectName:   project.Name,
+			ProjectSlug:   project.Slug,
+			DataSource:    row.DataSource,
+			Enabled:       row.Enabled,
+			DestinationID: uuidString(row.OtelDestinationID),
+		})
+	}
+	return output, nil
+}
+
+type dataExportProjects struct {
+	organizationSlug string
+	byID             map[uuid.UUID]Project
+}
+
+func (r *PostgresReader) dataExportProjects(ctx context.Context, principal Principal, input ListDataExportsInput) (dataExportProjects, *ResolvedProject, error) {
+	organization, err := organizationsrepo.New(r.dataExports.db).GetOrganizationMetadata(ctx, principal.OrganizationID)
+	if err != nil {
+		return dataExportProjects{}, nil, fmt.Errorf("resolve data export organization: %w", err)
+	}
+	result := dataExportProjects{organizationSlug: organization.Slug, byID: map[uuid.UUID]Project{}}
+	if input.ProjectID != "" || input.ProjectSlug != "" {
+		selected, resolveErr := r.resolveInventoryProject(ctx, principal.OrganizationID, FindMCPInput{ProjectID: input.ProjectID, ProjectSlug: input.ProjectSlug})
+		if resolveErr != nil {
+			return dataExportProjects{}, nil, resolveErr
+		}
+		result.byID[selected.ID] = Project{ID: selected.ID.String(), Name: selected.Name, Slug: selected.Slug}
+		return result, &selected, nil
+	}
+
+	rows, err := r.reader.ListProjects(ctx, principal.OrganizationID)
+	if err != nil {
+		return dataExportProjects{}, nil, fmt.Errorf("list data export projects: %w", err)
+	}
+	for _, row := range rows {
+		result.byID[row.ID] = Project{ID: row.ID.String(), Name: row.Name, Slug: row.Slug}
+	}
+	return result, nil, nil
+}
+
+func registerDataExportTools(reg *Registrar, reader *PostgresReader) {
+	addTool(reg, &mcp.Tool{
+		Name:        "list_data_exports",
+		Title:       "List Data Exports",
+		Description: "List the organization's configured OpenTelemetry data exports, optionally narrowed to one project. Returns destinations, routes, enabled state, endpoint URLs, the sensitive-data policy, and only header names plus whether each has a value; secret header values are never returned. The structured route-to-destination relationships can be rendered as a Mermaid diagram. The management URL opens the dashboard where exports can be changed.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input ListDataExportsInput) (*mcp.CallToolResult, ListDataExportsOutput, error) {
+		principal, err := principalFromToolContext(ctx)
+		if err != nil {
+			return nil, ListDataExportsOutput{}, err
+		}
+		output, err := reader.ListDataExports(ctx, principal, input)
+		return nil, output, err
+	})
+}
+
+func registerUnavailableDataExportTools(reg *Registrar) {
+	addTool(reg, &mcp.Tool{
+		Name:        "list_data_exports",
+		Title:       "List Data Exports",
+		Description: "List configured OpenTelemetry data exports and the route-to-destination relationships. This is not switched on for your organization yet.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, unavailableTool("data_exports"))
+}

--- a/server/internal/platformmcp/tool_data_exports.go
+++ b/server/internal/platformmcp/tool_data_exports.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/dataexports"
 	dataexportsrepo "github.com/speakeasy-api/gram/server/internal/dataexports/repo"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
@@ -110,7 +111,7 @@ func (r *PostgresReader) ListDataExports(ctx context.Context, principal Principa
 	destinations, err := query.ListOtelDestinationsWithProjectMetadata(ctx, dataexportsrepo.ListOtelDestinationsWithProjectMetadataParams{
 		OrganizationID: principal.OrganizationID,
 		ProjectID:      projectID,
-		ResultLimit:    int32(limit + 1),
+		ResultLimit:    conv.SafeInt32(limit + 1),
 	})
 	if err != nil {
 		return ListDataExportsOutput{}, fmt.Errorf("list platform data export destinations: %w", err)
@@ -118,7 +119,7 @@ func (r *PostgresReader) ListDataExports(ctx context.Context, principal Principa
 	routes, err := query.ListDataExportRoutesWithProjectMetadata(ctx, dataexportsrepo.ListDataExportRoutesWithProjectMetadataParams{
 		OrganizationID: principal.OrganizationID,
 		ProjectID:      projectID,
-		ResultLimit:    int32(limit + 1),
+		ResultLimit:    conv.SafeInt32(limit + 1),
 	})
 	if err != nil {
 		return ListDataExportsOutput{}, fmt.Errorf("list platform data export routes: %w", err)

--- a/server/internal/platformmcp/tool_data_exports.go
+++ b/server/internal/platformmcp/tool_data_exports.go
@@ -33,7 +33,7 @@ func newDataExportReadService(db *pgxpool.Pool, encryptionClient *encryption.Cli
 }
 
 func validDashboardURL(value *url.URL) bool {
-	return value != nil && (value.Scheme == "http" || value.Scheme == "https") && value.Host != "" && value.User == nil
+	return value != nil && value.Scheme == "https" && value.Host != "" && value.User == nil
 }
 
 // WithDataExports enables the safe data export inventory on this reader.
@@ -92,46 +92,47 @@ func (r *PostgresReader) ListDataExports(ctx context.Context, principal Principa
 		return ListDataExportsOutput{}, fmt.Errorf("only one of project_id or project_slug may be supplied")
 	}
 
-	projects, selectedProject, err := r.dataExportProjects(ctx, principal, input)
+	organization, err := organizationsrepo.New(r.dataExports.db).GetOrganizationMetadata(ctx, principal.OrganizationID)
 	if err != nil {
-		return ListDataExportsOutput{}, err
+		return ListDataExportsOutput{}, fmt.Errorf("resolve data export organization: %w", err)
 	}
-
-	query := dataexportsrepo.New(r.dataExports.db)
-	var destinations []dataexportsrepo.OtelDestination
-	var routes []dataexportsrepo.DataExportRoute
-	if selectedProject != nil {
-		destinations, err = query.ListOtelDestinations(ctx, dataexportsrepo.ListOtelDestinationsParams{
-			OrganizationID: principal.OrganizationID,
-			ProjectID:      selectedProject.ID,
-		})
-		if err == nil {
-			routes, err = query.ListDataExportRoutes(ctx, dataexportsrepo.ListDataExportRoutesParams{
-				OrganizationID: principal.OrganizationID,
-				ProjectID:      selectedProject.ID,
-			})
+	projectID := uuid.NullUUID{}
+	if input.ProjectID != "" || input.ProjectSlug != "" {
+		selectedProject, resolveErr := r.resolveInventoryProject(ctx, principal.OrganizationID, FindMCPInput{ProjectID: input.ProjectID, ProjectSlug: input.ProjectSlug})
+		if resolveErr != nil {
+			return ListDataExportsOutput{}, resolveErr
 		}
-	} else {
-		destinations, err = query.ListOtelDestinationsByOrganizationID(ctx, principal.OrganizationID)
-		if err == nil {
-			routes, err = query.ListDataExportRoutesByOrganizationID(ctx, principal.OrganizationID)
-		}
-	}
-	if err != nil {
-		return ListDataExportsOutput{}, fmt.Errorf("list platform data exports: %w", err)
+		projectID = uuid.NullUUID{UUID: selectedProject.ID, Valid: true}
 	}
 
 	limit := boundedLimit(input.Limit)
+	query := dataexportsrepo.New(r.dataExports.db)
+	destinations, err := query.ListOtelDestinationsWithProjectMetadata(ctx, dataexportsrepo.ListOtelDestinationsWithProjectMetadataParams{
+		OrganizationID: principal.OrganizationID,
+		ProjectID:      projectID,
+		ResultLimit:    int32(limit + 1),
+	})
+	if err != nil {
+		return ListDataExportsOutput{}, fmt.Errorf("list platform data export destinations: %w", err)
+	}
+	routes, err := query.ListDataExportRoutesWithProjectMetadata(ctx, dataexportsrepo.ListDataExportRoutesWithProjectMetadataParams{
+		OrganizationID: principal.OrganizationID,
+		ProjectID:      projectID,
+		ResultLimit:    int32(limit + 1),
+	})
+	if err != nil {
+		return ListDataExportsOutput{}, fmt.Errorf("list platform data export routes: %w", err)
+	}
+
 	destinations, destinationsTruncated := boundedRows(destinations, limit)
 	routes, routesTruncated := boundedRows(routes, limit)
 	output := ListDataExportsOutput{
 		Destinations:  make([]DataExportDestination, 0, len(destinations)),
 		Routes:        make([]DataExportRoute, 0, len(routes)),
-		ManagementURL: r.dataExports.dashboardURL.JoinPath(projects.organizationSlug, "data", "exports").String(),
+		ManagementURL: r.dataExports.dashboardURL.JoinPath(organization.Slug, "data", "exports").String(),
 		Truncated:     destinationsTruncated || routesTruncated,
 	}
 	for _, row := range destinations {
-		project := projects.byID[row.ProjectID]
 		headers, decodeErr := dataexports.DecodeDestinationHeaderMetadata(r.dataExports.encryption, row.HeadersEncrypted)
 		if decodeErr != nil {
 			return ListDataExportsOutput{}, fmt.Errorf("decode data export destination headers: %w", decodeErr)
@@ -147,8 +148,8 @@ func (r *PostgresReader) ListDataExports(ctx context.Context, principal Principa
 		output.Destinations = append(output.Destinations, DataExportDestination{
 			ID:            row.ID.String(),
 			ProjectID:     row.ProjectID.String(),
-			ProjectName:   project.Name,
-			ProjectSlug:   project.Slug,
+			ProjectName:   row.ProjectName,
+			ProjectSlug:   row.ProjectSlug,
 			Name:          row.Name,
 			Type:          "otel",
 			EndpointURL:   row.EndpointUrl,
@@ -157,48 +158,17 @@ func (r *PostgresReader) ListDataExports(ctx context.Context, principal Principa
 		})
 	}
 	for _, row := range routes {
-		project := projects.byID[row.ProjectID]
 		output.Routes = append(output.Routes, DataExportRoute{
 			ID:            row.ID.String(),
 			ProjectID:     row.ProjectID.String(),
-			ProjectName:   project.Name,
-			ProjectSlug:   project.Slug,
+			ProjectName:   row.ProjectName,
+			ProjectSlug:   row.ProjectSlug,
 			DataSource:    row.DataSource,
 			Enabled:       row.Enabled,
 			DestinationID: uuidString(row.OtelDestinationID),
 		})
 	}
 	return output, nil
-}
-
-type dataExportProjects struct {
-	organizationSlug string
-	byID             map[uuid.UUID]Project
-}
-
-func (r *PostgresReader) dataExportProjects(ctx context.Context, principal Principal, input ListDataExportsInput) (dataExportProjects, *ResolvedProject, error) {
-	organization, err := organizationsrepo.New(r.dataExports.db).GetOrganizationMetadata(ctx, principal.OrganizationID)
-	if err != nil {
-		return dataExportProjects{}, nil, fmt.Errorf("resolve data export organization: %w", err)
-	}
-	result := dataExportProjects{organizationSlug: organization.Slug, byID: map[uuid.UUID]Project{}}
-	if input.ProjectID != "" || input.ProjectSlug != "" {
-		selected, resolveErr := r.resolveInventoryProject(ctx, principal.OrganizationID, FindMCPInput{ProjectID: input.ProjectID, ProjectSlug: input.ProjectSlug})
-		if resolveErr != nil {
-			return dataExportProjects{}, nil, resolveErr
-		}
-		result.byID[selected.ID] = Project{ID: selected.ID.String(), Name: selected.Name, Slug: selected.Slug}
-		return result, &selected, nil
-	}
-
-	rows, err := r.reader.ListProjects(ctx, principal.OrganizationID)
-	if err != nil {
-		return dataExportProjects{}, nil, fmt.Errorf("list data export projects: %w", err)
-	}
-	for _, row := range rows {
-		result.byID[row.ID] = Project{ID: row.ID.String(), Name: row.Name, Slug: row.Slug}
-	}
-	return result, nil, nil
 }
 
 func registerDataExportTools(reg *Registrar, reader *PostgresReader) {

--- a/server/internal/platformmcp/tool_recent_tool_calls.go
+++ b/server/internal/platformmcp/tool_recent_tool_calls.go
@@ -11,6 +11,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	organizationsrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	telemetrysvc "github.com/speakeasy-api/gram/server/internal/telemetry"
 	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 )
 
@@ -100,12 +101,17 @@ func (r *PostgresReader) ListRecentToolCalls(ctx context.Context, principal Prin
 		statuses = []string{outcome}
 	}
 
+	hostedMCPMatchers, mcpServerMatchers, err := telemetrysvc.LoadToolUsageMatchers(ctx, r.db, project.ID)
+	if err != nil {
+		return ListRecentToolCallsOutput{}, fmt.Errorf("load recent tool call matchers: %w", err)
+	}
+
 	rows, err := r.recentToolCalls.telemetry.ListToolUsageTraces(ctx, telemetryrepo.ListToolUsageTracesParams{
 		GramProjectID:      project.ID.String(),
 		TimeStart:          window.start.UnixNano(),
 		TimeEnd:            window.end.UnixNano(),
-		HostedMCPMatchers:  nil,
-		MCPServerMatchers:  nil,
+		HostedMCPMatchers:  hostedMCPMatchers,
+		MCPServerMatchers:  mcpServerMatchers,
 		TargetTypes:        nil,
 		HostedToolsetSlugs: nil,
 		ShadowServerNames:  nil,

--- a/server/internal/platformmcp/tool_recent_tool_calls.go
+++ b/server/internal/platformmcp/tool_recent_tool_calls.go
@@ -35,7 +35,7 @@ type RecentToolCallReadService struct {
 
 // WithRecentToolCalls enables recent project-scoped Tool Logs summaries.
 func (r *PostgresReader) WithRecentToolCalls(telemetry RecentToolCallReader, dashboardURL *url.URL) *PostgresReader {
-	if r != nil && telemetry != nil && validDashboardURL(dashboardURL) {
+	if r != nil && r.db != nil && telemetry != nil && validDashboardURL(dashboardURL) {
 		copyURL := *dashboardURL
 		r.recentToolCalls = &RecentToolCallReadService{telemetry: telemetry, dashboardURL: &copyURL, now: time.Now}
 	}

--- a/server/internal/platformmcp/tool_recent_tool_calls.go
+++ b/server/internal/platformmcp/tool_recent_tool_calls.go
@@ -1,0 +1,219 @@
+//nolint:exhaustruct // MCP SDK manifests intentionally rely on documented zero-value optional fields.
+package platformmcp
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	organizationsrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
+)
+
+const (
+	defaultRecentToolCallLimit = 10
+	maxRecentToolCallLimit     = 50
+)
+
+// RecentToolCallReader is the bounded Tool Logs summary read used by Platform
+// MCP. It intentionally cannot read raw log bodies or attributes.
+type RecentToolCallReader interface {
+	ListToolUsageTraces(ctx context.Context, arg telemetryrepo.ListToolUsageTracesParams) ([]telemetryrepo.ToolUsageTraceSummary, error)
+}
+
+// RecentToolCallReadService owns the summary reader and trusted dashboard URL.
+type RecentToolCallReadService struct {
+	telemetry    RecentToolCallReader
+	dashboardURL *url.URL
+	now          func() time.Time
+}
+
+// WithRecentToolCalls enables recent project-scoped Tool Logs summaries.
+func (r *PostgresReader) WithRecentToolCalls(telemetry RecentToolCallReader, dashboardURL *url.URL) *PostgresReader {
+	if r != nil && telemetry != nil && validDashboardURL(dashboardURL) {
+		copyURL := *dashboardURL
+		r.recentToolCalls = &RecentToolCallReadService{telemetry: telemetry, dashboardURL: &copyURL, now: time.Now}
+	}
+	return r
+}
+
+type ListRecentToolCallsInput struct {
+	ProjectID   string `json:"project_id,omitempty" jsonschema:"project ID to inspect; supply exactly one project selector"`
+	ProjectSlug string `json:"project_slug,omitempty" jsonschema:"project slug to inspect; supply exactly one project selector"`
+	Window      string `json:"window,omitempty" jsonschema:"observation window: 1h (default) or 24h"`
+	Outcome     string `json:"outcome,omitempty" jsonschema:"optional outcome filter: success, error, blocked, or pending"`
+	Limit       int    `json:"limit,omitempty" jsonschema:"maximum calls to return; defaults to 10 and is capped at 50"`
+}
+
+type RecentToolCall struct {
+	OccurredAt string `json:"occurred_at"`
+	ToolName   string `json:"tool_name,omitempty"`
+	TargetType string `json:"target_type"`
+	TargetKind string `json:"target_kind"`
+	Target     string `json:"target,omitempty"`
+	Outcome    string `json:"outcome"`
+	Client     string `json:"client,omitempty"`
+}
+
+type ListRecentToolCallsOutput struct {
+	ProjectID   string           `json:"project_id"`
+	ProjectName string           `json:"project_name"`
+	ProjectSlug string           `json:"project_slug"`
+	Window      ResolvedWindow   `json:"window"`
+	Calls       []RecentToolCall `json:"calls"`
+	More        bool             `json:"more"`
+	ToolLogsURL string           `json:"tool_logs_url"`
+}
+
+func (r *PostgresReader) ListRecentToolCalls(ctx context.Context, principal Principal, input ListRecentToolCallsInput) (ListRecentToolCallsOutput, error) {
+	if r == nil || r.reader == nil || r.recentToolCalls == nil || r.recentToolCalls.telemetry == nil || r.recentToolCalls.now == nil {
+		return ListRecentToolCallsOutput{}, ErrUnavailable
+	}
+	if (input.ProjectID == "") == (input.ProjectSlug == "") {
+		return ListRecentToolCallsOutput{}, fmt.Errorf("exactly one of project_id or project_slug is required")
+	}
+	outcome := strings.ToLower(strings.TrimSpace(input.Outcome))
+	if outcome != "" && !validRecentToolCallOutcome(outcome) {
+		return ListRecentToolCallsOutput{}, fmt.Errorf("outcome must be one of success, error, blocked, pending")
+	}
+
+	project, err := r.resolveInventoryProject(ctx, principal.OrganizationID, FindMCPInput{ProjectID: input.ProjectID, ProjectSlug: input.ProjectSlug})
+	if err != nil {
+		return ListRecentToolCallsOutput{}, err
+	}
+	now := r.recentToolCalls.now().UTC()
+	window, err := resolveWindow(input.Window, now, windowSpec{Fallback: DiagnosticWindowLastHour, Max: DiagnosticWindowLastDay})
+	if err != nil {
+		return ListRecentToolCallsOutput{}, err
+	}
+	limit := input.Limit
+	if limit <= 0 {
+		limit = defaultRecentToolCallLimit
+	}
+	limit = min(limit, maxRecentToolCallLimit)
+	statuses := []string(nil)
+	if outcome != "" {
+		statuses = []string{outcome}
+	}
+
+	rows, err := r.recentToolCalls.telemetry.ListToolUsageTraces(ctx, telemetryrepo.ListToolUsageTracesParams{
+		GramProjectID:      project.ID.String(),
+		TimeStart:          window.start.UnixNano(),
+		TimeEnd:            window.end.UnixNano(),
+		HostedMCPMatchers:  nil,
+		MCPServerMatchers:  nil,
+		TargetTypes:        nil,
+		HostedToolsetSlugs: nil,
+		ShadowServerNames:  nil,
+		UserFilters:        nil,
+		HookSources:        nil,
+		AccountType:        "",
+		Statuses:           statuses,
+		Query:              "",
+		Filters:            nil,
+		SortOrder:          "desc",
+		CursorTimeUnixNano: 0,
+		CursorID:           "",
+		Limit:              limit + 1,
+	})
+	if err != nil {
+		return ListRecentToolCallsOutput{}, fmt.Errorf("list recent tool calls: %w", err)
+	}
+	rows, more := boundedRows(rows, limit)
+	calls := make([]RecentToolCall, 0, len(rows))
+	for _, row := range rows {
+		calls = append(calls, RecentToolCall{
+			OccurredAt: time.Unix(0, row.StartTimeUnixNano).UTC().Format(time.RFC3339Nano),
+			ToolName:   row.ToolName,
+			TargetType: row.TargetType,
+			TargetKind: row.TargetKind,
+			Target:     recentToolCallTarget(row),
+			Outcome:    recentToolCallOutcome(row),
+			Client:     dereferenceString(row.HookSource),
+		})
+	}
+	organization, err := organizationsrepo.New(r.db).GetOrganizationMetadata(ctx, principal.OrganizationID)
+	if err != nil {
+		return ListRecentToolCallsOutput{}, fmt.Errorf("resolve recent tool calls organization: %w", err)
+	}
+	return ListRecentToolCallsOutput{
+		ProjectID:   project.ID.String(),
+		ProjectName: project.Name,
+		ProjectSlug: project.Slug,
+		Window:      window,
+		Calls:       calls,
+		More:        more,
+		ToolLogsURL: r.recentToolCalls.dashboardURL.JoinPath(organization.Slug, "projects", project.Slug, "logs").String(),
+	}, nil
+}
+
+func validRecentToolCallOutcome(outcome string) bool {
+	switch outcome {
+	case "success", "error", "blocked", "pending":
+		return true
+	default:
+		return false
+	}
+}
+
+func recentToolCallOutcome(row telemetryrepo.ToolUsageTraceSummary) string {
+	if row.HookStatus != nil {
+		if *row.HookStatus == "failure" {
+			return "error"
+		}
+		return *row.HookStatus
+	}
+	if row.HTTPStatusCode == nil {
+		return "unknown"
+	}
+	if *row.HTTPStatusCode >= 400 {
+		return "error"
+	}
+	if *row.HTTPStatusCode >= 200 {
+		return "success"
+	}
+	return "unknown"
+}
+
+func recentToolCallTarget(row telemetryrepo.ToolUsageTraceSummary) string {
+	if row.TargetType == telemetryrepo.ToolUsageTargetTypeShadowMCP {
+		return ""
+	}
+	return row.TargetLabel
+}
+
+func dereferenceString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func registerRecentToolCallTools(reg *Registrar, reader *PostgresReader) {
+	addTool(reg, &mcp.Tool{
+		Name:        "list_recent_tool_calls",
+		Title:       "List Recent Tool Calls",
+		Description: "List the newest Tool Logs summaries for one project, defaulting to 10 calls from the last hour. Each call is reduced to when it happened, the tool and target, how it ended, and the calling app when known. Constraints: this uses the bounded Tool Logs summary path and never returns arguments, results, bodies, headers, URLs, attributes, or user identities. The returned dashboard link opens the full Tool Logs page.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input ListRecentToolCallsInput) (*mcp.CallToolResult, ListRecentToolCallsOutput, error) {
+		principal, err := principalFromToolContext(ctx)
+		if err != nil {
+			return nil, ListRecentToolCallsOutput{}, err
+		}
+		output, err := reader.ListRecentToolCalls(ctx, principal, input)
+		return nil, output, err
+	})
+}
+
+func registerUnavailableRecentToolCallTools(reg *Registrar) {
+	addTool(reg, &mcp.Tool{
+		Name:        "list_recent_tool_calls",
+		Title:       "List Recent Tool Calls",
+		Description: "List recent Tool Logs summaries for one project. This is not switched on for your organization yet.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeExplicit}, unavailableTool("recent_tool_calls"))
+}

--- a/server/internal/platformmcp/tools.go
+++ b/server/internal/platformmcp/tools.go
@@ -172,6 +172,7 @@ func newServerWithRiskMutations(reader Reader, catalog Catalog, registrations *R
 			"Never request or accept OAuth codes, tokens, client secrets, passwords, API keys, or secret headers in chat. The registration dashboard_setup_url is the Authentication settings fallback, not the authorization page. Force a fresh readiness check after user authorization.",
 			"Setup also decides which MCP clients may sign in to the new server: read get_mcp_client_admission, explain in plain words which apps that lets in, and only change it with set_mcp_client_admission after the user explicitly confirms.",
 			"Registration never distributes an MCP: use list_plugins to show the project's plugins, ask the user which one should carry it, then call distribute_mcp_to_plugin naming that plugin exactly. There is no implicit default.",
+			"Creating a data export is a mutation: first show the exact project, endpoint, data source, enabled state, and sensitive-data policy, then ask for explicit confirmation. Never request or accept authorization header values in chat; create the export without headers and send the user to the returned management URL to add authentication securely.",
 		}, "\n\n"),
 		PageSize: 32,
 	})
@@ -186,6 +187,11 @@ func newServerWithRiskMutations(reader Reader, catalog Catalog, registrations *R
 		} else {
 			registerDataExportTools(reg, postgresReader)
 		}
+		if postgresReader.dataExportMutations == nil {
+			registerUnavailableDataExportMutationTool(reg)
+		} else {
+			registerDataExportMutationTool(reg, postgresReader)
+		}
 		if postgresReader.recentToolCalls == nil {
 			registerUnavailableRecentToolCallTools(reg)
 		} else {
@@ -194,6 +200,7 @@ func newServerWithRiskMutations(reader Reader, catalog Catalog, registrations *R
 	} else {
 		registerUnavailableRiskToolsWithMutations(reg, riskMutations)
 		registerUnavailableDataExportTools(reg)
+		registerUnavailableDataExportMutationTool(reg)
 		registerUnavailableRecentToolCallTools(reg)
 	}
 	registerSetupResources(reg, setupResources, time.Now)

--- a/server/internal/platformmcp/tools.go
+++ b/server/internal/platformmcp/tools.go
@@ -181,8 +181,20 @@ func newServerWithRiskMutations(reader Reader, catalog Catalog, registrations *R
 	registerReadTools(reg, reader, cursorKeyMaterial)
 	if postgresReader, ok := reader.(*PostgresReader); ok {
 		registerRiskToolsWithMutations(reg, postgresReader.riskReads, riskMutations)
+		if postgresReader.dataExports == nil {
+			registerUnavailableDataExportTools(reg)
+		} else {
+			registerDataExportTools(reg, postgresReader)
+		}
+		if postgresReader.recentToolCalls == nil {
+			registerUnavailableRecentToolCallTools(reg)
+		} else {
+			registerRecentToolCallTools(reg, postgresReader)
+		}
 	} else {
 		registerUnavailableRiskToolsWithMutations(reg, riskMutations)
+		registerUnavailableDataExportTools(reg)
+		registerUnavailableRecentToolCallTools(reg)
 	}
 	registerSetupResources(reg, setupResources, time.Now)
 	if registrations == nil || !registrations.budgets.Docs.valid() {

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -3381,11 +3381,7 @@ func (s *Service) resolveToolUsageParams(ctx context.Context, f toolUsageFilters
 		})
 	}
 
-	hostedMCPMatchers, err := s.toolUsageHostedMCPMatchers(ctx, *authCtx.ProjectID)
-	if err != nil {
-		return repo.GetToolUsageSummaryParams{}, oops.E(oops.CodeUnexpected, err, "error listing hosted MCP servers")
-	}
-	mcpServerMatchers, err := s.toolUsageMCPServerMatchers(ctx, *authCtx.ProjectID)
+	hostedMCPMatchers, mcpServerMatchers, err := LoadToolUsageMatchers(ctx, s.db, *authCtx.ProjectID)
 	if err != nil {
 		return repo.GetToolUsageSummaryParams{}, oops.E(oops.CodeUnexpected, err, "error listing MCP servers")
 	}
@@ -3623,11 +3619,7 @@ func (s *Service) ListToolUsageTraces(ctx context.Context, payload *telem_gen.Li
 		}
 	}
 
-	hostedMCPMatchers, err := s.toolUsageHostedMCPMatchers(ctx, *authCtx.ProjectID)
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error listing hosted MCP servers").LogError(ctx, logger)
-	}
-	mcpServerMatchers, err := s.toolUsageMCPServerMatchers(ctx, *authCtx.ProjectID)
+	hostedMCPMatchers, mcpServerMatchers, err := LoadToolUsageMatchers(ctx, s.db, *authCtx.ProjectID)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error listing MCP servers").LogError(ctx, logger)
 	}
@@ -3690,11 +3682,7 @@ func (s *Service) GetToolUsageFilterOptions(ctx context.Context, payload *telem_
 		return nil, err
 	}
 
-	hostedMCPMatchers, err := s.toolUsageHostedMCPMatchers(ctx, *authCtx.ProjectID)
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error listing hosted MCP servers")
-	}
-	mcpServerMatchers, err := s.toolUsageMCPServerMatchers(ctx, *authCtx.ProjectID)
+	hostedMCPMatchers, mcpServerMatchers, err := LoadToolUsageMatchers(ctx, s.db, *authCtx.ProjectID)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error listing MCP servers")
 	}
@@ -3750,11 +3738,7 @@ func (s *Service) GetMcpServerActivity(ctx context.Context, payload *telem_gen.G
 	timeStart := now.AddDate(0, 0, -mcpServerActivityLookbackDays).UnixNano()
 	recentThreshold := now.AddDate(0, 0, -recentWindowDays).UnixNano()
 
-	hostedMCPMatchers, err := s.toolUsageHostedMCPMatchers(ctx, *authCtx.ProjectID)
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "error listing hosted MCP servers")
-	}
-	mcpServerMatchers, err := s.toolUsageMCPServerMatchers(ctx, *authCtx.ProjectID)
+	hostedMCPMatchers, mcpServerMatchers, err := LoadToolUsageMatchers(ctx, s.db, *authCtx.ProjectID)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "error listing MCP servers")
 	}
@@ -3840,39 +3824,38 @@ func (s *Service) resolveMetaMCPServerLabels(ctx context.Context, authCtx *conte
 	return nil
 }
 
-func (s *Service) toolUsageHostedMCPMatchers(ctx context.Context, projectID uuid.UUID) ([]repo.HostedMCPMatcher, error) {
-	toolsets, err := toolsetsRepo.New(s.db).ListToolsetsByProject(ctx, projectID)
+// LoadToolUsageMatchers loads the project-owned names and stable source IDs
+// used to classify hosted, direct-remote, and tunneled MCP telemetry.
+func LoadToolUsageMatchers(ctx context.Context, db *pgxpool.Pool, projectID uuid.UUID) ([]repo.HostedMCPMatcher, []repo.MCPServerMatcher, error) {
+	toolsets, err := toolsetsRepo.New(db).ListToolsetsByProject(ctx, projectID)
 	if err != nil {
-		return nil, fmt.Errorf("list project toolsets: %w", err)
+		return nil, nil, fmt.Errorf("list project toolsets: %w", err)
 	}
 
-	matchers := make([]repo.HostedMCPMatcher, 0, len(toolsets))
+	hostedMatchers := make([]repo.HostedMCPMatcher, 0, len(toolsets))
 	for _, toolset := range toolsets {
 		if !toolset.McpEnabled || !toolset.McpSlug.Valid || toolset.McpSlug.String == "" {
 			continue
 		}
-		matchers = append(matchers, repo.HostedMCPMatcher{
+		hostedMatchers = append(hostedMatchers, repo.HostedMCPMatcher{
 			ToolsetSlug: toolset.Slug,
 			ToolsetName: toolset.Name,
 			McpSlug:     toolset.McpSlug.String,
 		})
 	}
-	return matchers, nil
-}
 
-func (s *Service) toolUsageMCPServerMatchers(ctx context.Context, projectID uuid.UUID) ([]repo.MCPServerMatcher, error) {
 	// Include soft-deleted servers: tool_source on telemetry rows is the
 	// backend remote/tunneled server id, which outlives the mcp_servers row.
 	// Matching against deleted servers keeps a deleted (or recreated) server's
 	// historical calls classified as their true type instead of falling through
 	// to shadow_mcp_server. The query returns live servers first so a source id
 	// shared by a live and a deleted server resolves to the live one.
-	servers, err := mcpserversRepo.New(s.db).ListMCPServersForTelemetryByProjectID(ctx, projectID)
+	servers, err := mcpserversRepo.New(db).ListMCPServersForTelemetryByProjectID(ctx, projectID)
 	if err != nil {
-		return nil, fmt.Errorf("list project MCP servers: %w", err)
+		return nil, nil, fmt.Errorf("list project MCP servers: %w", err)
 	}
 
-	matchers := make([]repo.MCPServerMatcher, 0, len(servers))
+	serverMatchers := make([]repo.MCPServerMatcher, 0, len(servers))
 	seen := make(map[string]struct{}, len(servers))
 	for _, server := range servers {
 		targetType := repo.ToolUsageTargetTypeHostedMCP
@@ -3903,14 +3886,14 @@ func (s *Service) toolUsageMCPServerMatchers(ctx context.Context, projectID uuid
 			targetLabel = server.Name.String
 		}
 
-		matchers = append(matchers, repo.MCPServerMatcher{
+		serverMatchers = append(serverMatchers, repo.MCPServerMatcher{
 			SourceID:    sourceID,
 			TargetType:  targetType,
 			TargetID:    targetID,
 			TargetLabel: targetLabel,
 		})
 	}
-	return matchers, nil
+	return hostedMatchers, serverMatchers, nil
 }
 
 func encodeToolUsageTraceCursor(startTimeUnixNano int64, id string) string {


### PR DESCRIPTION
## Summary

- Add `list_data_exports`, a read-only Platform MCP inventory tool for OpenTelemetry destinations and routes, including management links and header metadata without secret values. Reads are bounded in SQL and project metadata is joined consistently.
- Add `create_data_export`, a confirmed mutation that atomically creates a headerless OTEL destination and route for product telemetry or risk findings. Authentication secrets remain dashboard-only, and both records are audit logged in the same transaction.
- Add `list_recent_tool_calls`, a read-only, project-scoped tool backed by the bounded Tool Logs summary path, with closed time and outcome filters, project-owned target classification, and a privacy-safe response projection.
- Expose data export management on the external Platform MCP surface, admit recent tool-call reads to managed assistants, and preserve stable unavailable descriptors when dependencies are absent.

Platform MCP is not read-only: individual read tools are annotated as read-only, while `create_data_export` and the existing management tools remain mutations.

## Motivation

Administrators need to inspect and configure telemetry delivery and review recent tool activity from their agent without opening raw logs or exposing destination credentials, request payloads, trace identifiers, or user identities.

## Verification

- `mise run test:server ./internal/platformmcp ./internal/dataexports ./internal/telemetry` — 933 tests passed
- `mise lint:server` — passed
- GitHub CI gate and Cubic review — passed
- Unresolved review threads — 0