### PR TITLE
fix: fail-open missing feature flags on preview hosts

### DIFF
--- a/.changeset/preview-fail-open-flags.md
+++ b/.changeset/preview-fail-open-flags.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Show gated features on preview environments when a flag is missing from the dev PostHog project, while still honoring flags that are explicitly turned off.

--- a/client/dashboard/src/contexts/TelemetryProvider.test.ts
+++ b/client/dashboard/src/contexts/TelemetryProvider.test.ts
@@ -1,20 +1,62 @@
-import { describe, expect, it } from "vitest";
-import { shouldUseDevTelemetry } from "./TelemetryProvider";
+import { describe, expect, it, vi } from "vitest";
+import { nullTelemetry, type Telemetry } from "./Telemetry";
+import {
+  failOpenMissingFlags,
+  shouldFailOpenMissingFlags,
+  shouldUseDevTelemetry,
+} from "./TelemetryProvider";
 
 describe("shouldUseDevTelemetry", () => {
-  it("enables every flag on localhost", () => {
+  it("enables every flag on localhost only", () => {
     expect(shouldUseDevTelemetry("https://localhost:8080")).toBe(true);
     expect(shouldUseDevTelemetry("http://localhost:5173")).toBe(true);
   });
 
-  it("enables every flag on PR preview hosts", () => {
-    expect(shouldUseDevTelemetry("https://pr-6012.dev.getgram.ai")).toBe(true);
-    expect(shouldUseDevTelemetry("https://pr-1.dev.getgram.ai")).toBe(true);
-  });
-
-  it("keeps shared staging and production on real PostHog", () => {
+  it("does not force every flag on outside localhost", () => {
+    expect(shouldUseDevTelemetry("https://pr-6012.dev.getgram.ai")).toBe(false);
     expect(shouldUseDevTelemetry("https://dev.getgram.ai")).toBe(false);
     expect(shouldUseDevTelemetry("https://app.getgram.ai")).toBe(false);
     expect(shouldUseDevTelemetry("https://staging.getgram.ai")).toBe(false);
+  });
+});
+
+describe("shouldFailOpenMissingFlags", () => {
+  it("fail-opens missing flags on PR preview hosts", () => {
+    expect(shouldFailOpenMissingFlags("https://pr-6012.dev.getgram.ai")).toBe(
+      true,
+    );
+    expect(shouldFailOpenMissingFlags("https://pr-1.dev.getgram.ai")).toBe(
+      true,
+    );
+  });
+
+  it("does not fail-open on localhost, staging, or production", () => {
+    expect(shouldFailOpenMissingFlags("https://localhost:8080")).toBe(false);
+    expect(shouldFailOpenMissingFlags("https://dev.getgram.ai")).toBe(false);
+    expect(shouldFailOpenMissingFlags("https://app.getgram.ai")).toBe(false);
+    expect(shouldFailOpenMissingFlags("https://staging.getgram.ai")).toBe(
+      false,
+    );
+  });
+});
+
+describe("failOpenMissingFlags", () => {
+  function wrap(value: boolean | undefined): Telemetry {
+    return failOpenMissingFlags({
+      ...nullTelemetry,
+      isFeatureEnabled: vi.fn(() => value) as Telemetry["isFeatureEnabled"],
+    });
+  }
+
+  it("treats a missing flag as enabled", () => {
+    expect(wrap(undefined).isFeatureEnabled("gram-risk-watchdog")).toBe(true);
+  });
+
+  it("preserves an explicit off so rollouts can be tested", () => {
+    expect(wrap(false).isFeatureEnabled("gram-risk-watchdog")).toBe(false);
+  });
+
+  it("preserves an explicit on", () => {
+    expect(wrap(true).isFeatureEnabled("gram-risk-watchdog")).toBe(true);
   });
 });

--- a/client/dashboard/src/contexts/TelemetryProvider.test.ts
+++ b/client/dashboard/src/contexts/TelemetryProvider.test.ts
@@ -59,4 +59,20 @@ describe("failOpenMissingFlags", () => {
   it("preserves an explicit on", () => {
     expect(wrap(true).isFeatureEnabled("gram-risk-watchdog")).toBe(true);
   });
+
+  it("delegates PostHog methods without spreading the instance", () => {
+    const onFeatureFlags = vi.fn(() => () => {});
+    const identify = vi.fn(() => undefined);
+    const wrapped = failOpenMissingFlags({
+      ...nullTelemetry,
+      onFeatureFlags,
+      identify,
+    });
+
+    wrapped.onFeatureFlags(() => {});
+    wrapped.identify("user@example.com", {});
+
+    expect(onFeatureFlags).toHaveBeenCalledOnce();
+    expect(identify).toHaveBeenCalledOnce();
+  });
 });

--- a/client/dashboard/src/contexts/TelemetryProvider.test.ts
+++ b/client/dashboard/src/contexts/TelemetryProvider.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { shouldUseDevTelemetry } from "./TelemetryProvider";
+
+describe("shouldUseDevTelemetry", () => {
+  it("enables every flag on localhost", () => {
+    expect(shouldUseDevTelemetry("https://localhost:8080")).toBe(true);
+    expect(shouldUseDevTelemetry("http://localhost:5173")).toBe(true);
+  });
+
+  it("enables every flag on PR preview hosts", () => {
+    expect(shouldUseDevTelemetry("https://pr-6012.dev.getgram.ai")).toBe(true);
+    expect(shouldUseDevTelemetry("https://pr-1.dev.getgram.ai")).toBe(true);
+  });
+
+  it("keeps shared staging and production on real PostHog", () => {
+    expect(shouldUseDevTelemetry("https://dev.getgram.ai")).toBe(false);
+    expect(shouldUseDevTelemetry("https://app.getgram.ai")).toBe(false);
+    expect(shouldUseDevTelemetry("https://staging.getgram.ai")).toBe(false);
+  });
+});

--- a/client/dashboard/src/contexts/TelemetryProvider.test.ts
+++ b/client/dashboard/src/contexts/TelemetryProvider.test.ts
@@ -60,19 +60,36 @@ describe("failOpenMissingFlags", () => {
     expect(wrap(true).isFeatureEnabled("gram-risk-watchdog")).toBe(true);
   });
 
-  it("delegates PostHog methods without spreading the instance", () => {
-    const onFeatureFlags = vi.fn(() => () => {});
-    const identify = vi.fn(() => undefined);
-    const wrapped = failOpenMissingFlags({
-      ...nullTelemetry,
-      onFeatureFlags,
-      identify,
-    });
+  it("keeps PostHog methods bound to the original instance", () => {
+    class Stub {
+      label = "source";
+      isFeatureEnabled() {
+        return undefined;
+      }
+      onFeatureFlags() {
+        if (this.label !== "source") {
+          throw new Error("onFeatureFlags lost its receiver");
+        }
+        return () => {};
+      }
+      capture() {
+        return { uuid: "", event: "", properties: {} };
+      }
+      identify() {
+        if (this.label !== "source") {
+          throw new Error("identify lost its receiver");
+        }
+      }
+      register() {}
+      reset() {}
+      group() {}
+    }
 
+    const source = new Stub() as unknown as Telemetry;
+    const wrapped = failOpenMissingFlags(source);
+
+    expect(wrapped.onFeatureFlags).toBeTypeOf("function");
     wrapped.onFeatureFlags(() => {});
     wrapped.identify("user@example.com", {});
-
-    expect(onFeatureFlags).toHaveBeenCalledOnce();
-    expect(identify).toHaveBeenCalledOnce();
   });
 });

--- a/client/dashboard/src/contexts/TelemetryProvider.tsx
+++ b/client/dashboard/src/contexts/TelemetryProvider.tsx
@@ -22,6 +22,12 @@ const AM_TESTING_TELEMETRY = false;
 const isPublicSharePath = (): boolean =>
   window.location.pathname.startsWith("/shared/");
 
+// Localhost and PR preview hosts (*.dev.getgram.ai) skip PostHog flag
+// evaluation so gated UI such as Watchdog and Functions is visible. Shared
+// staging (dev.getgram.ai) and production stay on the real project.
+export const shouldUseDevTelemetry = (serverURL: string): boolean =>
+  serverURL.includes("localhost") || serverURL.includes(".dev.getgram.ai");
+
 export const TelemetryProvider = (props: {
   children: ReactNode;
 }): JSX.Element => {
@@ -75,7 +81,7 @@ export const TelemetryProvider = (props: {
   }, []);
 
   let value: Telemetry = ph ?? nullTelemetry;
-  if (!isPublicSharePath() && getServerURL().includes("localhost")) {
+  if (!isPublicSharePath() && shouldUseDevTelemetry(getServerURL())) {
     value = AM_TESTING_TELEMETRY ? testTelemetry : devTelemetry;
   }
 

--- a/client/dashboard/src/contexts/TelemetryProvider.tsx
+++ b/client/dashboard/src/contexts/TelemetryProvider.tsx
@@ -35,11 +35,16 @@ export const shouldFailOpenMissingFlags = (serverURL: string): boolean =>
 
 export function failOpenMissingFlags(telemetry: Telemetry): Telemetry {
   return {
-    ...telemetry,
     isFeatureEnabled: ((flag, options) => {
       const result = telemetry.isFeatureEnabled(flag, options);
       return result === undefined ? true : result;
     }) as Telemetry["isFeatureEnabled"],
+    onFeatureFlags: telemetry.onFeatureFlags.bind(telemetry),
+    capture: telemetry.capture.bind(telemetry),
+    identify: telemetry.identify.bind(telemetry),
+    register: telemetry.register.bind(telemetry),
+    reset: telemetry.reset.bind(telemetry),
+    group: telemetry.group.bind(telemetry),
   };
 }
 
@@ -96,7 +101,8 @@ export const TelemetryProvider = (props: {
   }, []);
 
   let value: Telemetry = ph ?? nullTelemetry;
-  let flagsInitiallyAvailable = false;
+  // Share page uses nullTelemetry and never emits onFeatureFlags.
+  let flagsInitiallyAvailable = ph == null;
   if (!isPublicSharePath() && shouldUseDevTelemetry(serverURL)) {
     value = AM_TESTING_TELEMETRY ? testTelemetry : devTelemetry;
     flagsInitiallyAvailable = true;

--- a/client/dashboard/src/contexts/TelemetryProvider.tsx
+++ b/client/dashboard/src/contexts/TelemetryProvider.tsx
@@ -22,11 +22,26 @@ const AM_TESTING_TELEMETRY = false;
 const isPublicSharePath = (): boolean =>
   window.location.pathname.startsWith("/shared/");
 
-// Localhost and PR preview hosts (*.dev.getgram.ai) skip PostHog flag
-// evaluation so gated UI such as Watchdog and Functions is visible. Shared
-// staging (dev.getgram.ai) and production stay on the real project.
+// Localhost skips PostHog flag evaluation so every flag is on. Preview
+// hosts keep talking to the real project so configured flags can be
+// toggled; only missing keys fail open (see failOpenMissingFlags).
 export const shouldUseDevTelemetry = (serverURL: string): boolean =>
-  serverURL.includes("localhost") || serverURL.includes(".dev.getgram.ai");
+  serverURL.includes("localhost");
+
+// PR preview hosts (*.dev.getgram.ai). Shared staging is the apex host
+// (dev.getgram.ai) and must not match.
+export const shouldFailOpenMissingFlags = (serverURL: string): boolean =>
+  serverURL.includes(".dev.getgram.ai");
+
+export function failOpenMissingFlags(telemetry: Telemetry): Telemetry {
+  return {
+    ...telemetry,
+    isFeatureEnabled: ((flag, options) => {
+      const result = telemetry.isFeatureEnabled(flag, options);
+      return result === undefined ? true : result;
+    }) as Telemetry["isFeatureEnabled"],
+  };
+}
 
 export const TelemetryProvider = (props: {
   children: ReactNode;
@@ -81,14 +96,22 @@ export const TelemetryProvider = (props: {
   }, []);
 
   let value: Telemetry = ph ?? nullTelemetry;
-  if (!isPublicSharePath() && shouldUseDevTelemetry(getServerURL())) {
+  let flagsInitiallyAvailable = false;
+  if (!isPublicSharePath() && shouldUseDevTelemetry(serverURL)) {
     value = AM_TESTING_TELEMETRY ? testTelemetry : devTelemetry;
+    flagsInitiallyAvailable = true;
+  } else if (
+    !isPublicSharePath() &&
+    ph &&
+    shouldFailOpenMissingFlags(serverURL)
+  ) {
+    value = failOpenMissingFlags(ph);
   }
 
   return (
     <TelemetryStateProvider
       telemetry={value}
-      featureFlagsInitiallyAvailable={value !== ph}
+      featureFlagsInitiallyAvailable={flagsInitiallyAvailable}
     >
       {props.children}
     </TelemetryStateProvider>

--- a/client/dashboard/src/hooks/useFeatureFlag.ts
+++ b/client/dashboard/src/hooks/useFeatureFlag.ts
@@ -33,11 +33,12 @@ function assertNever(value: never): never {
  *   registered key. Treat this as a configuration error rather than as off.
  * - `"error"`: PostHog reported that its flag request failed.
  *
- * Local development and PR preview hosts (`*.dev.getgram.ai`) use a
- * deterministic provider where every flag is immediately enabled. Shared
- * staging and production still read the real PostHog project. PostHog flags
- * are rollout controls only; never use them as authorization checks or
- * entitlement enforcement.
+ * Local development uses a deterministic provider where every flag is
+ * immediately enabled. PR preview hosts (`*.dev.getgram.ai`) still read the
+ * real PostHog project so configured flags can be toggled, but a missing key
+ * fails open (treated as enabled). Shared staging and production treat a
+ * missing key as unavailable. PostHog flags are rollout controls only; never
+ * use them as authorization checks or entitlement enforcement.
  */
 export function useFeatureFlag(flag: FeatureFlag): FeatureFlagResult {
   const { telemetry, featureFlags } = useTelemetryContext();

--- a/client/dashboard/src/hooks/useFeatureFlag.ts
+++ b/client/dashboard/src/hooks/useFeatureFlag.ts
@@ -33,9 +33,11 @@ function assertNever(value: never): never {
  *   registered key. Treat this as a configuration error rather than as off.
  * - `"error"`: PostHog reported that its flag request failed.
  *
- * Local development uses a deterministic provider where every flag is
- * immediately enabled. PostHog flags are rollout controls only; never use them
- * as authorization checks or entitlement enforcement.
+ * Local development and PR preview hosts (`*.dev.getgram.ai`) use a
+ * deterministic provider where every flag is immediately enabled. Shared
+ * staging and production still read the real PostHog project. PostHog flags
+ * are rollout controls only; never use them as authorization checks or
+ * entitlement enforcement.
  */
 export function useFeatureFlag(flag: FeatureFlag): FeatureFlagResult {
   const { telemetry, featureFlags } = useTelemetryContext();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [GRW-70](https://linear.app/speakeasy/issue/GRW-70/bug-restore-feature-flags-in-preview-environments).

## Problem

Preview apps (`pr-*.dev.getgram.ai`) use the **dev** PostHog project. Flags that exist only in prod — Watchdog, Functions, and others — resolve as `missing`. After #4649, every `useFeatureFlag` caller gates on `status === "enabled"`, and loose callers use `?? false`, so missing is treated as off. Preview hid gated UI even though those flags were never configured in the dev project.

Localhost already fail-opens by swapping in `devTelemetry` (`isFeatureEnabled: () => true`). Preview never matched that path.

## What this does **not** do

Preview does **not** turn every flag on. That would make on/off rollout testing impossible. Shared staging (`dev.getgram.ai`) is also unchanged.

## Change

Preview still talks to the real PostHog project. A wrapper around `isFeatureEnabled` treats only **missing** keys (`undefined`) as enabled. Explicit on/off is preserved, so a flag that exists in the dev project can still be turned off.

| | Flag on | Flag off | Flag missing |
|---|---|---|---|
| Localhost | on | on | on |
| Preview (`*.dev.getgram.ai`) | on | off | **on** |
| Staging (`dev.getgram.ai`) | on | off | off |
| Production | on | off | off |

The wrapper is applied at the telemetry layer so both `useFeatureFlag` and `isFeatureEnabled(...) ?? false` get the same behavior. Methods are bound to the real PostHog instance (no object spread — prototype methods are not enumerable). The public `/shared/*` page still marks flags as initially available so it does not sit in `loading`.

## Tests

`TelemetryProvider.test.ts` covers host classification (preview vs staging vs prod vs localhost), missing → on, explicit off stays off, and method delegation.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [GRW-70](https://linear.app/speakeasy/issue/GRW-70/bug-restore-feature-flags-in-preview-environments)

<div><a href="https://cursor.com/agents/bc-49f4f727-3e00-452c-a66c-b67eb52fbc28?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49f4f727-3e00-452c-a66c-b67eb52fbc28&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes [GRW-70](https://linear.app/speakeasy/issue/GRW-70/bug-restore-feature-flags-in-preview-environments). Preview hosts (`pr-*.dev.getgram.ai`) read the real dev PostHog project, where several flags were missing and treated as off, so gated UI like Watchdog and Functions disappeared. Preview hosts now fail open on missing flags only: configured flags can still be toggled, and unknown keys resolve as enabled. Localhost stays all-flags-on; `dev.getgram.ai` staging and `app.getgram.ai` production remain fail-closed.

- The fail-open wrapper delegates each telemetry method instead of spreading the PostHog instance, so prototype methods survive and previews don't crash.
- The share page's null telemetry is marked as already resolved so flags don't stay loading.
- Adds coverage for host classification, fail-open behavior, and method receiver binding in `TelemetryProvider.test.ts`, plus a `dashboard` patch changeset.

<sup>Written for commit a4e453b1e4b5083dda56fbfeba49b438a0193bc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

