### PR TITLE
feat: restore the wizard/board switcher on organization setup

### DIFF
--- a/.changeset/restore-setup-view-switcher.md
+++ b/.changeset/restore-setup-view-switcher.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+Restore the Wizard/Board switcher on organization setup, bringing back the linear setup wizard at /setup/wizard alongside the board.

--- a/client/dashboard/src/pages/setup/SetupBoard.tsx
+++ b/client/dashboard/src/pages/setup/SetupBoard.tsx
@@ -32,7 +32,7 @@ type FailedInvite = { email: string; roleId: string };
 
 function BoardPage({ children }: { children: React.ReactNode }): JSX.Element {
   return (
-    <SetupShell>
+    <SetupShell view="board">
       <main className="flex min-h-0 flex-1 overflow-hidden">
         <div className="@container/main mx-auto flex h-full min-h-0 w-full max-w-7xl flex-col gap-4 p-8 pb-8 [&>div]:mb-0 [&>div]:min-h-0 [&>div]:flex-1">
           <Page.Section>

--- a/client/dashboard/src/pages/setup/components/onboarding-stepper.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-stepper.tsx
@@ -1,0 +1,141 @@
+import { Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface Step {
+  id: string;
+  title: string;
+  description: string;
+  /** Optional inline marker after the title, e.g. "Required" / "Optional". */
+  badge?: string;
+}
+
+interface OnboardingStepperProps {
+  steps: Step[];
+  currentStep: number;
+  onStepClick?: (index: number) => void;
+  maxAllowedStep?: number;
+  /** Allow clicking ahead to upcoming (unlocked) steps, not just back to
+   *  completed ones. Off by default to preserve the linear onboarding flow. */
+  allowJumpAhead?: boolean;
+}
+
+export function OnboardingStepper({
+  steps,
+  currentStep,
+  onStepClick,
+  maxAllowedStep = steps.length - 1,
+  allowJumpAhead = false,
+}: OnboardingStepperProps): JSX.Element {
+  return (
+    <nav className="flex flex-col" aria-label="Progress">
+      {steps.map((step, index) => {
+        const isCompleted = index < currentStep;
+        const isCurrent = index === currentStep;
+        const isUpcoming = index > currentStep;
+        const isLocked = index > maxAllowedStep;
+        const isLast = index === steps.length - 1;
+        const canJump =
+          !!onStepClick &&
+          !isLocked &&
+          !isCurrent &&
+          (isCompleted || allowJumpAhead);
+
+        return (
+          <div key={step.id} className="relative flex gap-4">
+            {/* Vertical line connector - runs through all steps except last */}
+            {!isLast && (
+              <div
+                className="absolute top-[28px] left-[13px] h-[calc(100%-28px)] w-px bg-border"
+                aria-hidden="true"
+              />
+            )}
+
+            {/* Step indicator */}
+            <div className="relative z-10 flex-shrink-0">
+              {isCurrent ? (
+                /* Active step: dark filled square */
+                <div className="flex h-[28px] w-[28px] items-center justify-center bg-foreground text-sm font-semibold text-background">
+                  {index + 1}
+                </div>
+              ) : isCompleted ? (
+                /* Completed step: outlined square with a bold green checkmark;
+                   active keeps the solid ink fill, upcoming stays outlined */
+                <button
+                  onClick={() => onStepClick?.(index)}
+                  className="border-border text-default-success flex h-[28px] w-[28px] cursor-pointer items-center justify-center border bg-background transition-all duration-200 ease-out hover:scale-[1.2] hover:border-foreground"
+                >
+                  <Check className="h-4 w-4" strokeWidth={3} />
+                </button>
+              ) : canJump ? (
+                /* Upcoming but jumpable: outlined square as a button so the
+                   number itself previews the step, matching the content click. */
+                <button
+                  onClick={() => onStepClick?.(index)}
+                  className="border-border text-muted-foreground flex h-[28px] w-[28px] cursor-pointer items-center justify-center border bg-background text-sm font-normal transition-all duration-200 ease-out hover:scale-[1.2] hover:text-foreground"
+                >
+                  {index + 1}
+                </button>
+              ) : (
+                /* Upcoming step: light outlined square with white fill to cover track */
+                <div
+                  className={cn(
+                    "flex h-[28px] w-[28px] items-center justify-center border bg-background text-sm font-normal",
+                    isLocked
+                      ? "border-border text-muted-foreground/40"
+                      : "border-border text-muted-foreground",
+                  )}
+                >
+                  {index + 1}
+                </div>
+              )}
+            </div>
+
+            {/* Step content */}
+            <div
+              className={cn("min-w-0 pt-1 pb-8", canJump && "cursor-pointer")}
+              onClick={canJump ? () => onStepClick?.(index) : undefined}
+              role={canJump ? "button" : undefined}
+              tabIndex={canJump ? 0 : undefined}
+              onKeyDown={
+                canJump
+                  ? (e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        onStepClick?.(index);
+                      }
+                    }
+                  : undefined
+              }
+            >
+              <h3
+                className={cn(
+                  "flex items-center gap-2 text-sm leading-tight font-semibold",
+                  isCurrent && "text-foreground",
+                  isCompleted && "text-foreground",
+                  isUpcoming && "text-muted-foreground",
+                )}
+              >
+                {step.title}
+                {step.badge && (
+                  <span className="text-muted-foreground text-[10px] font-semibold tracking-wide uppercase">
+                    {step.badge}
+                  </span>
+                )}
+              </h3>
+              <p
+                className={cn(
+                  "mt-0.5 text-sm leading-snug",
+                  isCurrent && "text-muted-foreground",
+                  isCompleted && "text-muted-foreground",
+                  isUpcoming && "text-muted-foreground/60",
+                )}
+              >
+                {step.description}
+              </p>
+            </div>
+          </div>
+        );
+      })}
+    </nav>
+  );
+}

--- a/client/dashboard/src/pages/setup/components/onboarding-stepper.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-stepper.tsx
@@ -50,7 +50,8 @@ export function OnboardingStepper({
             key={step.id}
             className={cn(
               "group relative flex gap-4",
-              canJump && "cursor-pointer",
+              canJump &&
+                "focus-visible:ring-ring/50 cursor-pointer outline-none focus-visible:ring-[3px]",
             )}
             aria-current={isCurrent ? "step" : undefined}
             role={canJump ? "button" : undefined}

--- a/client/dashboard/src/pages/setup/components/onboarding-stepper.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-stepper.tsx
@@ -41,7 +41,32 @@ export function OnboardingStepper({
           (isCompleted || allowJumpAhead);
 
         return (
-          <div key={step.id} className="relative flex gap-4">
+          // The whole row is the single interactive control for the step. The
+          // indicator used to be a nested <button> alongside a role="button"
+          // content div, which gave completed steps two tab stops for one
+          // action; the indicator is now presentational and the row owns the
+          // click, keyboard handling, and accessible name (its title + text).
+          <div
+            key={step.id}
+            className={cn(
+              "group relative flex gap-4",
+              canJump && "cursor-pointer",
+            )}
+            aria-current={isCurrent ? "step" : undefined}
+            role={canJump ? "button" : undefined}
+            tabIndex={canJump ? 0 : undefined}
+            onClick={canJump ? () => onStepClick?.(index) : undefined}
+            onKeyDown={
+              canJump
+                ? (e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      onStepClick?.(index);
+                    }
+                  }
+                : undefined
+            }
+          >
             {/* Vertical line connector - runs through all steps except last */}
             {!isLast && (
               <div
@@ -60,21 +85,21 @@ export function OnboardingStepper({
               ) : isCompleted ? (
                 /* Completed step: outlined square with a bold green checkmark;
                    active keeps the solid ink fill, upcoming stays outlined */
-                <button
-                  onClick={() => onStepClick?.(index)}
-                  className="border-border text-default-success flex h-[28px] w-[28px] cursor-pointer items-center justify-center border bg-background transition-all duration-200 ease-out hover:scale-[1.2] hover:border-foreground"
+                <div
+                  aria-hidden="true"
+                  className="border-border text-default-success flex h-[28px] w-[28px] items-center justify-center border bg-background transition-all duration-200 ease-out group-hover:scale-[1.2] group-hover:border-foreground"
                 >
                   <Check className="h-4 w-4" strokeWidth={3} />
-                </button>
+                </div>
               ) : canJump ? (
-                /* Upcoming but jumpable: outlined square as a button so the
-                   number itself previews the step, matching the content click. */
-                <button
-                  onClick={() => onStepClick?.(index)}
-                  className="border-border text-muted-foreground flex h-[28px] w-[28px] cursor-pointer items-center justify-center border bg-background text-sm font-normal transition-all duration-200 ease-out hover:scale-[1.2] hover:text-foreground"
+                /* Upcoming but jumpable: outlined square. Presentational —
+                   the row wrapper carries the click and the accessible name. */
+                <div
+                  aria-hidden="true"
+                  className="border-border text-muted-foreground flex h-[28px] w-[28px] items-center justify-center border bg-background text-sm font-normal transition-all duration-200 ease-out group-hover:scale-[1.2] group-hover:text-foreground"
                 >
                   {index + 1}
-                </button>
+                </div>
               ) : (
                 /* Upcoming step: light outlined square with white fill to cover track */
                 <div
@@ -91,22 +116,7 @@ export function OnboardingStepper({
             </div>
 
             {/* Step content */}
-            <div
-              className={cn("min-w-0 pt-1 pb-8", canJump && "cursor-pointer")}
-              onClick={canJump ? () => onStepClick?.(index) : undefined}
-              role={canJump ? "button" : undefined}
-              tabIndex={canJump ? 0 : undefined}
-              onKeyDown={
-                canJump
-                  ? (e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault();
-                        onStepClick?.(index);
-                      }
-                    }
-                  : undefined
-              }
-            >
+            <div className="min-w-0 pt-1 pb-8">
               <h3
                 className={cn(
                   "flex items-center gap-2 text-sm leading-tight font-semibold",

--- a/client/dashboard/src/pages/setup/components/onboarding-wizard.test.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-wizard.test.tsx
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+
+import { SetupWizard } from "./onboarding-wizard";
+
+const searchParamsState = vi.hoisted(() => ({
+  current: new URLSearchParams(),
+  setSearchParams: vi.fn(),
+}));
+
+const onboardingStatus = vi.hoisted(() => ({
+  current: {
+    data: { ssoConfigured: false, dsyncConfigured: false },
+    isLoading: false,
+  },
+}));
+
+const publishStatus = vi.hoisted(() => ({
+  current: { data: { connected: false }, isLoading: false },
+}));
+
+vi.mock("react-router", () => ({
+  useNavigate: () => vi.fn(),
+  useParams: () => ({ orgSlug: "acme" }),
+  useSearchParams: () => [
+    searchParamsState.current,
+    searchParamsState.setSearchParams,
+  ],
+}));
+vi.mock("@gram/client/react-query/onboardingStatus", () => ({
+  useOnboardingStatus: () => onboardingStatus.current,
+}));
+vi.mock("@gram/client/react-query/publishStatus", () => ({
+  usePublishStatus: () => publishStatus.current,
+}));
+
+vi.mock("@/components/ui/Skeleton", () => ({
+  Skeleton: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock("./setup-shell", () => ({
+  SetupShell: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock("./onboarding-stepper", () => ({
+  OnboardingStepper: () => null,
+}));
+vi.mock("./steps", () => ({
+  ConnectIdpStep: () => null,
+  DirectorySyncStep: () => null,
+  CreateMarketplaceStep: () => null,
+  DistributeServersStep: () => null,
+  InstrumentAgentsStep: () => null,
+  AdditionalAgentConfigStep: () => null,
+  ConfirmTrafficStep: () => null,
+  ConfigurePoliciesStep: () => null,
+  PlatformMCPSetupStep: () => null,
+}));
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+beforeEach(() => {
+  searchParamsState.current = new URLSearchParams();
+  searchParamsState.setSearchParams.mockReset();
+  onboardingStatus.current = {
+    data: { ssoConfigured: false, dsyncConfigured: false },
+    isLoading: false,
+  };
+  publishStatus.current = { data: { connected: false }, isLoading: false };
+});
+
+function resumedStep(): string | null {
+  const updater = searchParamsState.setSearchParams.mock.calls[0]?.[0] as
+    | ((prev: URLSearchParams) => URLSearchParams)
+    | undefined;
+  if (!updater) return null;
+  return updater(new URLSearchParams()).get("step");
+}
+
+describe("SetupWizard", () => {
+  it("records that the setup view was opened for the org", () => {
+    render(<SetupWizard />);
+
+    expect(localStorage.getItem("gram-org-welcome-rollout-started:acme")).toBe(
+      "true",
+    );
+  });
+
+  it("resumes at instrument-agents after the marketplace is published", () => {
+    publishStatus.current = { data: { connected: true }, isLoading: false };
+
+    render(<SetupWizard />);
+
+    expect(resumedStep()).toBe("instrument-agents");
+  });
+
+  it("resumes at create-marketplace after directory sync is configured", () => {
+    onboardingStatus.current = {
+      data: { ssoConfigured: true, dsyncConfigured: true },
+      isLoading: false,
+    };
+
+    render(<SetupWizard />);
+
+    expect(resumedStep()).toBe("create-marketplace");
+  });
+});

--- a/client/dashboard/src/pages/setup/components/onboarding-wizard.test.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-wizard.test.tsx
@@ -95,6 +95,17 @@ describe("SetupWizard", () => {
     expect(resumedStep()).toBe("instrument-agents");
   });
 
+  it("resumes at directory-sync when only SSO is configured", () => {
+    onboardingStatus.current = {
+      data: { ssoConfigured: true, dsyncConfigured: false },
+      isLoading: false,
+    };
+
+    render(<SetupWizard />);
+
+    expect(resumedStep()).toBe("directory-sync");
+  });
+
   it("resumes at create-marketplace after directory sync is configured", () => {
     onboardingStatus.current = {
       data: { ssoConfigured: true, dsyncConfigured: true },

--- a/client/dashboard/src/pages/setup/components/onboarding-wizard.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-wizard.tsx
@@ -106,10 +106,14 @@ export function SetupWizard(): JSX.Element {
   // additional-agent-config, confirm-traffic, distribute-servers) have no
   // server signal — once marketplace is published we land on instrument-agents
   // and let the user click forward.
+  // throwOnError: false so a failed resume check degrades to step 0 (as the
+  // effect below assumes) instead of throwing to the page error boundary. The
+  // QueryClient default only suppresses 401/403, so a 500 here would otherwise
+  // replace the whole wizard with an error screen.
   const { data: onboardingStatus, isLoading: isOnboardingStatusLoading } =
-    useOnboardingStatus();
+    useOnboardingStatus(undefined, undefined, { throwOnError: false });
   const { data: publishStatus, isLoading: isPublishStatusLoading } =
-    usePublishStatus();
+    usePublishStatus(undefined, undefined, { throwOnError: false });
   const statusLoading = isOnboardingStatusLoading || isPublishStatusLoading;
 
   useEffect(() => {

--- a/client/dashboard/src/pages/setup/components/onboarding-wizard.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-wizard.tsx
@@ -1,0 +1,348 @@
+import { useCallback, useEffect, useMemo } from "react";
+import { useNavigate, useParams, useSearchParams } from "react-router";
+import { useOnboardingStatus } from "@gram/client/react-query/onboardingStatus";
+import { usePublishStatus } from "@gram/client/react-query/publishStatus";
+import { useOrgSetupStarted } from "@/hooks/useOrgSetupStarted";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { OnboardingStepper, type Step } from "./onboarding-stepper";
+import { SetupShell } from "./setup-shell";
+import {
+  ConnectIdpStep,
+  DirectorySyncStep,
+  CreateMarketplaceStep,
+  DistributeServersStep,
+  InstrumentAgentsStep,
+  AdditionalAgentConfigStep,
+  ConfirmTrafficStep,
+  ConfigurePoliciesStep,
+  PlatformMCPSetupStep,
+} from "./steps";
+
+const CORE_STEPS: Step[] = [
+  {
+    id: "connect-idp",
+    title: "Connect identity provider",
+    description: "Link SSO for authentication",
+  },
+  {
+    id: "directory-sync",
+    title: "Directory sync",
+    description: "Confirm users and roles",
+  },
+  {
+    id: "create-marketplace",
+    title: "Create plugin marketplace",
+    description: "For distributing servers to your users",
+  },
+  {
+    id: "instrument-agents",
+    title: "Instrument agents",
+    description: "Connect AI coding assistants",
+  },
+  {
+    id: "additional-agent-config",
+    title: "Additional agent configuration",
+    description: "Optional API keys for usage and compliance data",
+  },
+  {
+    id: "confirm-traffic",
+    title: "Confirm traffic",
+    description: "Verify connectivity and compliance",
+  },
+  {
+    id: "distribute-servers",
+    title: "Distribute MCP servers",
+    description: "Choose some MCP Servers to distribute to your organization",
+  },
+];
+
+const CONFIGURE_POLICIES_STEP: Step = {
+  id: "configure-policies",
+  title: "Configure policies",
+  description: "Pick the categories to flag in agent traffic",
+};
+
+const PLATFORM_MCP_STEP: Step = {
+  id: "platform-mcp",
+  title: "Set up Platform MCP",
+  description: "Optional agent-assisted MCP setup",
+  badge: "Optional",
+};
+
+function indexOfStep(steps: Step[], id: string): number {
+  const index = steps.findIndex((step) => step.id === id);
+  return index === -1 ? 0 : index;
+}
+
+export function SetupWizard(): JSX.Element {
+  const navigate = useNavigate();
+  const { orgSlug } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { markSetupStarted } = useOrgSetupStarted(orgSlug);
+
+  useEffect(() => {
+    markSetupStarted();
+  }, [markSetupStarted]);
+
+  const setupProjectSlug = searchParams.get("projectSlug") ?? undefined;
+  const setupPath = searchParams.get("setupPath");
+  const usesPlatformMcpPath = setupPath === "platform-mcp";
+  const steps = useMemo(
+    () =>
+      usesPlatformMcpPath
+        ? [...CORE_STEPS, PLATFORM_MCP_STEP, CONFIGURE_POLICIES_STEP]
+        : [...CORE_STEPS, CONFIGURE_POLICIES_STEP, PLATFORM_MCP_STEP],
+    [usesPlatformMcpPath],
+  );
+
+  // All steps are accessible — SSO and DSYNC are both skippable.
+  const maxAllowedStep = steps.length - 1;
+
+  const stepSlug = searchParams.get("step");
+
+  // Server-side onboarding signals used to resume at the right step on reload.
+  // `onboardingStatus` covers SSO + DSYNC; `publishStatus` covers the
+  // marketplace step. Steps after marketplace (instrument-agents,
+  // additional-agent-config, confirm-traffic, distribute-servers) have no
+  // server signal — once marketplace is published we land on instrument-agents
+  // and let the user click forward.
+  const { data: onboardingStatus, isLoading: isOnboardingStatusLoading } =
+    useOnboardingStatus();
+  const { data: publishStatus, isLoading: isPublishStatusLoading } =
+    usePublishStatus();
+  const statusLoading = isOnboardingStatusLoading || isPublishStatusLoading;
+
+  useEffect(() => {
+    if (stepSlug) return;
+    if (statusLoading) return; // wait so we don't flash step 0 then jump
+    // If either query errored, its data is undefined and the checks below all
+    // fail — we fall back to step 0.
+    let resumeStep = 0;
+    if (publishStatus?.connected) {
+      resumeStep = indexOfStep(steps, "instrument-agents");
+    } else if (onboardingStatus?.dsyncConfigured) {
+      resumeStep = indexOfStep(steps, "create-marketplace");
+    } else if (onboardingStatus?.ssoConfigured) {
+      resumeStep = indexOfStep(steps, "directory-sync");
+    }
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.set("step", steps[resumeStep]!.id!);
+        return next;
+      },
+      { replace: true },
+    );
+  }, [
+    stepSlug,
+    statusLoading,
+    onboardingStatus,
+    publishStatus,
+    setSearchParams,
+    steps,
+  ]);
+
+  const requestedStep = stepSlug
+    ? Math.max(
+        0,
+        steps.findIndex((s) => s.id === stepSlug),
+      )
+    : 0;
+
+  const currentStep = Math.min(requestedStep, maxAllowedStep);
+
+  const setCurrentStep = useCallback(
+    (index: number) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.set("step", steps[index]!.id!);
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams, steps],
+  );
+
+  // Clicking a step in the stepper previews that step (forward or back) by
+  // swapping the `step` query param. It never advances the real onboarding
+  // signals — those only move when the user completes a step via Continue — so
+  // this is a pure preview, safe to jump anywhere in range.
+  const goToStep = useCallback(
+    (index: number) => {
+      if (index >= 0 && index <= maxAllowedStep && index !== currentStep) {
+        setCurrentStep(index);
+      }
+    },
+    [currentStep, maxAllowedStep, setCurrentStep],
+  );
+
+  const completeCurrentStep = useCallback(() => {
+    const nextIndex = currentStep + 1;
+    if (nextIndex < steps.length) {
+      setCurrentStep(nextIndex);
+    } else {
+      const projectSlug = searchParams.get("projectSlug") ?? "default";
+      void navigate(`/${orgSlug}/projects/${projectSlug}`);
+    }
+  }, [
+    currentStep,
+    navigate,
+    orgSlug,
+    searchParams,
+    setCurrentStep,
+    steps.length,
+  ]);
+
+  const goBack = useCallback(() => {
+    if (currentStep > 0) {
+      setCurrentStep(currentStep - 1);
+    }
+  }, [currentStep, setCurrentStep]);
+
+  const leavePlatformMcpPath = useCallback(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete("setupPath");
+        next.set("step", "distribute-servers");
+        return next;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
+
+  // While we're still figuring out where to resume (no slug + queries in
+  // flight), keep the page shell visible with skeletons rather than briefly
+  // mounting step 0. The resume-step useEffect above will set the slug as soon
+  // as the queries resolve (or error, which falls back to step 0).
+  const resolvingResume = !stepSlug && statusLoading;
+
+  const startPlatformMcpPath = useCallback(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.set("setupPath", "platform-mcp");
+        next.set("step", PLATFORM_MCP_STEP.id);
+        return next;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
+
+  const renderStep = () => {
+    switch (steps[currentStep]?.id) {
+      case "connect-idp":
+        return (
+          <ConnectIdpStep
+            onSkip={completeCurrentStep}
+            onComplete={completeCurrentStep}
+          />
+        );
+      case "directory-sync":
+        return (
+          <DirectorySyncStep onComplete={completeCurrentStep} onBack={goBack} />
+        );
+      case "create-marketplace":
+        return (
+          <CreateMarketplaceStep
+            onComplete={completeCurrentStep}
+            onBack={goBack}
+          />
+        );
+      case "instrument-agents":
+        return (
+          <InstrumentAgentsStep
+            onComplete={completeCurrentStep}
+            onBack={goBack}
+          />
+        );
+      case "additional-agent-config":
+        return (
+          <AdditionalAgentConfigStep
+            onComplete={completeCurrentStep}
+            onSkip={completeCurrentStep}
+            onBack={goBack}
+          />
+        );
+      case "confirm-traffic":
+        return (
+          <ConfirmTrafficStep
+            onComplete={completeCurrentStep}
+            onBack={goBack}
+          />
+        );
+      case "distribute-servers":
+        return (
+          <DistributeServersStep
+            onComplete={completeCurrentStep}
+            onSkip={completeCurrentStep}
+            onBack={goBack}
+            onSetupPlatformMCP={startPlatformMcpPath}
+          />
+        );
+      case "configure-policies":
+        return (
+          <ConfigurePoliciesStep
+            onComplete={completeCurrentStep}
+            onBack={goBack}
+          />
+        );
+      case "platform-mcp":
+        return (
+          <PlatformMCPSetupStep
+            onComplete={completeCurrentStep}
+            onBack={usesPlatformMcpPath ? leavePlatformMcpPath : goBack}
+            onSkip={completeCurrentStep}
+            currentProjectSlug={setupProjectSlug}
+            continueLabel={
+              usesPlatformMcpPath
+                ? "Continue to Configure policies"
+                : "Finish setup"
+            }
+          />
+        );
+      case undefined:
+        return null;
+    }
+  };
+
+  return (
+    <SetupShell view="wizard">
+      <main className="flex min-h-0 flex-1 items-start justify-center overflow-y-auto px-4 py-8 md:px-8 md:py-16">
+        <div className="flex w-full max-w-5xl gap-24">
+          <div className="order-first hidden w-64 flex-shrink-0 md:block">
+            {resolvingResume ? (
+              <Skeleton>
+                {steps.map((step) => (
+                  <div key={step.id} className="h-8 w-full" />
+                ))}
+              </Skeleton>
+            ) : (
+              <OnboardingStepper
+                steps={steps}
+                currentStep={currentStep}
+                onStepClick={goToStep}
+                maxAllowedStep={maxAllowedStep}
+                allowJumpAhead
+              />
+            )}
+          </div>
+
+          <div className="order-last min-w-0 flex-1">
+            {resolvingResume ? (
+              <Skeleton>
+                <div className="h-12 w-2/3" />
+                <div className="h-5 w-full" />
+                <div className="h-64 w-full" />
+              </Skeleton>
+            ) : (
+              renderStep()
+            )}
+          </div>
+        </div>
+      </main>
+    </SetupShell>
+  );
+}

--- a/client/dashboard/src/pages/setup/components/setup-shell.tsx
+++ b/client/dashboard/src/pages/setup/components/setup-shell.tsx
@@ -2,14 +2,23 @@ import type { ReactNode } from "react";
 import { useNavigate, useParams } from "react-router";
 import { OnboardingFooter } from "./onboarding-footer";
 import { OnboardingHeader } from "./onboarding-header";
+import { SetupViewToggle } from "./setup-view-toggle";
 
-export function SetupShell({ children }: { children: ReactNode }): JSX.Element {
+export function SetupShell({
+  view,
+  children,
+}: {
+  view: "wizard" | "board";
+  children: ReactNode;
+}): JSX.Element {
   const navigate = useNavigate();
   const { orgSlug } = useParams();
 
   return (
     <div className="bg-background flex h-screen max-h-dvh flex-col overflow-hidden supports-[height:100dvh]:h-dvh">
-      <OnboardingHeader onLeave={() => void navigate(`/${orgSlug}`)} />
+      <OnboardingHeader onLeave={() => void navigate(`/${orgSlug}`)}>
+        <SetupViewToggle view={view} />
+      </OnboardingHeader>
       {children}
       <OnboardingFooter />
     </div>

--- a/client/dashboard/src/pages/setup/components/setup-view-toggle.test.tsx
+++ b/client/dashboard/src/pages/setup/components/setup-view-toggle.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/contexts/Sdk", () => ({
+  useSlugs: () => ({ orgSlug: "org", projectSlug: "project" }),
+}));
+
+// The footer's ThemeSwitcher needs a ConfigProvider; this suite is about the
+// header, so stub it out rather than dragging in app-wide context.
+vi.mock("./onboarding-footer", () => ({
+  OnboardingFooter: () => null,
+}));
+
+import { SetupShell } from "./setup-shell";
+import { SetupViewToggle } from "./setup-view-toggle";
+
+function LocationPath(): JSX.Element {
+  const location = useLocation();
+  return <output>{location.pathname}</output>;
+}
+
+function renderToggle(view: "board" | "wizard") {
+  return render(
+    <MemoryRouter initialEntries={["/org/setup"]}>
+      <SetupViewToggle view={view} />
+      <LocationPath />
+    </MemoryRouter>,
+  );
+}
+
+afterEach(cleanup);
+
+describe("SetupViewToggle", () => {
+  it("offers both setup views", () => {
+    renderToggle("board");
+
+    expect(screen.getByRole("button", { name: "Board" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Wizard" })).toBeTruthy();
+  });
+
+  it("marks the current view as active", () => {
+    renderToggle("board");
+
+    expect(
+      screen
+        .getByRole("button", { name: "Board" })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+  });
+
+  it("navigates to the wizard from the board", () => {
+    renderToggle("board");
+
+    fireEvent.click(screen.getByRole("button", { name: "Wizard" }));
+
+    expect(screen.getByText("/org/setup/wizard")).toBeTruthy();
+  });
+
+  it("navigates back to the board from the wizard", () => {
+    renderToggle("wizard");
+
+    fireEvent.click(screen.getByRole("button", { name: "Board" }));
+
+    expect(screen.getByText("/org/setup")).toBeTruthy();
+  });
+});
+
+describe("SetupShell", () => {
+  it("puts the view switcher in the setup header", () => {
+    render(
+      <MemoryRouter initialEntries={["/org/setup"]}>
+        <SetupShell view="board">
+          <div>content</div>
+        </SetupShell>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("group", { name: "Setup view" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Wizard" })).toBeTruthy();
+  });
+});

--- a/client/dashboard/src/pages/setup/components/setup-view-toggle.tsx
+++ b/client/dashboard/src/pages/setup/components/setup-view-toggle.tsx
@@ -1,0 +1,25 @@
+import { SegmentedControl } from "@/components/ui/SegmentedControl";
+import { useOrgRoutes } from "@/routes";
+
+type SetupView = "wizard" | "board";
+
+export function SetupViewToggle({ view }: { view: SetupView }): JSX.Element {
+  const routes = useOrgRoutes();
+
+  return (
+    <div role="group" aria-label="Setup view">
+      <SegmentedControl
+        value={view}
+        onChange={(nextView) => {
+          if (nextView === view) return;
+          if (nextView === "wizard") routes.setupWizard.goTo();
+          else routes.setup.goTo();
+        }}
+        options={[
+          { value: "board", label: "Board" },
+          { value: "wizard", label: "Wizard" },
+        ]}
+      />
+    </div>
+  );
+}

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -160,6 +160,11 @@ const KillswitchDetail = React.lazy(
   () => import("./pages/killswitch/KillswitchDetail"),
 );
 const SetupBoard = React.lazy(() => import("./pages/setup/SetupBoard"));
+const SetupWizard = React.lazy(() =>
+  import("./pages/setup/components/onboarding-wizard").then((module) => ({
+    default: module.SetupWizard,
+  })),
+);
 
 type AppRouteBasic = {
   title: string;
@@ -1427,6 +1432,15 @@ const ORG_ROUTE_STRUCTURE = {
     url: "setup",
     icon: "settings",
     component: SetupBoard,
+    outsideMainLayout: true,
+  },
+  // The linear wizard walks one owner through setup step by step; the board at
+  // /setup is the default. SetupViewToggle swaps between the two.
+  setupWizard: {
+    title: "Setup wizard",
+    url: "setup/wizard",
+    icon: "list-checks",
+    component: SetupWizard,
     outsideMainLayout: true,
   },
   // Headless mode renders its own chrome (mode tabs only, no sidebar or


### PR DESCRIPTION
## Summary

Brings back the Wizard/Board switcher on organization setup, and with it the linear setup wizard that #6031 removed.

- Restores `onboarding-wizard.tsx` and its stepper rail (`onboarding-stepper.tsx`), both deleted late in #6031.
- Restores `setup-view-toggle.tsx` — a `SegmentedControl` in the setup header — and gives `SetupShell` its `view` prop back so both views render it in the same place.
- Adds a `setupWizard` route at `/setup/wizard`.
- Adds `setup-view-toggle.test.tsx` covering the piece that had no coverage: that both segments render, the current view is marked active, and each segment navigates to the other view's URL.

`/setup` stays the **board**, preserving #6031's "make setup board the default" decision; the wizard moves to `/setup/wizard`. This inverts the pre-#6031 arrangement, where `/setup` was the wizard and the board lived at `/setup/board`.

The old `gram-setup-board` flag gate around the toggle is not restored — that flag was deleted when the board went GA, so both views ship unconditionally.

## Motivation

#6031 built the switcher (`feat: switch between setup views`) and then dropped it again two commits later, when `fix: simplify setup board layout` deleted the toggle component and `feat: make setup board the default` deleted the wizard. The PR description still advertises "a Wizard/Board URL switcher on both setup views", so the removal reads as collateral from the layout cleanup rather than a deliberate call.

The board and the wizard answer different questions. The board is for a team dividing setup work across several owners; the wizard is for one person who wants to be walked through it in order. Losing the wizard removed the second path entirely, with no way back to it.

The switcher had no test of its own — the board and the wizard each had a suite, but nothing covered the component connecting them — which is why the revert went unnoticed through review. The new test closes that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LzT5BkHxPCRBFCRHGY7Yb

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Organization setup previously exposed only the board. It now restores the linear wizard at `/setup/wizard`, while `/setup` remains the default board view.

- Adds a shared Board/Wizard switcher to the setup header.
- Resumes the wizard from SSO, directory sync, or marketplace status and shows loading placeholders during status checks.
- Supports optional Platform MCP setup, step navigation (jumpable rows get a focus ring), and a safe first-step fallback when status requests fail.
- Adds coverage for view switching and wizard resume behavior.

<sup>Written for commit 5a4397404a2826fe20a5149f00bc868c7f6f2eb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

