### PR TITLE
chore: upgrade Atlas actions and use mise-managed CLI

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -870,11 +870,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Atlas
-        uses: ariga/setup-atlas@2f3c785c89a15e1c0d07bcae3900fb5feb969eea # v0
-        with:
-          cloud-token: ${{ secrets.ATLAS_TOKEN }}
-
       - name: Setup Mise
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
@@ -883,8 +878,17 @@ jobs:
           cache_key_prefix: mise-blacksmith-v1
           env: false
 
+      # Mise supplies atlas; the SHA-pinned actions download a separate atlas-action wrapper.
+      - name: Login to Atlas
+        env:
+          ATLAS_TOKEN: ${{ secrets.ATLAS_TOKEN }}
+        run: |
+          if [ -n "$ATLAS_TOKEN" ]; then
+            atlas login --token "$ATLAS_TOKEN"
+          fi
+
       - name: Lint PostgreSQL migrations
-        uses: ariga/atlas-action/migrate/lint@ba65b510ea74c2886c9c52ce7aa54fd7f5fc6293 # v1.15.6
+        uses: ariga/atlas-action/migrate/lint@1caacd9d054d7b8521b7d90d7c7946cde16a67eb # v1.16.5
         with:
           dir: file://server/migrations
           dir-name: gram
@@ -895,7 +899,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Lint ClickHouse migrations
-        uses: ariga/atlas-action/migrate/lint@ba65b510ea74c2886c9c52ce7aa54fd7f5fc6293 # v1.15.6
+        uses: ariga/atlas-action/migrate/lint@1caacd9d054d7b8521b7d90d7c7946cde16a67eb # v1.16.5
         with:
           dir: file://server/clickhouse/migrations
           dir-name: gram-clickhouse
@@ -979,10 +983,22 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Atlas
-        uses: ariga/setup-atlas@2f3c785c89a15e1c0d07bcae3900fb5feb969eea # v0
+      - name: Setup Mise
+        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
-          cloud-token: ${{ secrets.ATLAS_TOKEN }}
+          install: true
+          install_args: atlas
+          cache: true
+          cache_key_prefix: mise-atlas-blacksmith-v1
+          env: false
+
+      - name: Login to Atlas
+        env:
+          ATLAS_TOKEN: ${{ secrets.ATLAS_TOKEN }}
+        run: |
+          if [ -n "$ATLAS_TOKEN" ]; then
+            atlas login --token "$ATLAS_TOKEN"
+          fi
 
       - name: Generate tag
         id: tag
@@ -996,7 +1012,7 @@ jobs:
           fi
 
       - name: Push PostgreSQL migrations
-        uses: ariga/atlas-action/migrate/push@a6a4733a3fcccd0690570184deb2f7f50b13e656 # v1.16.1
+        uses: ariga/atlas-action/migrate/push@1caacd9d054d7b8521b7d90d7c7946cde16a67eb # v1.16.5
         with:
           dir: file://server/migrations
           dir-name: gram
@@ -1004,7 +1020,7 @@ jobs:
           tag: ${{ steps.tag.outputs.tag }}
 
       - name: Push ClickHouse migrations
-        uses: ariga/atlas-action/migrate/push@a6a4733a3fcccd0690570184deb2f7f50b13e656 # v1.16.1
+        uses: ariga/atlas-action/migrate/push@1caacd9d054d7b8521b7d90d7c7946cde16a67eb # v1.16.5
         with:
           dir: file://server/clickhouse/migrations
           dir-name: gram-clickhouse
@@ -1157,10 +1173,13 @@ jobs:
       - name: Run "go mod tidy"
         run: mise run go:tidy
 
-      - name: Setup Atlas
-        uses: ariga/setup-atlas@2f3c785c89a15e1c0d07bcae3900fb5feb969eea # v0
-        with:
-          cloud-token: ${{ secrets.ATLAS_TOKEN }}
+      - name: Login to Atlas
+        env:
+          ATLAS_TOKEN: ${{ secrets.ATLAS_TOKEN }}
+        run: |
+          if [ -n "$ATLAS_TOKEN" ]; then
+            atlas login --token "$ATLAS_TOKEN"
+          fi
 
       - name: Run migrations
         run: mise run db:migrate

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -883,8 +883,8 @@ jobs:
         env:
           ATLAS_TOKEN: ${{ secrets.ATLAS_TOKEN }}
         run: |
