### PR TITLE
feat: capture upstream identity from ID tokens on remote session grants

### DIFF
--- a/.changeset/remote-session-id-token-identity.md
+++ b/.changeset/remote-session-id-token-identity.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Capture who an upstream grant belongs to from the OpenID Connect ID token an issuer returns at code exchange or refresh. The token is verified against the issuer's published key set and reduced to its claims; the consent card shows the result as "Connected as". Non-standard token response members are kept alongside, minus anything credential-shaped.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1105,6 +1105,11 @@ func newStartCommand() *cli.Command {
 				platformtoolsruntime.WithExternalTools(assistantPlatformExtras),
 			)
 
+			idTokenKeys, err := remotesessions.NewIDTokenKeyResolver(logger, guardianPolicy, meterProvider, ratelimit.NewRedisStore(redisClient))
+			if err != nil {
+				return fmt.Errorf("initialize remote session id token key resolver: %w", err)
+			}
+			idTokenVerifier := remotesessions.NewIDTokenVerifier(idTokenKeys)
 			remoteChallengeManager := remotesessions.NewChallengeManager(
 				logger,
 				tracerProvider,
@@ -1117,6 +1122,7 @@ func newStartCommand() *cli.Command {
 				remotesessions.WithPrivateAuthorityValidator(func(ctx context.Context, state remotesessions.RemoteLoginState) error {
 					return mcp.ValidateRemoteLoginPrivateAuthority(ctx, db, logger, state)
 				}),
+				remotesessions.WithIDTokenVerifier(idTokenVerifier),
 			)
 
 			toolDispositionCache := mcpservers.NewToolDispositionCache(logger, db, cache.NewRedisCacheAdapter(redisClient))
@@ -1664,7 +1670,7 @@ func newStartCommand() *cli.Command {
 			mcpendpoints.Attach(mux, mcpendpoints.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, temporalEnv, pluginsGitHub != nil))
 			metamcp.Attach(mux, metamcp.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, temporalEnv, networkIngressAdmission))
 			remoteSessionsCache := cache.NewRedisCacheAdapter(redisClient)