-          if [ -n "$ATLAS_TOKEN" ]; then
-            atlas login --token "$ATLAS_TOKEN"
+          if [ -n "${ATLAS_TOKEN:+set}" ]; then
+            atlas login
           fi
 
       - name: Lint PostgreSQL migrations
@@ -996,8 +996,8 @@ jobs:
         env:
           ATLAS_TOKEN: ${{ secrets.ATLAS_TOKEN }}
         run: |
-          if [ -n "$ATLAS_TOKEN" ]; then
-            atlas login --token "$ATLAS_TOKEN"
+          if [ -n "${ATLAS_TOKEN:+set}" ]; then
+            atlas login
           fi
 
       - name: Generate tag
@@ -1177,8 +1177,8 @@ jobs:
         env:
           ATLAS_TOKEN: ${{ secrets.ATLAS_TOKEN }}
         run: |
-          if [ -n "$ATLAS_TOKEN" ]; then
-            atlas login --token "$ATLAS_TOKEN"
+          if [ -n "${ATLAS_TOKEN:+set}" ]; then
+            atlas login
           fi
 
       - name: Run migrations

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -847,6 +847,8 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: changes
     if: needs.changes.outputs.migrations == 'true' && github.event_name == 'pull_request'
+    env:
+      ATLAS_TOKEN: ${{ secrets.ATLAS_TOKEN }}
     permissions:
       contents: read
       pull-requests: write
@@ -879,14 +881,6 @@ jobs:
           env: false
 
       # Mise supplies atlas; the SHA-pinned actions download a separate atlas-action wrapper.
-      - name: Login to Atlas
-        env:
-          ATLAS_TOKEN: ${{ secrets.ATLAS_TOKEN }}
-        run: |
-          if [ -n "${ATLAS_TOKEN:+set}" ]; then
-            atlas login
-          fi
-
       - name: Lint PostgreSQL migrations
         uses: ariga/atlas-action/migrate/lint@1caacd9d054d7b8521b7d90d7c7946cde16a67eb # v1.16.5
         with:
@@ -957,6 +951,8 @@ jobs:
     if: |
       github.event_name != 'merge_group' &&
       (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
+    env:
+      ATLAS_TOKEN: ${{ secrets.ATLAS_TOKEN }}
     permissions:
       contents: read
       pull-requests: write
@@ -987,18 +983,10 @@ jobs:
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           install: true
-          install_args: atlas
+          install_args: aqua:ariga/atlas
           cache: true
           cache_key_prefix: mise-atlas-blacksmith-v1
           env: false
-
-      - name: Login to Atlas
-        env:
-          ATLAS_TOKEN: ${{ secrets.ATLAS_TOKEN }}
-        run: |
-          if [ -n "${ATLAS_TOKEN:+set}" ]; then
-            atlas login
-          fi
 
       - name: Generate tag
         id: tag
@@ -1084,6 +1072,7 @@ jobs:
     if: needs.changes.outputs.server == 'true'
     env:
       GOMAXPROCS: 16
+      ATLAS_TOKEN: ${{ secrets.ATLAS_TOKEN }}
     services:
       postgres:
         image: pgvector/pgvector:pg17
@@ -1172,14 +1161,6 @@ jobs:
 
       - name: Run "go mod tidy"
         run: mise run go:tidy
-
-      - name: Login to Atlas
-        env:
-          ATLAS_TOKEN: ${{ secrets.ATLAS_TOKEN }}
-        run: |
-          if [ -n "${ATLAS_TOKEN:+set}" ]; then
-            atlas login
-          fi
 
       - name: Run migrations
         run: mise run db:migrate

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -847,8 +847,6 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: changes
     if: needs.changes.outputs.migrations == 'true' && github.event_name == 'pull_request'
-    env:
-      ATLAS_TOKEN: ${{ secrets.ATLAS_TOKEN }}
     permissions:
       contents: read
       pull-requests: write
@@ -891,6 +889,7 @@ jobs:
           git-base: origin/main
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          ATLAS_TOKEN: ${{ secrets.ATLAS_TOKEN }}
 
       - name: Lint ClickHouse migrations
         uses: ariga/atlas-action/migrate/lint@1caacd9d054d7b8521b7d90d7c7946cde16a67eb # v1.16.5
@@ -901,9 +900,12 @@ jobs:
           git-base: origin/main
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          ATLAS_TOKEN: ${{ secrets.ATLAS_TOKEN }}
 
       - name: Check migration state is clean
         shell: bash
+        env:
+          ATLAS_TOKEN: ${{ secrets.ATLAS_TOKEN }}
         run: |
           failed=0
 
@@ -951,8 +953,6 @@ jobs:
     if: |
       github.event_name != 'merge_group' &&
       (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
-    env:
-      ATLAS_TOKEN: ${{ secrets.ATLAS_TOKEN }}
     permissions:
       contents: read
       pull-requests: write
@@ -1001,6 +1001,8 @@ jobs:
 
       - name: Push PostgreSQL migrations
         uses: ariga/atlas-action/migrate/push@1caacd9d054d7b8521b7d90d7c7946cde16a67eb # v1.16.5
+        env:
+          ATLAS_TOKEN: ${{ secrets.ATLAS_TOKEN }}
         with:
           dir: file://server/migrations
           dir-name: gram
@@ -1009,6 +1011,8 @@ jobs:
 
       - name: Push ClickHouse migrations
         uses: ariga/atlas-action/migrate/push@1caacd9d054d7b8521b7d90d7c7946cde16a67eb # v1.16.5
+        env:
+          ATLAS_TOKEN: ${{ secrets.ATLAS_TOKEN }}
         with:
           dir: file://server/clickhouse/migrations
           dir-name: gram-clickhouse
@@ -1072,7 +1076,6 @@ jobs:
     if: needs.changes.outputs.server == 'true'
     env:
       GOMAXPROCS: 16
-      ATLAS_TOKEN: ${{ secrets.ATLAS_TOKEN }}
     services:
       postgres:
         image: pgvector/pgvector:pg17
@@ -1163,11 +1166,17 @@ jobs:
         run: mise run go:tidy
 
       - name: Run migrations
+        env:
+          ATLAS_TOKEN: ${{ secrets.ATLAS_TOKEN }}
         run: mise run db:migrate
       - name: Diff database with schema
+        env:
+          ATLAS_TOKEN: ${{ secrets.ATLAS_TOKEN }}
         run: mise run db:diff out-of-sync
 
       - name: Check for dirty files
+        env:
+          ATLAS_TOKEN: ${{ secrets.ATLAS_TOKEN }}
         run: |
           mise run db:migrate --dry
           mise run git:porcelain

--- a/mise.lock
+++ b/mise.lock
@@ -343,6 +343,7 @@ checksum = "sha256:1b1630c3ae133448a9445911499ab2d59bd77f860abbd595dbc89da4eb82c
 url = "https://github.com/pnpm/pnpm/releases/download/v11.19.0/pnpm-linux-arm64.tar.gz"
 url_api = "https://api.github.com/repos/pnpm/pnpm/releases/assets/496485122"
 provenance = "github-attestations"
+provenance_verified = true
 
 [tools."github:pnpm/pnpm"."platforms.linux-arm64-musl"]
 checksum = "sha256:89309036b565a41e28f970a95c45ae2c448f80cc54c77a309f140e11706dd858"

--- a/mise.lock
+++ b/mise.lock
@@ -35,36 +35,36 @@ url = "https://github.com/chainguard-dev/apko/releases/download/v1.2.31/apko_1.2
 url_api = "https://api.github.com/repos/chainguard-dev/apko/releases/assets/499430053"
 
 [[tools."aqua:ariga/atlas"]]
-version = "1.0.0"
+version = "1.3.0"
 backend = "aqua:ariga/atlas"
 
 [tools."aqua:ariga/atlas"."platforms.linux-arm64"]
-checksum = "sha256:69a463cf6d51a93abeffbdc906b69f969c12e7a706a6d0a4e388b4ebd713c5f9"
-url = "https://release.ariga.io/atlas/atlas-linux-arm64-v1.0.0"
+checksum = "sha256:d2cfb1c71e58170bb4ddbe62107a38da4490f516ffa53a13abf57583819b6a40"
+url = "https://release.ariga.io/atlas/atlas-linux-arm64-v1.3.0"
 
 [tools."aqua:ariga/atlas"."platforms.linux-arm64-musl"]
-checksum = "sha256:69a463cf6d51a93abeffbdc906b69f969c12e7a706a6d0a4e388b4ebd713c5f9"
-url = "https://release.ariga.io/atlas/atlas-linux-arm64-v1.0.0"
+checksum = "sha256:d2cfb1c71e58170bb4ddbe62107a38da4490f516ffa53a13abf57583819b6a40"
+url = "https://release.ariga.io/atlas/atlas-linux-arm64-v1.3.0"
 
 [tools."aqua:ariga/atlas"."platforms.linux-x64"]
-checksum = "sha256:7147245d95af96cd1e90ef5cfd57aa9e9df2a9e7ca5a735ddf0a1230f325cee2"
-url = "https://release.ariga.io/atlas/atlas-linux-amd64-v1.0.0"
+checksum = "sha256:cfc773e5b4e845bc01d680390c174648938a7f88bf30e5a2c83ae85217c21587"
+url = "https://release.ariga.io/atlas/atlas-linux-amd64-v1.3.0"
 
 [tools."aqua:ariga/atlas"."platforms.linux-x64-musl"]
-checksum = "sha256:7147245d95af96cd1e90ef5cfd57aa9e9df2a9e7ca5a735ddf0a1230f325cee2"
-url = "https://release.ariga.io/atlas/atlas-linux-amd64-v1.0.0"
+checksum = "sha256:cfc773e5b4e845bc01d680390c174648938a7f88bf30e5a2c83ae85217c21587"
+url = "https://release.ariga.io/atlas/atlas-linux-amd64-v1.3.0"
 
 [tools."aqua:ariga/atlas"."platforms.macos-arm64"]
-checksum = "sha256:e7fb3098cc46cf8c2a84f5ed57f371f0ed80986d37f0f606ec464518c20518b5"
-url = "https://release.ariga.io/atlas/atlas-darwin-arm64-v1.0.0"
+checksum = "sha256:47aaf7c295c7569c7eecfcbc53f02de862846ce1fbef16f1bd8ae98b03c3c68f"
+url = "https://release.ariga.io/atlas/atlas-darwin-arm64-v1.3.0"
 
 [tools."aqua:ariga/atlas"."platforms.macos-x64"]
-checksum = "sha256:29c140e14d7b359af9cb36a91661a882fd806d4de16867b08b8b948aeba7a507"
-url = "https://release.ariga.io/atlas/atlas-darwin-amd64-v1.0.0"
+checksum = "sha256:4b4d8621332eabc3e6e7554d799a98ceef6376c4d8bbad6ed7832b49655e3480"
+url = "https://release.ariga.io/atlas/atlas-darwin-amd64-v1.3.0"
 
 [tools."aqua:ariga/atlas"."platforms.windows-x64"]
-checksum = "sha256:abf36ade639454afe25f646a09eb5c46629b0b06c640b565496fc5d45e56f8ec"
-url = "https://release.ariga.io/atlas/atlas-windows-amd64-v1.0.0.exe"
+checksum = "sha256:19b3bf812be93d1b30d7199c5700af01002cbd606c2aec2394fd618af7e3f7b1"
+url = "https://release.ariga.io/atlas/atlas-windows-amd64-v1.3.0.exe"
 
 [[tools.aube]]
 version = "1.38.1"

--- a/mise.toml
+++ b/mise.toml
@@ -12,7 +12,7 @@ pin = true
 # file, you can specify more tools or different version of listed ones below as
 # well as overriding environment variables.
 [tools]
-"aqua:ariga/atlas" = "1.0.0"
+"aqua:ariga/atlas" = "1.3.0"
 "github:speakeasy-api/openapi" = "1.24.0"
 # Keep in sync with speakeasyVersion in .speakeasy/workflow.yaml, otherwise the
 # installed version and the version generation runs on can mismatch.


### PR DESCRIPTION
## Summary
- Upgrade all four Atlas lint/push actions to v1.16.5, pinned to commit `1caacd9d054d7b8521b7d90d7c7946cde16a67eb`.
- Upgrade the mise-managed Atlas CLI to v1.3.0 and refresh its platform checksums.
- Replace setup-atlas with job-scoped ATLAS_TOKEN authentication for the mise-installed CLI; add a fully qualified Atlas-only mise install/cache to the push job.

## Motivation
Use the same pinned Atlas CLI locally and in CI instead of separately installing the latest CLI. The pinned actions download their available prebuilt atlas-action wrapper, avoiding a CI build while preserving lint reporting and registry pushes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades Atlas lint and push actions to v1.16.5 and switches CI to the mise-managed Atlas CLI v1.3.0, keeping local and CI tooling identical.

- Replaces `ariga/setup-atlas` with `ATLAS_TOKEN` env vars scoped to migration steps only, keeping the token out of command arguments.
- Adds an Atlas-only mise install and cache step to the push job.
- Refreshes Atlas platform checksums in `mise.lock`.
- The pinned actions ship their own prebuilt wrapper, so no CI build is needed and lint reports and registry pushes remain unchanged.

<sup>Written for commit a00dae5b8c46dd85f9dea6ab59d092b6b6cf7653. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