-			remoteSessionsService := remotesessions.NewService(logger, tracerProvider, meterProvider, db, sessionManager, authzEngine, encryptionClient, env, guardianPolicy, auditLogger, serverURL, remotesessions.NewRefreshService(logger, meterProvider, db, encryptionClient, guardianPolicy, remoteSessionsCache), productFeatures)
+			remoteSessionsService := remotesessions.NewService(logger, tracerProvider, meterProvider, db, sessionManager, authzEngine, encryptionClient, env, guardianPolicy, auditLogger, serverURL, remotesessions.NewRefreshService(logger, meterProvider, db, encryptionClient, guardianPolicy, remoteSessionsCache, remotesessions.WithRefreshIDTokenVerifier(idTokenVerifier)), productFeatures)
 			usersessions.Attach(mux, usersessions.NewService(logger, tracerProvider, meterProvider, db, sessionManager, chatSessionsManager, authzEngine, auditLogger, guardianPolicy, encryptionClient, usersessions.NewSigner(c.String(usersessions.JWTSigningKeyFlag)), serverURL.String(), ratelimit.NewRedisStore(redisClient)))
 			tokenexchange.Attach(mux, tokenexchange.NewService(logger, tracerProvider, db, sessionManager, authzEngine, c.String("environment")))
 			remotesessions.Attach(mux, remoteSessionsService)

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -240,6 +240,7 @@ func NewActivities(
 	riskFingerprinter risk.Fingerprinter,
 	disableRiskRetroReconcile bool,
 	tumMeterStreamingEnabled bool,
+	idTokenVerifier remotesessions.IDTokenVerifier,
 ) *Activities {
 	// Spend rule evaluation reads ClickHouse; workers without a ClickHouse
 	// connection get a nil repo and the activity fails loudly if scheduled.
@@ -315,7 +316,7 @@ func NewActivities(
 		remoteSessionRefresh = activities.NewRemoteSessionRefresh(
 			logger,
 			db,
-			remotesessions.NewRefreshService(logger, meterProvider, db, encryption, guardianPolicy, cacheAdapter),
+			remotesessions.NewRefreshService(logger, meterProvider, db, encryption, guardianPolicy, cacheAdapter, remotesessions.WithRefreshIDTokenVerifier(idTokenVerifier)),
 		)
 	}
 

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -49,6 +49,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/rag"
 	"github.com/speakeasy-api/gram/server/internal/ratelimit"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 	"github.com/speakeasy-api/gram/server/internal/risk"
 	"github.com/speakeasy-api/gram/server/internal/risk/celenv"
 	"github.com/speakeasy-api/gram/server/internal/risk/presetlib"
@@ -357,6 +358,16 @@ func NewTemporalWorker(
 
 	judgeRateLimiter := openrouter.NewJudgeRateLimiter(ratelimit.NewRedisStore(opts.RedisClient))
 
+	// Identity capture is best effort: without a policy the sweep stores no identity.
+	idTokenVerifier := remotesessions.NoIDTokenVerifier()
+	if opts.GuardianPolicy != nil {
+		if idTokenKeys, err := remotesessions.NewIDTokenKeyResolver(logger, opts.GuardianPolicy, meterProvider, ratelimit.NewRedisStore(opts.RedisClient)); err != nil {
+			logger.ErrorContext(context.Background(), "build id token key resolver for the refresh sweep", attr.SlogError(err))
+		} else {
+			idTokenVerifier = remotesessions.NewIDTokenVerifier(idTokenKeys)
+		}
+	}
+
 	activities := NewActivities(
 		logger,
 		tracerProvider,
@@ -408,6 +419,7 @@ func NewTemporalWorker(
 		opts.RiskFingerprinter,
 		opts.DisableRiskRetroReconcile,
 		opts.TUMMeterStreamingEnabled,
+		idTokenVerifier,
 	)
 
 	temporalWorker.RegisterActivity(activities.ProcessDeployment)

--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -232,6 +232,9 @@ type remoteSessionCard struct {
 	// the stored preference when the organization lets subjects choose,
 	// otherwise the organization's own policy value.
 	AutoRefreshChecked bool
+
+	// ConnectedAs is upstream-supplied text, rendered escaped as a secondary line.
+	ConnectedAs string
 }
 
 // autoRefreshPolicy is an organization's policy for automatic remote-session
@@ -1197,6 +1200,7 @@ func (s *Service) buildRemoteSessionCards(
 			AuthorizationExpiresAt: authorizationExpiresAt,
 			AuthorizationExpiresIn: authorizationExpiresIn,
 			AutoRefreshChecked:     checked,
+			ConnectedAs:            state.ConnectedAs,
 		})
 	}
 	return cards, nil

--- a/server/internal/mcp/authnchallenge_consent_template_test.go
+++ b/server/internal/mcp/authnchallenge_consent_template_test.go
@@ -618,3 +618,37 @@ func TestConsentTemplateFirstPartyNoCardCopy(t *testing.T) {
 	require.NotContains(t, html, "Link the services this MCP server needs")
 	require.NotContains(t, html, "connected the services above")
 }
+
+func TestConsentTemplateShowsConnectedIdentity(t *testing.T) {
+	t.Parallel()
+
+	render := func(t *testing.T, card remoteSessionCard) string {
+		t.Helper()
+
+		var page bytes.Buffer
+		err := consentTemplate.Execute(&page, consentTemplateData{
+			ClientName:         "Example Client",
+			MCPSlug:            "example",
+			MCPRouteBase:       "mcp",
+			State:              "state",
+			CSRFToken:          "csrf",
+			SubjectDisplay:     "user@example.com",
+			ScriptURL:          "/mcp/consent-page-test.js",
+			RemoteSessionCards: []remoteSessionCard{card},
+			ConsentEnabled:     true,
+		})
+		require.NoError(t, err)
+		return normalizeWhitespace(page.String())
+	}
+
+	html := render(t, remoteSessionCard{ClientID: "client-id", IssuerSlug: "corp-okta", Connected: true, ConnectedAs: "grant-owner@example.com"})
+	require.Contains(t, html, "Connected as grant-owner@example.com")
+
+	// The identity is provider-supplied text and must render escaped.
+	html = render(t, remoteSessionCard{ClientID: "client-id", IssuerSlug: "corp-okta", Connected: true, ConnectedAs: "<img src=x>"})
+	require.Contains(t, html, "Connected as &lt;img src=x&gt;")
+	require.NotContains(t, html, "<img src=x>")
+
+	html = render(t, remoteSessionCard{ClientID: "client-id", IssuerSlug: "corp-okta", Connected: false, ConnectedAs: "grant-owner@example.com"})
+	require.NotContains(t, html, "Connected as", "a disconnected card names nobody")
+}

--- a/server/internal/mcp/consent_template.html
+++ b/server/internal/mcp/consent_template.html
@@ -196,6 +196,13 @@
                     >Connected{{if .AutoRefreshChecked}} · auto refresh
                     on{{end}}</span
                   >
+                  {{if .ConnectedAs}}
+                  <span
+                    class="truncate text-xs text-muted-foreground"
+                    title="{{.ConnectedAs}}"
+                    >Connected as {{.ConnectedAs}}</span
+                  >
+                  {{end}}
                   {{/* Two different deadlines, stated differently. The idle
                   timeout is what auto refresh exists to defeat, so it is only
                   worth raising when nothing is renewing the session. The

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -1021,12 +1021,13 @@ func (m *ChallengeManager) identityFromExchange(ctx context.Context, logger *slo
 		return nil
 	}
 	identity, err := m.idTokens.Verify(ctx, tok.IDToken, IDTokenExpectation{
-		issuer:     issuer.IssuerUrl,
-		clientID:   externalClientID,
-		jwksURI:    issuer.JwksUri.String,
-		fetchScope: issuer.RemoteSessionIssuerID.String(),
-		nonce:      nonce,
-		subject:    "",
+		issuer:      issuer.IssuerUrl,
+		clientID:    externalClientID,
+		jwksURI:     issuer.JwksUri.String,
+		fetchScope:  issuer.RemoteSessionIssuerID.String(),
+		signingAlgs: issuer.IDTokenSigningAlgValuesSupported,
+		nonce:       nonce,
+		subject:     "",
 	})
 	if errors.Is(err, errIDTokenVerificationDisabled) {
 		return nil

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -133,7 +133,9 @@ type RemoteLoginState struct {
 	// client capability's default at persist time.
 	AutoRefresh *bool                    `json:"auto_refresh,omitempty"`
 	Authority   networkingress.Authority `json:"authority,omitzero"`
-	CreatedAt   time.Time                `json:"created_at"`
+	// Nonce is echoed by the ID token; empty for states minted before it existed.
+	Nonce     string    `json:"nonce,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
 var _ cache.CacheableObject[RemoteLoginState] = (*RemoteLoginState)(nil)
@@ -168,6 +170,9 @@ type ChallengeManager struct {
 	// privateAuthorityValidator is injected at construction. The callback package
 	// owns state mechanics; the caller owns endpoint resolution.
 	privateAuthorityValidator PrivateAuthorityValidator
+
+	// idTokens verifies the ID token a code exchange or refresh returns.
+	idTokens IDTokenVerifier
 }
 
 // PrivateAuthorityValidator revalidates a private endpoint without introducing
@@ -180,6 +185,11 @@ func WithPrivateAuthorityValidator(validator PrivateAuthorityValidator) Challeng
 	return func(m *ChallengeManager) {
 		m.privateAuthorityValidator = validator
 	}
+}
+
+// WithIDTokenVerifier enables identity capture from ID tokens on the exchange and the manager's refreshes.
+func WithIDTokenVerifier(verifier IDTokenVerifier) ChallengeManagerOption {
+	return func(m *ChallengeManager) { m.idTokens = verifier }
 }
 
 func NewChallengeManager(
@@ -205,7 +215,7 @@ func NewChallengeManager(
 			cache.SuffixNone,
 		),
 		locks:     cacheImpl,
-		refresher: NewRefreshService(logger, meterProvider, db, enc, policy, cacheImpl),
+		refresher: nil,
 		serverURL: serverURL,
 		revoker:   NewUpstreamRevoker(logger, tracerProvider, meterProvider, db, enc, policy),
 		authorizeInterceptors: []interceptors.AuthorizeInterceptor{
@@ -213,10 +223,13 @@ func NewChallengeManager(
 		},
 		metrics:                   remotesessionmetrics.NewAuthorize(logger, meterProvider),
 		privateAuthorityValidator: nil,
+		idTokens:                  NoIDTokenVerifier(),
 	}
 	for _, option := range options {
 		option(manager)
 	}
+	// The manager's own refreshes restate identity with the same verifier.
+	manager.refresher = NewRefreshService(logger, meterProvider, db, enc, policy, cacheImpl, WithRefreshIDTokenVerifier(manager.idTokens))
 	return manager
 }
 
@@ -342,6 +355,10 @@ type RemoteSessionState struct {
 	CanRefresh             bool
 	// Resource is the RFC 8707 resource recorded on the grant, if any.
 	Resource string
+	// ConnectedAs is the upstream email, else display name; empty when unknown.
+	ConnectedAs string
+	// IdentitySource names the interface ConnectedAs came from.
+	IdentitySource string
 }
 
 // RemoteSessionStatuses returns, per remote_session_client_id, the state of
@@ -396,6 +413,8 @@ func (m *ChallengeManager) RemoteSessionStatuses(
 			AuthorizationExpiresAt: authorizationExpiresAt,
 			CanRefresh:             row.CanRefresh,
 			Resource:               row.Resource.String,
+			ConnectedAs:            conv.Default(row.UpstreamEmail.String, row.UpstreamDisplayName.String),
+			IdentitySource:         row.IdentitySource.String,
 		}
 	}
 	return statuses, nil
@@ -540,6 +559,10 @@ func (m *ChallengeManager) BuildAuthorizationUrl(
 	if err != nil {
 		return "", fmt.Errorf("generate code verifier: %w", err)
 	}
+	nonce, err := randomToken(16)
+	if err != nil {
+		return "", fmt.Errorf("generate nonce: %w", err)
+	}
 	codeChallenge := s256Challenge(verifier)
 	redirectURI := m.callbackURL(canonicalCallbackRouteBase)
 	stateParam := stateID
@@ -582,6 +605,7 @@ func (m *ChallengeManager) BuildAuthorizationUrl(
 		FinalRedirectURI:      parent.FinalRedirectURI,
 		AutoRefresh:           parent.AutoRefresh,
 		Authority:             parent.Authority,
+		Nonce:                 nonce,
 		CreatedAt:             time.Now(),
 	}
 	if err := m.cache.Store(ctx, state); err != nil {
@@ -595,6 +619,9 @@ func (m *ChallengeManager) BuildAuthorizationUrl(
 	q.Set("state", stateParam)
 	q.Set("code_challenge", codeChallenge)
 	q.Set("code_challenge_method", "S256")
+	// Harmless to a plain OAuth server and required for an OpenID one to
+	// bind the ID token to this request.
+	q.Set("nonce", nonce)
 	if scopes := client.resolveScopes(); len(scopes) > 0 {
 		q.Set("scope", strings.Join(scopes, " "))
 	}
@@ -720,7 +747,6 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 	if err != nil {
 		return oops.E(oops.CodeUnauthorized, err, "upstream token exchange failed").LogError(ctx, logger)
 	}
-
 	// The pair is live upstream from this line on, and every path out of here
 	// that does not store it strands it: unreachable through Gram, and outside
 	// the reach of every revoke path since no row points at it. So arm the
@@ -734,6 +760,13 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 		}
 		m.revoker.RevokeUnstoredDetached(ctx, state.RemoteSessionClientID, tok.AccessToken, tok.RefreshToken)
 	}()
+
+	identity := m.identityFromExchange(ctx, logger, tok, client.ID, client.ClientID, state.Nonce)
+	identityCols := identity.columns()
+	enrichment, err := buildEnrichment(tok, identity)
+	if err != nil {
+		logIdentityFailure(ctx, logger, "enrichment document dropped; session stored without it", err, attr.SlogRemoteSessionClientID(client.ID.String()))
+	}
 
 	accessEnc, err := m.enc.Encrypt([]byte(tok.AccessToken))
 	if err != nil {
@@ -837,10 +870,15 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 		AuthorizationExpiresAt: conv.PtrToPGTimestamptz(
 			authorizationExpires,
 		),
-		RefreshExpiresAt: conv.PtrToPGTimestamptz(refreshExpires),
-		Scopes:           scopes,
-		Resource:         conv.ToPGTextEmpty(state.Resource),
-		AutoRefresh:      autoRefresh,
+		RefreshExpiresAt:    conv.PtrToPGTimestamptz(refreshExpires),
+		Scopes:              scopes,
+		Resource:            conv.ToPGTextEmpty(state.Resource),
+		AutoRefresh:         autoRefresh,
+		UpstreamSubject:     identityCols.Subject,
+		UpstreamEmail:       identityCols.Email,
+		UpstreamDisplayName: identityCols.DisplayName,
+		IdentitySource:      identityCols.Source,
+		Enrichment:          enrichment,
 	}); err != nil {
 		return oops.E(oops.CodeUnexpected, err, "store remote session").LogError(ctx, logger)
 	}
@@ -962,7 +1000,42 @@ func (m *ChallengeManager) exchangeCode(
 	if tok.AccessToken == "" {
 		return tokenResponse{}, errors.New("token endpoint returned no access_token")
 	}
+	tok.raw = body
 	return tok, nil
+}
+
+// identityFromExchange verifies the exchange's ID token; a rejected token
+// yields nil and the grant is stored without identity.
+func (m *ChallengeManager) identityFromExchange(ctx context.Context, logger *slog.Logger, tok tokenResponse, clientRowID uuid.UUID, externalClientID string, nonce string) *UpstreamIdentity {
+	if tok.IDToken == "" {
+		return nil
+	}
+	issuer, err := remotesessions_repo.New(m.db).GetRemoteSessionClientWithIssuerByID(ctx, clientRowID)
+	if err != nil {
+		logIdentityFailure(ctx, logger, "upstream id token rejected; session stored without identity", fmt.Errorf("load issuer for id token verification: %w", err), attr.SlogRemoteSessionClientID(clientRowID.String()))
+		return nil
+	}
+	// An issuer with no published key set cannot have its tokens verified;
+	// that is a configuration state, not an event worth a warning per grant.
+	if !issuer.JwksUri.Valid || issuer.JwksUri.String == "" {
+		return nil
+	}
+	identity, err := m.idTokens.Verify(ctx, tok.IDToken, IDTokenExpectation{
+		issuer:     issuer.IssuerUrl,
+		clientID:   externalClientID,
+		jwksURI:    issuer.JwksUri.String,
+		fetchScope: issuer.RemoteSessionIssuerID.String(),
+		nonce:      nonce,
+		subject:    "",
+	})
+	if errors.Is(err, errIDTokenVerificationDisabled) {
+		return nil
+	}
+	if err != nil {
+		logIdentityFailure(ctx, logger, "upstream id token rejected; session stored without identity", err, attr.SlogOAuthIssuer(issuer.IssuerUrl), attr.SlogRemoteSessionClientID(clientRowID.String()))
+		return nil
+	}
+	return &identity
 }
 
 func randomToken(n int) (string, error) {

--- a/server/internal/remotesessions/challenge_identity_e2e_test.go
+++ b/server/internal/remotesessions/challenge_identity_e2e_test.go
@@ -6,12 +6,14 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -24,6 +26,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+	"github.com/speakeasy-api/gram/server/internal/usersessions/jwks"
 )
 
 // idTokenIssuer stands in for an OpenID provider: it publishes an ES256 key
@@ -35,6 +39,11 @@ type idTokenIssuer struct {
 	jwksURI   string
 	pool      *x509.CertPool
 	signer    jose.Signer
+	key       *ecdsa.PrivateKey
+	// keySet is the published JWK Set document.
+	keySet []byte
+	// fetches counts key-set downloads.
+	fetches atomic.Int64
 }
 
 func newIDTokenIssuer(t *testing.T) *idTokenIssuer {
@@ -52,7 +61,17 @@ func newIDTokenIssuer(t *testing.T) *idTokenIssuer {
 	body, err := json.Marshal(set)
 	require.NoError(t, err)
 
+	issuer := &idTokenIssuer{
+		issuerURL: "https://" + uuid.NewString() + ".idp.example.com",
+		jwksURI:   "",
+		pool:      nil,
+		signer:    nil,
+		key:       key,
+		keySet:    body,
+		fetches:   atomic.Int64{},
+	}
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		issuer.fetches.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write(body)
 	}))
@@ -66,12 +85,10 @@ func newIDTokenIssuer(t *testing.T) *idTokenIssuer {
 	)
 	require.NoError(t, err)
 
-	return &idTokenIssuer{
-		issuerURL: "https://" + uuid.NewString() + ".idp.example.com",
-		jwksURI:   server.URL + "/jwks.json",
-		pool:      pool,
-		signer:    signer,
-	}
+	issuer.jwksURI = server.URL + "/jwks.json"
+	issuer.pool = pool
+	issuer.signer = signer
+	return issuer
 }
 
 // claims is an ID token body that verifies against the synthetic fixture
@@ -102,6 +119,53 @@ func (i *idTokenIssuer) mint(t *testing.T, claims map[string]any) string {
 	return raw
 }
 
+// mintWithKid signs with the issuer's key under a kid its key set never published.
+func (i *idTokenIssuer) mintWithKid(t *testing.T, kid string, claims map[string]any) string {
+	t.Helper()
+
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.ES256, Key: i.key},
+		(&jose.SignerOptions{}).WithType("JWT").WithHeader(jose.HeaderKey("kid"), kid),
+	)
+	require.NoError(t, err)
+	raw, err := jwt.Signed(signer).Claims(claims).Serialize()
+	require.NoError(t, err)
+	return raw
+}
+
+func mintHS256(t *testing.T, claims map[string]any) string {
+	t.Helper()
+
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.HS256, Key: []byte("synthetic-hmac-key-of-32-bytes!!")},
+		(&jose.SignerOptions{}).WithType("JWT").WithHeader(jose.HeaderKey("kid"), "synthetic-kid"),
+	)
+	require.NoError(t, err)
+	raw, err := jwt.Signed(signer).Claims(claims).Serialize()
+	require.NoError(t, err)
+	return raw
+}
+
+func mintUnsigned(t *testing.T, claims map[string]any) string {
+	t.Helper()
+
+	body, err := json.Marshal(claims)
+	require.NoError(t, err)
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT","kid":"synthetic-kid"}`))
+	return header + "." + base64.RawURLEncoding.EncodeToString(body) + "."
+}
+
+// verifierFunc adapts a closure to IDTokenVerifier for withIDTokenVerifierWrapper.
+type verifierFunc func(context.Context, string, remotesessions.IDTokenExpectation) (remotesessions.UpstreamIdentity, error)
+
+func (f verifierFunc) Verify(ctx context.Context, raw string, expect remotesessions.IDTokenExpectation) (remotesessions.UpstreamIdentity, error) {
+	identity, err := f(ctx, raw, expect)
+	if err != nil {
+		return identity, fmt.Errorf("wrapped verifier: %w", err)
+	}
+	return identity, nil
+}
+
 // enrichmentDoc mirrors the shape of the enrichment column for assertions.
 type enrichmentDoc struct {
 	IDToken       map[string]json.RawMessage `json:"id_token"`
@@ -125,6 +189,31 @@ func reloadSession(t *testing.T, env syntheticExpiryEnv) repo.RemoteSession {
 	})
 	require.NoError(t, err)
 	return sess
+}
+
+// restatedSession waits for the detached restatement a request-path refresh left behind, then reads the row.
+func restatedSession(t *testing.T, env syntheticExpiryEnv) repo.RemoteSession {
+	t.Helper()
+
+	env.mgr.WaitIdentityRestatements()
+	return reloadSession(t, env)
+}
+
+// refreshTokenHandler answers the code exchange with exchange and every refresh with the members
+// currently in refreshBody, both expiring inside the skew so each resolve refreshes.
+func refreshTokenHandler(t *testing.T, refreshes *atomic.Int64, exchange string, refreshBody *atomic.Pointer[string]) http.HandlerFunc {
+	t.Helper()
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		w.Header().Set("Content-Type", "application/json")
+		if r.Form.Get("grant_type") != "refresh_token" {
+			_, _ = w.Write([]byte(`{"access_token":"access-0","refresh_token":"refresh-0","token_type":"Bearer","expires_in":1` + exchange + `}`))
+			return
+		}
+		n := strconv.FormatInt(refreshes.Add(1), 10)
+		_, _ = w.Write([]byte(`{"access_token":"access-` + n + `","refresh_token":"refresh-` + n + `","token_type":"Bearer","expires_in":1` + loadString(refreshBody) + `}`))
+	}
 }
 
 // loadString reads a string shared between the test and the fixture
@@ -220,10 +309,17 @@ func TestRemoteLoginStoresSessionWithoutIdentityWhenIDTokenIsRejected(t *testing
 		mutate func(claims map[string]any)
 		// signer, when set, signs with a key the fixture issuer never published.
 		signer *idTokenIssuer
+		// mint, when set, serializes the claims itself.
+		mint func(t *testing.T, claims map[string]any) string
 		// noVerifier leaves the manager without an ID token verifier.
 		noVerifier bool
 	}{
 		{name: "wrong nonce", mutate: func(c map[string]any) { c["nonce"] = "stale" }},
+		{name: "missing nonce", mutate: func(c map[string]any) { delete(c, "nonce") }},
+		{name: "nbf in the future", mutate: func(c map[string]any) { c["nbf"] = time.Now().Add(5 * time.Minute).Unix() }},
+		{name: "iat in the future", mutate: func(c map[string]any) { c["iat"] = time.Now().Add(5 * time.Minute).Unix() }},
+		{name: "unsigned", mint: mintUnsigned},
+		{name: "hmac signed", mint: mintHS256},
 		{name: "wrong audience", mutate: func(c map[string]any) { c["aud"] = "someone-else" }},
 		{name: "wrong issuer", mutate: func(c map[string]any) { c["iss"] = "https://other.example.com" }},
 		{name: "expired", mutate: func(c map[string]any) { c["exp"] = time.Now().Add(-5 * time.Minute).Unix() }},
@@ -238,9 +334,12 @@ func TestRemoteLoginStoresSessionWithoutIdentityWhenIDTokenIsRejected(t *testing
 			t.Parallel()
 
 			issuer := newIDTokenIssuer(t)
-			signer := issuer
+			mint := issuer.mint
 			if tc.signer != nil {
-				signer = tc.signer
+				mint = tc.signer.mint
+			}
+			if tc.mint != nil {
+				mint = tc.mint
 			}
 			suffix := fmt.Sprintf("idtoken-reject-%d", i)
 			clientID := "synthetic-cid-" + suffix
@@ -257,7 +356,7 @@ func TestRemoteLoginStoresSessionWithoutIdentityWhenIDTokenIsRejected(t *testing
 				}
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(`{"access_token":"access","token_type":"Bearer","expires_in":3600,"id_token":"` +
-					signer.mint(t, claims) + `","ok":true}`))
+					mint(t, claims) + `","ok":true}`))
 			}, opts...)
 
 			sess := env.session
@@ -313,7 +412,7 @@ func TestRefreshRestatesIdentityOnlyWhenIDTokenReturned(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "access-1", resolved)
 	require.EqualValues(t, 1, refreshes.Load())
-	sess := reloadSession(t, env)
+	sess := restatedSession(t, env)
 	require.Equal(t, "grant-owner@example.com", sess.UpstreamEmail.String, "a refresh without an ID token keeps the stored identity")
 	require.Equal(t, "user-123", sess.UpstreamSubject.String)
 	require.Equal(t, remotesessions.IdentitySourceIDToken, sess.IdentitySource.String)
@@ -333,7 +432,7 @@ func TestRefreshRestatesIdentityOnlyWhenIDTokenReturned(t *testing.T) {
 		resolved, err = env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
 		require.NoError(t, err)
 		require.Equal(t, access, resolved)
-		sess = reloadSession(t, env)
+		sess = restatedSession(t, env)
 		require.Equal(t, "user-123", sess.UpstreamSubject.String)
 		require.Equal(t, "grant-owner@example.com", sess.UpstreamEmail.String)
 		require.Equal(t, remotesessions.IdentitySourceIDToken, sess.IdentitySource.String)
@@ -353,7 +452,7 @@ func TestRefreshRestatesIdentityOnlyWhenIDTokenReturned(t *testing.T) {
 	resolved, err = env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
 	require.NoError(t, err)
 	require.Equal(t, "access-4", resolved)
-	sess = reloadSession(t, env)
+	sess = restatedSession(t, env)
 	require.Equal(t, "grant-owner@example.com", sess.UpstreamEmail.String)
 	require.Equal(t, "Renamed Owner", sess.UpstreamDisplayName.String)
 	doc = decodeEnrichment(t, sess.Enrichment)
@@ -371,7 +470,7 @@ func TestRefreshRestatesIdentityOnlyWhenIDTokenReturned(t *testing.T) {
 	resolved, err = env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
 	require.NoError(t, err)
 	require.Equal(t, "access-5", resolved)
-	sess = reloadSession(t, env)
+	sess = restatedSession(t, env)
 	require.Equal(t, "renamed@example.com", sess.UpstreamEmail.String)
 	require.Equal(t, "Grant Owner", sess.UpstreamDisplayName.String)
 	doc = decodeEnrichment(t, sess.Enrichment)
@@ -437,4 +536,249 @@ func TestRevocationPathsClearIdentity(t *testing.T) {
 			require.NotEmpty(t, tombstone.AccessTokenEncrypted, "credentials stay for upstream revocation")
 		})
 	}
+}
+
+func TestRemoteLoginRefetchesKeySetForUnknownKid(t *testing.T) {
+	t.Parallel()
+
+	issuer := newIDTokenIssuer(t)
+	const clientID = "synthetic-cid-idtoken-unknown-kid"
+	var nonce atomic.Pointer[string]
+	// A fresh cached set last confirmed outside the negative-cache window, so the unknown kid re-fetches.
+	keyCache := jwks.NewMemoryCache()
+	require.NoError(t, keyCache.Put(t.Context(), issuer.jwksURI, jwks.CacheState{
+		Document:    issuer.keySet,
+		ETag:        "",
+		ExpiresAt:   time.Now().Add(time.Hour),
+		RefreshedAt: time.Now().Add(-time.Minute),
+	}))
+	_, env := newSyntheticExpiryEnv(t, "idtoken-unknown-kid", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"access","token_type":"Bearer","expires_in":3600,"id_token":"` +
+			issuer.mintWithKid(t, "rotated-kid", issuer.claims(clientID, loadString(&nonce))) + `","ok":true}`))
+	}, withIDTokenIssuer(issuer), observeNonce(&nonce), withIDTokenKeyCache(keyCache))
+
+	require.EqualValues(t, 1, issuer.fetches.Load(), "an unknown kid re-fetches the key set once")
+	require.False(t, env.session.UpstreamSubject.Valid)
+	require.False(t, env.session.IdentitySource.Valid)
+	require.Nil(t, decodeEnrichment(t, env.session.Enrichment).IDToken)
+}
+
+func TestRemoteLoginAcceptsIDTokenNamingSeveralAudiencesWithAzp(t *testing.T) {
+	t.Parallel()
+
+	issuer := newIDTokenIssuer(t)
+	const clientID = "synthetic-cid-idtoken-azp"
+	var nonce atomic.Pointer[string]
+	_, env := newSyntheticExpiryEnv(t, "idtoken-azp", func(w http.ResponseWriter, _ *http.Request) {
+		claims := issuer.claims(clientID, loadString(&nonce))
+		claims["aud"] = []any{clientID, "someone-else"}
+		claims["azp"] = clientID
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"access","token_type":"Bearer","expires_in":3600,"id_token":"` +
+			issuer.mint(t, claims) + `"}`))
+	}, withIDTokenIssuer(issuer), observeNonce(&nonce))
+
+	require.Equal(t, "user-123", env.session.UpstreamSubject.String)
+	require.Equal(t, "grant-owner@example.com", env.session.UpstreamEmail.String)
+	require.Equal(t, remotesessions.IdentitySourceIDToken, env.session.IdentitySource.String)
+}
+
+func TestRemoteLoginStoresIdentityWithoutOversizedEnrichment(t *testing.T) {
+	t.Parallel()
+
+	issuer := newIDTokenIssuer(t)
+	const clientID = "synthetic-cid-idtoken-oversized"
+	var nonce atomic.Pointer[string]
+	_, env := newSyntheticExpiryEnv(t, "idtoken-oversized", func(w http.ResponseWriter, _ *http.Request) {
+		claims := issuer.claims(clientID, loadString(&nonce))
+		claims["blob"] = strings.Repeat("x", 16<<10)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"access","token_type":"Bearer","expires_in":3600,"id_token":"` +
+			issuer.mint(t, claims) + `","ok":true}`))
+	}, withIDTokenIssuer(issuer), observeNonce(&nonce))
+
+	require.Equal(t, "user-123", env.session.UpstreamSubject.String)
+	require.Equal(t, "grant-owner@example.com", env.session.UpstreamEmail.String)
+	require.Equal(t, remotesessions.IdentitySourceIDToken, env.session.IdentitySource.String)
+	require.Nil(t, env.session.Enrichment, "a document over the cap is dropped whole")
+}
+
+func TestRefreshGivesLegacySessionIdentity(t *testing.T) {
+	t.Parallel()
+
+	issuer := newIDTokenIssuer(t)
+	const clientID = "synthetic-cid-idtoken-legacy"
+	var refreshes atomic.Int64
+	var refreshBody atomic.Pointer[string]
+	ctx, env := newSyntheticExpiryEnv(t, "idtoken-legacy", refreshTokenHandler(t, &refreshes, "", &refreshBody), withIDTokenIssuer(issuer))
+	require.False(t, env.session.UpstreamSubject.Valid, "the exchange returned no ID token")
+	require.False(t, env.session.IdentitySource.Valid)
+
+	claims := issuer.claims(clientID, "")
+	delete(claims, "nonce")
+	body := `,"id_token":"` + issuer.mint(t, claims) + `"`
+	refreshBody.Store(&body)
+	resolved, err := env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
+	require.NoError(t, err)
+	require.Equal(t, "access-1", resolved)
+
+	sess := restatedSession(t, env)
+	require.Equal(t, "user-123", sess.UpstreamSubject.String)
+	require.Equal(t, "grant-owner@example.com", sess.UpstreamEmail.String)
+	require.Equal(t, "Grant Owner", sess.UpstreamDisplayName.String)
+	require.Equal(t, remotesessions.IdentitySourceIDToken, sess.IdentitySource.String)
+	require.JSONEq(t, `"grant-owner@example.com"`, string(decodeEnrichment(t, sess.Enrichment).IDToken["email"]))
+}
+
+func TestReconnectDuringRestatementKeepsItsIdentity(t *testing.T) {
+	t.Parallel()
+
+	issuer := newIDTokenIssuer(t)
+	const clientID = "synthetic-cid-idtoken-reconnect-race"
+	var nonce atomic.Pointer[string]
+	var refreshes atomic.Int64
+	var refreshBody atomic.Pointer[string]
+	var env syntheticExpiryEnv
+	var armed atomic.Bool
+	// reconnectErr is written inside the restatement and read after the wait hook.
+	var reconnectErr error
+	// A reconnect lands between the refresh's token CAS and its identity CAS.
+	reconnect := func(inner remotesessions.IDTokenVerifier) remotesessions.IDTokenVerifier {
+		return verifierFunc(func(ctx context.Context, raw string, expect remotesessions.IDTokenExpectation) (remotesessions.UpstreamIdentity, error) {
+			identity, err := inner.Verify(ctx, raw, expect)
+			if err != nil {
+				return identity, fmt.Errorf("verify: %w", err)
+			}
+			if !armed.Swap(false) {
+				return identity, nil
+			}
+			current, gerr := env.q.GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{SubjectUrn: env.subject, RemoteSessionClientID: env.clientID})
+			if gerr != nil {
+				reconnectErr = gerr
+				return identity, nil
+			}
+			_, reconnectErr = env.q.UpsertRemoteSession(ctx, repo.UpsertRemoteSessionParams{
+				SubjectUrn:             env.subject,
+				UserSessionIssuerID:    current.UserSessionIssuerID,
+				RemoteSessionClientID:  env.clientID,
+				AccessTokenEncrypted:   current.AccessTokenEncrypted,
+				AccessExpiresAt:        current.AccessExpiresAt,
+				RefreshTokenEncrypted:  current.RefreshTokenEncrypted,
+				AuthorizationExpiresAt: current.AuthorizationExpiresAt,
+				RefreshExpiresAt:       current.RefreshExpiresAt,
+				Scopes:                 current.Scopes,
+				Resource:               current.Resource,
+				AutoRefresh:            current.AutoRefresh,
+				UpstreamSubject:        conv.ToPGText("user-123"),
+				UpstreamEmail:          conv.ToPGText("reconnect@example.com"),
+				UpstreamDisplayName:    conv.ToPGText("Reconnected Owner"),
+				IdentitySource:         conv.ToPGText(remotesessions.IdentitySourceIDToken),
+				Enrichment:             []byte(`{"id_token":{"sub":"user-123","email":"reconnect@example.com"}}`),
+			})
+			return identity, nil
+		})
+	}
+	ctx, env := newSyntheticExpiryEnv(t, "idtoken-reconnect-race", func(w http.ResponseWriter, r *http.Request) {
+		exchange := ""
+		if r.FormValue("grant_type") != "refresh_token" {
+			exchange = `,"id_token":"` + issuer.mint(t, issuer.claims(clientID, loadString(&nonce))) + `"`
+		}
+		refreshTokenHandler(t, &refreshes, exchange, &refreshBody)(w, r)
+	}, withIDTokenIssuer(issuer), observeNonce(&nonce), withIDTokenVerifierWrapper(reconnect))
+	require.Equal(t, "grant-owner@example.com", env.session.UpstreamEmail.String)
+
+	refreshed := issuer.claims(clientID, "")
+	delete(refreshed, "nonce")
+	refreshed["email"] = "refreshed@example.com"
+	body := `,"id_token":"` + issuer.mint(t, refreshed) + `"`
+	refreshBody.Store(&body)
+	armed.Store(true)
+	resolved, err := env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
+	require.NoError(t, err)
+	require.Equal(t, "access-1", resolved)
+
+	sess := restatedSession(t, env)
+	require.NoError(t, reconnectErr)
+	require.False(t, armed.Load(), "the reconnect ran inside verification")
+	require.Equal(t, "reconnect@example.com", sess.UpstreamEmail.String, "the reconnect's identity stands")
+	require.Equal(t, "Reconnected Owner", sess.UpstreamDisplayName.String)
+	require.JSONEq(t, `"reconnect@example.com"`, string(decodeEnrichment(t, sess.Enrichment).IDToken["email"]))
+	require.NotContains(t, string(sess.Enrichment), "refreshed@example.com")
+}
+
+func TestRefreshDropsEmailVerifiedWhenEmailChanges(t *testing.T) {
+	t.Parallel()
+
+	issuer := newIDTokenIssuer(t)
+	const clientID = "synthetic-cid-idtoken-email-verified"
+	var nonce atomic.Pointer[string]
+	var refreshes atomic.Int64
+	var refreshBody atomic.Pointer[string]
+	ctx, env := newSyntheticExpiryEnv(t, "idtoken-email-verified", func(w http.ResponseWriter, r *http.Request) {
+		exchange := ""
+		if r.FormValue("grant_type") != "refresh_token" {
+			exchange = `,"id_token":"` + issuer.mint(t, issuer.claims(clientID, loadString(&nonce))) + `"`
+		}
+		refreshTokenHandler(t, &refreshes, exchange, &refreshBody)(w, r)
+	}, withIDTokenIssuer(issuer), observeNonce(&nonce))
+	require.JSONEq(t, `true`, string(decodeEnrichment(t, env.session.Enrichment).IDToken["email_verified"]))
+
+	restate := func(mutate func(map[string]any)) enrichmentDoc {
+		t.Helper()
+		claims := issuer.claims(clientID, "")
+		delete(claims, "nonce")
+		delete(claims, "email_verified")
+		mutate(claims)
+		body := `,"id_token":"` + issuer.mint(t, claims) + `"`
+		refreshBody.Store(&body)
+		_, err := env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
+		require.NoError(t, err)
+		return decodeEnrichment(t, restatedSession(t, env).Enrichment)
+	}
+
+	doc := restate(func(map[string]any) {})
+	require.JSONEq(t, `"grant-owner@example.com"`, string(doc.IDToken["email"]))
+	require.JSONEq(t, `true`, string(doc.IDToken["email_verified"]), "the same email restated keeps its flag")
+
+	doc = restate(func(c map[string]any) { c["email"] = "renamed@example.com" })
+	require.JSONEq(t, `"renamed@example.com"`, string(doc.IDToken["email"]))
+	require.NotContains(t, doc.IDToken, "email_verified", "a new email drops the stale flag")
+
+	doc = restate(func(c map[string]any) { c["email"] = "renamed@example.com"; c["email_verified"] = false })
+	require.JSONEq(t, `false`, string(doc.IDToken["email_verified"]))
+	require.EqualValues(t, 3, refreshes.Load())
+}
+
+func TestRefreshWithUnchangedExtrasSkipsIdentityWrite(t *testing.T) {
+	t.Parallel()
+
+	var refreshes atomic.Int64
+	var refreshBody atomic.Pointer[string]
+	ctx, env := newSyntheticExpiryEnv(t, "unchanged-extras", refreshTokenHandler(t, &refreshes, `,"ok":true,"team":{"id":"T1","n":1}`, &refreshBody))
+	before := decodeEnrichment(t, env.session.Enrichment)
+	require.JSONEq(t, `{"id":"T1","n":1}`, string(before.TokenResponse["team"]))
+
+	require.NoError(t, testrepo.New(env.db).InstallRemoteSessionIdentityWriteMarkerFixture(ctx))
+	identityWrites := func(sess repo.RemoteSession) int {
+		return strings.Count(sess.ValidationReason.String, "identity-write;")
+	}
+
+	same := `, "team": {"n": 1, "id": "T1"}, "ok": true`
+	refreshBody.Store(&same)
+	resolved, err := env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
+	require.NoError(t, err)
+	require.Equal(t, "access-1", resolved)
+	sess := restatedSession(t, env)
+	require.Equal(t, 0, identityWrites(sess), "reordered and reformatted extras are not a change")
+	require.Equal(t, before, decodeEnrichment(t, sess.Enrichment))
+
+	changed := `,"ok":true,"team":{"id":"T2","n":1}`
+	refreshBody.Store(&changed)
+	resolved, err = env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
+	require.NoError(t, err)
+	require.Equal(t, "access-2", resolved)
+	sess = restatedSession(t, env)
+	require.Equal(t, 1, identityWrites(sess))
+	require.JSONEq(t, `{"id":"T2","n":1}`, string(decodeEnrichment(t, sess.Enrichment).TokenResponse["team"]))
 }

--- a/server/internal/remotesessions/challenge_identity_e2e_test.go
+++ b/server/internal/remotesessions/challenge_identity_e2e_test.go
@@ -1,0 +1,440 @@
+package remotesessions_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+)
+
+// idTokenIssuer stands in for an OpenID provider: it publishes an ES256 key
+// set over TLS and mints ID tokens signed with the matching private key.
+type idTokenIssuer struct {
+	// issuerURL is unique per issuer so the key-set fetch budget, which is
+	// charged per issuer, is never shared between tests.
+	issuerURL string
+	jwksURI   string
+	pool      *x509.CertPool
+	signer    jose.Signer
+}
+
+func newIDTokenIssuer(t *testing.T) *idTokenIssuer {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	set := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{
+		Key:       key.Public(),
+		KeyID:     "synthetic-kid",
+		Algorithm: string(jose.ES256),
+		Use:       "sig",
+	}}}
+	body, err := json.Marshal(set)
+	require.NoError(t, err)
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(server.Close)
+	pool := x509.NewCertPool()
+	pool.AddCert(server.Certificate())
+
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.ES256, Key: key},
+		(&jose.SignerOptions{}).WithType("JWT").WithHeader(jose.HeaderKey("kid"), "synthetic-kid"),
+	)
+	require.NoError(t, err)
+
+	return &idTokenIssuer{
+		issuerURL: "https://" + uuid.NewString() + ".idp.example.com",
+		jwksURI:   server.URL + "/jwks.json",
+		pool:      pool,
+		signer:    signer,
+	}
+}
+
+// claims is an ID token body that verifies against the synthetic fixture
+// for clientID and nonce, for tests to mutate one member at a time.
+func (i *idTokenIssuer) claims(clientID, nonce string) map[string]any {
+	now := time.Now()
+	return map[string]any{
+		"iss":            i.issuerURL,
+		"sub":            "user-123",
+		"aud":            clientID,
+		"exp":            now.Add(5 * time.Minute).Unix(),
+		"iat":            now.Unix(),
+		"nonce":          nonce,
+		"email":          "grant-owner@example.com",
+		"email_verified": true,
+		"name":           "Grant Owner",
+		"picture":        "https://idp.example.com/avatar.png",
+		"sid":            "sid-abc",
+		"auth_time":      now.Add(-time.Minute).Unix(),
+	}
+}
+
+func (i *idTokenIssuer) mint(t *testing.T, claims map[string]any) string {
+	t.Helper()
+
+	raw, err := jwt.Signed(i.signer).Claims(claims).Serialize()
+	require.NoError(t, err)
+	return raw
+}
+
+// enrichmentDoc mirrors the shape of the enrichment column for assertions.
+type enrichmentDoc struct {
+	IDToken       map[string]json.RawMessage `json:"id_token"`
+	TokenResponse map[string]json.RawMessage `json:"token_response"`
+}
+
+func decodeEnrichment(t *testing.T, raw []byte) enrichmentDoc {
+	t.Helper()
+
+	var doc enrichmentDoc
+	require.NoError(t, json.Unmarshal(raw, &doc))
+	return doc
+}
+
+func reloadSession(t *testing.T, env syntheticExpiryEnv) repo.RemoteSession {
+	t.Helper()
+
+	sess, err := env.q.GetActiveRemoteSession(t.Context(), repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            env.subject,
+		RemoteSessionClientID: env.clientID,
+	})
+	require.NoError(t, err)
+	return sess
+}
+
+// loadString reads a string shared between the test and the fixture
+// server's handler goroutine.
+func loadString(p *atomic.Pointer[string]) string {
+	if v := p.Load(); v != nil {
+		return *v
+	}
+	return ""
+}
+
+// observeNonce records the nonce the authorize redirect carried, for the
+// fixture server to echo in its ID token.
+func observeNonce(into *atomic.Pointer[string]) syntheticLoginOption {
+	return withAuthorizationURLObserver(func(u *url.URL) {
+		nonce := u.Query().Get("nonce")
+		into.Store(&nonce)
+	})
+}
+
+func TestRemoteLoginCapturesIDTokenIdentity(t *testing.T) {
+	t.Parallel()
+
+	issuer := newIDTokenIssuer(t)
+	const clientID = "synthetic-cid-idtoken"
+	var nonce, rawIDToken atomic.Pointer[string]
+	ctx, env := newSyntheticExpiryEnv(t, "idtoken", func(w http.ResponseWriter, _ *http.Request) {
+		minted := issuer.mint(t, issuer.claims(clientID, loadString(&nonce)))
+		rawIDToken.Store(&minted)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"access","refresh_token":"refresh","token_type":"Bearer","expires_in":3600,` +
+			`"id_token":"` + minted + `","ok":true,"team":{"id":"T1"},"bot_token":"xoxb-not-for-storage"}`))
+	},
+		withIDTokenIssuer(issuer),
+		observeNonce(&nonce),
+	)
+	require.NotEmpty(t, loadString(&nonce), "the authorize request carries a nonce for the ID token to echo")
+
+	sess := env.session
+	require.Equal(t, "user-123", sess.UpstreamSubject.String)
+	require.Equal(t, "grant-owner@example.com", sess.UpstreamEmail.String)
+
+	require.Equal(t, "Grant Owner", sess.UpstreamDisplayName.String)
+
+	require.Equal(t, remotesessions.IdentitySourceIDToken, sess.IdentitySource.String)
+	require.False(t, sess.ValidationStatus.Valid, "identity capture says nothing about token validity")
+	require.False(t, sess.LastValidatedAt.Valid)
+
+	doc := decodeEnrichment(t, sess.Enrichment)
+	require.JSONEq(t, `"grant-owner@example.com"`, string(doc.IDToken["email"]))
+	require.JSONEq(t, `"user-123"`, string(doc.IDToken["sub"]))
+	require.JSONEq(t, `"https://idp.example.com/avatar.png"`, string(doc.IDToken["picture"]), "claims without a column stay in the document")
+	require.JSONEq(t, `"sid-abc"`, string(doc.IDToken["sid"]))
+	require.JSONEq(t, `true`, string(doc.TokenResponse["ok"]))
+	require.JSONEq(t, `{"id":"T1"}`, string(doc.TokenResponse["team"]))
+	for _, member := range []string{"access_token", "refresh_token", "id_token", "bot_token"} {
+		require.NotContains(t, doc.TokenResponse, member)
+	}
+	require.NotContains(t, string(sess.Enrichment), loadString(&rawIDToken), "the ID token itself is never persisted")
+	require.NotContains(t, string(sess.Enrichment), "xoxb-not-for-storage")
+
+	states, err := env.mgr.RemoteSessionStatuses(ctx, env.subject, env.projectID, env.organizationID, sess.UserSessionIssuerID)
+	require.NoError(t, err)
+	state := states[env.clientID]
+	require.Equal(t, "grant-owner@example.com", state.ConnectedAs)
+	require.Equal(t, remotesessions.IdentitySourceIDToken, state.IdentitySource)
+
+	// The tombstone keeps its credentials for upstream revocation but none
+	// of the personal data.
+	_, err = env.q.SoftDeleteRemoteSessionsByClientID(ctx, env.clientID)
+	require.NoError(t, err)
+	tombstone, err := env.q.GetRemoteSessionByIDIncludingDeleted(ctx, repo.GetRemoteSessionByIDIncludingDeletedParams{
+		ID:        sess.ID,
+		ProjectID: conv.ToNullUUID(env.projectID),
+	})
+	require.NoError(t, err)
+	require.True(t, tombstone.Deleted)
+	require.False(t, tombstone.UpstreamSubject.Valid, "revocation clears the identity columns")
+	require.False(t, tombstone.UpstreamEmail.Valid)
+	require.False(t, tombstone.UpstreamDisplayName.Valid)
+	require.False(t, tombstone.IdentitySource.Valid)
+	require.Nil(t, tombstone.Enrichment)
+	require.NotEmpty(t, tombstone.AccessTokenEncrypted, "credentials stay for upstream revocation")
+}
+
+func TestRemoteLoginStoresSessionWithoutIdentityWhenIDTokenIsRejected(t *testing.T) {
+	t.Parallel()
+
+	foreign := newIDTokenIssuer(t)
+	cases := []struct {
+		name string
+		// mutate edits an otherwise valid claim set.
+		mutate func(claims map[string]any)
+		// signer, when set, signs with a key the fixture issuer never published.
+		signer *idTokenIssuer
+		// noVerifier leaves the manager without an ID token verifier.
+		noVerifier bool
+	}{
+		{name: "wrong nonce", mutate: func(c map[string]any) { c["nonce"] = "stale" }},
+		{name: "wrong audience", mutate: func(c map[string]any) { c["aud"] = "someone-else" }},
+		{name: "wrong issuer", mutate: func(c map[string]any) { c["iss"] = "https://other.example.com" }},
+		{name: "expired", mutate: func(c map[string]any) { c["exp"] = time.Now().Add(-5 * time.Minute).Unix() }},
+		{name: "missing subject", mutate: func(c map[string]any) { delete(c, "sub") }},
+		{name: "several audiences without azp", mutate: func(c map[string]any) { c["aud"] = []any{c["aud"], "someone-else"} }},
+		{name: "azp naming another client", mutate: func(c map[string]any) { c["azp"] = "someone-else" }},
+		{name: "signed by an unpublished key", signer: foreign},
+		{name: "verifier not configured", noVerifier: true},
+	}
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			issuer := newIDTokenIssuer(t)
+			signer := issuer
+			if tc.signer != nil {
+				signer = tc.signer
+			}
+			suffix := fmt.Sprintf("idtoken-reject-%d", i)
+			clientID := "synthetic-cid-" + suffix
+			var nonce atomic.Pointer[string]
+			opts := []syntheticLoginOption{observeNonce(&nonce)}
+			if !tc.noVerifier {
+				opts = append(opts, withIDTokenIssuer(issuer))
+			}
+
+			ctx, env := newSyntheticExpiryEnv(t, suffix, func(w http.ResponseWriter, _ *http.Request) {
+				claims := issuer.claims(clientID, loadString(&nonce))
+				if tc.mutate != nil {
+					tc.mutate(claims)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"access_token":"access","token_type":"Bearer","expires_in":3600,"id_token":"` +
+					signer.mint(t, claims) + `","ok":true}`))
+			}, opts...)
+
+			sess := env.session
+			require.False(t, sess.UpstreamSubject.Valid, "a rejected ID token leaves no identity behind")
+			require.False(t, sess.UpstreamEmail.Valid)
+			require.False(t, sess.UpstreamDisplayName.Valid)
+			require.False(t, sess.IdentitySource.Valid)
+
+			doc := decodeEnrichment(t, sess.Enrichment)
+			require.Nil(t, doc.IDToken)
+			require.JSONEq(t, `true`, string(doc.TokenResponse["ok"]), "token response extras are kept regardless")
+
+			states, err := env.mgr.RemoteSessionStatuses(ctx, env.subject, env.projectID, env.organizationID, sess.UserSessionIssuerID)
+			require.NoError(t, err)
+			state := states[env.clientID]
+			require.Empty(t, state.ConnectedAs)
+			require.Empty(t, state.IdentitySource)
+		})
+	}
+}
+
+func TestRefreshRestatesIdentityOnlyWhenIDTokenReturned(t *testing.T) {
+	t.Parallel()
+
+	issuer := newIDTokenIssuer(t)
+	const clientID = "synthetic-cid-idtoken-refresh"
+	var nonce atomic.Pointer[string]
+	var refreshes atomic.Int64
+	var refreshIDToken atomic.Pointer[string]
+	// expires_in of one second lands every stored token inside the refresh
+	// skew, so each resolve goes back to the token endpoint.
+	ctx, env := newSyntheticExpiryEnv(t, "idtoken-refresh", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		w.Header().Set("Content-Type", "application/json")
+		if r.Form.Get("grant_type") == "refresh_token" {
+			n := strconv.FormatInt(refreshes.Add(1), 10)
+			body := `{"access_token":"access-` + n + `","refresh_token":"refresh-` + n + `","token_type":"Bearer","expires_in":1,"ok":true`
+			if tok := refreshIDToken.Load(); tok != nil {
+				body += `,"id_token":"` + *tok + `"`
+			}
+			_, _ = w.Write([]byte(body + `}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"access_token":"access-0","refresh_token":"refresh-0","token_type":"Bearer","expires_in":1,"id_token":"` +
+			issuer.mint(t, issuer.claims(clientID, loadString(&nonce))) + `"}`))
+	},
+		withIDTokenIssuer(issuer),
+		observeNonce(&nonce),
+	)
+	require.Equal(t, "grant-owner@example.com", env.session.UpstreamEmail.String)
+
+	resolved, err := env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
+	require.NoError(t, err)
+	require.Equal(t, "access-1", resolved)
+	require.EqualValues(t, 1, refreshes.Load())
+	sess := reloadSession(t, env)
+	require.Equal(t, "grant-owner@example.com", sess.UpstreamEmail.String, "a refresh without an ID token keeps the stored identity")
+	require.Equal(t, "user-123", sess.UpstreamSubject.String)
+	require.Equal(t, remotesessions.IdentitySourceIDToken, sess.IdentitySource.String)
+	doc := decodeEnrichment(t, sess.Enrichment)
+	require.JSONEq(t, `"grant-owner@example.com"`, string(doc.IDToken["email"]), "the exchange's claims survive a refresh that returned none")
+	require.JSONEq(t, `true`, string(doc.TokenResponse["ok"]))
+
+	// A token for another subject is rejected (§12.2), twice in a row; the
+	// exchange identity stands.
+	stranger := issuer.claims(clientID, "")
+	delete(stranger, "nonce")
+	stranger["sub"] = "user-456"
+	stranger["email"] = "stranger@example.com"
+	strangerToken := issuer.mint(t, stranger)
+	refreshIDToken.Store(&strangerToken)
+	for _, access := range []string{"access-2", "access-3"} {
+		resolved, err = env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
+		require.NoError(t, err)
+		require.Equal(t, access, resolved)
+		sess = reloadSession(t, env)
+		require.Equal(t, "user-123", sess.UpstreamSubject.String)
+		require.Equal(t, "grant-owner@example.com", sess.UpstreamEmail.String)
+		require.Equal(t, remotesessions.IdentitySourceIDToken, sess.IdentitySource.String)
+		doc = decodeEnrichment(t, sess.Enrichment)
+		require.JSONEq(t, `"grant-owner@example.com"`, string(doc.IDToken["email"]))
+		require.NotContains(t, string(sess.Enrichment), "stranger@example.com")
+	}
+
+	// Omitted claims are kept in both the columns and the document.
+	partial := issuer.claims(clientID, "")
+	delete(partial, "nonce")
+	delete(partial, "email")
+	delete(partial, "picture")
+	partial["name"] = "Renamed Owner"
+	partialToken := issuer.mint(t, partial)
+	refreshIDToken.Store(&partialToken)
+	resolved, err = env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
+	require.NoError(t, err)
+	require.Equal(t, "access-4", resolved)
+	sess = reloadSession(t, env)
+	require.Equal(t, "grant-owner@example.com", sess.UpstreamEmail.String)
+	require.Equal(t, "Renamed Owner", sess.UpstreamDisplayName.String)
+	doc = decodeEnrichment(t, sess.Enrichment)
+	require.JSONEq(t, `"grant-owner@example.com"`, string(doc.IDToken["email"]))
+	require.JSONEq(t, `"Renamed Owner"`, string(doc.IDToken["name"]))
+	require.JSONEq(t, `"https://idp.example.com/avatar.png"`, string(doc.IDToken["picture"]))
+	require.JSONEq(t, `true`, string(doc.TokenResponse["ok"]))
+
+	// What a refresh restates replaces the stored value.
+	renamed := issuer.claims(clientID, "")
+	delete(renamed, "nonce")
+	renamed["email"] = "renamed@example.com"
+	tok := issuer.mint(t, renamed)
+	refreshIDToken.Store(&tok)
+	resolved, err = env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
+	require.NoError(t, err)
+	require.Equal(t, "access-5", resolved)
+	sess = reloadSession(t, env)
+	require.Equal(t, "renamed@example.com", sess.UpstreamEmail.String)
+	require.Equal(t, "Grant Owner", sess.UpstreamDisplayName.String)
+	doc = decodeEnrichment(t, sess.Enrichment)
+	require.JSONEq(t, `"renamed@example.com"`, string(doc.IDToken["email"]))
+	require.NotContains(t, string(sess.Enrichment), tok)
+}
+
+// Every soft-delete path clears the identity and enrichment columns while
+// keeping the credentials an upstream revocation still needs.
+func TestRevocationPathsClearIdentity(t *testing.T) {
+	t.Parallel()
+
+	paths := map[string]func(t *testing.T, ctx context.Context, env syntheticExpiryEnv){
+		"by-subject-and-client": func(t *testing.T, ctx context.Context, env syntheticExpiryEnv) {
+			t.Helper()
+			_, err := env.q.SoftDeleteRemoteSessionBySubjectAndClient(ctx, repo.SoftDeleteRemoteSessionBySubjectAndClientParams{
+				SubjectUrn:            env.subject,
+				RemoteSessionClientID: env.clientID,
+				UserSessionIssuerID:   env.session.UserSessionIssuerID,
+				ProjectID:             env.projectID,
+			})
+			require.NoError(t, err)
+		},
+		"revoke-by-id": func(t *testing.T, ctx context.Context, env syntheticExpiryEnv) {
+			t.Helper()
+			_, err := env.q.RevokeRemoteSession(ctx, repo.RevokeRemoteSessionParams{
+				ID:             env.session.ID,
+				ProjectID:      env.projectID,
+				OrganizationID: env.organizationID,
+			})
+			require.NoError(t, err)
+		},
+	}
+	for name, revoke := range paths {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			issuer := newIDTokenIssuer(t)
+			suffix := "idtoken-" + name
+			clientID := "synthetic-cid-" + suffix
+			var nonce atomic.Pointer[string]
+			ctx, env := newSyntheticExpiryEnv(t, suffix, func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"access_token":"access","refresh_token":"refresh","token_type":"Bearer","expires_in":3600,"id_token":"` +
+					issuer.mint(t, issuer.claims(clientID, loadString(&nonce))) + `","ok":true}`))
+			}, withIDTokenIssuer(issuer), observeNonce(&nonce))
+			require.Equal(t, "user-123", env.session.UpstreamSubject.String)
+			require.NotNil(t, env.session.Enrichment)
+
+			revoke(t, ctx, env)
+
+			tombstone, err := env.q.GetRemoteSessionByIDIncludingDeleted(ctx, repo.GetRemoteSessionByIDIncludingDeletedParams{
+				ID:        env.session.ID,
+				ProjectID: conv.ToNullUUID(env.projectID),
+			})
+			require.NoError(t, err)
+			require.True(t, tombstone.Deleted)
+			require.False(t, tombstone.UpstreamSubject.Valid)
+			require.False(t, tombstone.UpstreamEmail.Valid)
+			require.False(t, tombstone.UpstreamDisplayName.Valid)
+			require.False(t, tombstone.IdentitySource.Valid)
+			require.Nil(t, tombstone.Enrichment)
+			require.NotEmpty(t, tombstone.AccessTokenEncrypted, "credentials stay for upstream revocation")
+		})
+	}
+}

--- a/server/internal/remotesessions/challenge_identity_e2e_test.go
+++ b/server/internal/remotesessions/challenge_identity_e2e_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
@@ -40,6 +41,8 @@ type idTokenIssuer struct {
 	pool      *x509.CertPool
 	signer    jose.Signer
 	key       *ecdsa.PrivateKey
+	// rsaKey signs RS256 tokens; newSharedKidIDTokenIssuer publishes it under the ES256 key's kid.
+	rsaKey *rsa.PrivateKey
 	// keySet is the published JWK Set document.
 	keySet []byte
 	// fetches counts key-set downloads.
@@ -49,16 +52,41 @@ type idTokenIssuer struct {
 func newIDTokenIssuer(t *testing.T) *idTokenIssuer {
 	t.Helper()
 
+	return newIDTokenIssuerWithKeys(t, false)
+}
+
+// newSharedKidIDTokenIssuer publishes an undeclared-alg RSA key ahead of the
+// ES256 key under the same kid, so a kid-only lookup picks the wrong one.
+func newSharedKidIDTokenIssuer(t *testing.T) *idTokenIssuer {
+	t.Helper()
+
+	return newIDTokenIssuerWithKeys(t, true)
+}
+
+func newIDTokenIssuerWithKeys(t *testing.T, sharedKid bool) *idTokenIssuer {
+	t.Helper()
+
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 
-	set := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{
+	keys := []jose.JSONWebKey{{
 		Key:       key.Public(),
 		KeyID:     "synthetic-kid",
 		Algorithm: string(jose.ES256),
 		Use:       "sig",
-	}}}
-	body, err := json.Marshal(set)
+	}}
+	var rsaKey *rsa.PrivateKey
+	if sharedKid {
+		rsaKey, err = rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+		keys = append([]jose.JSONWebKey{{
+			Key:       rsaKey.Public(),
+			KeyID:     "synthetic-kid",
+			Algorithm: "",
+			Use:       "sig",
+		}}, keys...)
+	}
+	body, err := json.Marshal(jose.JSONWebKeySet{Keys: keys})
 	require.NoError(t, err)
 
 	issuer := &idTokenIssuer{
@@ -67,6 +95,7 @@ func newIDTokenIssuer(t *testing.T) *idTokenIssuer {
 		pool:      nil,
 		signer:    nil,
 		key:       key,
+		rsaKey:    rsaKey,
 		keySet:    body,
 		fetches:   atomic.Int64{},
 	}
@@ -126,6 +155,21 @@ func (i *idTokenIssuer) mintWithKid(t *testing.T, kid string, claims map[string]
 	signer, err := jose.NewSigner(
 		jose.SigningKey{Algorithm: jose.ES256, Key: i.key},
 		(&jose.SignerOptions{}).WithType("JWT").WithHeader(jose.HeaderKey("kid"), kid),
+	)
+	require.NoError(t, err)
+	raw, err := jwt.Signed(signer).Claims(claims).Serialize()
+	require.NoError(t, err)
+	return raw
+}
+
+// mintRS256 signs with the RSA key under the shared kid.
+func (i *idTokenIssuer) mintRS256(t *testing.T, claims map[string]any) string {
+	t.Helper()
+
+	require.NotNil(t, i.rsaKey, "only newSharedKidIDTokenIssuer publishes an RSA key")
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: i.rsaKey},
+		(&jose.SignerOptions{}).WithType("JWT").WithHeader(jose.HeaderKey("kid"), "synthetic-kid"),
 	)
 	require.NoError(t, err)
 	raw, err := jwt.Signed(signer).Claims(claims).Serialize()
@@ -245,7 +289,7 @@ func TestRemoteLoginCapturesIDTokenIdentity(t *testing.T) {
 		rawIDToken.Store(&minted)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"access_token":"access","refresh_token":"refresh","token_type":"Bearer","expires_in":3600,` +
-			`"id_token":"` + minted + `","ok":true,"team":{"id":"T1"},"bot_token":"xoxb-not-for-storage"}`))
+			`"id_token":"` + minted + `","app_id":"A1","team":{"id":"T1"},"bot_token":"xoxb-not-for-storage"}`))
 	},
 		withIDTokenIssuer(issuer),
 		observeNonce(&nonce),
@@ -267,7 +311,7 @@ func TestRemoteLoginCapturesIDTokenIdentity(t *testing.T) {
 	require.JSONEq(t, `"user-123"`, string(doc.IDToken["sub"]))
 	require.JSONEq(t, `"https://idp.example.com/avatar.png"`, string(doc.IDToken["picture"]), "claims without a column stay in the document")
 	require.JSONEq(t, `"sid-abc"`, string(doc.IDToken["sid"]))
-	require.JSONEq(t, `true`, string(doc.TokenResponse["ok"]))
+	require.JSONEq(t, `"A1"`, string(doc.TokenResponse["app_id"]))
 	require.JSONEq(t, `{"id":"T1"}`, string(doc.TokenResponse["team"]))
 	for _, member := range []string{"access_token", "refresh_token", "id_token", "bot_token"} {
 		require.NotContains(t, doc.TokenResponse, member)
@@ -356,7 +400,7 @@ func TestRemoteLoginStoresSessionWithoutIdentityWhenIDTokenIsRejected(t *testing
 				}
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(`{"access_token":"access","token_type":"Bearer","expires_in":3600,"id_token":"` +
-					mint(t, claims) + `","ok":true}`))
+					mint(t, claims) + `","app_id":"A1"}`))
 			}, opts...)
 
 			sess := env.session
@@ -367,7 +411,7 @@ func TestRemoteLoginStoresSessionWithoutIdentityWhenIDTokenIsRejected(t *testing
 
 			doc := decodeEnrichment(t, sess.Enrichment)
 			require.Nil(t, doc.IDToken)
-			require.JSONEq(t, `true`, string(doc.TokenResponse["ok"]), "token response extras are kept regardless")
+			require.JSONEq(t, `"A1"`, string(doc.TokenResponse["app_id"]), "token response extras are kept regardless")
 
 			states, err := env.mgr.RemoteSessionStatuses(ctx, env.subject, env.projectID, env.organizationID, sess.UserSessionIssuerID)
 			require.NoError(t, err)
@@ -393,7 +437,7 @@ func TestRefreshRestatesIdentityOnlyWhenIDTokenReturned(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.Form.Get("grant_type") == "refresh_token" {
 			n := strconv.FormatInt(refreshes.Add(1), 10)
-			body := `{"access_token":"access-` + n + `","refresh_token":"refresh-` + n + `","token_type":"Bearer","expires_in":1,"ok":true`
+			body := `{"access_token":"access-` + n + `","refresh_token":"refresh-` + n + `","token_type":"Bearer","expires_in":1,"app_id":"A1"`
 			if tok := refreshIDToken.Load(); tok != nil {
 				body += `,"id_token":"` + *tok + `"`
 			}
@@ -418,7 +462,7 @@ func TestRefreshRestatesIdentityOnlyWhenIDTokenReturned(t *testing.T) {
 	require.Equal(t, remotesessions.IdentitySourceIDToken, sess.IdentitySource.String)
 	doc := decodeEnrichment(t, sess.Enrichment)
 	require.JSONEq(t, `"grant-owner@example.com"`, string(doc.IDToken["email"]), "the exchange's claims survive a refresh that returned none")
-	require.JSONEq(t, `true`, string(doc.TokenResponse["ok"]))
+	require.JSONEq(t, `"A1"`, string(doc.TokenResponse["app_id"]))
 
 	// A token for another subject is rejected (§12.2), twice in a row; the
 	// exchange identity stands.
@@ -459,7 +503,7 @@ func TestRefreshRestatesIdentityOnlyWhenIDTokenReturned(t *testing.T) {
 	require.JSONEq(t, `"grant-owner@example.com"`, string(doc.IDToken["email"]))
 	require.JSONEq(t, `"Renamed Owner"`, string(doc.IDToken["name"]))
 	require.JSONEq(t, `"https://idp.example.com/avatar.png"`, string(doc.IDToken["picture"]))
-	require.JSONEq(t, `true`, string(doc.TokenResponse["ok"]))
+	require.JSONEq(t, `"A1"`, string(doc.TokenResponse["app_id"]))
 
 	// What a refresh restates replaces the stored value.
 	renamed := issuer.claims(clientID, "")
@@ -515,7 +559,7 @@ func TestRevocationPathsClearIdentity(t *testing.T) {
 			ctx, env := newSyntheticExpiryEnv(t, suffix, func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(`{"access_token":"access","refresh_token":"refresh","token_type":"Bearer","expires_in":3600,"id_token":"` +
-					issuer.mint(t, issuer.claims(clientID, loadString(&nonce))) + `","ok":true}`))
+					issuer.mint(t, issuer.claims(clientID, loadString(&nonce))) + `","app_id":"A1"}`))
 			}, withIDTokenIssuer(issuer), observeNonce(&nonce))
 			require.Equal(t, "user-123", env.session.UpstreamSubject.String)
 			require.NotNil(t, env.session.Enrichment)
@@ -555,7 +599,7 @@ func TestRemoteLoginRefetchesKeySetForUnknownKid(t *testing.T) {
 	_, env := newSyntheticExpiryEnv(t, "idtoken-unknown-kid", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"access_token":"access","token_type":"Bearer","expires_in":3600,"id_token":"` +
-			issuer.mintWithKid(t, "rotated-kid", issuer.claims(clientID, loadString(&nonce))) + `","ok":true}`))
+			issuer.mintWithKid(t, "rotated-kid", issuer.claims(clientID, loadString(&nonce))) + `","app_id":"A1"}`))
 	}, withIDTokenIssuer(issuer), observeNonce(&nonce), withIDTokenKeyCache(keyCache))
 
 	require.EqualValues(t, 1, issuer.fetches.Load(), "an unknown kid re-fetches the key set once")
@@ -595,7 +639,7 @@ func TestRemoteLoginStoresIdentityWithoutOversizedEnrichment(t *testing.T) {
 		claims["blob"] = strings.Repeat("x", 16<<10)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"access_token":"access","token_type":"Bearer","expires_in":3600,"id_token":"` +
-			issuer.mint(t, claims) + `","ok":true}`))
+			issuer.mint(t, claims) + `","app_id":"A1"}`))
 	}, withIDTokenIssuer(issuer), observeNonce(&nonce))
 
 	require.Equal(t, "user-123", env.session.UpstreamSubject.String)
@@ -755,7 +799,7 @@ func TestRefreshWithUnchangedExtrasSkipsIdentityWrite(t *testing.T) {
 
 	var refreshes atomic.Int64
 	var refreshBody atomic.Pointer[string]
-	ctx, env := newSyntheticExpiryEnv(t, "unchanged-extras", refreshTokenHandler(t, &refreshes, `,"ok":true,"team":{"id":"T1","n":1}`, &refreshBody))
+	ctx, env := newSyntheticExpiryEnv(t, "unchanged-extras", refreshTokenHandler(t, &refreshes, `,"app_id":"A1","team":{"id":"T1","n":1}`, &refreshBody))
 	before := decodeEnrichment(t, env.session.Enrichment)
 	require.JSONEq(t, `{"id":"T1","n":1}`, string(before.TokenResponse["team"]))
 
@@ -764,7 +808,7 @@ func TestRefreshWithUnchangedExtrasSkipsIdentityWrite(t *testing.T) {
 		return strings.Count(sess.ValidationReason.String, "identity-write;")
 	}
 
-	same := `, "team": {"n": 1, "id": "T1"}, "ok": true`
+	same := `, "team": {"n": 1, "id": "T1"}, "app_id": "A1"`
 	refreshBody.Store(&same)
 	resolved, err := env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
 	require.NoError(t, err)
@@ -773,7 +817,7 @@ func TestRefreshWithUnchangedExtrasSkipsIdentityWrite(t *testing.T) {
 	require.Equal(t, 0, identityWrites(sess), "reordered and reformatted extras are not a change")
 	require.Equal(t, before, decodeEnrichment(t, sess.Enrichment))
 
-	changed := `,"ok":true,"team":{"id":"T2","n":1}`
+	changed := `,"app_id":"A1","team":{"id":"T2","n":1}`
 	refreshBody.Store(&changed)
 	resolved, err = env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
 	require.NoError(t, err)

--- a/server/internal/remotesessions/challenge_identity_policy_e2e_test.go
+++ b/server/internal/remotesessions/challenge_identity_policy_e2e_test.go
@@ -1,0 +1,170 @@
+package remotesessions_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+)
+
+func TestRepeatedRefreshesKeepEnrichmentUnderCap(t *testing.T) {
+	t.Parallel()
+
+	issuer := newIDTokenIssuer(t)
+	const clientID = "synthetic-cid-idtoken-cap"
+	var nonce atomic.Pointer[string]
+	var refreshes atomic.Int64
+	var refreshBody atomic.Pointer[string]
+	ctx, env := newSyntheticExpiryEnv(t, "idtoken-cap", func(w http.ResponseWriter, r *http.Request) {
+		exchange := ""
+		if r.FormValue("grant_type") != "refresh_token" {
+			exchange = `,"id_token":"` + issuer.mint(t, issuer.claims(clientID, loadString(&nonce))) + `"`
+		}
+		refreshTokenHandler(t, &refreshes, exchange, &refreshBody)(w, r)
+	}, withIDTokenIssuer(issuer), observeNonce(&nonce))
+	require.Equal(t, "grant-owner@example.com", env.session.UpstreamEmail.String)
+
+	// Each refresh adds a distinct 3 KiB claim, so the merge would pass the cap on the sixth.
+	const refreshCount = 8
+	for n := 1; n <= refreshCount; n++ {
+		claims := issuer.claims(clientID, "")
+		delete(claims, "nonce")
+		claims["blob_"+strconv.Itoa(n)] = strings.Repeat("x", 3<<10)
+		body := `,"id_token":"` + issuer.mint(t, claims) + `"`
+		refreshBody.Store(&body)
+		_, err := env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
+		require.NoError(t, err)
+
+		sess := restatedSession(t, env)
+		require.LessOrEqual(t, len(sess.Enrichment), remotesessions.MaxEnrichmentBytes, "refresh %d", n)
+		doc := decodeEnrichment(t, sess.Enrichment)
+		require.Contains(t, doc.IDToken, "blob_"+strconv.Itoa(n), "the latest token's claims are present after refresh %d", n)
+		require.JSONEq(t, `"grant-owner@example.com"`, string(doc.IDToken["email"]))
+		require.Equal(t, "user-123", sess.UpstreamSubject.String)
+	}
+	require.EqualValues(t, refreshCount, refreshes.Load())
+
+	doc := decodeEnrichment(t, restatedSession(t, env).Enrichment)
+	require.NotContains(t, doc.IDToken, "blob_1", "a merge over the cap keeps only the incoming document")
+	require.Contains(t, doc.IDToken, "blob_6")
+	require.Contains(t, doc.IDToken, "blob_"+strconv.Itoa(refreshCount))
+}
+
+func TestOverlappingRefreshesKeepStoredIdentity(t *testing.T) {
+	t.Parallel()
+
+	issuer := newIDTokenIssuer(t)
+	const clientID = "synthetic-cid-idtoken-overlap"
+	var nonce atomic.Pointer[string]
+	var refreshes atomic.Int64
+	var env syntheticExpiryEnv
+	var armed atomic.Bool
+	// nestedToken and nestedErr are written inside the restatement and read after the wait hook.
+	var nestedToken atomic.Pointer[string]
+	var nestedErr error
+	// A second refresh, answered without an ID token, rotates the row while the first's ID token is verified.
+	overlap := func(inner remotesessions.IDTokenVerifier) remotesessions.IDTokenVerifier {
+		return verifierFunc(func(ctx context.Context, raw string, expect remotesessions.IDTokenExpectation) (remotesessions.UpstreamIdentity, error) {
+			identity, err := inner.Verify(ctx, raw, expect)
+			if err != nil {
+				return identity, fmt.Errorf("verify: %w", err)
+			}
+			if !armed.Swap(false) {
+				return identity, nil
+			}
+			var resolved string
+			resolved, nestedErr = env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
+			nestedToken.Store(&resolved)
+			return identity, nil
+		})
+	}
+	ctx, env := newSyntheticExpiryEnv(t, "idtoken-overlap", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		w.Header().Set("Content-Type", "application/json")
+		if r.Form.Get("grant_type") != "refresh_token" {
+			_, _ = w.Write([]byte(`{"access_token":"access-0","refresh_token":"refresh-0","token_type":"Bearer","expires_in":1,"id_token":"` +
+				issuer.mint(t, issuer.claims(clientID, loadString(&nonce))) + `"}`))
+			return
+		}
+		n := refreshes.Add(1)
+		body := `{"access_token":"access-` + strconv.FormatInt(n, 10) + `","refresh_token":"refresh-` + strconv.FormatInt(n, 10) + `","token_type":"Bearer","expires_in":1`
+		if n == 1 {
+			refreshed := issuer.claims(clientID, "")
+			delete(refreshed, "nonce")
+			refreshed["email"] = "refreshed@example.com"
+			body += `,"id_token":"` + issuer.mint(t, refreshed) + `"`
+		}
+		_, _ = w.Write([]byte(body + `}`))
+	}, withIDTokenIssuer(issuer), observeNonce(&nonce), withIDTokenVerifierWrapper(overlap))
+	require.Equal(t, "grant-owner@example.com", env.session.UpstreamEmail.String)
+
+	armed.Store(true)
+	resolved, err := env.mgr.ResolveAccessToken(ctx, env.clientID, env.subject, "")
+	require.NoError(t, err)
+	require.Equal(t, "access-1", resolved)
+
+	sess := restatedSession(t, env)
+	require.False(t, armed.Load(), "the second refresh ran inside the first's verification")
+	require.NoError(t, nestedErr)
+	require.Equal(t, "access-2", loadString(&nestedToken))
+	require.EqualValues(t, 2, refreshes.Load())
+	require.Equal(t, "grant-owner@example.com", sess.UpstreamEmail.String, "the rotated row keeps the identity verified at the exchange")
+	require.Equal(t, "user-123", sess.UpstreamSubject.String)
+	require.JSONEq(t, `"grant-owner@example.com"`, string(decodeEnrichment(t, sess.Enrichment).IDToken["email"]))
+	require.NotContains(t, string(sess.Enrichment), "refreshed@example.com")
+}
+
+func TestIDTokenSigningAlgorithmPolicy(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		// advertised is the issuer's id_token_signing_alg_values_supported.
+		advertised []string
+		// rs256 signs with the RSA key sharing the ES256 key's kid.
+		rs256 bool
+		// captured reports whether the exchange stores an identity.
+		captured bool
+	}{
+		{name: "shared kid picks the ES256 key by algorithm", advertised: nil, rs256: false, captured: true},
+		{name: "shared kid picks the RSA key by algorithm", advertised: nil, rs256: true, captured: true},
+		{name: "issuer advertising only ES256 rejects RS256", advertised: []string{"ES256"}, rs256: true, captured: false},
+		{name: "issuer advertising RS256 accepts RS256", advertised: []string{"RS256"}, rs256: true, captured: true},
+		{name: "issuer advertising nothing acceptable rejects everything", advertised: []string{"HS256"}, rs256: false, captured: false},
+	}
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			issuer := newSharedKidIDTokenIssuer(t)
+			mint := issuer.mint
+			if tc.rs256 {
+				mint = issuer.mintRS256
+			}
+			suffix := fmt.Sprintf("idtoken-alg-%d", i)
+			clientID := "synthetic-cid-" + suffix
+			var nonce atomic.Pointer[string]
+			_, env := newSyntheticExpiryEnv(t, suffix, func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"access_token":"access","token_type":"Bearer","expires_in":3600,"id_token":"` +
+					mint(t, issuer.claims(clientID, loadString(&nonce))) + `"}`))
+			}, withIDTokenIssuer(issuer), observeNonce(&nonce), withIDTokenSigningAlgs(tc.advertised...))
+
+			if !tc.captured {
+				require.False(t, env.session.UpstreamSubject.Valid, "a token outside the issuer's algorithm policy leaves no identity behind")
+				require.False(t, env.session.IdentitySource.Valid)
+				return
+			}
+			require.Equal(t, "user-123", env.session.UpstreamSubject.String)
+			require.Equal(t, "grant-owner@example.com", env.session.UpstreamEmail.String)
+			require.Equal(t, remotesessions.IdentitySourceIDToken, env.session.IdentitySource.String)
+		})
+	}
+}

--- a/server/internal/remotesessions/challenge_synthetic_expiry_test.go
+++ b/server/internal/remotesessions/challenge_synthetic_expiry_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/ratelimit"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
@@ -170,15 +171,34 @@ type syntheticExpiryEnv struct {
 	session        repo.RemoteSession
 }
 
+// syntheticLoginConfig is what the options to driveSyntheticLogin adjust.
+type syntheticLoginConfig struct {
+	// idTokenIssuer, when set, publishes jwks_uri on the fixture and wires a verifier that trusts its TLS cert.
+	idTokenIssuer *idTokenIssuer
+	// onAuthorizationURL sees the authorize URL the manager built before the
+	// callback is driven, so a token handler can mint claims that match it.
+	onAuthorizationURL func(*url.URL)
+}
+
+type syntheticLoginOption func(*syntheticLoginConfig)
+
+func withIDTokenIssuer(issuer *idTokenIssuer) syntheticLoginOption {
+	return func(c *syntheticLoginConfig) { c.idTokenIssuer = issuer }
+}
+
+func withAuthorizationURLObserver(fn func(*url.URL)) syntheticLoginOption {
+	return func(c *syntheticLoginConfig) { c.onAuthorizationURL = fn }
+}
+
 // newSyntheticExpiryEnv wires a ChallengeManager to a mock upstream token
 // endpoint (tokenHandler) and drives BuildAuthorizationUrl →
 // HandleRemoteLoginCallback, returning the request context plus the persisted
 // remote_sessions row and the handles needed to resolve it. slugSuffix keeps
 // fixtures unique per test.
-func newSyntheticExpiryEnv(t *testing.T, slugSuffix string, tokenHandler http.HandlerFunc) (context.Context, syntheticExpiryEnv) {
+func newSyntheticExpiryEnv(t *testing.T, slugSuffix string, tokenHandler http.HandlerFunc, opts ...syntheticLoginOption) (context.Context, syntheticExpiryEnv) {
 	t.Helper()
 
-	ctx, env, callback, err := driveSyntheticLogin(t, slugSuffix, tokenHandler)
+	ctx, env, callback, err := driveSyntheticLogin(t, slugSuffix, tokenHandler, opts...)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusSeeOther, callback.Code)
 
@@ -196,8 +216,13 @@ func newSyntheticExpiryEnv(t *testing.T, slugSuffix string, tokenHandler http.Ha
 // callback. The callback's recorder and error come back unasserted, so a test
 // can exercise a code exchange the callback is expected to reject; the
 // returned env carries no session row.
-func driveSyntheticLogin(t *testing.T, slugSuffix string, tokenHandler http.HandlerFunc) (context.Context, syntheticExpiryEnv, *httptest.ResponseRecorder, error) {
+func driveSyntheticLogin(t *testing.T, slugSuffix string, tokenHandler http.HandlerFunc, opts ...syntheticLoginOption) (context.Context, syntheticExpiryEnv, *httptest.ResponseRecorder, error) {
 	t.Helper()
+
+	var cfg syntheticLoginConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
 
 	ctx, ti := newTestService(t)
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
@@ -210,7 +235,13 @@ func driveSyntheticLogin(t *testing.T, slugSuffix string, tokenHandler http.Hand
 	enc := testenv.NewEncryptionClient(t)
 	logger := testenv.NewLogger(t)
 	tracerProvider := testenv.NewTracerProvider(t)
-	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
+	var policyOptions []func(*guardian.Policy)
+	issuerURL, jwksURI := "https://idp.example.com", ""
+	if cfg.idTokenIssuer != nil {
+		policyOptions = append(policyOptions, guardian.WithTLSRootCAs(cfg.idTokenIssuer.pool))
+		issuerURL, jwksURI = cfg.idTokenIssuer.issuerURL, cfg.idTokenIssuer.jwksURI
+	}
+	policy, err := guardian.NewUnsafePolicy(tracerProvider, []string{}, policyOptions...)
 	require.NoError(t, err)
 
 	// A real Redis-backed cache is required: BuildAuthorizationUrl writes the
@@ -218,6 +249,16 @@ func driveSyntheticLogin(t *testing.T, slugSuffix string, tokenHandler http.Hand
 	// (used by the URL-shape e2e tests) would drop it.
 	redisClient, err := infra.NewRedisClient(t, 0)
 	require.NoError(t, err)
+
+	var managerOptions []remotesessions.ChallengeManagerOption
+	var refreshOptions []remotesessions.RefreshOption
+	if cfg.idTokenIssuer != nil {
+		keys, err := remotesessions.NewIDTokenKeyResolver(logger, policy, testenv.NewMeterProvider(t), ratelimit.NewRedisStore(redisClient))
+		require.NoError(t, err)
+		verifier := remotesessions.NewIDTokenVerifier(keys)
+		managerOptions = append(managerOptions, remotesessions.WithIDTokenVerifier(verifier))
+		refreshOptions = append(refreshOptions, remotesessions.WithRefreshIDTokenVerifier(verifier))
+	}
 	mgr := remotesessions.NewChallengeManager(
 		logger,
 		testenv.NewTracerProvider(t),
@@ -227,20 +268,21 @@ func driveSyntheticLogin(t *testing.T, slugSuffix string, tokenHandler http.Hand
 		policy,
 		cache.NewRedisCacheAdapter(redisClient),
 		mustURL(t, "http://localhost"),
+		managerOptions...,
 	)
-	refresher := remotesessions.NewRefreshService(logger, testenv.NewMeterProvider(t), ti.conn, enc, policy, cache.NewRedisCacheAdapter(redisClient))
+	refresher := remotesessions.NewRefreshService(logger, testenv.NewMeterProvider(t), ti.conn, enc, policy, cache.NewRedisCacheAdapter(redisClient), refreshOptions...)
 
 	q := repo.New(ti.conn)
 	issuer, err := q.CreateRemoteSessionIssuer(ctx, repo.CreateRemoteSessionIssuerParams{
 		ProjectID:                         uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
 		Slug:                              "synthetic-expiry-issuer-" + slugSuffix,
-		Issuer:                            "https://idp.example.com",
+		Issuer:                            issuerURL,
 		Name:                              pgtype.Text{String: "", Valid: false},
 		LogoAssetID:                       uuid.NullUUID{},
 		AuthorizationEndpoint:             conv.ToPGText("https://idp.example.com/authorize"),
 		TokenEndpoint:                     conv.ToPGText(tokenServer.URL),
 		RegistrationEndpoint:              pgtype.Text{String: "", Valid: false},
-		JwksUri:                           pgtype.Text{String: "", Valid: false},
+		JwksUri:                           conv.ToPGTextEmpty(jwksURI),
 		ScopesSupported:                   []string{"channels:history"},
 		GrantTypesSupported:               []string{"authorization_code", "refresh_token"},
 		ResponseTypesSupported:            []string{"code"},
@@ -293,6 +335,9 @@ func driveSyntheticLogin(t *testing.T, slugSuffix string, tokenHandler http.Hand
 	require.NoError(t, err)
 	state := parsed.Query().Get("state")
 	require.NotEmpty(t, state)
+	if cfg.onAuthorizationURL != nil {
+		cfg.onAuthorizationURL(parsed)
+	}
 
 	// The upstream code is single-use and opaque to the mock; any non-empty
 	// value drives exchangeCode against the token server.
@@ -308,7 +353,7 @@ func driveSyntheticLogin(t *testing.T, slugSuffix string, tokenHandler http.Hand
 		mgr:       mgr,
 		refresher: refresher,
 		newRefresher: func(meterProvider metric.MeterProvider, locks cache.Cache) *remotesessions.RefreshService {
-			return remotesessions.NewRefreshService(logger, meterProvider, ti.conn, enc, policy, locks)
+			return remotesessions.NewRefreshService(logger, meterProvider, ti.conn, enc, policy, locks, refreshOptions...)
 		},
 		q:              q,
 		projectID:      *authCtx.ProjectID,

--- a/server/internal/remotesessions/challenge_synthetic_expiry_test.go
+++ b/server/internal/remotesessions/challenge_synthetic_expiry_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/metric"
 
@@ -37,6 +38,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/urn"
+	"github.com/speakeasy-api/gram/server/internal/usersessions/jwks"
 )
 
 // TestRemoteLoginCallback_NoExpiresIn_NoRefresh_NonExpiring covers the live
@@ -163,6 +165,7 @@ type syntheticExpiryEnv struct {
 	// encryption key, with the caller's meter provider and lock cache, so a
 	// test can observe recorded metrics or simulate a degraded lock cache.
 	newRefresher   func(metric.MeterProvider, cache.Cache) *remotesessions.RefreshService
+	db             *pgxpool.Pool
 	q              *repo.Queries
 	projectID      uuid.UUID
 	organizationID string
@@ -175,6 +178,10 @@ type syntheticExpiryEnv struct {
 type syntheticLoginConfig struct {
 	// idTokenIssuer, when set, publishes jwks_uri on the fixture and wires a verifier that trusts its TLS cert.
 	idTokenIssuer *idTokenIssuer
+	// wrapVerifier, when set, decorates the verifier so a test can act mid-verification.
+	wrapVerifier func(remotesessions.IDTokenVerifier) remotesessions.IDTokenVerifier
+	// keyCache, when set, backs the key resolver so a test can seed key-set state.
+	keyCache jwks.Cache
 	// onAuthorizationURL sees the authorize URL the manager built before the
 	// callback is driven, so a token handler can mint claims that match it.
 	onAuthorizationURL func(*url.URL)
@@ -184,6 +191,14 @@ type syntheticLoginOption func(*syntheticLoginConfig)
 
 func withIDTokenIssuer(issuer *idTokenIssuer) syntheticLoginOption {
 	return func(c *syntheticLoginConfig) { c.idTokenIssuer = issuer }
+}
+
+func withIDTokenVerifierWrapper(wrap func(remotesessions.IDTokenVerifier) remotesessions.IDTokenVerifier) syntheticLoginOption {
+	return func(c *syntheticLoginConfig) { c.wrapVerifier = wrap }
+}
+
+func withIDTokenKeyCache(keyCache jwks.Cache) syntheticLoginOption {
+	return func(c *syntheticLoginConfig) { c.keyCache = keyCache }
 }
 
 func withAuthorizationURLObserver(fn func(*url.URL)) syntheticLoginOption {
@@ -253,9 +268,18 @@ func driveSyntheticLogin(t *testing.T, slugSuffix string, tokenHandler http.Hand
 	var managerOptions []remotesessions.ChallengeManagerOption
 	var refreshOptions []remotesessions.RefreshOption
 	if cfg.idTokenIssuer != nil {
-		keys, err := remotesessions.NewIDTokenKeyResolver(logger, policy, testenv.NewMeterProvider(t), ratelimit.NewRedisStore(redisClient))
+		store := ratelimit.NewRedisStore(redisClient)
+		keys, err := remotesessions.NewIDTokenKeyResolver(logger, policy, testenv.NewMeterProvider(t), store)
+		if cfg.keyCache != nil {
+			keys, err = jwks.NewKeyResolver(jwks.NewResolver(policy, testenv.NewMeterProvider(t), logger), cfg.keyCache,
+				ratelimit.New(store, "test_id_token_jwks_refresh", remotesessions.IDTokenKeyRefreshRate),
+				ratelimit.New(store, "test_id_token_jwks_fetch", remotesessions.IDTokenKeyFetchRate), logger)
+		}
 		require.NoError(t, err)
 		verifier := remotesessions.NewIDTokenVerifier(keys)
+		if cfg.wrapVerifier != nil {
+			verifier = cfg.wrapVerifier(verifier)
+		}
 		managerOptions = append(managerOptions, remotesessions.WithIDTokenVerifier(verifier))
 		refreshOptions = append(refreshOptions, remotesessions.WithRefreshIDTokenVerifier(verifier))
 	}
@@ -271,6 +295,9 @@ func driveSyntheticLogin(t *testing.T, slugSuffix string, tokenHandler http.Hand
 		managerOptions...,
 	)
 	refresher := remotesessions.NewRefreshService(logger, testenv.NewMeterProvider(t), ti.conn, enc, policy, cache.NewRedisCacheAdapter(redisClient), refreshOptions...)
+	// Detached restatements finish before the pool closes.
+	t.Cleanup(mgr.WaitIdentityRestatements)
+	t.Cleanup(refresher.WaitIdentityRestatements)
 
 	q := repo.New(ti.conn)
 	issuer, err := q.CreateRemoteSessionIssuer(ctx, repo.CreateRemoteSessionIssuerParams{
@@ -353,8 +380,11 @@ func driveSyntheticLogin(t *testing.T, slugSuffix string, tokenHandler http.Hand
 		mgr:       mgr,
 		refresher: refresher,
 		newRefresher: func(meterProvider metric.MeterProvider, locks cache.Cache) *remotesessions.RefreshService {
-			return remotesessions.NewRefreshService(logger, meterProvider, ti.conn, enc, policy, locks, refreshOptions...)
+			r := remotesessions.NewRefreshService(logger, meterProvider, ti.conn, enc, policy, locks, refreshOptions...)
+			t.Cleanup(r.WaitIdentityRestatements)
+			return r
 		},
+		db:             ti.conn,
 		q:              q,
 		projectID:      *authCtx.ProjectID,
 		organizationID: authCtx.ActiveOrganizationID,

--- a/server/internal/remotesessions/challenge_synthetic_expiry_test.go
+++ b/server/internal/remotesessions/challenge_synthetic_expiry_test.go
@@ -182,6 +182,8 @@ type syntheticLoginConfig struct {
 	wrapVerifier func(remotesessions.IDTokenVerifier) remotesessions.IDTokenVerifier
 	// keyCache, when set, backs the key resolver so a test can seed key-set state.
 	keyCache jwks.Cache
+	// signingAlgs is the issuer row's id_token_signing_alg_values_supported.
+	signingAlgs []string
 	// onAuthorizationURL sees the authorize URL the manager built before the
 	// callback is driven, so a token handler can mint claims that match it.
 	onAuthorizationURL func(*url.URL)
@@ -191,6 +193,10 @@ type syntheticLoginOption func(*syntheticLoginConfig)
 
 func withIDTokenIssuer(issuer *idTokenIssuer) syntheticLoginOption {
 	return func(c *syntheticLoginConfig) { c.idTokenIssuer = issuer }
+}
+
+func withIDTokenSigningAlgs(algs ...string) syntheticLoginOption {
+	return func(c *syntheticLoginConfig) { c.signingAlgs = algs }
 }
 
 func withIDTokenVerifierWrapper(wrap func(remotesessions.IDTokenVerifier) remotesessions.IDTokenVerifier) syntheticLoginOption {
@@ -310,6 +316,7 @@ func driveSyntheticLogin(t *testing.T, slugSuffix string, tokenHandler http.Hand
 		TokenEndpoint:                     conv.ToPGText(tokenServer.URL),
 		RegistrationEndpoint:              pgtype.Text{String: "", Valid: false},
 		JwksUri:                           conv.ToPGTextEmpty(jwksURI),
+		IDTokenSigningAlgValuesSupported:  cfg.signingAlgs,
 		ScopesSupported:                   []string{"channels:history"},
 		GrantTypesSupported:               []string{"authorization_code", "refresh_token"},
 		ResponseTypesSupported:            []string{"code"},

--- a/server/internal/remotesessions/export_test.go
+++ b/server/internal/remotesessions/export_test.go
@@ -1,0 +1,6 @@
+package remotesessions
+
+// WaitIdentityRestatements blocks until every detached identity restatement has finished.
+func (s *RefreshService) WaitIdentityRestatements() { s.restatements.Wait() }
+
+func (m *ChallengeManager) WaitIdentityRestatements() { m.refresher.WaitIdentityRestatements() }

--- a/server/internal/remotesessions/export_test.go
+++ b/server/internal/remotesessions/export_test.go
@@ -4,3 +4,6 @@ package remotesessions
 func (s *RefreshService) WaitIdentityRestatements() { s.restatements.Wait() }
 
 func (m *ChallengeManager) WaitIdentityRestatements() { m.refresher.WaitIdentityRestatements() }
+
+// MaxEnrichmentBytes exposes the enrichment cap to e2e tests.
+const MaxEnrichmentBytes = maxEnrichmentBytes

--- a/server/internal/remotesessions/identity.go
+++ b/server/internal/remotesessions/identity.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"log/slog"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
+	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/jackc/pgx/v5/pgtype"
 	"go.opentelemetry.io/otel/metric"
@@ -41,7 +43,8 @@ var errIDTokenSubjectMismatch = errors.New("id token subject differs from the id
 // errIDTokenVerificationDisabled is NoIDTokenVerifier's answer; callers treat it as silence.
 var errIDTokenVerificationDisabled = errors.New("id token verification is disabled")
 
-// maxEnrichmentBytes caps the provider-controlled enrichment document; larger ones are dropped.
+// maxEnrichmentBytes caps the provider-controlled enrichment document; larger
+// ones are dropped. UpdateRemoteSessionIdentity repeats it as the 16384 literal.
 const maxEnrichmentBytes = 16 << 10
 
 // errEnrichmentTooLarge reports an enrichment document over maxEnrichmentBytes.
@@ -62,11 +65,12 @@ type UpstreamIdentity struct {
 	// Subject is the provider's stable identifier for the user.
 	Subject string
 
-	// Email is the user's email at the provider.
+	// Email is the user's email as the issuer asserted it, not necessarily
+	// verified: display-only, it never keys a grant or an authorization decision.
 	Email string
 
 	// DisplayName is the best human-readable name the interface offered:
-	// name, then given and family name, then a preferred username.
+	// name, then given and family name, then a preferred username. Display-only, like Email.
 	DisplayName string
 
 	// Source is the identity_source value naming the interface.
@@ -153,8 +157,29 @@ type IDTokenExpectation struct {
 	// fetchScope is the issuer row id, so tenants sharing an issuer URL cannot spend each other's budget.
 	fetchScope string
 
+	// signingAlgs is the issuer's id_token_signing_alg_values_supported; empty means unadvertised.
+	signingAlgs []string
+
 	nonce   string
 	subject string
+}
+
+// acceptedIDTokenAlgorithms narrows the shared allowlist to what the issuer advertises, when it advertises anything.
+func acceptedIDTokenAlgorithms(advertised []string) ([]jose.SignatureAlgorithm, error) {
+	allowed := jwks.AllowedSignatureAlgorithms()
+	if len(advertised) == 0 {
+		return allowed, nil
+	}
+	accepted := make([]jose.SignatureAlgorithm, 0, len(allowed))
+	for _, alg := range allowed {
+		if slices.Contains(advertised, string(alg)) {
+			accepted = append(accepted, alg)
+		}
+	}
+	if len(accepted) == 0 {
+		return nil, errors.New("issuer advertises no id token signing algorithm this verifier accepts")
+	}
+	return accepted, nil
 }
 
 // Verify checks an ID token per OpenID Connect Core §3.1.3.7; the raw token is never retained or logged.
@@ -169,14 +194,19 @@ func (v *jwksIDTokenVerifier) Verify(ctx context.Context, rawIDToken string, exp
 	if err != nil {
 		return UpstreamIdentity{}, fmt.Errorf("issuer jwks_uri: %w", err)
 	}
-	token, err := jwt.ParseSigned(rawIDToken, jwks.AllowedSignatureAlgorithms())
+	algorithms, err := acceptedIDTokenAlgorithms(expect.signingAlgs)
+	if err != nil {
+		return UpstreamIdentity{}, err
+	}
+	token, err := jwt.ParseSigned(rawIDToken, algorithms)
 	if err != nil {
 		return UpstreamIdentity{}, fmt.Errorf("parse id token: %w", err)
 	}
 	if len(token.Headers) != 1 {
 		return UpstreamIdentity{}, errors.New("id token must carry exactly one signature")
 	}
-	key, err := v.keys.VerificationKey(ctx, source.WithFetchScope(conv.Default(expect.fetchScope, expect.issuer)), token.Headers[0].KeyID)
+	header := token.Headers[0]
+	key, err := v.keys.VerificationKeyForAlgorithm(ctx, source.WithFetchScope(conv.Default(expect.fetchScope, expect.issuer)), header.KeyID, jose.SignatureAlgorithm(header.Algorithm))
 	if err != nil {
 		return UpstreamIdentity{}, fmt.Errorf("resolve id token signing key: %w", err)
 	}

--- a/server/internal/remotesessions/identity.go
+++ b/server/internal/remotesessions/identity.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"reflect"
 	"strings"
 	"time"
 
@@ -213,6 +214,7 @@ func (v *jwksIDTokenVerifier) Verify(ctx context.Context, rawIDToken string, exp
 	if expect.subject != "" && claims.Subject != expect.subject {
 		return UpstreamIdentity{}, errIDTokenSubjectMismatch
 	}
+	// An empty expectation is a state minted before the nonce existed; bounded to the login-state TTL after rollout.
 	if expect.nonce != "" && claimString(all, "nonce") != expect.nonce {
 		return UpstreamIdentity{}, errors.New("id token nonce does not match the authorize request")
 	}
@@ -261,6 +263,13 @@ func buildEnrichment(tok tokenResponse, identity *UpstreamIdentity) ([]byte, err
 	if identity != nil && identity.Source == IdentitySourceIDToken {
 		doc.IDToken = retainedClaims(identity.Claims)
 	}
+	// email_verified describes the email beside it; without one it is meaningless.
+	if claimString(doc.IDToken, "email") == "" {
+		delete(doc.IDToken, "email_verified")
+		if len(doc.IDToken) == 0 {
+			doc.IDToken = nil
+		}
+	}
 	if doc.IDToken == nil && doc.TokenResponse == nil {
 		return nil, nil
 	}
@@ -272,6 +281,37 @@ func buildEnrichment(tok tokenResponse, identity *UpstreamIdentity) ([]byte, err
 		return nil, errEnrichmentTooLarge
 	}
 	return raw, nil
+}
+
+// tokenResponseUnchanged reports whether every member of extras already reads the same in the stored document.
+func tokenResponseUnchanged(stored []byte, extras map[string]json.RawMessage) bool {
+	if len(stored) == 0 {
+		return len(extras) == 0
+	}
+	var doc enrichmentDocument
+	if err := json.Unmarshal(stored, &doc); err != nil {
+		return false
+	}
+	for name, raw := range extras {
+		have, ok := doc.TokenResponse[name]
+		if !ok || !jsonValuesEqual(have, raw) {
+			return false
+		}
+	}
+	return true
+}
+
+// jsonValuesEqual compares two JSON values structurally, since jsonb reformats what it stores.
+func jsonValuesEqual(a, b json.RawMessage) bool {
+	var x, y any
+	da := json.NewDecoder(bytes.NewReader(a))
+	da.UseNumber()
+	db := json.NewDecoder(bytes.NewReader(b))
+	db.UseNumber()
+	if da.Decode(&x) != nil || db.Decode(&y) != nil {
+		return false
+	}
+	return reflect.DeepEqual(x, y)
 }
 
 // retainedClaims strips credential-shaped members at every nesting level; nil when nothing survives.

--- a/server/internal/remotesessions/identity.go
+++ b/server/internal/remotesessions/identity.go
@@ -1,0 +1,308 @@
+package remotesessions
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/jackc/pgx/v5/pgtype"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/ratelimit"
+	"github.com/speakeasy-api/gram/server/internal/usersessions/jwks"
+)
+
+// IdentitySourceIDToken is the identity_source value for an identity taken
+// from a verified OpenID Connect ID token returned by the token endpoint.
+const IdentitySourceIDToken = "id_token"
+
+// idTokenMaxSkew is the clock difference tolerated on an ID token's temporal
+// claims, in both directions.
+const idTokenMaxSkew = time.Minute
+
+// idTokenVerifyBudget bounds one verification including the key fetch; past it
+// the session is stored without identity.
+const idTokenVerifyBudget = 5 * time.Second
+
+// errIDTokenSubjectMismatch reports an ID token for someone other than the
+// identity the session carries.
+var errIDTokenSubjectMismatch = errors.New("id token subject differs from the identity the session carries")
+
+// errIDTokenVerificationDisabled is NoIDTokenVerifier's answer; callers treat it as silence.
+var errIDTokenVerificationDisabled = errors.New("id token verification is disabled")
+
+// maxEnrichmentBytes caps the provider-controlled enrichment document; larger ones are dropped.
+const maxEnrichmentBytes = 16 << 10
+
+// errEnrichmentTooLarge reports an enrichment document over maxEnrichmentBytes.
+var errEnrichmentTooLarge = errors.New("enrichment document exceeds the size limit")
+
+var (
+	// IDTokenKeyRefreshRate bounds how often one issuer's key set is re-fetched
+	// because an ID token named an unknown kid.
+	IDTokenKeyRefreshRate = ratelimit.PerMinute(10)
+
+	// IDTokenKeyFetchRate bounds every upstream key set consult an issuer
+	// causes, cold or forced.
+	IDTokenKeyFetchRate = ratelimit.PerMinute(30)
+)
+
+// UpstreamIdentity is who a grant belongs to at the provider; unstated fields are zero.
+type UpstreamIdentity struct {
+	// Subject is the provider's stable identifier for the user.
+	Subject string
+
+	// Email is the user's email at the provider.
+	Email string
+
+	// DisplayName is the best human-readable name the interface offered:
+	// name, then given and family name, then a preferred username.
+	DisplayName string
+
+	// Source is the identity_source value naming the interface.
+	Source string
+
+	// Claims is every claim returned; enrichment keeps them minus credential-shaped members.
+	Claims map[string]json.RawMessage
+}
+
+// identityColumns is an identity projected onto the nullable remote_sessions
+// identity columns: NULL wherever the identity is nil or the field is empty.
+type identityColumns struct {
+	Subject     pgtype.Text
+	Email       pgtype.Text
+	DisplayName pgtype.Text
+	Source      pgtype.Text
+}
+
+// columns projects the identity onto its columns; a nil identity is all NULL.
+func (i *UpstreamIdentity) columns() identityColumns {
+	if i == nil {
+		return identityColumns{
+			Subject:     pgtype.Text{String: "", Valid: false},
+			Email:       pgtype.Text{String: "", Valid: false},
+			DisplayName: pgtype.Text{String: "", Valid: false},
+			Source:      pgtype.Text{String: "", Valid: false},
+		}
+	}
+	return identityColumns{
+		Subject:     conv.ToPGTextEmpty(i.Subject),
+		Email:       conv.ToPGTextEmpty(i.Email),
+		DisplayName: conv.ToPGTextEmpty(i.DisplayName),
+		Source:      conv.ToPGTextEmpty(i.Source),
+	}
+}
+
+// IDTokenVerifier verifies an ID token and returns the identity it asserts. Safe for concurrent use.
+type IDTokenVerifier interface {
+	Verify(ctx context.Context, rawIDToken string, expect IDTokenExpectation) (UpstreamIdentity, error)
+}
+
+// jwksIDTokenVerifier verifies ID tokens against the issuer's published key
+// set.
+type jwksIDTokenVerifier struct {
+	keys *jwks.KeyResolver
+}
+
+// NewIDTokenVerifier binds the key resolver an ID token verification needs.
+func NewIDTokenVerifier(keys *jwks.KeyResolver) IDTokenVerifier {
+	return &jwksIDTokenVerifier{keys: keys}
+}
+
+// noIDTokenVerifier answers every token with errIDTokenVerificationDisabled.
+type noIDTokenVerifier struct{}
+
+// NoIDTokenVerifier is the verifier for deployments that capture no
+// identity: sessions are stored without one and nothing is logged.
+func NoIDTokenVerifier() IDTokenVerifier {
+	return noIDTokenVerifier{}
+}
+
+func (noIDTokenVerifier) Verify(context.Context, string, IDTokenExpectation) (UpstreamIdentity, error) {
+	return UpstreamIdentity{}, errIDTokenVerificationDisabled
+}
+
+// NewIDTokenKeyResolver builds the resolver with refresh and fetch budgets charged to store.
+func NewIDTokenKeyResolver(logger *slog.Logger, policy *guardian.Policy, meterProvider metric.MeterProvider, store ratelimit.Store) (*jwks.KeyResolver, error) {
+	refreshLimiter := ratelimit.New(store, "remote_session_id_token_jwks_refresh", IDTokenKeyRefreshRate)
+	fetchLimiter := ratelimit.New(store, "remote_session_id_token_jwks_fetch", IDTokenKeyFetchRate)
+	keys, err := jwks.NewKeyResolver(jwks.NewResolver(policy, meterProvider, logger), jwks.NewMemoryCache(), refreshLimiter, fetchLimiter, logger)
+	if err != nil {
+		return nil, fmt.Errorf("new id token key resolver: %w", err)
+	}
+	return keys, nil
+}
+
+// IDTokenExpectation is what a verified ID token must say. Nonce is empty on
+// a refresh (§12.2); subject is the stored identity a refresh must restate.
+type IDTokenExpectation struct {
+	issuer   string
+	clientID string
+	jwksURI  string
+
+	// fetchScope is the issuer row id, so tenants sharing an issuer URL cannot spend each other's budget.
+	fetchScope string
+
+	nonce   string
+	subject string
+}
+
+// Verify checks an ID token per OpenID Connect Core §3.1.3.7; the raw token is never retained or logged.
+func (v *jwksIDTokenVerifier) Verify(ctx context.Context, rawIDToken string, expect IDTokenExpectation) (UpstreamIdentity, error) {
+	ctx, cancel := context.WithTimeout(ctx, idTokenVerifyBudget)
+	defer cancel()
+
+	if expect.jwksURI == "" {
+		return UpstreamIdentity{}, errors.New("issuer advertises no jwks_uri")
+	}
+	source, err := jwks.NewRemoteSource(expect.jwksURI)
+	if err != nil {
+		return UpstreamIdentity{}, fmt.Errorf("issuer jwks_uri: %w", err)
+	}
+	token, err := jwt.ParseSigned(rawIDToken, jwks.AllowedSignatureAlgorithms())
+	if err != nil {
+		return UpstreamIdentity{}, fmt.Errorf("parse id token: %w", err)
+	}
+	if len(token.Headers) != 1 {
+		return UpstreamIdentity{}, errors.New("id token must carry exactly one signature")
+	}
+	key, err := v.keys.VerificationKey(ctx, source.WithFetchScope(conv.Default(expect.fetchScope, expect.issuer)), token.Headers[0].KeyID)
+	if err != nil {
+		return UpstreamIdentity{}, fmt.Errorf("resolve id token signing key: %w", err)
+	}
+
+	var claims jwt.Claims
+	var all map[string]json.RawMessage
+	if err := token.Claims(key, &claims, &all); err != nil {
+		return UpstreamIdentity{}, fmt.Errorf("verify id token signature: %w", err)
+	}
+	if claims.Expiry == nil {
+		return UpstreamIdentity{}, errors.New("id token has no exp")
+	}
+	// Compared by hand so a trailing-slash difference is tolerated like elsewhere in the package.
+	if !issuerURLsEqual(claims.Issuer, expect.issuer) {
+		return UpstreamIdentity{}, fmt.Errorf("id token issuer %q is not the grant's issuer", truncateForMessage(claims.Issuer))
+	}
+	now := time.Now()
+	if err := claims.ValidateWithLeeway(jwt.Expected{
+		Issuer:      "",
+		Subject:     "",
+		AnyAudience: jwt.Audience{expect.clientID},
+		ID:          "",
+		Time:        now,
+	}, idTokenMaxSkew); err != nil {
+		return UpstreamIdentity{}, fmt.Errorf("validate id token claims: %w", err)
+	}
+	// §3.1.3.7 steps 4 and 5: an azp claim must name this client, and one
+	// is required when the token names several audiences.
+	if azp := claimString(all, "azp"); (azp != "" || len(claims.Audience) > 1) && azp != expect.clientID {
+		return UpstreamIdentity{}, errors.New("id token authorized party is not this client")
+	}
+	if claims.Subject == "" {
+		return UpstreamIdentity{}, errors.New("id token has no sub")
+	}
+	if expect.subject != "" && claims.Subject != expect.subject {
+		return UpstreamIdentity{}, errIDTokenSubjectMismatch
+	}
+	if expect.nonce != "" && claimString(all, "nonce") != expect.nonce {
+		return UpstreamIdentity{}, errors.New("id token nonce does not match the authorize request")
+	}
+
+	identity := UpstreamIdentity{
+		Subject:     claims.Subject,
+		Email:       claimString(all, "email"),
+		DisplayName: displayNameFromClaims(all),
+		Source:      IdentitySourceIDToken,
+		Claims:      all,
+	}
+	return identity, nil
+}
+
+// displayNameFromClaims picks the best human-readable name the standard
+// OpenID Connect claims offer.
+func displayNameFromClaims(claims map[string]json.RawMessage) string {
+	if name := claimString(claims, "name"); name != "" {
+		return name
+	}
+	given, family := claimString(claims, "given_name"), claimString(claims, "family_name")
+	if full := strings.TrimSpace(given + " " + family); full != "" {
+		return full
+	}
+	return claimString(claims, "preferred_username")
+}
+
+// claimString reads a string claim, tolerating absence and other types.
+func claimString(claims map[string]json.RawMessage, name string) string {
+	var s string
+	if raw, ok := claims[name]; ok && json.Unmarshal(raw, &s) == nil {
+		return s
+	}
+	return ""
+}
+
+// enrichmentDocument is the enrichment column: ID token claims and non-standard token response members.
+type enrichmentDocument struct {
+	IDToken       map[string]json.RawMessage `json:"id_token,omitempty"`
+	TokenResponse map[string]json.RawMessage `json:"token_response,omitempty"`
+}
+
+// buildEnrichment serializes the enrichment column; nil when there is nothing to keep.
+func buildEnrichment(tok tokenResponse, identity *UpstreamIdentity) ([]byte, error) {
+	doc := enrichmentDocument{IDToken: nil, TokenResponse: tok.extras()}
+	if identity != nil && identity.Source == IdentitySourceIDToken {
+		doc.IDToken = retainedClaims(identity.Claims)
+	}
+	if doc.IDToken == nil && doc.TokenResponse == nil {
+		return nil, nil
+	}
+	raw, err := json.Marshal(doc)
+	if err != nil {
+		return nil, fmt.Errorf("marshal enrichment document: %w", err)
+	}
+	if len(raw) > maxEnrichmentBytes {
+		return nil, errEnrichmentTooLarge
+	}
+	return raw, nil
+}
+
+// retainedClaims strips credential-shaped members at every nesting level; nil when nothing survives.
+func retainedClaims(claims map[string]json.RawMessage) map[string]json.RawMessage {
+	members := make(map[string]any, len(claims))
+	for name, raw := range claims {
+		dec := json.NewDecoder(bytes.NewReader(raw))
+		dec.UseNumber()
+		var value any
+		if err := dec.Decode(&value); err != nil {
+			continue
+		}
+		members[name] = value
+	}
+	stripCredentialMembers(members)
+	if len(members) == 0 {
+		return nil
+	}
+	kept := make(map[string]json.RawMessage, len(members))
+	for name, value := range members {
+		raw, err := json.Marshal(value)
+		if err != nil {
+			continue
+		}
+		kept[name] = raw
+	}
+	return kept
+}
+
+// logIdentityFailure logs at warn with capped error text; the token value is never logged.
+func logIdentityFailure(ctx context.Context, logger *slog.Logger, msg string, err error, attrs ...slog.Attr) {
+	capped := errors.New(truncateForMessage(err.Error()))
+	logger.LogAttrs(ctx, slog.LevelWarn, msg, append([]slog.Attr{attr.SlogError(capped)}, attrs...)...)
+}

--- a/server/internal/remotesessions/identity_test.go
+++ b/server/internal/remotesessions/identity_test.go
@@ -105,6 +105,61 @@ func TestBuildEnrichment(t *testing.T) {
 	require.Nil(t, raw, "only ID token claims are kept under id_token")
 }
 
+func TestBuildEnrichmentDropsEmailVerifiedWithoutEmail(t *testing.T) {
+	t.Parallel()
+
+	plain := tokenResponse{raw: []byte(`{"access_token":"a","token_type":"Bearer"}`)}
+	identity := &UpstreamIdentity{
+		Subject: "user-1",
+		Source:  IdentitySourceIDToken,
+		Claims:  rawClaims(t, `{"sub":"user-1","email_verified":true,"name":"Ada"}`),
+	}
+
+	raw, err := buildEnrichment(plain, identity)
+	require.NoError(t, err)
+	var doc enrichmentDocument
+	require.NoError(t, json.Unmarshal(raw, &doc))
+	require.NotContains(t, doc.IDToken, "email_verified")
+	require.JSONEq(t, `"Ada"`, string(doc.IDToken["name"]))
+
+	identity.Claims = rawClaims(t, `{"email_verified":true}`)
+	raw, err = buildEnrichment(plain, identity)
+	require.NoError(t, err)
+	require.Nil(t, raw, "a flag with nothing to describe leaves no document")
+
+	for _, email := range []string{`""`, `null`, `42`} {
+		identity.Claims = rawClaims(t, `{"sub":"user-1","email":`+email+`,"email_verified":true}`)
+		raw, err = buildEnrichment(plain, identity)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(raw, &doc))
+		require.NotContains(t, doc.IDToken, "email_verified", "email %s", email)
+	}
+
+	identity.Claims = rawClaims(t, `{"sub":"user-1","email":"ada@example.com","email_verified":true}`)
+	raw, err = buildEnrichment(plain, identity)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(raw, &doc))
+	require.JSONEq(t, `true`, string(doc.IDToken["email_verified"]))
+}
+
+func TestTokenResponseUnchanged(t *testing.T) {
+	t.Parallel()
+
+	stored := []byte(`{"id_token":{"sub":"u"},"token_response":{"ok":true,"team":{"id":"T1","n":1}}}`)
+	extras := func(doc string) map[string]json.RawMessage {
+		return (tokenResponse{raw: []byte(doc)}).extras()
+	}
+
+	require.True(t, tokenResponseUnchanged(stored, extras(`{"access_token":"a","team": {"n": 1, "id": "T1"}, "ok": true}`)), "order and whitespace are not changes")
+	require.True(t, tokenResponseUnchanged(stored, extras(`{"access_token":"a","ok":true}`)), "omitted members keep their stored value")
+	require.False(t, tokenResponseUnchanged(stored, extras(`{"access_token":"a","team":{"id":"T2","n":1}}`)))
+	require.False(t, tokenResponseUnchanged(stored, extras(`{"access_token":"a","ok":true,"extra":1}`)))
+	require.False(t, tokenResponseUnchanged(stored, extras(`{"access_token":"a","team":{"id":"T1","n":1.0}}`)), "numbers compare by their text")
+	require.True(t, tokenResponseUnchanged(nil, nil))
+	require.False(t, tokenResponseUnchanged(nil, extras(`{"access_token":"a","ok":true}`)))
+	require.False(t, tokenResponseUnchanged([]byte(`not json`), nil))
+}
+
 func TestBuildEnrichmentRejectsOversizedDocument(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/remotesessions/identity_test.go
+++ b/server/internal/remotesessions/identity_test.go
@@ -1,0 +1,126 @@
+package remotesessions
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func rawClaims(t *testing.T, doc string) map[string]json.RawMessage {
+	t.Helper()
+
+	var claims map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(doc), &claims))
+	return claims
+}
+
+func TestDisplayNameFromClaims(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		doc  string
+		want string
+	}{
+		{"name wins over the parts", `{"name":"Ada Lovelace","given_name":"Ada","preferred_username":"ada"}`, "Ada Lovelace"},
+		{"given and family name", `{"given_name":"Ada","family_name":"Lovelace"}`, "Ada Lovelace"},
+		{"family name alone", `{"family_name":"Lovelace"}`, "Lovelace"},
+		{"preferred username last", `{"preferred_username":"ada"}`, "ada"},
+		{"non-string name is skipped", `{"name":42,"preferred_username":"ada"}`, "ada"},
+		{"nothing usable", `{"sub":"1"}`, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, displayNameFromClaims(rawClaims(t, tc.doc)))
+		})
+	}
+}
+
+func TestTokenResponseExtras(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{
+		"access_token":"a","refresh_token":"r","token_type":"Bearer","expires_in":3600,"scope":"x","id_token":"i",
+		"ok":true,"team":{"id":"T1"},
+		"authed_user":{"id":"U1","scope":"chat:write","access_token":"xoxp-secret","token_type":"user"},
+		"workspaces":[{"id":"W1","bot_token":"xoxb-secret"}],
+		"incoming_webhook":{"channel":"#general","url":"https://hooks.example.com/services/T1/B1/secret"},
+		"bot_token":"secret","UserToken":"secret","client_secret":"secret","device_code":"secret","client_assertion":"secret",
+		"password":"secret","api_key":"secret","private_key":"secret","jwt":"secret","credentials":{"x":1},
+		"big":9007199254740993
+	}`)
+	extras := (tokenResponse{raw: raw}).extras()
+	require.Len(t, extras, 5)
+	require.Equal(t, `9007199254740993`, string(extras["big"]), "large integers survive untouched")
+	require.JSONEq(t, `true`, string(extras["ok"]))
+	require.JSONEq(t, `{"id":"T1"}`, string(extras["team"]))
+	require.JSONEq(t, `{"id":"U1","scope":"chat:write"}`, string(extras["authed_user"]), "nested credentials are stripped too, and the rule is by name so token_type goes with them")
+	require.JSONEq(t, `[{"id":"W1"}]`, string(extras["workspaces"]))
+
+	require.Nil(t, (tokenResponse{raw: []byte(`{"access_token":"a","token_type":"Bearer"}`)}).extras(), "standard members only")
+	require.Nil(t, (tokenResponse{raw: nil}).extras())
+	require.Nil(t, (tokenResponse{raw: []byte(`[1,2]`)}).extras(), "a non-object body yields nothing")
+}
+
+func TestBuildEnrichment(t *testing.T) {
+	t.Parallel()
+
+	plain := tokenResponse{raw: []byte(`{"access_token":"a","token_type":"Bearer"}`)}
+	withExtras := tokenResponse{raw: []byte(`{"access_token":"a","token_type":"Bearer","ok":true}`)}
+	identity := &UpstreamIdentity{
+		Subject: "user-1",
+		Source:  IdentitySourceIDToken,
+		Claims:  rawClaims(t, `{"sub":"user-1","email":"grant-owner@example.com","api_key":"secret","at_hash":"h","address":{"locality":"Berlin","access_token":"nested"},"big":9007199254740993}`),
+	}
+
+	raw, err := buildEnrichment(plain, nil)
+	require.NoError(t, err)
+	require.Nil(t, raw, "nothing to keep yields no document")
+
+	raw, err = buildEnrichment(withExtras, nil)
+	require.NoError(t, err)
+	var doc enrichmentDocument
+	require.NoError(t, json.Unmarshal(raw, &doc))
+	require.Nil(t, doc.IDToken)
+	require.JSONEq(t, `true`, string(doc.TokenResponse["ok"]))
+
+	raw, err = buildEnrichment(plain, identity)
+	require.NoError(t, err)
+	doc = enrichmentDocument{IDToken: nil, TokenResponse: nil}
+	require.NoError(t, json.Unmarshal(raw, &doc))
+	require.JSONEq(t, `"grant-owner@example.com"`, string(doc.IDToken["email"]))
+	require.NotContains(t, doc.IDToken, "api_key", "credential-shaped claims are dropped")
+	require.JSONEq(t, `{"locality":"Berlin"}`, string(doc.IDToken["address"]), "at every nesting level")
+	require.Equal(t, `9007199254740993`, string(doc.IDToken["big"]), "large integers survive untouched")
+	require.Contains(t, doc.IDToken, "at_hash")
+	require.Nil(t, doc.TokenResponse)
+
+	other := *identity
+	other.Source = "userinfo"
+	raw, err = buildEnrichment(plain, &other)
+	require.NoError(t, err)
+	require.Nil(t, raw, "only ID token claims are kept under id_token")
+}
+
+func TestBuildEnrichmentRejectsOversizedDocument(t *testing.T) {
+	t.Parallel()
+
+	oversized := tokenResponse{raw: []byte(`{"access_token":"a","token_type":"Bearer","blob":"` + strings.Repeat("x", maxEnrichmentBytes) + `"}`)}
+	raw, err := buildEnrichment(oversized, nil)
+	require.ErrorIs(t, err, errEnrichmentTooLarge)
+	require.Nil(t, raw)
+}
+
+func TestCredentialMemberName(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"access_token", "refreshToken", "client_secret", "Authorization", "session_state", "cookie", "signature", "webhook_url", "api_key", "device_code", "jwt", "client_assertion", "password"} {
+		require.True(t, credentialMemberName(name), name)
+	}
+	for _, name := range []string{"ok", "team", "scope", "workspace_name", "email", "locality", "bot_user_id"} {
+		require.False(t, credentialMemberName(name), name)
+	}
+}

--- a/server/internal/remotesessions/identity_test.go
+++ b/server/internal/remotesessions/identity_test.go
@@ -5,7 +5,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-jose/go-jose/v4"
 	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/usersessions/jwks"
 )
 
 func rawClaims(t *testing.T, doc string) map[string]json.RawMessage {
@@ -46,30 +49,49 @@ func TestTokenResponseExtras(t *testing.T) {
 		"access_token":"a","refresh_token":"r","token_type":"Bearer","expires_in":3600,"scope":"x","id_token":"i",
 		"ok":true,"team":{"id":"T1"},
 		"authed_user":{"id":"U1","scope":"chat:write","access_token":"xoxp-secret","token_type":"user"},
-		"workspaces":[{"id":"W1","bot_token":"xoxb-secret"}],
+		"Workspace_Name":"Acme","hub_id":9007199254740993,
+		"owner":{"user":{"id":"u1"},"api_key":"secret"},
+		"workspaces":[{"id":"W1"}],
 		"incoming_webhook":{"channel":"#general","url":"https://hooks.example.com/services/T1/B1/secret"},
-		"bot_token":"secret","UserToken":"secret","client_secret":"secret","device_code":"secret","client_assertion":"secret",
-		"password":"secret","api_key":"secret","private_key":"secret","jwt":"secret","credentials":{"x":1},
-		"big":9007199254740993
+		"value":"secret","refresh":"secret","url":"https://example.com/secret","bot_token":"secret"
 	}`)
 	extras := (tokenResponse{raw: raw}).extras()
 	require.Len(t, extras, 5)
-	require.Equal(t, `9007199254740993`, string(extras["big"]), "large integers survive untouched")
-	require.JSONEq(t, `true`, string(extras["ok"]))
 	require.JSONEq(t, `{"id":"T1"}`, string(extras["team"]))
 	require.JSONEq(t, `{"id":"U1","scope":"chat:write"}`, string(extras["authed_user"]), "nested credentials are stripped too, and the rule is by name so token_type goes with them")
-	require.JSONEq(t, `[{"id":"W1"}]`, string(extras["workspaces"]))
+	require.JSONEq(t, `"Acme"`, string(extras["Workspace_Name"]), "the allowlist matches regardless of case")
+	require.Equal(t, `9007199254740993`, string(extras["hub_id"]), "large integers survive untouched")
+	require.JSONEq(t, `{"user":{"id":"u1"}}`, string(extras["owner"]))
+	for _, name := range []string{"ok", "workspaces", "incoming_webhook", "value", "refresh", "url", "bot_token"} {
+		require.NotContains(t, extras, name, "members off the allowlist are dropped whatever their name")
+	}
 
 	require.Nil(t, (tokenResponse{raw: []byte(`{"access_token":"a","token_type":"Bearer"}`)}).extras(), "standard members only")
+	require.Nil(t, (tokenResponse{raw: []byte(`{"access_token":"a","value":"x","ok":true}`)}).extras(), "unlisted members alone yield nothing")
 	require.Nil(t, (tokenResponse{raw: nil}).extras())
 	require.Nil(t, (tokenResponse{raw: []byte(`[1,2]`)}).extras(), "a non-object body yields nothing")
+}
+
+func TestAcceptedIDTokenAlgorithms(t *testing.T) {
+	t.Parallel()
+
+	all, err := acceptedIDTokenAlgorithms(nil)
+	require.NoError(t, err)
+	require.Equal(t, jwks.AllowedSignatureAlgorithms(), all, "an issuer advertising nothing gets the shared allowlist")
+
+	narrowed, err := acceptedIDTokenAlgorithms([]string{"HS256", "ES256", "none", "RS256"})
+	require.NoError(t, err)
+	require.Equal(t, []jose.SignatureAlgorithm{jose.RS256, jose.ES256}, narrowed, "the intersection keeps the allowlist's order and drops HS* and none")
+
+	_, err = acceptedIDTokenAlgorithms([]string{"HS256"})
+	require.Error(t, err, "an empty intersection is a rejection, not a fallback")
 }
 
 func TestBuildEnrichment(t *testing.T) {
 	t.Parallel()
 
 	plain := tokenResponse{raw: []byte(`{"access_token":"a","token_type":"Bearer"}`)}
-	withExtras := tokenResponse{raw: []byte(`{"access_token":"a","token_type":"Bearer","ok":true}`)}
+	withExtras := tokenResponse{raw: []byte(`{"access_token":"a","token_type":"Bearer","app_id":"A1"}`)}
 	identity := &UpstreamIdentity{
 		Subject: "user-1",
 		Source:  IdentitySourceIDToken,
@@ -85,7 +107,7 @@ func TestBuildEnrichment(t *testing.T) {
 	var doc enrichmentDocument
 	require.NoError(t, json.Unmarshal(raw, &doc))
 	require.Nil(t, doc.IDToken)
-	require.JSONEq(t, `true`, string(doc.TokenResponse["ok"]))
+	require.JSONEq(t, `"A1"`, string(doc.TokenResponse["app_id"]))
 
 	raw, err = buildEnrichment(plain, identity)
 	require.NoError(t, err)
@@ -145,25 +167,25 @@ func TestBuildEnrichmentDropsEmailVerifiedWithoutEmail(t *testing.T) {
 func TestTokenResponseUnchanged(t *testing.T) {
 	t.Parallel()
 
-	stored := []byte(`{"id_token":{"sub":"u"},"token_response":{"ok":true,"team":{"id":"T1","n":1}}}`)
+	stored := []byte(`{"id_token":{"sub":"u"},"token_response":{"app_id":"A1","team":{"id":"T1","n":1}}}`)
 	extras := func(doc string) map[string]json.RawMessage {
 		return (tokenResponse{raw: []byte(doc)}).extras()
 	}
 
-	require.True(t, tokenResponseUnchanged(stored, extras(`{"access_token":"a","team": {"n": 1, "id": "T1"}, "ok": true}`)), "order and whitespace are not changes")
-	require.True(t, tokenResponseUnchanged(stored, extras(`{"access_token":"a","ok":true}`)), "omitted members keep their stored value")
+	require.True(t, tokenResponseUnchanged(stored, extras(`{"access_token":"a","team": {"n": 1, "id": "T1"}, "app_id": "A1"}`)), "order and whitespace are not changes")
+	require.True(t, tokenResponseUnchanged(stored, extras(`{"access_token":"a","app_id":"A1"}`)), "omitted members keep their stored value")
 	require.False(t, tokenResponseUnchanged(stored, extras(`{"access_token":"a","team":{"id":"T2","n":1}}`)))
-	require.False(t, tokenResponseUnchanged(stored, extras(`{"access_token":"a","ok":true,"extra":1}`)))
+	require.False(t, tokenResponseUnchanged(stored, extras(`{"access_token":"a","app_id":"A1","hub_id":1}`)))
 	require.False(t, tokenResponseUnchanged(stored, extras(`{"access_token":"a","team":{"id":"T1","n":1.0}}`)), "numbers compare by their text")
 	require.True(t, tokenResponseUnchanged(nil, nil))
-	require.False(t, tokenResponseUnchanged(nil, extras(`{"access_token":"a","ok":true}`)))
+	require.False(t, tokenResponseUnchanged(nil, extras(`{"access_token":"a","app_id":"A1"}`)))
 	require.False(t, tokenResponseUnchanged([]byte(`not json`), nil))
 }
 
 func TestBuildEnrichmentRejectsOversizedDocument(t *testing.T) {
 	t.Parallel()
 
-	oversized := tokenResponse{raw: []byte(`{"access_token":"a","token_type":"Bearer","blob":"` + strings.Repeat("x", maxEnrichmentBytes) + `"}`)}
+	oversized := tokenResponse{raw: []byte(`{"access_token":"a","token_type":"Bearer","hub_domain":"` + strings.Repeat("x", maxEnrichmentBytes) + `"}`)}
 	raw, err := buildEnrichment(oversized, nil)
 	require.ErrorIs(t, err, errEnrichmentTooLarge)
 	require.Nil(t, raw)

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -1003,7 +1003,9 @@ RETURNING *;
 -- name: UpdateRemoteSessionIdentity :one
 -- Restates identity after a refresh, outside the token CAS and without touching
 -- updated_at. Omitted claims keep their stored value (§12.2); the enrichment
--- id_token and token_response members merge key by key.
+-- id_token and token_response members merge key by key. A merge over 16384
+-- bytes (maxEnrichmentBytes in Go) keeps only the incoming document, which the
+-- writer already capped, so repeated refreshes cannot grow the column past it.
 UPDATE remote_sessions
 SET
     upstream_subject = COALESCE(sqlc.narg('upstream_subject')::text, upstream_subject),
@@ -1012,19 +1014,24 @@ SET
     identity_source = COALESCE(sqlc.narg('identity_source')::text, identity_source),
     enrichment = CASE
         WHEN sqlc.narg('enrichment')::jsonb IS NULL THEN enrichment
-        ELSE COALESCE(enrichment, '{}'::jsonb) || sqlc.narg('enrichment')::jsonb
-            || CASE WHEN enrichment ? 'id_token' AND sqlc.narg('enrichment')::jsonb ? 'id_token'
-                THEN jsonb_build_object('id_token',
-                    -- A stored email_verified describes the stored email, so a restated email drops it.
-                    CASE WHEN (sqlc.narg('enrichment')::jsonb -> 'id_token') ? 'email'
-                            AND (enrichment -> 'id_token' -> 'email') IS DISTINCT FROM (sqlc.narg('enrichment')::jsonb -> 'id_token' -> 'email')
-                        THEN (enrichment -> 'id_token') - 'email_verified'
-                        ELSE enrichment -> 'id_token' END
-                    || (sqlc.narg('enrichment')::jsonb -> 'id_token'))
-                ELSE '{}'::jsonb END
-            || CASE WHEN enrichment ? 'token_response' AND sqlc.narg('enrichment')::jsonb ? 'token_response'
-                THEN jsonb_build_object('token_response', (enrichment -> 'token_response') || (sqlc.narg('enrichment')::jsonb -> 'token_response'))
-                ELSE '{}'::jsonb END
+        ELSE (
+            SELECT CASE WHEN octet_length(merged.doc::text) > 16384 THEN sqlc.narg('enrichment')::jsonb ELSE merged.doc END
+            FROM (SELECT
+                COALESCE(remote_sessions.enrichment, '{}'::jsonb) || sqlc.narg('enrichment')::jsonb
+                || CASE WHEN remote_sessions.enrichment ? 'id_token' AND sqlc.narg('enrichment')::jsonb ? 'id_token'
+                    THEN jsonb_build_object('id_token',
+                        -- A stored email_verified describes the stored email, so a restated email drops it.
+                        CASE WHEN (sqlc.narg('enrichment')::jsonb -> 'id_token') ? 'email'
+                                AND (remote_sessions.enrichment -> 'id_token' -> 'email') IS DISTINCT FROM (sqlc.narg('enrichment')::jsonb -> 'id_token' -> 'email')
+                            THEN (remote_sessions.enrichment -> 'id_token') - 'email_verified'
+                            ELSE remote_sessions.enrichment -> 'id_token' END
+                        || (sqlc.narg('enrichment')::jsonb -> 'id_token'))
+                    ELSE '{}'::jsonb END
+                || CASE WHEN remote_sessions.enrichment ? 'token_response' AND sqlc.narg('enrichment')::jsonb ? 'token_response'
+                    THEN jsonb_build_object('token_response', (remote_sessions.enrichment -> 'token_response') || (sqlc.narg('enrichment')::jsonb -> 'token_response'))
+                    ELSE '{}'::jsonb END
+                AS doc) AS merged
+        )
     END
 WHERE id = @id
   AND subject_urn = @subject_urn
@@ -1185,6 +1192,7 @@ SELECT
     i.revocation_endpoint                  AS revocation_endpoint,
     i.jwks_uri                             AS jwks_uri,
     i.scopes_supported                     AS scopes_supported,
+    i.id_token_signing_alg_values_supported AS id_token_signing_alg_values_supported,
     i.passthrough                          AS passthrough,
     i.oidc                                 AS oidc
 FROM remote_session_clients AS c

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -1014,7 +1014,13 @@ SET
         WHEN sqlc.narg('enrichment')::jsonb IS NULL THEN enrichment
         ELSE COALESCE(enrichment, '{}'::jsonb) || sqlc.narg('enrichment')::jsonb
             || CASE WHEN enrichment ? 'id_token' AND sqlc.narg('enrichment')::jsonb ? 'id_token'
-                THEN jsonb_build_object('id_token', (enrichment -> 'id_token') || (sqlc.narg('enrichment')::jsonb -> 'id_token'))
+                THEN jsonb_build_object('id_token',
+                    -- A stored email_verified describes the stored email, so a restated email drops it.
+                    CASE WHEN (sqlc.narg('enrichment')::jsonb -> 'id_token') ? 'email'
+                            AND (enrichment -> 'id_token' -> 'email') IS DISTINCT FROM (sqlc.narg('enrichment')::jsonb -> 'id_token' -> 'email')
+                        THEN (enrichment -> 'id_token') - 'email_verified'
+                        ELSE enrichment -> 'id_token' END
+                    || (sqlc.narg('enrichment')::jsonb -> 'id_token'))
                 ELSE '{}'::jsonb END
             || CASE WHEN enrichment ? 'token_response' AND sqlc.narg('enrichment')::jsonb ? 'token_response'
                 THEN jsonb_build_object('token_response', (enrichment -> 'token_response') || (sqlc.narg('enrichment')::jsonb -> 'token_response'))

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -882,7 +882,13 @@ RETURNING *;
 -- name: SoftDeleteRemoteSessionsByClientID :many
 -- Returns the stored credentials of every session it tombstones.
 UPDATE remote_sessions
-SET deleted_at = clock_timestamp()
+SET deleted_at = clock_timestamp(),
+    -- Tombstones keep credentials for upstream revocation but no identity.
+    upstream_subject = NULL,
+    upstream_email = NULL,
+    upstream_display_name = NULL,
+    identity_source = NULL,
+    enrichment = NULL
 WHERE remote_session_client_id = @remote_session_client_id AND deleted IS FALSE
 RETURNING remote_session_client_id, access_token_encrypted, refresh_token_encrypted;
 
@@ -891,7 +897,13 @@ RETURNING remote_session_client_id, access_token_encrypted, refresh_token_encryp
 -- every client one issuer deletion stranded, so it sweeps them in a single
 -- statement rather than a round trip per client while holding their locks.
 UPDATE remote_sessions
-SET deleted_at = clock_timestamp()
+SET deleted_at = clock_timestamp(),
+    -- Tombstones keep credentials for upstream revocation but no identity.
+    upstream_subject = NULL,
+    upstream_email = NULL,
+    upstream_display_name = NULL,
+    identity_source = NULL,
+    enrichment = NULL
 WHERE remote_session_client_id = ANY(@remote_session_client_ids::uuid[]) AND deleted IS FALSE
 RETURNING remote_session_client_id, access_token_encrypted, refresh_token_encrypted;
 
@@ -918,7 +930,12 @@ INSERT INTO remote_sessions (
     refresh_expires_at,
     scopes,
     resource,
-    auto_refresh
+    auto_refresh,
+    upstream_subject,
+    upstream_email,
+    upstream_display_name,
+    identity_source,
+    enrichment
 )
 VALUES (
     @subject_urn,
@@ -931,7 +948,12 @@ VALUES (
     @refresh_expires_at,
     @scopes,
     @resource,
-    @auto_refresh
+    @auto_refresh,
+    @upstream_subject,
+    @upstream_email,
+    @upstream_display_name,
+    @identity_source,
+    @enrichment
 )
 ON CONFLICT (subject_urn, remote_session_client_id) WHERE deleted IS FALSE
 DO UPDATE SET
@@ -942,6 +964,15 @@ DO UPDATE SET
     refresh_expires_at = EXCLUDED.refresh_expires_at,
     scopes = EXCLUDED.scopes,
     resource = EXCLUDED.resource,
+    -- A new grant replaces the identity wholesale and resets observed validity.
+    upstream_subject = EXCLUDED.upstream_subject,
+    upstream_email = EXCLUDED.upstream_email,
+    upstream_display_name = EXCLUDED.upstream_display_name,
+    identity_source = EXCLUDED.identity_source,
+    enrichment = EXCLUDED.enrichment,
+    last_validated_at = NULL,
+    validation_status = NULL,
+    validation_reason = NULL,
     updated_at = clock_timestamp()
 RETURNING *;
 
@@ -964,6 +995,33 @@ SET
     resource = COALESCE(resource, NULLIF(sqlc.narg('backfill_resource')::text, '')),
     updated_at = clock_timestamp()
 WHERE subject_urn = @subject_urn
+  AND remote_session_client_id = @remote_session_client_id
+  AND deleted IS FALSE
+  AND updated_at = @expected_updated_at
+RETURNING *;
+
+-- name: UpdateRemoteSessionIdentity :one
+-- Restates identity after a refresh, outside the token CAS and without touching
+-- updated_at. Omitted claims keep their stored value (§12.2); the enrichment
+-- id_token and token_response members merge key by key.
+UPDATE remote_sessions
+SET
+    upstream_subject = COALESCE(sqlc.narg('upstream_subject')::text, upstream_subject),
+    upstream_email = COALESCE(sqlc.narg('upstream_email')::text, upstream_email),
+    upstream_display_name = COALESCE(sqlc.narg('upstream_display_name')::text, upstream_display_name),
+    identity_source = COALESCE(sqlc.narg('identity_source')::text, identity_source),
+    enrichment = CASE
+        WHEN sqlc.narg('enrichment')::jsonb IS NULL THEN enrichment
+        ELSE COALESCE(enrichment, '{}'::jsonb) || sqlc.narg('enrichment')::jsonb
+            || CASE WHEN enrichment ? 'id_token' AND sqlc.narg('enrichment')::jsonb ? 'id_token'
+                THEN jsonb_build_object('id_token', (enrichment -> 'id_token') || (sqlc.narg('enrichment')::jsonb -> 'id_token'))
+                ELSE '{}'::jsonb END
+            || CASE WHEN enrichment ? 'token_response' AND sqlc.narg('enrichment')::jsonb ? 'token_response'
+                THEN jsonb_build_object('token_response', (enrichment -> 'token_response') || (sqlc.narg('enrichment')::jsonb -> 'token_response'))
+                ELSE '{}'::jsonb END
+    END
+WHERE id = @id
+  AND subject_urn = @subject_urn
   AND remote_session_client_id = @remote_session_client_id
   AND deleted IS FALSE
   AND updated_at = @expected_updated_at
@@ -1041,6 +1099,9 @@ SELECT
   s.access_expires_at,
   s.authorization_expires_at,
   s.refresh_expires_at,
+  s.upstream_email,
+  s.upstream_display_name,
+  s.identity_source,
   (s.refresh_token_encrypted IS NOT NULL
     AND (s.authorization_expires_at IS NULL OR s.authorization_expires_at > now())
     AND (s.refresh_expires_at IS NULL OR s.refresh_expires_at > now()))::boolean AS can_refresh,
@@ -1077,6 +1138,14 @@ WHERE s.id = @id
   AND s.remote_session_client_id = c.id
   AND c.project_id = @project_id;
 
+-- name: GetRemoteSessionByIDIncludingDeleted :one
+-- Test helper: reads a session row even when tombstoned, scoped by project.
+SELECT s.*
+FROM remote_sessions AS s
+JOIN remote_session_clients AS c ON c.id = s.remote_session_client_id
+WHERE s.id = @id
+  AND c.project_id = @project_id;
+
 -- name: SetRemoteSessionAccessExpiresAt :exec
 -- Test helper for exercising lazy refresh without waiting for a real token
 -- lifetime. Scoped through the owning remote_session_client's project.
@@ -1108,6 +1177,7 @@ SELECT
     i.authorization_endpoint               AS authorization_endpoint,
     i.token_endpoint                       AS token_endpoint,
     i.revocation_endpoint                  AS revocation_endpoint,
+    i.jwks_uri                             AS jwks_uri,
     i.scopes_supported                     AS scopes_supported,
     i.passthrough                          AS passthrough,
     i.oidc                                 AS oidc
@@ -1216,7 +1286,13 @@ WHERE s.id = @id AND (usi.project_id = @project_id::uuid OR (usi.project_id IS N
 -- established through an organization-level client bound to their own
 -- user_session_issuer, but not another project's session on a shared one.
 UPDATE remote_sessions AS s
-SET deleted_at = clock_timestamp()
+SET deleted_at = clock_timestamp(),
+    -- Tombstones keep credentials for upstream revocation but no identity.
+    upstream_subject = NULL,
+    upstream_email = NULL,
+    upstream_display_name = NULL,
+    identity_source = NULL,
+    enrichment = NULL
 FROM remote_session_clients AS c, user_session_issuers AS usi
 WHERE s.id = @id
   AND s.remote_session_client_id = c.id
@@ -1272,7 +1348,13 @@ WHERE s.subject_urn = @subject_urn
 -- still tombstone a row minted by another. A revoke that left the upstream
 -- tokens alive would not be a revoke.
 UPDATE remote_sessions AS s
-SET deleted_at = clock_timestamp()
+SET deleted_at = clock_timestamp(),
+    -- Tombstones keep credentials for upstream revocation but no identity.
+    upstream_subject = NULL,
+    upstream_email = NULL,
+    upstream_display_name = NULL,
+    identity_source = NULL,
+    enrichment = NULL
 FROM remote_session_clients AS c,
      user_session_issuers AS usi
 WHERE s.subject_urn = @subject_urn
@@ -1311,7 +1393,13 @@ RETURNING s.remote_session_client_id, s.access_token_encrypted, s.refresh_token_
 -- grant's provenance issuer, so a grant minted through a now-soft-deleted
 -- issuer stays reachable — and still RFC 7009'd — from any live bound surface.
 UPDATE remote_sessions AS s
-SET deleted_at = clock_timestamp()
+SET deleted_at = clock_timestamp(),
+    -- Tombstones keep credentials for upstream revocation but no identity.
+    upstream_subject = NULL,
+    upstream_email = NULL,
+    upstream_display_name = NULL,
+    identity_source = NULL,
+    enrichment = NULL
 FROM remote_session_client_user_session_issuers AS link
 JOIN remote_session_clients AS c ON c.id = link.remote_session_client_id
 JOIN user_session_issuers AS usi ON usi.id = link.user_session_issuer_id
@@ -2089,7 +2177,13 @@ LIMIT sqlc.arg('limit_value');
 -- organization-level clients). See the ORG REACHABILITY note on
 -- ListOrganizationRemoteSessionClientsByIssuerID.
 UPDATE remote_sessions AS s
-SET deleted_at = clock_timestamp()
+SET deleted_at = clock_timestamp(),
+    -- Tombstones keep credentials for upstream revocation but no identity.
+    upstream_subject = NULL,
+    upstream_email = NULL,
+    upstream_display_name = NULL,
+    identity_source = NULL,
+    enrichment = NULL
 FROM remote_session_clients AS c, remote_session_issuers AS i
 WHERE s.id = @id
   AND s.remote_session_client_id = c.id

--- a/server/internal/remotesessions/refreshservice.go
+++ b/server/internal/remotesessions/refreshservice.go
@@ -206,11 +206,9 @@ func (s *RefreshService) RefreshNow(ctx context.Context, sess remotesessions_rep
 		// the issuer's key set, and the lease is sized for the token POST.
 		if trigger == remotesessionmetrics.RefreshTriggerRequest {
 			// Detached so a cold key-set fetch never holds the tool call; the write is CAS-protected.
-			s.restatements.Add(1)
-			go func() {
-				defer s.restatements.Done()
+			s.restatements.Go(func() {
 				s.restateIdentity(ctx, q, restatement.client, result.Session, restatement.tok)
-			}()
+			})
 		} else {
 			result.Session = s.restateIdentity(ctx, q, restatement.client, result.Session, restatement.tok)
 		}

--- a/server/internal/remotesessions/refreshservice.go
+++ b/server/internal/remotesessions/refreshservice.go
@@ -80,17 +80,41 @@ type RefreshService struct {
 	policy  *guardian.Policy
 	locks   cache.Cache
 	metrics *remotesessionmetrics.Refresh
+
+	// idTokens verifies an ID token a refresh returns so the session's
+	// identity is restated.
+	idTokens IDTokenVerifier
 }
 
-func NewRefreshService(logger *slog.Logger, meterProvider metric.MeterProvider, db *pgxpool.Pool, enc *encryption.Client, policy *guardian.Policy, locks cache.Cache) *RefreshService {
-	return &RefreshService{
-		logger:  logger.With(attr.SlogComponent("remotesessions_refresh")),
-		db:      db,
-		enc:     enc,
-		policy:  policy,
-		locks:   locks,
-		metrics: remotesessionmetrics.NewRefresh(logger, meterProvider),
+// identityRestatement carries a refresh response out of the lease so identity is written after release.
+type identityRestatement struct {
+	client remotesessions_repo.GetRemoteSessionClientWithIssuerByIDRow
+	tok    tokenResponse
+}
+
+// RefreshOption configures optional RefreshService behaviour.
+type RefreshOption func(*RefreshService)
+
+// WithRefreshIDTokenVerifier restates a session's upstream identity from the
+// ID token a refresh grant returns.
+func WithRefreshIDTokenVerifier(verifier IDTokenVerifier) RefreshOption {
+	return func(s *RefreshService) { s.idTokens = verifier }
+}
+
+func NewRefreshService(logger *slog.Logger, meterProvider metric.MeterProvider, db *pgxpool.Pool, enc *encryption.Client, policy *guardian.Policy, locks cache.Cache, opts ...RefreshOption) *RefreshService {
+	s := &RefreshService{
+		logger:   logger.With(attr.SlogComponent("remotesessions_refresh")),
+		db:       db,
+		enc:      enc,
+		policy:   policy,
+		locks:    locks,
+		metrics:  remotesessionmetrics.NewRefresh(logger, meterProvider),
+		idTokens: NoIDTokenVerifier(),
 	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
 }
 
 // FallbackResourceForClient derives the RFC 8707 resource for a client from
@@ -165,12 +189,17 @@ func (s *RefreshService) RefreshNow(ctx context.Context, sess remotesessions_rep
 		return zero, &RefreshError{IssuerURL: "", Outcome: outcome, err: err}
 	}
 
-	result, postLockIssuerURL, err := s.refresh(ctx, q, sess, callerResource)
+	result, postLockIssuerURL, restatement, err := s.refresh(ctx, q, sess, callerResource)
 	issuerURL := conv.Default(postLockIssuerURL, client.IssuerUrl)
 	if err != nil {
 		outcome := refreshOutcomeForError(ctx, err)
 		s.metrics.Record(ctx, issuerURL, trigger, outcome)
 		return zero, &RefreshError{IssuerURL: issuerURL, Outcome: outcome, err: err}
+	}
+	if restatement != nil {
+		// Outside the single-flight lease: verifying an ID token may wait on
+		// the issuer's key set, and the lease is sized for the token POST.
+		result.Session = s.restateIdentity(ctx, q, restatement.client, result.Session, restatement.tok)
 	}
 	result.IssuerURL = issuerURL
 	s.metrics.Record(ctx, issuerURL, trigger, result.Outcome)
@@ -229,7 +258,7 @@ func (s *RefreshService) refresh(
 	q *remotesessions_repo.Queries,
 	sess remotesessions_repo.RemoteSession,
 	callerResource string,
-) (RefreshResult, string, error) {
+) (RefreshResult, string, *identityRestatement, error) {
 	var zero RefreshResult
 
 	lockKey := refreshLockKey(sess.SubjectUrn, sess.RemoteSessionClientID)
@@ -247,7 +276,7 @@ func (s *RefreshService) refresh(
 		)
 	case !held:
 		if winner, ok := s.awaitRefreshedSession(ctx, q, sess); ok {
-			return winner, "", nil
+			return winner, "", nil, nil
 		}
 		// A duplicate POST beats a guaranteed reconnect prompt.
 		s.logger.WarnContext(ctx, "timed out waiting on a concurrent remote session refresh; refreshing directly",
@@ -289,11 +318,11 @@ func (s *RefreshService) refresh(
 		// Revoked while we were acquiring. Refreshing anyway would rotate
 		// tokens upstream that nothing will ever hold.
 		var inactive remotesessions_repo.RemoteSession
-		return RefreshResult{Session: inactive, AccessToken: "", Outcome: remotesessionmetrics.RefreshOutcomeSessionInactive, IssuerURL: ""}, "", nil
+		return RefreshResult{Session: inactive, AccessToken: "", Outcome: remotesessionmetrics.RefreshOutcomeSessionInactive, IssuerURL: ""}, "", nil, nil
 	case currentErr != nil:
 		// Whatever broke this read breaks the write below too, and a refresh we
 		// cannot persist leaves the stored token dead upstream.
-		return zero, "", fmt.Errorf("re-read active remote_session: %w", currentErr)
+		return zero, "", nil, fmt.Errorf("re-read active remote_session: %w", currentErr)
 	}
 
 	sess = current
@@ -302,16 +331,16 @@ func (s *RefreshService) refresh(
 		if accessTokenLive(current, time.Now()) {
 			plain, err := s.enc.Decrypt(current.AccessTokenEncrypted)
 			if err != nil {
-				return zero, "", fmt.Errorf("decrypt concurrently refreshed access token: %w", err)
+				return zero, "", nil, fmt.Errorf("decrypt concurrently refreshed access token: %w", err)
 			}
-			return RefreshResult{Session: current, AccessToken: plain, Outcome: remotesessionmetrics.RefreshOutcomeAdoptedConcurrentWinner, IssuerURL: ""}, "", nil
+			return RefreshResult{Session: current, AccessToken: plain, Outcome: remotesessionmetrics.RefreshOutcomeAdoptedConcurrentWinner, IssuerURL: ""}, "", nil, nil
 		}
 	}
 	if !hasRefreshToken(current) {
-		return zero, "", ErrNoValidToken
+		return zero, "", nil, ErrNoValidToken
 	}
 	if !refreshTokenUsable(current, time.Now()) {
-		return zero, "", ErrNoValidToken
+		return zero, "", nil, ErrNoValidToken
 	}
 
 	// The persisted binding wins over the caller-derived fallback: the token
@@ -328,7 +357,7 @@ func (s *RefreshService) refresh(
 		var err error
 		resource, err = s.FallbackResourceForClient(ctx, sess.RemoteSessionClientID)
 		if err != nil {
-			return zero, "", fmt.Errorf("derive fallback resource: %w", err)
+			return zero, "", nil, fmt.Errorf("derive fallback resource: %w", err)
 		}
 	}
 
@@ -336,11 +365,12 @@ func (s *RefreshService) refresh(
 	// a client secret or token endpoint rotated meanwhile must reach the POST.
 	client, err := q.GetRemoteSessionClientWithIssuerByID(ctx, sess.RemoteSessionClientID)
 	if err != nil {
-		return zero, "", fmt.Errorf("load remote_session_client for refresh: %w", err)
+		return zero, "", nil, fmt.Errorf("load remote_session_client for refresh: %w", err)
 	}
 
-	updated, accessToken, refreshErr := refreshSessionTokens(ctx, q, s.enc, s.policy, client, sess, resource)
+	updated, tok, refreshErr := s.refreshSessionTokens(ctx, q, client, sess, resource)
 	if refreshErr == nil {
+		accessToken := tok.AccessToken
 		// The stamp is permanent, so record which rows the backfill wrote and
 		// what it wrote — the only way to find them again if a value is wrong.
 		if !sess.Resource.Valid && updated.Resource.Valid {
@@ -350,7 +380,7 @@ func (s *RefreshService) refresh(
 				attr.SlogOAuthResource(updated.Resource.String),
 			)
 		}
-		return RefreshResult{Session: updated, AccessToken: accessToken, Outcome: remotesessionmetrics.RefreshOutcomeRefreshed, IssuerURL: ""}, client.IssuerUrl, nil
+		return RefreshResult{Session: updated, AccessToken: accessToken, Outcome: remotesessionmetrics.RefreshOutcomeRefreshed, IssuerURL: ""}, client.IssuerUrl, &identityRestatement{client: client, tok: tok}, nil
 	}
 
 	var tokenRefreshErr *TokenRefreshError
@@ -363,9 +393,9 @@ func (s *RefreshService) refresh(
 		})
 		switch {
 		case err == nil:
-			return zero, client.IssuerUrl, refreshErr
+			return zero, client.IssuerUrl, nil, refreshErr
 		case !errors.Is(err, pgx.ErrNoRows):
-			return zero, client.IssuerUrl, fmt.Errorf("clear remote session refresh token after invalid_grant: %w", err)
+			return zero, client.IssuerUrl, nil, fmt.Errorf("clear remote session refresh token after invalid_grant: %w", err)
 		}
 		// A row that moved after our refresh attempt belongs to a concurrent
 		// winner. Re-read it below and adopt that token instead of clearing it.
@@ -376,24 +406,24 @@ func (s *RefreshService) refresh(
 		RemoteSessionClientID: sess.RemoteSessionClientID,
 	})
 	if err != nil {
-		return zero, client.IssuerUrl, refreshErr
+		return zero, client.IssuerUrl, nil, refreshErr
 	}
 
 	// Nothing else moved the row, so our failure is the real state of the
 	// session rather than the losing half of a race.
 	if !latest.UpdatedAt.Time.After(sess.UpdatedAt.Time) {
-		return zero, client.IssuerUrl, refreshErr
+		return zero, client.IssuerUrl, nil, refreshErr
 	}
 
 	if !accessTokenLive(latest, time.Now()) {
-		return zero, client.IssuerUrl, refreshErr
+		return zero, client.IssuerUrl, nil, refreshErr
 	}
 	plain, err := s.enc.Decrypt(latest.AccessTokenEncrypted)
 	if err != nil {
-		return zero, client.IssuerUrl, refreshErr
+		return zero, client.IssuerUrl, nil, refreshErr
 	}
 
-	return RefreshResult{Session: latest, AccessToken: plain, Outcome: remotesessionmetrics.RefreshOutcomeAdoptedConcurrentWinner, IssuerURL: ""}, client.IssuerUrl, nil
+	return RefreshResult{Session: latest, AccessToken: plain, Outcome: remotesessionmetrics.RefreshOutcomeAdoptedConcurrentWinner, IssuerURL: ""}, client.IssuerUrl, nil, nil
 }
 
 // AccessTokenExpirySkew is the window before access_expires_at within which a

--- a/server/internal/remotesessions/refreshservice.go
+++ b/server/internal/remotesessions/refreshservice.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -84,6 +85,9 @@ type RefreshService struct {
 	// idTokens verifies an ID token a refresh returns so the session's
 	// identity is restated.
 	idTokens IDTokenVerifier
+
+	// restatements tracks identity restatements detached from request-path refreshes.
+	restatements sync.WaitGroup
 }
 
 // identityRestatement carries a refresh response out of the lease so identity is written after release.
@@ -103,13 +107,14 @@ func WithRefreshIDTokenVerifier(verifier IDTokenVerifier) RefreshOption {
 
 func NewRefreshService(logger *slog.Logger, meterProvider metric.MeterProvider, db *pgxpool.Pool, enc *encryption.Client, policy *guardian.Policy, locks cache.Cache, opts ...RefreshOption) *RefreshService {
 	s := &RefreshService{
-		logger:   logger.With(attr.SlogComponent("remotesessions_refresh")),
-		db:       db,
-		enc:      enc,
-		policy:   policy,
-		locks:    locks,
-		metrics:  remotesessionmetrics.NewRefresh(logger, meterProvider),
-		idTokens: NoIDTokenVerifier(),
+		logger:       logger.With(attr.SlogComponent("remotesessions_refresh")),
+		db:           db,
+		enc:          enc,
+		policy:       policy,
+		locks:        locks,
+		metrics:      remotesessionmetrics.NewRefresh(logger, meterProvider),
+		idTokens:     NoIDTokenVerifier(),
+		restatements: sync.WaitGroup{},
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -199,7 +204,16 @@ func (s *RefreshService) RefreshNow(ctx context.Context, sess remotesessions_rep
 	if restatement != nil {
 		// Outside the single-flight lease: verifying an ID token may wait on
 		// the issuer's key set, and the lease is sized for the token POST.
-		result.Session = s.restateIdentity(ctx, q, restatement.client, result.Session, restatement.tok)
+		if trigger == remotesessionmetrics.RefreshTriggerRequest {
+			// Detached so a cold key-set fetch never holds the tool call; the write is CAS-protected.
+			s.restatements.Add(1)
+			go func() {
+				defer s.restatements.Done()
+				s.restateIdentity(ctx, q, restatement.client, result.Session, restatement.tok)
+			}()
+		} else {
+			result.Session = s.restateIdentity(ctx, q, restatement.client, result.Session, restatement.tok)
+		}
 	}
 	result.IssuerURL = issuerURL
 	s.metrics.Record(ctx, issuerURL, trigger, result.Outcome)

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -2349,6 +2349,7 @@ SELECT
     i.revocation_endpoint                  AS revocation_endpoint,
     i.jwks_uri                             AS jwks_uri,
     i.scopes_supported                     AS scopes_supported,
+    i.id_token_signing_alg_values_supported AS id_token_signing_alg_values_supported,
     i.passthrough                          AS passthrough,
     i.oidc                                 AS oidc
 FROM remote_session_clients AS c
@@ -2359,23 +2360,24 @@ WHERE c.id = $1
 `
 
 type GetRemoteSessionClientWithIssuerByIDRow struct {
-	ClientID                uuid.UUID
-	ExternalClientID        string
-	ClientSecretEncrypted   pgtype.Text
-	TokenEndpointAuthMethod pgtype.Text
-	ClientScope             []string
-	ClientAudience          pgtype.Text
-	LegacyCallbackUrl       bool
-	RemoteSessionIssuerID   uuid.UUID
-	IssuerSlug              string
-	IssuerUrl               string
-	AuthorizationEndpoint   pgtype.Text
-	TokenEndpoint           pgtype.Text
-	RevocationEndpoint      pgtype.Text
-	JwksUri                 pgtype.Text
-	ScopesSupported         []string
-	Passthrough             bool
-	Oidc                    bool
+	ClientID                         uuid.UUID
+	ExternalClientID                 string
+	ClientSecretEncrypted            pgtype.Text
+	TokenEndpointAuthMethod          pgtype.Text
+	ClientScope                      []string
+	ClientAudience                   pgtype.Text
+	LegacyCallbackUrl                bool
+	RemoteSessionIssuerID            uuid.UUID
+	IssuerSlug                       string
+	IssuerUrl                        string
+	AuthorizationEndpoint            pgtype.Text
+	TokenEndpoint                    pgtype.Text
+	RevocationEndpoint               pgtype.Text
+	JwksUri                          pgtype.Text
+	ScopesSupported                  []string
+	IDTokenSigningAlgValuesSupported []string
+	Passthrough                      bool
+	Oidc                             bool
 }
 
 // Joined client + issuer view scoped to a single client_id. Used by
@@ -2403,6 +2405,7 @@ func (q *Queries) GetRemoteSessionClientWithIssuerByID(ctx context.Context, id u
 		&i.RevocationEndpoint,
 		&i.JwksUri,
 		&i.ScopesSupported,
+		&i.IDTokenSigningAlgValuesSupported,
 		&i.Passthrough,
 		&i.Oidc,
 	)
@@ -6278,19 +6281,24 @@ SET
     identity_source = COALESCE($4::text, identity_source),
     enrichment = CASE
         WHEN $5::jsonb IS NULL THEN enrichment
-        ELSE COALESCE(enrichment, '{}'::jsonb) || $5::jsonb
-            || CASE WHEN enrichment ? 'id_token' AND $5::jsonb ? 'id_token'
-                THEN jsonb_build_object('id_token',
-                    -- A stored email_verified describes the stored email, so a restated email drops it.
-                    CASE WHEN ($5::jsonb -> 'id_token') ? 'email'
-                            AND (enrichment -> 'id_token' -> 'email') IS DISTINCT FROM ($5::jsonb -> 'id_token' -> 'email')
-                        THEN (enrichment -> 'id_token') - 'email_verified'
-                        ELSE enrichment -> 'id_token' END
-                    || ($5::jsonb -> 'id_token'))
-                ELSE '{}'::jsonb END
-            || CASE WHEN enrichment ? 'token_response' AND $5::jsonb ? 'token_response'
-                THEN jsonb_build_object('token_response', (enrichment -> 'token_response') || ($5::jsonb -> 'token_response'))
-                ELSE '{}'::jsonb END
+        ELSE (
+            SELECT CASE WHEN octet_length(merged.doc::text) > 16384 THEN $5::jsonb ELSE merged.doc END
+            FROM (SELECT
+                COALESCE(remote_sessions.enrichment, '{}'::jsonb) || $5::jsonb
+                || CASE WHEN remote_sessions.enrichment ? 'id_token' AND $5::jsonb ? 'id_token'
+                    THEN jsonb_build_object('id_token',
+                        -- A stored email_verified describes the stored email, so a restated email drops it.
+                        CASE WHEN ($5::jsonb -> 'id_token') ? 'email'
+                                AND (remote_sessions.enrichment -> 'id_token' -> 'email') IS DISTINCT FROM ($5::jsonb -> 'id_token' -> 'email')
+                            THEN (remote_sessions.enrichment -> 'id_token') - 'email_verified'
+                            ELSE remote_sessions.enrichment -> 'id_token' END
+                        || ($5::jsonb -> 'id_token'))
+                    ELSE '{}'::jsonb END
+                || CASE WHEN remote_sessions.enrichment ? 'token_response' AND $5::jsonb ? 'token_response'
+                    THEN jsonb_build_object('token_response', (remote_sessions.enrichment -> 'token_response') || ($5::jsonb -> 'token_response'))
+                    ELSE '{}'::jsonb END
+                AS doc) AS merged
+        )
     END
 WHERE id = $6
   AND subject_urn = $7
@@ -6314,7 +6322,9 @@ type UpdateRemoteSessionIdentityParams struct {
 
 // Restates identity after a refresh, outside the token CAS and without touching
 // updated_at. Omitted claims keep their stored value (§12.2); the enrichment
-// id_token and token_response members merge key by key.
+// id_token and token_response members merge key by key. A merge over 16384
+// bytes (maxEnrichmentBytes in Go) keeps only the incoming document, which the
+// writer already capped, so repeated refreshes cannot grow the column past it.
 func (q *Queries) UpdateRemoteSessionIdentity(ctx context.Context, arg UpdateRemoteSessionIdentityParams) (RemoteSession, error) {
 	row := q.db.QueryRow(ctx, updateRemoteSessionIdentity,
 		arg.UpstreamSubject,

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -2155,6 +2155,54 @@ func (q *Queries) GetRemoteSessionByID(ctx context.Context, arg GetRemoteSession
 	return i, err
 }
 
+const getRemoteSessionByIDIncludingDeleted = `-- name: GetRemoteSessionByIDIncludingDeleted :one
+SELECT s.id, s.subject_urn, s.user_session_issuer_id, s.remote_session_client_id, s.access_token_encrypted, s.access_expires_at, s.refresh_token_encrypted, s.authorization_expires_at, s.refresh_expires_at, s.scopes, s.resource, s.auto_refresh, s.last_refresh_attempt_at, s.last_used_at, s.upstream_subject, s.upstream_email, s.upstream_display_name, s.identity_source, s.enrichment, s.last_validated_at, s.validation_status, s.validation_reason, s.created_at, s.updated_at, s.deleted_at, s.deleted
+FROM remote_sessions AS s
+JOIN remote_session_clients AS c ON c.id = s.remote_session_client_id
+WHERE s.id = $1
+  AND c.project_id = $2
+`
+
+type GetRemoteSessionByIDIncludingDeletedParams struct {
+	ID        uuid.UUID
+	ProjectID uuid.NullUUID
+}
+
+// Test helper: reads a session row even when tombstoned, scoped by project.
+func (q *Queries) GetRemoteSessionByIDIncludingDeleted(ctx context.Context, arg GetRemoteSessionByIDIncludingDeletedParams) (RemoteSession, error) {
+	row := q.db.QueryRow(ctx, getRemoteSessionByIDIncludingDeleted, arg.ID, arg.ProjectID)
+	var i RemoteSession
+	err := row.Scan(
+		&i.ID,
+		&i.SubjectUrn,
+		&i.UserSessionIssuerID,
+		&i.RemoteSessionClientID,
+		&i.AccessTokenEncrypted,
+		&i.AccessExpiresAt,
+		&i.RefreshTokenEncrypted,
+		&i.AuthorizationExpiresAt,
+		&i.RefreshExpiresAt,
+		&i.Scopes,
+		&i.Resource,
+		&i.AutoRefresh,
+		&i.LastRefreshAttemptAt,
+		&i.LastUsedAt,
+		&i.UpstreamSubject,
+		&i.UpstreamEmail,
+		&i.UpstreamDisplayName,
+		&i.IdentitySource,
+		&i.Enrichment,
+		&i.LastValidatedAt,
+		&i.ValidationStatus,
+		&i.ValidationReason,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
 const getRemoteSessionClientByID = `-- name: GetRemoteSessionClientByID :one
 SELECT
     c.id, c.project_id, c.organization_id, c.remote_session_issuer_id, c.client_id, c.client_secret_encrypted, c.client_id_issued_at, c.client_secret_expires_at, c.token_endpoint_auth_method, c.json_web_key_set_id, c.scope, c.audience, c.client_id_metadata_uri, c.legacy_callback_url, c.created_at, c.updated_at, c.deleted_at, c.deleted,
@@ -2299,6 +2347,7 @@ SELECT
     i.authorization_endpoint               AS authorization_endpoint,
     i.token_endpoint                       AS token_endpoint,
     i.revocation_endpoint                  AS revocation_endpoint,
+    i.jwks_uri                             AS jwks_uri,
     i.scopes_supported                     AS scopes_supported,
     i.passthrough                          AS passthrough,
     i.oidc                                 AS oidc
@@ -2323,6 +2372,7 @@ type GetRemoteSessionClientWithIssuerByIDRow struct {
 	AuthorizationEndpoint   pgtype.Text
 	TokenEndpoint           pgtype.Text
 	RevocationEndpoint      pgtype.Text
+	JwksUri                 pgtype.Text
 	ScopesSupported         []string
 	Passthrough             bool
 	Oidc                    bool
@@ -2351,6 +2401,7 @@ func (q *Queries) GetRemoteSessionClientWithIssuerByID(ctx context.Context, id u
 		&i.AuthorizationEndpoint,
 		&i.TokenEndpoint,
 		&i.RevocationEndpoint,
+		&i.JwksUri,
 		&i.ScopesSupported,
 		&i.Passthrough,
 		&i.Oidc,
@@ -4291,6 +4342,9 @@ SELECT
   s.access_expires_at,
   s.authorization_expires_at,
   s.refresh_expires_at,
+  s.upstream_email,
+  s.upstream_display_name,
+  s.identity_source,
   (s.refresh_token_encrypted IS NOT NULL
     AND (s.authorization_expires_at IS NULL OR s.authorization_expires_at > now())
     AND (s.refresh_expires_at IS NULL OR s.refresh_expires_at > now()))::boolean AS can_refresh,
@@ -4331,6 +4385,9 @@ type ListRemoteSessionStatusesForSubjectRow struct {
 	AccessExpiresAt        pgtype.Timestamptz
 	AuthorizationExpiresAt pgtype.Timestamptz
 	RefreshExpiresAt       pgtype.Timestamptz
+	UpstreamEmail          pgtype.Text
+	UpstreamDisplayName    pgtype.Text
+	IdentitySource         pgtype.Text
 	CanRefresh             bool
 	Status                 string
 }
@@ -4389,6 +4446,9 @@ func (q *Queries) ListRemoteSessionStatusesForSubject(ctx context.Context, arg L
 			&i.AccessExpiresAt,
 			&i.AuthorizationExpiresAt,
 			&i.RefreshExpiresAt,
+			&i.UpstreamEmail,
+			&i.UpstreamDisplayName,
+			&i.IdentitySource,
 			&i.CanRefresh,
 			&i.Status,
 		); err != nil {
@@ -4842,7 +4902,13 @@ func (q *Queries) LockRemoteSessionIssuerForClientBinding(ctx context.Context, r
 
 const revokeOrganizationRemoteSession = `-- name: RevokeOrganizationRemoteSession :one
 UPDATE remote_sessions AS s
-SET deleted_at = clock_timestamp()
+SET deleted_at = clock_timestamp(),
+    -- Tombstones keep credentials for upstream revocation but no identity.
+    upstream_subject = NULL,
+    upstream_email = NULL,
+    upstream_display_name = NULL,
+    identity_source = NULL,
+    enrichment = NULL
 FROM remote_session_clients AS c, remote_session_issuers AS i
 WHERE s.id = $1
   AND s.remote_session_client_id = c.id
@@ -4930,7 +4996,13 @@ func (q *Queries) RevokeOrganizationRemoteSession(ctx context.Context, arg Revok
 
 const revokeRemoteSession = `-- name: RevokeRemoteSession :one
 UPDATE remote_sessions AS s
-SET deleted_at = clock_timestamp()
+SET deleted_at = clock_timestamp(),
+    -- Tombstones keep credentials for upstream revocation but no identity.
+    upstream_subject = NULL,
+    upstream_email = NULL,
+    upstream_display_name = NULL,
+    identity_source = NULL,
+    enrichment = NULL
 FROM remote_session_clients AS c, user_session_issuers AS usi
 WHERE s.id = $1
   AND s.remote_session_client_id = c.id
@@ -5317,7 +5389,13 @@ func (q *Queries) SetRemoteSessionUpdatedAt(ctx context.Context, arg SetRemoteSe
 
 const softDeleteRemoteSessionBySubjectAndClient = `-- name: SoftDeleteRemoteSessionBySubjectAndClient :many
 UPDATE remote_sessions AS s
-SET deleted_at = clock_timestamp()
+SET deleted_at = clock_timestamp(),
+    -- Tombstones keep credentials for upstream revocation but no identity.
+    upstream_subject = NULL,
+    upstream_email = NULL,
+    upstream_display_name = NULL,
+    identity_source = NULL,
+    enrichment = NULL
 FROM remote_session_client_user_session_issuers AS link
 JOIN remote_session_clients AS c ON c.id = link.remote_session_client_id
 JOIN user_session_issuers AS usi ON usi.id = link.user_session_issuer_id
@@ -5390,7 +5468,13 @@ func (q *Queries) SoftDeleteRemoteSessionBySubjectAndClient(ctx context.Context,
 
 const softDeleteRemoteSessionsByClientID = `-- name: SoftDeleteRemoteSessionsByClientID :many
 UPDATE remote_sessions
-SET deleted_at = clock_timestamp()
+SET deleted_at = clock_timestamp(),
+    -- Tombstones keep credentials for upstream revocation but no identity.
+    upstream_subject = NULL,
+    upstream_email = NULL,
+    upstream_display_name = NULL,
+    identity_source = NULL,
+    enrichment = NULL
 WHERE remote_session_client_id = $1 AND deleted IS FALSE
 RETURNING remote_session_client_id, access_token_encrypted, refresh_token_encrypted
 `
@@ -5424,7 +5508,13 @@ func (q *Queries) SoftDeleteRemoteSessionsByClientID(ctx context.Context, remote
 
 const softDeleteRemoteSessionsByClientIDs = `-- name: SoftDeleteRemoteSessionsByClientIDs :many
 UPDATE remote_sessions
-SET deleted_at = clock_timestamp()
+SET deleted_at = clock_timestamp(),
+    -- Tombstones keep credentials for upstream revocation but no identity.
+    upstream_subject = NULL,
+    upstream_email = NULL,
+    upstream_display_name = NULL,
+    identity_source = NULL,
+    enrichment = NULL
 WHERE remote_session_client_id = ANY($1::uuid[]) AND deleted IS FALSE
 RETURNING remote_session_client_id, access_token_encrypted, refresh_token_encrypted
 `
@@ -5460,7 +5550,13 @@ func (q *Queries) SoftDeleteRemoteSessionsByClientIDs(ctx context.Context, remot
 
 const softDeleteRemoteSessionsBySubjectAndUserSessionIssuer = `-- name: SoftDeleteRemoteSessionsBySubjectAndUserSessionIssuer :many
 UPDATE remote_sessions AS s
-SET deleted_at = clock_timestamp()
+SET deleted_at = clock_timestamp(),
+    -- Tombstones keep credentials for upstream revocation but no identity.
+    upstream_subject = NULL,
+    upstream_email = NULL,
+    upstream_display_name = NULL,
+    identity_source = NULL,
+    enrichment = NULL
 FROM remote_session_clients AS c,
      user_session_issuers AS usi
 WHERE s.subject_urn = $1
@@ -6173,6 +6269,90 @@ func (q *Queries) UpdateRemoteSessionClientsToRemoteSessionIssuer(ctx context.Co
 	return result.RowsAffected(), nil
 }
 
+const updateRemoteSessionIdentity = `-- name: UpdateRemoteSessionIdentity :one
+UPDATE remote_sessions
+SET
+    upstream_subject = COALESCE($1::text, upstream_subject),
+    upstream_email = COALESCE($2::text, upstream_email),
+    upstream_display_name = COALESCE($3::text, upstream_display_name),
+    identity_source = COALESCE($4::text, identity_source),
+    enrichment = CASE
+        WHEN $5::jsonb IS NULL THEN enrichment
+        ELSE COALESCE(enrichment, '{}'::jsonb) || $5::jsonb
+            || CASE WHEN enrichment ? 'id_token' AND $5::jsonb ? 'id_token'
+                THEN jsonb_build_object('id_token', (enrichment -> 'id_token') || ($5::jsonb -> 'id_token'))
+                ELSE '{}'::jsonb END
+            || CASE WHEN enrichment ? 'token_response' AND $5::jsonb ? 'token_response'
+                THEN jsonb_build_object('token_response', (enrichment -> 'token_response') || ($5::jsonb -> 'token_response'))
+                ELSE '{}'::jsonb END
+    END
+WHERE id = $6
+  AND subject_urn = $7
+  AND remote_session_client_id = $8
+  AND deleted IS FALSE
+  AND updated_at = $9
+RETURNING id, subject_urn, user_session_issuer_id, remote_session_client_id, access_token_encrypted, access_expires_at, refresh_token_encrypted, authorization_expires_at, refresh_expires_at, scopes, resource, auto_refresh, last_refresh_attempt_at, last_used_at, upstream_subject, upstream_email, upstream_display_name, identity_source, enrichment, last_validated_at, validation_status, validation_reason, created_at, updated_at, deleted_at, deleted
+`
+
+type UpdateRemoteSessionIdentityParams struct {
+	UpstreamSubject       pgtype.Text
+	UpstreamEmail         pgtype.Text
+	UpstreamDisplayName   pgtype.Text
+	IdentitySource        pgtype.Text
+	Enrichment            []byte
+	ID                    uuid.UUID
+	SubjectUrn            urn.SessionSubject
+	RemoteSessionClientID uuid.UUID
+	ExpectedUpdatedAt     pgtype.Timestamptz
+}
+
+// Restates identity after a refresh, outside the token CAS and without touching
+// updated_at. Omitted claims keep their stored value (§12.2); the enrichment
+// id_token and token_response members merge key by key.
+func (q *Queries) UpdateRemoteSessionIdentity(ctx context.Context, arg UpdateRemoteSessionIdentityParams) (RemoteSession, error) {
+	row := q.db.QueryRow(ctx, updateRemoteSessionIdentity,
+		arg.UpstreamSubject,
+		arg.UpstreamEmail,
+		arg.UpstreamDisplayName,
+		arg.IdentitySource,
+		arg.Enrichment,
+		arg.ID,
+		arg.SubjectUrn,
+		arg.RemoteSessionClientID,
+		arg.ExpectedUpdatedAt,
+	)
+	var i RemoteSession
+	err := row.Scan(
+		&i.ID,
+		&i.SubjectUrn,
+		&i.UserSessionIssuerID,
+		&i.RemoteSessionClientID,
+		&i.AccessTokenEncrypted,
+		&i.AccessExpiresAt,
+		&i.RefreshTokenEncrypted,
+		&i.AuthorizationExpiresAt,
+		&i.RefreshExpiresAt,
+		&i.Scopes,
+		&i.Resource,
+		&i.AutoRefresh,
+		&i.LastRefreshAttemptAt,
+		&i.LastUsedAt,
+		&i.UpstreamSubject,
+		&i.UpstreamEmail,
+		&i.UpstreamDisplayName,
+		&i.IdentitySource,
+		&i.Enrichment,
+		&i.LastValidatedAt,
+		&i.ValidationStatus,
+		&i.ValidationReason,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+		&i.Deleted,
+	)
+	return i, err
+}
+
 const updateRemoteSessionIssuer = `-- name: UpdateRemoteSessionIssuer :one
 UPDATE remote_session_issuers
 SET
@@ -6665,7 +6845,12 @@ INSERT INTO remote_sessions (
     refresh_expires_at,
     scopes,
     resource,
-    auto_refresh
+    auto_refresh,
+    upstream_subject,
+    upstream_email,
+    upstream_display_name,
+    identity_source,
+    enrichment
 )
 VALUES (
     $1,
@@ -6678,7 +6863,12 @@ VALUES (
     $8,
     $9,
     $10,
-    $11
+    $11,
+    $12,
+    $13,
+    $14,
+    $15,
+    $16
 )
 ON CONFLICT (subject_urn, remote_session_client_id) WHERE deleted IS FALSE
 DO UPDATE SET
@@ -6689,6 +6879,15 @@ DO UPDATE SET
     refresh_expires_at = EXCLUDED.refresh_expires_at,
     scopes = EXCLUDED.scopes,
     resource = EXCLUDED.resource,
+    -- A new grant replaces the identity wholesale and resets observed validity.
+    upstream_subject = EXCLUDED.upstream_subject,
+    upstream_email = EXCLUDED.upstream_email,
+    upstream_display_name = EXCLUDED.upstream_display_name,
+    identity_source = EXCLUDED.identity_source,
+    enrichment = EXCLUDED.enrichment,
+    last_validated_at = NULL,
+    validation_status = NULL,
+    validation_reason = NULL,
     updated_at = clock_timestamp()
 RETURNING id, subject_urn, user_session_issuer_id, remote_session_client_id, access_token_encrypted, access_expires_at, refresh_token_encrypted, authorization_expires_at, refresh_expires_at, scopes, resource, auto_refresh, last_refresh_attempt_at, last_used_at, upstream_subject, upstream_email, upstream_display_name, identity_source, enrichment, last_validated_at, validation_status, validation_reason, created_at, updated_at, deleted_at, deleted
 `
@@ -6705,6 +6904,11 @@ type UpsertRemoteSessionParams struct {
 	Scopes                 []string
 	Resource               pgtype.Text
 	AutoRefresh            bool
+	UpstreamSubject        pgtype.Text
+	UpstreamEmail          pgtype.Text
+	UpstreamDisplayName    pgtype.Text
+	IdentitySource         pgtype.Text
+	Enrichment             []byte
 }
 
 // Used by /mcp/remote_login_callback to materialise (or refresh) the
@@ -6726,6 +6930,11 @@ func (q *Queries) UpsertRemoteSession(ctx context.Context, arg UpsertRemoteSessi
 		arg.Scopes,
 		arg.Resource,
 		arg.AutoRefresh,
+		arg.UpstreamSubject,
+		arg.UpstreamEmail,
+		arg.UpstreamDisplayName,
+		arg.IdentitySource,
+		arg.Enrichment,
 	)
 	var i RemoteSession
 	err := row.Scan(

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -6280,7 +6280,13 @@ SET
         WHEN $5::jsonb IS NULL THEN enrichment
         ELSE COALESCE(enrichment, '{}'::jsonb) || $5::jsonb
             || CASE WHEN enrichment ? 'id_token' AND $5::jsonb ? 'id_token'
-                THEN jsonb_build_object('id_token', (enrichment -> 'id_token') || ($5::jsonb -> 'id_token'))
+                THEN jsonb_build_object('id_token',
+                    -- A stored email_verified describes the stored email, so a restated email drops it.
+                    CASE WHEN ($5::jsonb -> 'id_token') ? 'email'
+                            AND (enrichment -> 'id_token' -> 'email') IS DISTINCT FROM ($5::jsonb -> 'id_token' -> 'email')
+                        THEN (enrichment -> 'id_token') - 'email_verified'
+                        ELSE enrichment -> 'id_token' END
+                    || ($5::jsonb -> 'id_token'))
                 ELSE '{}'::jsonb END
             || CASE WHEN enrichment ? 'token_response' AND $5::jsonb ? 'token_response'
                 THEN jsonb_build_object('token_response', (enrichment -> 'token_response') || ($5::jsonb -> 'token_response'))

--- a/server/internal/remotesessions/token_response.go
+++ b/server/internal/remotesessions/token_response.go
@@ -31,15 +31,26 @@ type tokenResponse struct {
 	raw []byte
 }
 
-// tokenResponseStandardMembers are the RFC 6749 §5.1 and refresh-lifetime members plus id_token.
-var tokenResponseStandardMembers = map[string]struct{}{
-	"access_token": {}, "refresh_token": {}, "token_type": {}, "expires_in": {},
-	"refresh_token_timeout": {}, "authorization_expires_in": {}, "refresh_expires_in": {},
-	"refresh_token_expires_in": {}, "scope": {}, "id_token": {},
+// tokenResponseRetainedMembers are the provider metadata members a token
+// response may keep, matched by lower-cased name; anything else is dropped
+// unread, since no name rule can prove an arbitrary member holds no secret.
+var tokenResponseRetainedMembers = map[string]struct{}{
+	// Notion
+	"workspace_name": {}, "workspace_id": {}, "workspace_icon": {}, "bot_id": {}, "owner": {}, "duplicated_template_id": {},
+	// Slack
+	"team": {}, "enterprise": {}, "authed_user": {}, "bot_user_id": {}, "app_id": {}, "is_enterprise_install": {},
+	// PostHog
+	"posthog_region": {},
+	// HubSpot
+	"hub_id": {}, "hub_domain": {},
+	// Salesforce
+	"instance_url": {},
+	// Tenant identifiers several providers share
+	"account_id": {}, "tenant_id": {}, "organization_id": {}, "login": {},
 }
 
-// extras returns the non-standard, non-credential members at every nesting
-// level (Slack nests tokens under authed_user and incoming_webhook). Nil when empty.
+// extras returns the allowlisted members with credential-shaped members
+// stripped at every nesting level (Slack nests tokens under authed_user). Nil when empty.
 func (t tokenResponse) extras() map[string]json.RawMessage {
 	// UseNumber keeps large integers as the provider wrote them.
 	dec := json.NewDecoder(bytes.NewReader(t.raw))
@@ -49,7 +60,7 @@ func (t tokenResponse) extras() map[string]json.RawMessage {
 		return nil
 	}
 	for name := range members {
-		if _, standard := tokenResponseStandardMembers[strings.ToLower(name)]; standard {
+		if _, keep := tokenResponseRetainedMembers[strings.ToLower(name)]; !keep {
 			delete(members, name)
 		}
 	}

--- a/server/internal/remotesessions/token_response.go
+++ b/server/internal/remotesessions/token_response.go
@@ -1,6 +1,8 @@
 package remotesessions
 
 import (
+	"bytes"
+	"encoding/json"
 	"strings"
 	"time"
 
@@ -20,6 +22,89 @@ type tokenResponse struct {
 	RefreshExpiresIn       int64  `json:"refresh_expires_in"`
 	RefreshTokenExpiresIn  int64  `json:"refresh_token_expires_in"`
 	Scope                  string `json:"scope"`
+
+	// IDToken is verified and reduced to claims at the exchange; never persisted or logged.
+	IDToken string `json:"id_token"`
+
+	// raw is the response body the fields above were decoded from, kept so
+	// the non-standard members a provider adds can be retained.
+	raw []byte
+}
+
+// tokenResponseStandardMembers are the RFC 6749 §5.1 and refresh-lifetime members plus id_token.
+var tokenResponseStandardMembers = map[string]struct{}{
+	"access_token": {}, "refresh_token": {}, "token_type": {}, "expires_in": {},
+	"refresh_token_timeout": {}, "authorization_expires_in": {}, "refresh_expires_in": {},
+	"refresh_token_expires_in": {}, "scope": {}, "id_token": {},
+}
+
+// extras returns the non-standard, non-credential members at every nesting
+// level (Slack nests tokens under authed_user and incoming_webhook). Nil when empty.
+func (t tokenResponse) extras() map[string]json.RawMessage {
+	// UseNumber keeps large integers as the provider wrote them.
+	dec := json.NewDecoder(bytes.NewReader(t.raw))
+	dec.UseNumber()
+	var members map[string]any
+	if err := dec.Decode(&members); err != nil {
+		return nil
+	}
+	for name := range members {
+		if _, standard := tokenResponseStandardMembers[strings.ToLower(name)]; standard {
+			delete(members, name)
+		}
+	}
+	stripCredentialMembers(members)
+	if len(members) == 0 {
+		return nil
+	}
+	kept := make(map[string]json.RawMessage, len(members))
+	for name, value := range members {
+		raw, err := json.Marshal(value)
+		if err != nil {
+			return nil
+		}
+		kept[name] = raw
+	}
+	return kept
+}
+
+// stripCredentialMembers removes credential-shaped members from doc and from
+// every object nested under it.
+func stripCredentialMembers(doc map[string]any) {
+	for name, value := range doc {
+		if credentialMemberName(name) {
+			delete(doc, name)
+			continue
+		}
+		stripNestedCredentialMembers(value)
+	}
+}
+
+func stripNestedCredentialMembers(value any) {
+	switch v := value.(type) {
+	case map[string]any:
+		stripCredentialMembers(v)
+	case []any:
+		for _, item := range v {
+			stripNestedCredentialMembers(item)
+		}
+	}
+}
+
+// credentialMemberWords mark a member as credential material anywhere in its
+// name; benign matches (country_code) are dropped too.
+var credentialMemberWords = []string{"token", "secret", "assertion", "code", "password", "passwd", "credential", "key", "jwt", "webhook", "authorization", "session", "cookie", "signature"}
+
+// credentialMemberName reports whether a member name looks like it names a
+// credential, regardless of case.
+func credentialMemberName(name string) bool {
+	lower := strings.ToLower(name)
+	for _, word := range credentialMemberWords {
+		if strings.Contains(lower, word) {
+			return true
+		}
+	}
+	return false
 }
 
 // Scopes splits the space-delimited scope value per RFC 6749 §3.3, tolerating

--- a/server/internal/remotesessions/tokenservice.go
+++ b/server/internal/remotesessions/tokenservice.go
@@ -718,7 +718,7 @@ func (s *RefreshService) restateIdentity(
 	if err != nil {
 		logIdentityFailure(ctx, s.logger, "enrichment document dropped; stored document kept", err, attrs...)
 	}
-	if identity == nil && enrichment == nil {
+	if identity == nil && (enrichment == nil || tokenResponseUnchanged(sess.Enrichment, tok.extras())) {
 		return sess
 	}
 

--- a/server/internal/remotesessions/tokenservice.go
+++ b/server/internal/remotesessions/tokenservice.go
@@ -699,12 +699,13 @@ func (s *RefreshService) restateIdentity(
 	var identity *UpstreamIdentity
 	if tok.IDToken != "" && client.JwksUri.Valid && client.JwksUri.String != "" {
 		verified, err := s.idTokens.Verify(ctx, tok.IDToken, IDTokenExpectation{
-			issuer:     client.IssuerUrl,
-			clientID:   client.ExternalClientID,
-			jwksURI:    client.JwksUri.String,
-			fetchScope: client.RemoteSessionIssuerID.String(),
-			nonce:      "",
-			subject:    sess.UpstreamSubject.String,
+			issuer:      client.IssuerUrl,
+			clientID:    client.ExternalClientID,
+			jwksURI:     client.JwksUri.String,
+			fetchScope:  client.RemoteSessionIssuerID.String(),
+			signingAlgs: client.IDTokenSigningAlgValuesSupported,
+			nonce:       "",
+			subject:     sess.UpstreamSubject.String,
 		})
 		switch {
 		case errors.Is(err, errIDTokenVerificationDisabled):
@@ -735,8 +736,10 @@ func (s *RefreshService) restateIdentity(
 		ExpectedUpdatedAt:     sess.UpdatedAt,
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
-		// The grant was re-established or revoked while the ID token was
-		// being verified; that write's identity stands.
+		// updated_at moved during verification: a reconnect, a revocation, or
+		// another refresh's rotation. No column tells those apart, so a retry
+		// could stamp this grant's identity onto a reconnected one; the
+		// restatement is best-effort and the stored identity stands.
 		return sess
 	}
 	if err != nil {

--- a/server/internal/remotesessions/tokenservice.go
+++ b/server/internal/remotesessions/tokenservice.go
@@ -33,6 +33,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -44,8 +45,6 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/conv"
-	"github.com/speakeasy-api/gram/server/internal/encryption"
-	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/inv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions/remotesessionmetrics"
@@ -528,49 +527,48 @@ func refreshFailureAttrs(sess remotesessions_repo.RemoteSession, err error) []an
 
 // refreshSessionTokens POSTs grant_type=refresh_token to the upstream token
 // endpoint and persists the new token pair on success, returning the updated
-// remote_session row and the new plaintext access token.
+// remote_session row and the decoded token response the caller restates
+// identity from after the lease is released.
 //
-// RefreshService is its only caller and supplies the session's client +
-// issuer row, read after the single-flight lock so the POST runs on current
-// configuration. The upstream token POST is an external call, so q must be a
-// pool-bound querier, never a transaction-bound one — the POST must not run
-// inside an open database transaction.
+// The caller supplies the session's client + issuer row, read after the
+// single-flight lock so the POST runs on current configuration. The POST is
+// an external call, so q must be a pool-bound querier, never a
+// transaction-bound one.
 //
 // Operator-actionable failures (unreadable stored token, missing token
 // endpoint, an upstream rejection, no access token returned) come back as a
 // *TokenRefreshError carrying a public-safe Reason, so callers can distinguish
 // them from internal infrastructure errors and surface the Reason.
-func refreshSessionTokens(
+func (s *RefreshService) refreshSessionTokens(
 	ctx context.Context,
 	q *remotesessions_repo.Queries,
-	enc *encryption.Client,
-	policy *guardian.Policy,
 	client remotesessions_repo.GetRemoteSessionClientWithIssuerByIDRow,
 	sess remotesessions_repo.RemoteSession,
 	resource string,
-) (remotesessions_repo.RemoteSession, string, error) {
+) (remotesessions_repo.RemoteSession, tokenResponse, error) {
 	var zero remotesessions_repo.RemoteSession
+	var noToken tokenResponse
 
 	if !client.TokenEndpoint.Valid || client.TokenEndpoint.String == "" {
-		return zero, "", newTokenRefreshError("the identity provider has no token endpoint configured", nil)
+		return zero, noToken, newTokenRefreshError("the identity provider has no token endpoint configured", nil)
 	}
 
-	refreshToken, err := enc.Decrypt(sess.RefreshTokenEncrypted.String)
+	refreshToken, err := s.enc.Decrypt(sess.RefreshTokenEncrypted.String)
 	if err != nil {
-		return zero, "", newTokenRefreshError("the session's stored refresh token could not be read; revoke and re-link the session", err)
+		return zero, noToken, newTokenRefreshError("the session's stored refresh token could not be read; revoke and re-link the session", err)
 	}
 
 	var clientSecret string
 	if client.ClientSecretEncrypted.Valid {
-		clientSecret, err = enc.Decrypt(client.ClientSecretEncrypted.String)
+		clientSecret, err = s.enc.Decrypt(client.ClientSecretEncrypted.String)
 		if err != nil {
-			return zero, "", newTokenRefreshError("the client secret could not be read; check the issuer's configuration", err)
+			return zero, noToken, newTokenRefreshError("the client secret could not be read; check the issuer's configuration", err)
 		}
 	}
 
 	authMethod, err := ResolveTokenEndpointAuthMethod(client.TokenEndpointAuthMethod.String, clientSecret)
 	if err != nil {
-		return zero, "", newTokenRefreshError("the client's authentication configuration is invalid; check the issuer's configuration", err)
+		return zero, noToken, newTokenRefreshError("the client's authentication configuration is invalid; check the issuer's configuration", err)
 	}
 
 	form := url.Values{}
@@ -590,42 +588,43 @@ func refreshSessionTokens(
 
 	req, err := newTokenEndpointRequest(postCtx, client.TokenEndpoint.String, form, authMethod, client.ExternalClientID, clientSecret)
 	if err != nil {
-		return zero, "", fmt.Errorf("new refresh request: %w", err)
+		return zero, noToken, fmt.Errorf("new refresh request: %w", err)
 	}
 
-	resp, err := policy.PooledClient().Do(req)
+	resp, err := s.policy.PooledClient().Do(req)
 	if err != nil {
-		return zero, "", fmt.Errorf("post refresh: %w: %w", errRefreshUpstreamUnreachable, err)
+		return zero, noToken, fmt.Errorf("post refresh: %w: %w", errRefreshUpstreamUnreachable, err)
 	}
 	defer o11y.NoLogDefer(func() error { return resp.Body.Close() })
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
 	if err != nil {
-		return zero, "", fmt.Errorf("read refresh response: %w", err)
+		return zero, noToken, fmt.Errorf("read refresh response: %w", err)
 	}
 	if resp.StatusCode/100 != 2 {
-		return zero, "", newTokenRefreshErrorFromHTTP(resp.StatusCode, resp.Status, body)
+		return zero, noToken, newTokenRefreshErrorFromHTTP(resp.StatusCode, resp.Status, body)
 	}
 	var tok tokenResponse
 	if err := json.Unmarshal(body, &tok); err != nil {
-		return zero, "", fmt.Errorf("decode refresh response: %w", err)
+		return zero, noToken, fmt.Errorf("decode refresh response: %w", err)
 	}
+	tok.raw = body
 	if tok.AccessToken == "" {
 		if refreshErr, ok := newTokenRefreshErrorFromSuccessBody(resp.StatusCode, resp.Status, body); ok {
-			return zero, "", refreshErr
+			return zero, noToken, refreshErr
 		}
-		return zero, "", newTokenRefreshError("the identity provider returned no access token", nil)
+		return zero, noToken, newTokenRefreshError("the identity provider returned no access token", nil)
 	}
 
-	accessEnc, err := enc.Encrypt([]byte(tok.AccessToken))
+	accessEnc, err := s.enc.Encrypt([]byte(tok.AccessToken))
 	if err != nil {
-		return zero, "", fmt.Errorf("encrypt new access token: %w", err)
+		return zero, noToken, fmt.Errorf("encrypt new access token: %w", err)
 	}
 	newRefreshEnc := sess.RefreshTokenEncrypted
 	if tok.RefreshToken != "" {
-		v, eerr := enc.Encrypt([]byte(tok.RefreshToken))
+		v, eerr := s.enc.Encrypt([]byte(tok.RefreshToken))
 		if eerr != nil {
-			return zero, "", fmt.Errorf("encrypt new refresh token: %w", eerr)
+			return zero, noToken, fmt.Errorf("encrypt new refresh token: %w", eerr)
 		}
 		newRefreshEnc = conv.PtrToPGText(&v)
 	}
@@ -668,10 +667,81 @@ func refreshSessionTokens(
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return zero, "", newTokenRefreshError("the session was rotated by another request or revoked while this refresh was in flight; reload to see its current state", errRefreshNotApplied)
+			return zero, noToken, newTokenRefreshError("the session was rotated by another request or revoked while this refresh was in flight; reload to see its current state", errRefreshNotApplied)
 		}
-		return zero, "", fmt.Errorf("persist refreshed session: %w", err)
+		return zero, noToken, fmt.Errorf("persist refreshed session: %w", err)
 	}
 
-	return updated, tok.AccessToken, nil
+	return updated, tok, nil
+}
+
+// identityRestatementBudget bounds one restatement on a context detached from the request.
+const identityRestatementBudget = idTokenVerifyBudget + 5*time.Second
+
+// restateIdentity writes what a refresh said about the grant's owner after the
+// tokens are stored, outside the lease. Any rejection, including a different
+// subject (§12.2), keeps the identity verified at the exchange.
+func (s *RefreshService) restateIdentity(
+	ctx context.Context,
+	q *remotesessions_repo.Queries,
+	client remotesessions_repo.GetRemoteSessionClientWithIssuerByIDRow,
+	sess remotesessions_repo.RemoteSession,
+	tok tokenResponse,
+) remotesessions_repo.RemoteSession {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), identityRestatementBudget)
+	defer cancel()
+
+	attrs := []slog.Attr{
+		attr.SlogOAuthIssuer(client.IssuerUrl),
+		attr.SlogRemoteSessionClientID(sess.RemoteSessionClientID.String()),
+		attr.SlogUserSessionIssuerID(sess.UserSessionIssuerID.String()),
+	}
+	var identity *UpstreamIdentity
+	if tok.IDToken != "" && client.JwksUri.Valid && client.JwksUri.String != "" {
+		verified, err := s.idTokens.Verify(ctx, tok.IDToken, IDTokenExpectation{
+			issuer:     client.IssuerUrl,
+			clientID:   client.ExternalClientID,
+			jwksURI:    client.JwksUri.String,
+			fetchScope: client.RemoteSessionIssuerID.String(),
+			nonce:      "",
+			subject:    sess.UpstreamSubject.String,
+		})
+		switch {
+		case errors.Is(err, errIDTokenVerificationDisabled):
+		case err != nil:
+			logIdentityFailure(ctx, s.logger, "refresh id token rejected; stored identity kept", err, attrs...)
+		default:
+			identity = &verified
+		}
+	}
+	enrichment, err := buildEnrichment(tok, identity)
+	if err != nil {
+		logIdentityFailure(ctx, s.logger, "enrichment document dropped; stored document kept", err, attrs...)
+	}
+	if identity == nil && enrichment == nil {
+		return sess
+	}
+
+	cols := identity.columns()
+	restated, err := q.UpdateRemoteSessionIdentity(ctx, remotesessions_repo.UpdateRemoteSessionIdentityParams{
+		ID:                    sess.ID,
+		SubjectUrn:            sess.SubjectUrn,
+		RemoteSessionClientID: sess.RemoteSessionClientID,
+		UpstreamSubject:       cols.Subject,
+		UpstreamEmail:         cols.Email,
+		UpstreamDisplayName:   cols.DisplayName,
+		IdentitySource:        cols.Source,
+		Enrichment:            enrichment,
+		ExpectedUpdatedAt:     sess.UpdatedAt,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		// The grant was re-established or revoked while the ID token was
+		// being verified; that write's identity stands.
+		return sess
+	}
+	if err != nil {
+		s.logger.LogAttrs(ctx, slog.LevelError, "persist restated remote session identity", append([]slog.Attr{attr.SlogError(err)}, attrs...)...)
+		return sess
+	}
+	return restated
 }

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -1071,3 +1071,21 @@ RETURNING id;
 INSERT INTO meta_mcp_servers (id, organization_id, project_id, name)
 VALUES (@id, @organization_id, @project_id, @name)
 RETURNING id;
+
+-- name: InstallRemoteSessionIdentityWriteMarkerFixture :exec
+-- Marks every remote_sessions update that leaves updated_at and last_used_at alone, the
+-- identity restatement's signature, by appending to validation_reason.
+DO $install$
+BEGIN
+    CREATE FUNCTION mark_remote_session_identity_write() RETURNS trigger LANGUAGE plpgsql AS $fn$
+    BEGIN
+        NEW.validation_reason := concat(OLD.validation_reason, 'identity-write;');
+        RETURN NEW;
+    END
+    $fn$;
+    CREATE TRIGGER mark_remote_session_identity_write
+        BEFORE UPDATE ON remote_sessions FOR EACH ROW
+        WHEN (OLD.updated_at = NEW.updated_at AND OLD.last_used_at IS NOT DISTINCT FROM NEW.last_used_at)
+        EXECUTE FUNCTION mark_remote_session_identity_write();
+END
+$install$;

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -1466,6 +1466,30 @@ func (q *Queries) InstallOpenRouterAdminDisableAuditFailureFixture(ctx context.C
 	return err
 }
 
+const installRemoteSessionIdentityWriteMarkerFixture = `-- name: InstallRemoteSessionIdentityWriteMarkerFixture :exec
+DO $install$
+BEGIN
+    CREATE FUNCTION mark_remote_session_identity_write() RETURNS trigger LANGUAGE plpgsql AS $fn$
+    BEGIN
+        NEW.validation_reason := concat(OLD.validation_reason, 'identity-write;');
+        RETURN NEW;
+    END
+    $fn$;
+    CREATE TRIGGER mark_remote_session_identity_write
+        BEFORE UPDATE ON remote_sessions FOR EACH ROW
+        WHEN (OLD.updated_at = NEW.updated_at AND OLD.last_used_at IS NOT DISTINCT FROM NEW.last_used_at)
+        EXECUTE FUNCTION mark_remote_session_identity_write();
+END
+$install$
+`
+
+// Marks every remote_sessions update that leaves updated_at and last_used_at alone, the
+// identity restatement's signature, by appending to validation_reason.
+func (q *Queries) InstallRemoteSessionIdentityWriteMarkerFixture(ctx context.Context) error {
+	_, err := q.db.Exec(ctx, installRemoteSessionIdentityWriteMarkerFixture)
+	return err
+}
+
 const isQueryBlockedOnLockFixture = `-- name: IsQueryBlockedOnLockFixture :one
 SELECT EXISTS (
     SELECT 1

--- a/server/internal/usersessions/jwks/keyresolver.go
+++ b/server/internal/usersessions/jwks/keyresolver.go
@@ -167,6 +167,26 @@ func (k *KeyResolver) chargeFetch(ctx context.Context, source Source) error {
 // Concurrent callers coalesce: a burst of assertions bearing a freshly
 // rotated kid costs one refresh, not one per request.
 func (k *KeyResolver) VerificationKey(ctx context.Context, source Source, kid string) (*jose.JSONWebKey, error) {
+	return k.verificationKey(ctx, source, func(set jose.JSONWebKeySet) (*jose.JSONWebKey, error) {
+		return selectKey(set, kid)
+	})
+}
+
+// VerificationKeyForAlgorithm is VerificationKey for a caller that knows the
+// assertion's algorithm: among the keys matching kid it picks the one
+// declaring alg, else one declaring nothing whose type fits alg's family,
+// and refuses one declaring another alg (see selectKeyForAlgorithm). The
+// refresh policy is VerificationKey's; a matched kid that cannot carry alg
+// is ErrKeyAlgorithmMismatch and owes no refresh.
+func (k *KeyResolver) VerificationKeyForAlgorithm(ctx context.Context, source Source, kid string, alg jose.SignatureAlgorithm) (*jose.JSONWebKey, error) {
+	return k.verificationKey(ctx, source, func(set jose.JSONWebKeySet) (*jose.JSONWebKey, error) {
+		return selectKeyForAlgorithm(set, kid, alg)
+	})
+}
+
+// verificationKey is the resolution and unknown-kid refresh loop behind both
+// selection rules; pick reports ErrKeyNotFound when the set lacks the kid.
+func (k *KeyResolver) verificationKey(ctx context.Context, source Source, pick func(jose.JSONWebKeySet) (*jose.JSONWebKey, error)) (*jose.JSONWebKey, error) {
 	if source.kind == sourceInline {
 		// Inline sets have no upstream to refresh from, so an unknown kid is
 		// terminal by construction and no rate limit applies.
@@ -174,7 +194,7 @@ func (k *KeyResolver) VerificationKey(ctx context.Context, source Source, kid st
 		if err != nil {
 			return nil, err
 		}
-		return selectKey(result.KeySet, kid)
+		return pick(result.KeySet)
 	}
 
 	result, err := k.resolveShared(ctx, source)
@@ -182,7 +202,7 @@ func (k *KeyResolver) VerificationKey(ctx context.Context, source Source, kid st
 		return nil, err
 	}
 
-	key, err := selectKey(result.KeySet, kid)
+	key, err := pick(result.KeySet)
 	if err == nil {
 		return key, nil
 	}
@@ -201,7 +221,7 @@ func (k *KeyResolver) VerificationKey(ctx context.Context, source Source, kid st
 	if err != nil {
 		return nil, err
 	}
-	return selectKey(refreshed.KeySet, kid)
+	return pick(refreshed.KeySet)
 }
 
 // resolveShared runs one cache-honouring resolution for a source, coalescing

--- a/server/internal/usersessions/jwks/keyset.go
+++ b/server/internal/usersessions/jwks/keyset.go
@@ -2,6 +2,10 @@ package jwks
 
 import (
 	"bytes"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rsa"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -31,6 +35,11 @@ var (
 	// upstream within its refresh policy, this is the terminal answer for an
 	// assertion signed with an unknown key.
 	ErrKeyNotFound = errors.New("no verification key matches")
+
+	// ErrKeyAlgorithmMismatch reports that the keys matching a kid cannot
+	// carry the assertion's algorithm: each declares another alg or is of
+	// another type. The kid is known, so no refresh is owed.
+	ErrKeyAlgorithmMismatch = errors.New("no verification key can carry the signature algorithm")
 )
 
 // ValidatePublicOnly rejects a JWK Set document containing private or
@@ -235,4 +244,67 @@ func selectKey(set jose.JSONWebKeySet, kid string) (*jose.JSONWebKey, error) {
 		}
 	}
 	return nil, fmt.Errorf("kid %q: %w", kid, ErrKeyNotFound)
+}
+
+// selectKeyForAlgorithm is selectKey narrowed to keys able to carry alg.
+// Among the keys matching kid, one declaring alg wins; failing that, one
+// declaring nothing whose type fits alg's family; one declaring another alg
+// never does. Without a kid the narrowed candidates must be exactly one.
+func selectKeyForAlgorithm(set jose.JSONWebKeySet, kid string, alg jose.SignatureAlgorithm) (*jose.JSONWebKey, error) {
+	var declared, fitting []jose.JSONWebKey
+	matched := 0
+	for _, key := range set.Keys {
+		if kid != "" && key.KeyID != kid {
+			continue
+		}
+		matched++
+		switch {
+		case key.Algorithm == string(alg):
+			declared = append(declared, key)
+		case key.Algorithm == "" && keyFitsAlgorithm(key.Key, alg):
+			fitting = append(fitting, key)
+		}
+	}
+	if matched == 0 {
+		return nil, fmt.Errorf("kid %q: %w", kid, ErrKeyNotFound)
+	}
+	candidates := declared
+	if len(candidates) == 0 {
+		candidates = fitting
+	}
+	switch {
+	case len(candidates) == 0:
+		return nil, fmt.Errorf("kid %q with %s: %w", kid, alg, ErrKeyAlgorithmMismatch)
+	case kid == "" && len(candidates) != 1:
+		return nil, fmt.Errorf("assertion carries no kid and %d usable keys can carry %s: %w", len(candidates), alg, ErrKeyNotFound)
+	default:
+		selected := candidates[0]
+		return &selected, nil
+	}
+}
+
+// keyFitsAlgorithm reports whether a key that declares no alg is of the type
+// and curve alg's family requires.
+func keyFitsAlgorithm(key any, alg jose.SignatureAlgorithm) bool {
+	switch alg {
+	case jose.RS256, jose.RS384, jose.RS512, jose.PS256, jose.PS384, jose.PS512:
+		_, ok := key.(*rsa.PublicKey)
+		return ok
+	case jose.ES256:
+		return isCurve(key, elliptic.P256())
+	case jose.ES384:
+		return isCurve(key, elliptic.P384())
+	case jose.ES512:
+		return isCurve(key, elliptic.P521())
+	case jose.EdDSA:
+		_, ok := key.(ed25519.PublicKey)
+		return ok
+	default:
+		return false
+	}
+}
+
+func isCurve(key any, curve elliptic.Curve) bool {
+	ec, ok := key.(*ecdsa.PublicKey)
+	return ok && ec.Curve != nil && ec.Curve.Params().Name == curve.Params().Name
 }

--- a/server/internal/usersessions/jwks/keyset_algorithm_test.go
+++ b/server/internal/usersessions/jwks/keyset_algorithm_test.go
@@ -1,0 +1,115 @@
+package jwks
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/stretchr/testify/require"
+)
+
+// rsaTestKey is an RSA public JWK declaring no alg.
+func rsaTestKey(t *testing.T, kid string) jose.JSONWebKey {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	return jose.JSONWebKey{
+		Key:       key.Public(),
+		KeyID:     kid,
+		Algorithm: "",
+		Use:       "sig",
+	}
+}
+
+func TestSelectKeyForAlgorithm_SharedKidPicksByType(t *testing.T) {
+	t.Parallel()
+
+	ec := testKey(t, "shared")
+	ec.Algorithm = ""
+	set, err := parseKeySet(keySetJSON(t, rsaTestKey(t, "shared"), ec))
+	require.NoError(t, err)
+
+	key, err := selectKeyForAlgorithm(set, "shared", jose.ES256)
+	require.NoError(t, err)
+	require.IsType(t, &ecdsa.PublicKey{}, key.Key)
+
+	key, err = selectKeyForAlgorithm(set, "shared", jose.PS256)
+	require.NoError(t, err)
+	require.IsType(t, &rsa.PublicKey{}, key.Key)
+
+	_, err = selectKeyForAlgorithm(set, "shared", jose.ES384)
+	require.ErrorIs(t, err, ErrKeyAlgorithmMismatch, "a P-256 key cannot carry ES384")
+
+	_, err = selectKeyForAlgorithm(set, "shared", jose.EdDSA)
+	require.ErrorIs(t, err, ErrKeyAlgorithmMismatch)
+}
+
+func TestSelectKeyForAlgorithm_DeclaredAlgWins(t *testing.T) {
+	t.Parallel()
+
+	undeclared := testKey(t, "shared")
+	undeclared.Algorithm = ""
+	set, err := parseKeySet(keySetJSON(t, undeclared, testKey(t, "shared")))
+	require.NoError(t, err)
+
+	key, err := selectKeyForAlgorithm(set, "shared", jose.ES256)
+	require.NoError(t, err)
+	require.Equal(t, "ES256", key.Algorithm, "the key declaring the algorithm is preferred to one merely fitting it")
+}
+
+func TestSelectKeyForAlgorithm_DeclaredMismatchRejected(t *testing.T) {
+	t.Parallel()
+
+	set, err := parseKeySet(keySetJSON(t, testKey(t, "a")))
+	require.NoError(t, err)
+
+	_, err = selectKeyForAlgorithm(set, "a", jose.RS256)
+	require.ErrorIs(t, err, ErrKeyAlgorithmMismatch)
+	require.NotErrorIs(t, err, ErrKeyNotFound, "a known kid owes no refresh")
+
+	_, err = selectKeyForAlgorithm(set, "missing", jose.ES256)
+	require.ErrorIs(t, err, ErrKeyNotFound)
+}
+
+func TestSelectKeyForAlgorithm_NoKid(t *testing.T) {
+	t.Parallel()
+
+	set, err := parseKeySet(keySetJSON(t, rsaTestKey(t, "r"), testKey(t, "e")))
+	require.NoError(t, err)
+
+	key, err := selectKeyForAlgorithm(set, "", jose.RS256)
+	require.NoError(t, err)
+	require.Equal(t, "r", key.KeyID, "without a kid the one key able to carry the algorithm is unambiguous")
+
+	ambiguous, err := parseKeySet(keySetJSON(t, rsaTestKey(t, "r1"), rsaTestKey(t, "r2")))
+	require.NoError(t, err)
+	_, err = selectKeyForAlgorithm(ambiguous, "", jose.RS256)
+	require.ErrorIs(t, err, ErrKeyNotFound)
+}
+
+func TestVerificationKeyForAlgorithm_SharedKid(t *testing.T) {
+	t.Parallel()
+
+	server := newKeySetServer(t, keySetJSON(t, rsaTestKey(t, "shared"), testKey(t, "shared")))
+	resolver, _ := newTestKeyResolver(t, server, generousRate())
+	source := remoteSourceFor(t, server)
+
+	key, err := resolver.VerificationKeyForAlgorithm(t.Context(), source, "shared", jose.ES256)
+	require.NoError(t, err)
+	require.IsType(t, &ecdsa.PublicKey{}, key.Key)
+
+	key, err = resolver.VerificationKeyForAlgorithm(t.Context(), source, "shared", jose.RS256)
+	require.NoError(t, err)
+	require.IsType(t, &rsa.PublicKey{}, key.Key)
+
+	_, err = resolver.VerificationKeyForAlgorithm(t.Context(), source, "shared", jose.EdDSA)
+	require.ErrorIs(t, err, ErrKeyAlgorithmMismatch)
+	require.Equal(t, 1, server.Fetches(), "a known kid that cannot carry the algorithm triggers no refresh")
+
+	plain, err := resolver.VerificationKey(t.Context(), source, "shared")
+	require.NoError(t, err)
+	require.IsType(t, &rsa.PublicKey{}, plain.Key, "the kid-only lookup keeps first-match selection")
+}


### PR DESCRIPTION
AIM-203, part 2 of 2. Stacked on #6100; merge that first.

## Summary

- Authorize requests carry a `nonce`. When the token response has an `id_token`, it is verified (signature via the issuer's `jwks_uri` through the shared `jwks.KeyResolver`, `iss`, `aud`/`azp`, `exp`, nonce; 5s budget per verification, fetch budgets charged per issuer row). Accepted algorithms are the intersection of the shared allowlist and the issuer's `id_token_signing_alg_values_supported` when it advertises any, and the signing key is picked by the token's `alg` among keys sharing a `kid` (declared `alg` first, else key type and curve).
- A verified token fills the new `remote_sessions` identity columns (`upstream_subject`, `upstream_email`, `upstream_display_name`, `identity_source`). `enrichment` keeps the full ID-token claim set (so picture, sid, auth_time, and email_verified are retained without a column) and, from the token response, only an allowlist of known provider metadata members (Notion workspace fields, Slack team and bot ids, PostHog region, and similar), with credential-shaped members stripped at any depth as a second layer. A document over 16 KiB is dropped with a warning, and the stored merge is capped at the same size: when a merge would exceed it, the newest document replaces it. The raw ID token is never stored or logged, and provider-controlled text in log lines is capped.
- New grant: overwrites identity, clears `validation_*`. Refresh: tokens persist under the lease first; identity is verified and written afterwards, on a context detached from the request, with a CAS on the token write. The CAS also drops the restatement when another refresh rotated the tokens meanwhile; that is deliberate best-effort, since nothing on the row distinguishes a rotation from a reconnect and a retry could stamp a previous grant's identity onto a new one. The stored identity is untouched in that case and the next ID token restates it. Omitted claims keep their stored value in both the columns and the document (the `id_token` and `token_response` members merge key by key). A refresh ID token naming a different `sub` is rejected like any other invalid token and the identity verified at the exchange stands. Any soft-delete clears identity and enrichment.
- Consent card shows "Connected as {email or name}". `IDTokenVerifier` is an interface with a no-op implementation, so both services always hold a usable verifier; the API server and the keepalive worker wire the JWKS-backed one. Verification failures never fail a login or refresh; they log at warn.
- Tests: claim helpers, extras allowlist and claim denylist, enrichment document, size cap and merged cap under repeated refreshes, algorithm policy and shared-kid key selection, overlapping refreshes, template escaping, and end-to-end logins against a TLS key-set server covering capture, nine rejection cases, refresh restatement (no token, stranger twice, partial claims, renamed), and two revocation paths.

## Motivation

The card could say a grant existed but not whose. Issuers with OpenID Connect already say so, signed, at the exchange; a quarter of prod sessions in the last 30 days were granted with `openid`. Verifying rather than decoding matters because these columns will feed session-to-agent grants.

Not in this PR: a verification-outcome metric and reactive metadata refresh on unknown `kid` (AIM-210).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

