### PR TITLE
feat(platform-mcp): manage MCP access roles

### DIFF
--- a/.changeset/platform-mcp-inspect-access.md
+++ b/.changeset/platform-mcp-inspect-access.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Add privacy-safe Platform MCP tools for inspecting role, member, and configured MCP access.

--- a/.changeset/platform-mcp-manage-access-roles.md
+++ b/.changeset/platform-mcp-manage-access-roles.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Add confirmed, idempotent Platform MCP tools for creating and updating custom MCP access roles.

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -231,6 +231,10 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 			Connection:   ratelimit.New(limitStore, platformmcp.PluginsConnectionLimitName, ratelimit.PerMinute(platformmcp.PluginQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.PluginsOrganizationLimitName, ratelimit.PerMinute(platformmcp.PluginQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
+		AccessReads: platformmcp.OperationBudget{
+			Connection:   ratelimit.New(limitStore, platformmcp.AccessReadsConnectionLimitName, ratelimit.PerMinute(platformmcp.AccessReadQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+			Organization: ratelimit.New(limitStore, platformmcp.AccessReadsOrganizationLimitName, ratelimit.PerMinute(platformmcp.AccessReadQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+		},
 		// Metered separately and lower: personal-data reads (this and session
 		// recall below, each on its own budget) must not be fundable by
 		// spending the ordinary diagnostic allowance.
@@ -304,6 +308,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 	}
 	pluginInventory := platformmcp.NewPluginsService(config.DB, budgets.Plugins, config.JWTSigningKey).
 		WithAssignmentMutations(config.FeatureFlags, platformmcp.NewPostgresOrganizationSlugResolver(config.DB), config.AuditLogger, pluginAssignmentMutationBudget)
+	accessReads := platformmcp.NewAccessReadService(config.Logger, config.DB, budgets.AccessReads, config.JWTSigningKey)
 	distributions := newPlatformMCPDistributionService(config, pluginInventory)
 
 	registryHandler := localfixture.NewRegistryHTTP(fixtureConfig).Handler()
@@ -361,6 +366,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 		sessionRecall,
 		riskMutations,
 		fixtureConfig.CatalogDescriptor(),
+		accessReads,
 	).WithOAuthTelemetry(oauthTelemetry).WithRiskTelemetry(riskTelemetry)
 	oauth.Attach(config.Mux)
 	platformmcp.NewDashboardSetupHTTP(dashboardSetupStarter, config.Sessions).Attach(config.Mux)
@@ -577,6 +583,10 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 			Connection:   ratelimit.New(limitStore, platformmcp.PluginsConnectionLimitName, ratelimit.PerMinute(platformmcp.PluginQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.PluginsOrganizationLimitName, ratelimit.PerMinute(platformmcp.PluginQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
+		AccessReads: platformmcp.OperationBudget{
+			Connection:   ratelimit.New(limitStore, platformmcp.AccessReadsConnectionLimitName, ratelimit.PerMinute(platformmcp.AccessReadQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+			Organization: ratelimit.New(limitStore, platformmcp.AccessReadsOrganizationLimitName, ratelimit.PerMinute(platformmcp.AccessReadQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+		},
 		// Metered separately and lower: personal-data reads (this and session
 		// recall below, each on its own budget) must not be fundable by
 		// spending the ordinary diagnostic allowance.
@@ -650,6 +660,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 	}
 	pluginInventory := platformmcp.NewPluginsService(config.DB, budgets.Plugins, config.JWTSigningKey).
 		WithAssignmentMutations(config.FeatureFlags, platformmcp.NewPostgresOrganizationSlugResolver(config.DB), config.AuditLogger, pluginAssignmentMutationBudget)
+	accessReads := platformmcp.NewAccessReadService(config.Logger, config.DB, budgets.AccessReads, config.JWTSigningKey)
 	distributions := newPlatformMCPDistributionService(config, pluginInventory)
 	skillAuthoring := platformmcp.NewSkillsService(config.Skills, platformmcp.NewPostgresSkillTargets(config.DB), store, config.Authz, registrationGate, budgets.Skills)
 	platformReader := platformmcp.NewPostgresReader(config.Logger, config.DB).
@@ -693,6 +704,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 		sessionRecall,
 		riskMutations,
 		platformmcp.CatalogDescriptor{},
+		accessReads,
 	).WithOAuthTelemetry(oauthTelemetry).WithRiskTelemetry(riskTelemetry)
 	oauth.Attach(config.Mux)
 	platformmcp.NewDashboardSetupHTTP(dashboardSetupStarter, config.Sessions).Attach(config.Mux)

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -18,6 +18,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	goahttp "goa.design/goa/v3/http"
 
+	"github.com/speakeasy-api/gram/server/internal/access"
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth/identity"
 	"github.com/speakeasy-api/gram/server/internal/auth/sessions"
@@ -69,6 +71,7 @@ type platformMCPConfig struct {
 	GuardianPolicy          *guardian.Policy
 	RemoteChallengeManager  *remotesessions.ChallengeManager
 	AuditLogger             *audit.Logger
+	AccessRoles             access.RoleProvider
 	PluginPublisher         *plugins.Service
 	TemporalEnv             *tenv.Environment
 	Skills                  platformmcp.SkillsManagement
@@ -235,6 +238,10 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 			Connection:   ratelimit.New(limitStore, platformmcp.AccessReadsConnectionLimitName, ratelimit.PerMinute(platformmcp.AccessReadQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.AccessReadsOrganizationLimitName, ratelimit.PerMinute(platformmcp.AccessReadQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
+		AccessRoleMutations: platformmcp.OperationBudget{
+			Connection:   ratelimit.New(limitStore, platformmcp.AccessRoleMutationConnectionLimitName, ratelimit.PerMinute(platformmcp.AccessRoleMutationsPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+			Organization: ratelimit.New(limitStore, platformmcp.AccessRoleMutationOrganizationLimitName, ratelimit.PerMinute(platformmcp.AccessRoleMutationsPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+		},
 		// Metered separately and lower: personal-data reads (this and session
 		// recall below, each on its own budget) must not be fundable by
 		// spending the ordinary diagnostic allowance.
@@ -309,6 +316,10 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 	pluginInventory := platformmcp.NewPluginsService(config.DB, budgets.Plugins, config.JWTSigningKey).
 		WithAssignmentMutations(config.FeatureFlags, platformmcp.NewPostgresOrganizationSlugResolver(config.DB), config.AuditLogger, pluginAssignmentMutationBudget)
 	accessReads := platformmcp.NewAccessReadService(config.Logger, config.DB, budgets.AccessReads, config.JWTSigningKey)
+	accessRoleMutations, accessRoleMutationErr := platformmcp.NewAccessRoleMutationService(accessReads, config.FeatureFlags, budgets.AccessRoleMutations, config.JWTSigningKey, access.NewRoleManager(config.Logger, config.DB, config.AccessRoles, config.AuditLogger))
+	if accessRoleMutationErr != nil {
+		config.Logger.WarnContext(ctx, "Platform MCP access role mutations unavailable", attr.SlogError(accessRoleMutationErr))
+	}
 	distributions := newPlatformMCPDistributionService(config, pluginInventory)
 
 	registryHandler := localfixture.NewRegistryHTTP(fixtureConfig).Handler()
@@ -367,6 +378,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 		riskMutations,
 		fixtureConfig.CatalogDescriptor(),
 		accessReads,
+		accessRoleMutations,
 	).WithOAuthTelemetry(oauthTelemetry).WithRiskTelemetry(riskTelemetry)
 	oauth.Attach(config.Mux)
 	platformmcp.NewDashboardSetupHTTP(dashboardSetupStarter, config.Sessions).Attach(config.Mux)
@@ -587,6 +599,10 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 			Connection:   ratelimit.New(limitStore, platformmcp.AccessReadsConnectionLimitName, ratelimit.PerMinute(platformmcp.AccessReadQueriesPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 			Organization: ratelimit.New(limitStore, platformmcp.AccessReadsOrganizationLimitName, ratelimit.PerMinute(platformmcp.AccessReadQueriesPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
 		},
+		AccessRoleMutations: platformmcp.OperationBudget{
+			Connection:   ratelimit.New(limitStore, platformmcp.AccessRoleMutationConnectionLimitName, ratelimit.PerMinute(platformmcp.AccessRoleMutationsPerConnectionPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+			Organization: ratelimit.New(limitStore, platformmcp.AccessRoleMutationOrganizationLimitName, ratelimit.PerMinute(platformmcp.AccessRoleMutationsPerOrganizationPerMinute), ratelimit.WithMetrics(config.MeterProvider)),
+		},
 		// Metered separately and lower: personal-data reads (this and session
 		// recall below, each on its own budget) must not be fundable by
 		// spending the ordinary diagnostic allowance.
@@ -661,6 +677,10 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 	pluginInventory := platformmcp.NewPluginsService(config.DB, budgets.Plugins, config.JWTSigningKey).
 		WithAssignmentMutations(config.FeatureFlags, platformmcp.NewPostgresOrganizationSlugResolver(config.DB), config.AuditLogger, pluginAssignmentMutationBudget)
 	accessReads := platformmcp.NewAccessReadService(config.Logger, config.DB, budgets.AccessReads, config.JWTSigningKey)
+	accessRoleMutations, accessRoleMutationErr := platformmcp.NewAccessRoleMutationService(accessReads, config.FeatureFlags, budgets.AccessRoleMutations, config.JWTSigningKey, access.NewRoleManager(config.Logger, config.DB, config.AccessRoles, config.AuditLogger))
+	if accessRoleMutationErr != nil {
+		config.Logger.WarnContext(ctx, "Platform MCP access role mutations unavailable", attr.SlogError(accessRoleMutationErr))
+	}
 	distributions := newPlatformMCPDistributionService(config, pluginInventory)
 	skillAuthoring := platformmcp.NewSkillsService(config.Skills, platformmcp.NewPostgresSkillTargets(config.DB), store, config.Authz, registrationGate, budgets.Skills)
 	platformReader := platformmcp.NewPostgresReader(config.Logger, config.DB).
@@ -705,6 +725,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 		riskMutations,
 		platformmcp.CatalogDescriptor{},
 		accessReads,
+		accessRoleMutations,
 	).WithOAuthTelemetry(oauthTelemetry).WithRiskTelemetry(riskTelemetry)
 	oauth.Attach(config.Mux)
 	platformmcp.NewDashboardSetupHTTP(dashboardSetupStarter, config.Sessions).Attach(config.Mux)

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1647,6 +1647,7 @@ func newStartCommand() *cli.Command {
 				GuardianPolicy:          guardianPolicy,
 				RemoteChallengeManager:  remoteChallengeManager,
 				AuditLogger:             auditLogger,
+				AccessRoles:             roleClient,
 				PluginPublisher:         pluginPublisher,
 				TemporalEnv:             temporalEnv,
 				Skills:                  skillsService,

--- a/server/internal/access/impl.go
+++ b/server/internal/access/impl.go
@@ -232,7 +232,7 @@ func (s *Service) UpdateRole(ctx context.Context, payload *gen.UpdateRolePayload
 	if err != nil {
 		return nil, err
 	}
-	trace.SpanFromContext(ctx).SetAttributes(attr.AccessRoleSlug(updated.Role.Slug))
+	trace.SpanFromContext(ctx).SetAttributes(attr.AccessRoleSlug(updated.Slug))
 
 	return updated.After, nil
 }

--- a/server/internal/access/queries.sql
+++ b/server/internal/access/queries.sql
@@ -375,6 +375,17 @@ GROUP BY active_roles.id, active_roles.role_kind, active_roles.workos_slug, acti
 ORDER BY active_roles.role_kind DESC
 LIMIT 1;
 
+-- name: LockOrganizationRoleByID :one
+-- Platform mutations call this inside their receipt transaction before checking
+-- an optimistic role version. Only custom organization roles are eligible.
+SELECT id
+FROM organization_roles
+WHERE organization_id = @organization_id
+  AND id = sqlc.arg(id)
+  AND deleted IS FALSE
+  AND workos_deleted IS FALSE
+FOR UPDATE;
+
 -- name: GetOrganizationRoleByID :one
 WITH active_roles AS (
   SELECT id, workos_slug, workos_name, workos_description, workos_created_at, workos_updated_at, 'global'::text AS role_kind

--- a/server/internal/access/repo/queries.sql.go
+++ b/server/internal/access/repo/queries.sql.go
@@ -1610,6 +1610,30 @@ func (q *Queries) ListRetainedResolvedChallengeIDs(ctx context.Context, organiza
 	return items, nil
 }
 
+const lockOrganizationRoleByID = `-- name: LockOrganizationRoleByID :one
+SELECT id
+FROM organization_roles
+WHERE organization_id = $1
+  AND id = $2
+  AND deleted IS FALSE
+  AND workos_deleted IS FALSE
+FOR UPDATE
+`
+
+type LockOrganizationRoleByIDParams struct {
+	OrganizationID string
+	ID             uuid.UUID
+}
+
+// Platform mutations call this inside their receipt transaction before checking
+// an optimistic role version. Only custom organization roles are eligible.
+func (q *Queries) LockOrganizationRoleByID(ctx context.Context, arg LockOrganizationRoleByIDParams) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, lockOrganizationRoleByID, arg.OrganizationID, arg.ID)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
 const markGlobalRoleDeleted = `-- name: MarkGlobalRoleDeleted :execrows
 UPDATE global_roles
 SET workos_deleted_at = $1,

--- a/server/internal/access/role_manager.go
+++ b/server/internal/access/role_manager.go
@@ -35,7 +35,10 @@ var ErrRoleNotFound = errors.New("role not found")
 
 var validRoleNamePattern = regexp.MustCompile(`^[A-Za-z0-9 _-]+$`)
 
-const workOSSyncAttempts = 3
+const (
+	workOSSyncAttempts = 3
+	workOSSyncTimeout  = 10 * time.Second
+)
 
 type RoleProvider interface {
 	CreateRole(ctx context.Context, orgID string, opts workos.CreateRoleOpts) (*workos.Role, error)
@@ -1124,13 +1127,16 @@ func (r *RoleManager) ReconcileRoleIdentity(ctx context.Context, workosOrgID, sl
 	}})
 }
 
-// runWorkOSSyncs starts best-effort WorkOS writes after the local transaction commits.
+// runWorkOSSyncs starts best-effort WorkOS writes after the local transaction
+// commits. It detaches request cancellation but bounds the entire batch so a
+// stalled provider cannot retain background work indefinitely.
 func (r *RoleManager) runWorkOSSyncs(ctx context.Context, syncs []workosSync) {
 	if len(syncs) == 0 {
 		return
 	}
-	syncCtx := context.WithoutCancel(ctx)
+	syncCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), workOSSyncTimeout)
 	go func() {
+		defer cancel()
 		defer func() {
 			if recovered := recover(); recovered != nil {
 				r.logger.ErrorContext(syncCtx, "workos sync panic", attr.SlogError(fmt.Errorf("%v", recovered)))

--- a/server/internal/access/role_manager.go
+++ b/server/internal/access/role_manager.go
@@ -63,6 +63,12 @@ func NewRoleManager(logger *slog.Logger, db *pgxpool.Pool, roles RoleProvider, a
 	}
 }
 
+// MutationReady reports whether this manager has every dependency required for
+// role writes and post-commit WorkOS reconciliation.
+func (r *RoleManager) MutationReady() bool {
+	return r != nil && r.db != nil && r.logger != nil && r.roles != nil && r.audit != nil
+}
+
 // ListRoles returns active roles for an organization from local records and enriches them with local grants and member counts.
 func (r *RoleManager) ListRoles(ctx context.Context, gramOrgID string) (*gen.ListRolesResult, error) {
 	rows, err := repo.New(r.db).ListActiveOrganizationRoles(ctx, gramOrgID)
@@ -99,6 +105,25 @@ func (r *RoleManager) GetRoleByID(ctx context.Context, gramOrgID, id string) (*g
 	}
 
 	return r.roleViewFromLocalRole(ctx, gramOrgID, role)
+}
+
+// GetRoleByIDTx returns one active role and its grants from the caller's
+// transaction. Mutation adapters use it after locking the role so optimistic
+// version checks observe exactly the state the following patch will modify.
+func (r *RoleManager) GetRoleByIDTx(ctx context.Context, tx pgx.Tx, gramOrgID, id string) (*gen.Role, error) {
+	role, err := r.getLocalRoleByIDTx(ctx, tx, gramOrgID, id)
+	if err != nil {
+		return nil, err
+	}
+	grants, err := authz.PatchRoleGrantsTx(ctx, tx, gramOrgID, role.Slug, role.PrincipalURN, nil, nil)
+	if err != nil {
+		return nil, oops.E(oops.CodeUnexpected, err, "load grants for role").LogError(ctx, r.logger)
+	}
+	view := make([]*gen.RoleGrant, 0, len(grants))
+	for _, grant := range grants {
+		view = append(view, scopedGrantToGenRoleGrant(grant))
+	}
+	return roleViewFromLocalRoleAndGrants(role, view), nil
 }
 
 // ListMembers returns locally known organization members and includes a role ID only when a local assignment exists.
@@ -142,35 +167,63 @@ func (r *RoleManager) ListMembers(ctx context.Context, gramOrgID string) (*gen.L
 	return &gen.ListMembersResult{Members: result}, nil
 }
 
-type roleCreateResult struct {
+// RoleCreateResult is the safe local result of creating a role.
+type RoleCreateResult struct {
 	Role *gen.Role
 	Slug string
 }
 
 type workosSync func(context.Context)
 
-type accessAuditActor struct {
+// RoleReconciliation is an opaque set of best-effort WorkOS writes produced by
+// a transactional role mutation. Call ReconcileRole only after committing the
+// transaction passed to CreateRoleTx or UpdateRoleTx.
+type RoleReconciliation struct {
+	syncs []workosSync
+}
+
+// RoleAuditActor identifies the principal responsible for an access role mutation.
+type RoleAuditActor struct {
 	Principal   urn.Principal
 	DisplayName *string
 }
 
-// CreateRole creates the local role, grants, optional assignments, and audit entry atomically, then best-effort syncs WorkOS after commit.
-func (r *RoleManager) CreateRole(ctx context.Context, gramOrgID, workosOrgID string, actor accessAuditActor, payload *gen.CreateRolePayload) (roleCreateResult, error) {
+// Keep access service call sites concise while exposing the actor to other packages.
+type accessAuditActor = RoleAuditActor
+
+// CreateRole creates the local role, grants, optional assignments, and audit
+// entry atomically, then best-effort syncs WorkOS after commit.
+func (r *RoleManager) CreateRole(ctx context.Context, gramOrgID, workosOrgID string, actor RoleAuditActor, payload *gen.CreateRolePayload) (RoleCreateResult, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return RoleCreateResult{}, oops.E(oops.CodeUnexpected, err, "begin role transaction").LogError(ctx, r.logger)
+	}
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
+
+	result, reconciliation, err := r.CreateRoleTx(ctx, tx, gramOrgID, workosOrgID, actor, payload)
+	if err != nil {
+		return RoleCreateResult{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return RoleCreateResult{}, oops.E(oops.CodeUnexpected, err, "commit role transaction").LogError(ctx, r.logger)
+	}
+
+	r.ReconcileRole(ctx, reconciliation)
+	return result, nil
+}
+
+// CreateRoleTx performs the local role, grant, member-assignment, and audit
+// writes on tx. It neither commits tx nor contacts WorkOS.
+func (r *RoleManager) CreateRoleTx(ctx context.Context, tx pgx.Tx, gramOrgID, workosOrgID string, actor RoleAuditActor, payload *gen.CreateRolePayload) (RoleCreateResult, RoleReconciliation, error) {
 	roleSlug, err := slugify(payload.Name)
 	if err != nil {
-		return roleCreateResult{}, err
+		return RoleCreateResult{}, RoleReconciliation{}, err
 	}
 	description := conv.PtrValOr(payload.Description, "")
 	grants := roleGrantPayloads(payload.Grants)
 	if err := authz.ValidateGrantSurface(authz.GrantSurfaceAccess, grants); err != nil {
-		return roleCreateResult{}, oops.E(oops.CodeBadRequest, err, "invalid access role grant: %s", err).LogError(ctx, r.logger)
+		return RoleCreateResult{}, RoleReconciliation{}, oops.E(oops.CodeBadRequest, err, "invalid access role grant: %s", err).LogError(ctx, r.logger)
 	}
-
-	tx, err := r.db.Begin(ctx)
-	if err != nil {
-		return roleCreateResult{}, oops.E(oops.CodeUnexpected, err, "begin role transaction").LogError(ctx, r.logger)
-	}
-	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
 	now := time.Now().UTC()
 	createdRow, err := repo.New(tx).CreateOrganizationRole(ctx, repo.CreateOrganizationRoleParams{
@@ -185,12 +238,12 @@ func (r *RoleManager) CreateRole(ctx context.Context, gramOrgID, workosOrgID str
 	var pgErr *pgconn.PgError
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return roleCreateResult{}, oops.E(oops.CodeConflict, err, "role %q already exists", payload.Name).LogError(ctx, r.logger)
+		return RoleCreateResult{}, RoleReconciliation{}, oops.E(oops.CodeConflict, err, "role %q already exists", payload.Name).LogError(ctx, r.logger)
 	case errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation:
-		return roleCreateResult{}, oops.E(oops.CodeConflict, err, "role %q already exists", payload.Name).LogError(ctx, r.logger)
+		return RoleCreateResult{}, RoleReconciliation{}, oops.E(oops.CodeConflict, err, "role %q already exists", payload.Name).LogError(ctx, r.logger)
 	case err != nil:
 		trace.SpanFromContext(ctx).SetAttributes(attr.AccessRoleDBWriteFailed(true))
-		return roleCreateResult{}, oops.E(oops.CodeUnexpected, err, "create local role record").LogError(ctx, r.logger)
+		return RoleCreateResult{}, RoleReconciliation{}, oops.E(oops.CodeUnexpected, err, "create local role record").LogError(ctx, r.logger)
 	}
 
 	createdRole := localRole{
@@ -205,14 +258,20 @@ func (r *RoleManager) CreateRole(ctx context.Context, gramOrgID, workosOrgID str
 	}
 	trace.SpanFromContext(ctx).SetAttributes(attr.AccessRoleID(createdRole.ID))
 
-	if _, err := authz.PatchRoleGrantsTx(ctx, tx, gramOrgID, roleSlug, createdRole.PrincipalURN, grants, nil); err != nil {
-		return roleCreateResult{}, oops.E(oops.CodeUnexpected, err, "add grants for created role").LogError(ctx, r.logger)
+	syncedGrants, err := authz.PatchRoleGrantsTx(ctx, tx, gramOrgID, roleSlug, createdRole.PrincipalURN, grants, nil)
+	if err != nil {
+		return RoleCreateResult{}, RoleReconciliation{}, oops.E(oops.CodeUnexpected, err, "add grants for created role").LogError(ctx, r.logger)
+	}
+	roleGrants := make([]*gen.RoleGrant, 0, len(syncedGrants))
+	for _, grant := range syncedGrants {
+		roleGrants = append(roleGrants, scopedGrantToGenRoleGrant(grant))
 	}
 
+	roleName := payload.Name
 	workosSyncs := []workosSync{func(ctx context.Context) {
 		r.syncWorkOS(ctx, "create role in workos", func() error {
 			_, err := r.roles.CreateRole(ctx, workosOrgID, workos.CreateRoleOpts{
-				Name:        payload.Name,
+				Name:        roleName,
 				Slug:        roleSlug,
 				Description: description,
 			})
@@ -230,12 +289,12 @@ func (r *RoleManager) CreateRole(ctx context.Context, gramOrgID, workosOrgID str
 	if len(payload.MemberIds) > 0 {
 		var memberSyncs []workosSync
 		if _, memberSyncs, err = r.assignMembersToRoleTx(ctx, tx, gramOrgID, roleSlug, payload.MemberIds); err != nil {
-			return roleCreateResult{}, err
+			return RoleCreateResult{}, RoleReconciliation{}, err
 		}
 		workosSyncs = append(workosSyncs, memberSyncs...)
 		createdRole, err = r.getLocalRoleBySlugTx(ctx, tx, gramOrgID, roleSlug)
 		if err != nil {
-			return roleCreateResult{}, err
+			return RoleCreateResult{}, RoleReconciliation{}, err
 		}
 	}
 
@@ -248,21 +307,13 @@ func (r *RoleManager) CreateRole(ctx context.Context, gramOrgID, workosOrgID str
 		RoleName:         createdRole.Name,
 		RoleSlug:         createdRole.Slug,
 	}); err != nil {
-		return roleCreateResult{}, oops.E(oops.CodeUnexpected, err, "log access role creation").LogError(ctx, r.logger)
+		return RoleCreateResult{}, RoleReconciliation{}, oops.E(oops.CodeUnexpected, err, "log access role creation").LogError(ctx, r.logger)
 	}
 
-	if err := tx.Commit(ctx); err != nil {
-		return roleCreateResult{}, oops.E(oops.CodeUnexpected, err, "commit role transaction").LogError(ctx, r.logger)
-	}
-
-	r.runWorkOSSyncs(ctx, workosSyncs)
-
-	role, err := r.roleViewFromLocalRole(ctx, gramOrgID, createdRole)
-	if err != nil {
-		return roleCreateResult{}, err
-	}
-
-	return roleCreateResult{Role: role, Slug: roleSlug}, nil
+	return RoleCreateResult{
+		Role: roleViewFromLocalRoleAndGrants(createdRole, roleGrants),
+		Slug: roleSlug,
+	}, RoleReconciliation{syncs: workosSyncs}, nil
 }
 
 type localRole struct {
@@ -279,39 +330,81 @@ type localRole struct {
 type roleUpdateResult struct {
 	Before *gen.Role
 	After  *gen.Role
-	Role   localRole
+	Slug   string
 }
 
-// UpdateRole updates an existing local role, optional grants/assignments, and audit entry atomically, then best-effort syncs WorkOS after commit.
-func (r *RoleManager) UpdateRole(ctx context.Context, gramOrgID, workosOrgID string, actor accessAuditActor, payload *gen.UpdateRolePayload) (roleUpdateResult, error) {
-	currentRole, err := r.getLocalRoleByID(ctx, gramOrgID, payload.ID)
+// RoleUpdateResult is the safe local result of updating a role.
+type RoleUpdateResult struct {
+	Before *gen.Role
+	After  *gen.Role
+	Slug   string
+}
+
+// UpdateRole updates an existing local role, optional grants/assignments, and
+// audit entry atomically, then best-effort syncs WorkOS after commit.
+func (r *RoleManager) UpdateRole(ctx context.Context, gramOrgID, workosOrgID string, actor RoleAuditActor, payload *gen.UpdateRolePayload) (roleUpdateResult, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return roleUpdateResult{}, oops.E(oops.CodeUnexpected, err, "begin role transaction").LogError(ctx, r.logger)
+	}
+	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
+
+	result, reconciliation, err := r.UpdateRoleTx(ctx, tx, gramOrgID, workosOrgID, actor, payload)
 	if err != nil {
 		return roleUpdateResult{}, err
 	}
-	existingRole, err := r.roleViewFromLocalRole(ctx, gramOrgID, currentRole)
-	if err != nil {
-		return roleUpdateResult{}, err
+	if err := tx.Commit(ctx); err != nil {
+		return roleUpdateResult{}, oops.E(oops.CodeUnexpected, err, "commit role transaction").LogError(ctx, r.logger)
 	}
+
+	r.ReconcileRole(ctx, reconciliation)
+	return roleUpdateResult(result), nil
+}
+
+// UpdateRoleTx performs the local role, grant, member-assignment, and audit
+// writes on tx. It neither commits tx nor contacts WorkOS.
+func (r *RoleManager) UpdateRoleTx(ctx context.Context, tx pgx.Tx, gramOrgID, workosOrgID string, actor RoleAuditActor, payload *gen.UpdateRolePayload) (RoleUpdateResult, RoleReconciliation, error) {
+	roleID, err := uuid.Parse(payload.ID)
+	if err != nil {
+		return RoleUpdateResult{}, RoleReconciliation{}, oops.E(oops.CodeBadRequest, err, "invalid role ID").LogError(ctx, r.logger)
+	}
+	if _, err := repo.New(tx).LockOrganizationRoleByID(ctx, repo.LockOrganizationRoleByIDParams{OrganizationID: gramOrgID, ID: roleID}); err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return RoleUpdateResult{}, RoleReconciliation{}, oops.E(oops.CodeUnexpected, err, "lock role for update").LogError(ctx, r.logger)
+	}
+	currentRole, err := r.getLocalRoleByIDTx(ctx, tx, gramOrgID, payload.ID)
+	if err != nil {
+		return RoleUpdateResult{}, RoleReconciliation{}, err
+	}
+
+	currentGrants, err := authz.PatchRoleGrantsTx(ctx, tx, gramOrgID, currentRole.Slug, currentRole.PrincipalURN, nil, nil)
+	if err != nil {
+		return RoleUpdateResult{}, RoleReconciliation{}, oops.E(oops.CodeUnexpected, err, "load grants for role update").LogError(ctx, r.logger)
+	}
+	existingGrants := make([]*gen.RoleGrant, 0, len(currentGrants))
+	for _, grant := range currentGrants {
+		existingGrants = append(existingGrants, scopedGrantToGenRoleGrant(grant))
+	}
+	existingRole := roleViewFromLocalRoleAndGrants(currentRole, existingGrants)
 
 	sysRole := isSystemRole(currentRole.Slug)
 	// System role names/descriptions are platform-managed and shared globally
 	// (global_roles), so they stay immutable. Grants are stored per-org and may
 	// be customized, so grant and member changes are allowed below.
 	if sysRole && (payload.Name != nil || payload.Description != nil) {
-		return roleUpdateResult{}, oops.E(oops.CodeBadRequest, nil, "system role name and description cannot be changed").LogError(ctx, r.logger)
+		return RoleUpdateResult{}, RoleReconciliation{}, oops.E(oops.CodeBadRequest, nil, "system role name and description cannot be changed").LogError(ctx, r.logger)
 	}
 	if payload.Name != nil {
 		if _, err := slugify(*payload.Name); err != nil {
-			return roleUpdateResult{}, err
+			return RoleUpdateResult{}, RoleReconciliation{}, err
 		}
 	}
 	addGrants := roleGrantPayloads(payload.AddGrants)
 	removeGrants := roleGrantPayloads(payload.RemoveGrants)
 	if err := authz.ValidateGrantSurface(authz.GrantSurfaceAccess, addGrants); err != nil {
-		return roleUpdateResult{}, oops.E(oops.CodeBadRequest, err, "invalid access role grant: %s", err).LogError(ctx, r.logger)
+		return RoleUpdateResult{}, RoleReconciliation{}, oops.E(oops.CodeBadRequest, err, "invalid access role grant: %s", err).LogError(ctx, r.logger)
 	}
 	if err := authz.ValidateGrantSurface(authz.GrantSurfaceAccess, removeGrants); err != nil {
-		return roleUpdateResult{}, oops.E(oops.CodeBadRequest, err, "invalid access role grant: %s", err).LogError(ctx, r.logger)
+		return RoleUpdateResult{}, RoleReconciliation{}, oops.E(oops.CodeBadRequest, err, "invalid access role grant: %s", err).LogError(ctx, r.logger)
 	}
 
 	// Lockout guardrail: removing org:admin from the Admin role would lock the
@@ -328,27 +421,19 @@ func (r *RoleManager) UpdateRole(ctx context.Context, gramOrgID, workosOrgID str
 			// An org:admin add only counts if it actually writes a grant row:
 			// nil selectors flatten to a wildcard row, a non-empty slice writes
 			// the listed rows. An empty (non-nil) selector slice flattens to
-			// zero rows (see grants.go), so pairing such a no-op add with an
-			// org:admin removal must not satisfy the guardrail — that would
-			// strip org:admin from the Admin role and lock the org out.
+			// zero rows, so pairing such a no-op add with a removal is rejected.
 			if g.Scope == string(authz.ScopeOrgAdmin) {
 				addingOrgAdmin = addingOrgAdmin || g.Selectors == nil || len(g.Selectors) > 0
 			}
 		}
 		if removingOrgAdmin && !addingOrgAdmin {
-			return roleUpdateResult{}, oops.E(oops.CodeBadRequest, nil, "the Admin role must keep the org:admin permission").LogError(ctx, r.logger)
+			return RoleUpdateResult{}, RoleReconciliation{}, oops.E(oops.CodeBadRequest, nil, "the Admin role must keep the org:admin permission").LogError(ctx, r.logger)
 		}
 	}
 
-	tx, err := r.db.Begin(ctx)
-	if err != nil {
-		return roleUpdateResult{}, oops.E(oops.CodeUnexpected, err, "begin role transaction").LogError(ctx, r.logger)
-	}
-	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
-
 	updatedRole := currentRole
 	var workosSyncs []workosSync
-	var updatedGrants []*gen.RoleGrant
+	updatedGrants := existingGrants
 	if !sysRole {
 		localRecord := currentRole
 		if payload.Name != nil {
@@ -369,7 +454,7 @@ func (r *RoleManager) UpdateRole(ctx context.Context, gramOrgID, workosOrgID str
 		})
 		if err != nil {
 			trace.SpanFromContext(ctx).SetAttributes(attr.AccessRoleDBWriteFailed(true))
-			return roleUpdateResult{}, oops.E(oops.CodeUnexpected, err, "upsert local role record").LogError(ctx, r.logger)
+			return RoleUpdateResult{}, RoleReconciliation{}, oops.E(oops.CodeUnexpected, err, "upsert local role record").LogError(ctx, r.logger)
 		}
 		updatedRole = localRole{
 			ID:           updatedRow.ID.String(),
@@ -382,11 +467,14 @@ func (r *RoleManager) UpdateRole(ctx context.Context, gramOrgID, workosOrgID str
 			MemberCount:  int(updatedRow.MemberCount),
 		}
 
+		name := cloneString(payload.Name)
+		description := cloneString(payload.Description)
+		roleSlug := currentRole.Slug
 		workosSyncs = append(workosSyncs, func(ctx context.Context) {
 			r.syncWorkOS(ctx, "update role in workos", func() error {
-				_, err := r.roles.UpdateRole(ctx, workosOrgID, currentRole.Slug, workos.UpdateRoleOpts{
-					Name:        payload.Name,
-					Description: payload.Description,
+				_, err := r.roles.UpdateRole(ctx, workosOrgID, roleSlug, workos.UpdateRoleOpts{
+					Name:        name,
+					Description: description,
 				})
 				if err == nil {
 					return nil
@@ -398,11 +486,11 @@ func (r *RoleManager) UpdateRole(ctx context.Context, gramOrgID, workosOrgID str
 
 	// Grants live in the per-org grant store and are patched the same way for
 	// custom and system roles. WorkOS only tracks role identity/membership, not
-	// gram scopes, so no grant sync to WorkOS is needed.
+	// Gram scopes, so no grant sync to WorkOS is needed.
 	if payload.AddGrants != nil || payload.RemoveGrants != nil {
 		syncedGrants, err := authz.PatchRoleGrantsTx(ctx, tx, gramOrgID, currentRole.Slug, currentRole.PrincipalURN, addGrants, removeGrants)
 		if err != nil {
-			return roleUpdateResult{}, oops.E(oops.CodeUnexpected, err, "patch grants for updated role").LogError(ctx, r.logger)
+			return RoleUpdateResult{}, RoleReconciliation{}, oops.E(oops.CodeUnexpected, err, "patch grants for updated role").LogError(ctx, r.logger)
 		}
 		updatedGrants = make([]*gen.RoleGrant, 0, len(syncedGrants))
 		for _, grant := range syncedGrants {
@@ -413,31 +501,16 @@ func (r *RoleManager) UpdateRole(ctx context.Context, gramOrgID, workosOrgID str
 	if payload.MemberIds != nil {
 		var memberSyncs []workosSync
 		if _, memberSyncs, err = r.assignMembersToRoleTx(ctx, tx, gramOrgID, currentRole.Slug, payload.MemberIds); err != nil {
-			return roleUpdateResult{}, err
+			return RoleUpdateResult{}, RoleReconciliation{}, err
 		}
 		workosSyncs = append(workosSyncs, memberSyncs...)
 		updatedRole, err = r.getLocalRoleByIDTx(ctx, tx, gramOrgID, payload.ID)
 		if err != nil {
-			return roleUpdateResult{}, err
+			return RoleUpdateResult{}, RoleReconciliation{}, err
 		}
 	}
 
-	updatedRoleView := &gen.Role{
-		ID:           updatedRole.ID,
-		PrincipalUrn: updatedRole.PrincipalURN,
-		Name:         updatedRole.Name,
-		Slug:         updatedRole.Slug,
-		Description:  updatedRole.Description,
-		IsSystem:     isSystemRole(updatedRole.Slug),
-		Grants:       existingRole.Grants,
-		MemberCount:  updatedRole.MemberCount,
-		CreatedAt:    conv.Default(updatedRole.CreatedAt, time.Time{}.UTC().Format(time.RFC3339)),
-		UpdatedAt:    conv.Default(updatedRole.UpdatedAt, time.Time{}.UTC().Format(time.RFC3339)),
-	}
-	if updatedGrants != nil {
-		updatedRoleView.Grants = updatedGrants
-	}
-
+	updatedRoleView := roleViewFromLocalRoleAndGrants(updatedRole, updatedGrants)
 	if err := r.audit.LogAccessRoleUpdate(ctx, tx, audit.LogAccessRoleUpdateEvent{
 		OrganizationID:     gramOrgID,
 		Actor:              actor.Principal,
@@ -449,16 +522,14 @@ func (r *RoleManager) UpdateRole(ctx context.Context, gramOrgID, workosOrgID str
 		RoleSnapshotBefore: existingRole,
 		RoleSnapshotAfter:  updatedRoleView,
 	}); err != nil {
-		return roleUpdateResult{}, oops.E(oops.CodeUnexpected, err, "log access role update").LogError(ctx, r.logger)
+		return RoleUpdateResult{}, RoleReconciliation{}, oops.E(oops.CodeUnexpected, err, "log access role update").LogError(ctx, r.logger)
 	}
 
-	if err := tx.Commit(ctx); err != nil {
-		return roleUpdateResult{}, oops.E(oops.CodeUnexpected, err, "commit role transaction").LogError(ctx, r.logger)
-	}
-
-	r.runWorkOSSyncs(ctx, workosSyncs)
-
-	return roleUpdateResult{Before: existingRole, After: updatedRoleView, Role: updatedRole}, nil
+	return RoleUpdateResult{
+		Before: existingRole,
+		After:  updatedRoleView,
+		Slug:   updatedRole.Slug,
+	}, RoleReconciliation{syncs: workosSyncs}, nil
 }
 
 // DeleteRole deletes a custom local role, reassignment records, grants, and audit entry atomically, then best-effort syncs WorkOS after commit.
@@ -1017,6 +1088,42 @@ func (r *RoleManager) assignMembersToRoleTx(ctx context.Context, dbtx repo.DBTX,
 	return assignedCount, workosSyncs, nil
 }
 
+// ReconcileRole starts the opaque best-effort WorkOS writes returned by a role
+// transaction. The caller must invoke it only after that transaction commits.
+func (r *RoleManager) ReconcileRole(ctx context.Context, reconciliation RoleReconciliation) {
+	r.runWorkOSSyncs(ctx, reconciliation.syncs)
+}
+
+// ReconcileRoleIdentity reapplies one role's desired WorkOS identity after the
+// local transaction commits. Platform MCP calls it for fresh writes and exact
+// receipt replays so a transient provider failure can converge on retry.
+func (r *RoleManager) ReconcileRoleIdentity(ctx context.Context, workosOrgID, slug, name, description string, create bool) {
+	if r == nil || r.roles == nil || workosOrgID == "" || slug == "" || name == "" {
+		return
+	}
+	r.runWorkOSSyncs(ctx, []workosSync{func(ctx context.Context) {
+		operation := "update role in workos"
+		r.syncWorkOS(ctx, operation, func() error {
+			if create {
+				_, err := r.roles.CreateRole(ctx, workosOrgID, workos.CreateRoleOpts{Name: name, Slug: slug, Description: description})
+				var apiErr *workos.APIError
+				if errors.As(err, &apiErr) && apiErr.StatusCode == 409 {
+					return nil
+				}
+				if err != nil {
+					return fmt.Errorf("create role in workos: %w", err)
+				}
+				return nil
+			}
+			_, err := r.roles.UpdateRole(ctx, workosOrgID, slug, workos.UpdateRoleOpts{Name: &name, Description: &description})
+			if err != nil {
+				return fmt.Errorf("update role in workos: %w", err)
+			}
+			return nil
+		})
+	}})
+}
+
 // runWorkOSSyncs starts best-effort WorkOS writes after the local transaction commits.
 func (r *RoleManager) runWorkOSSyncs(ctx context.Context, syncs []workosSync) {
 	if len(syncs) == 0 {
@@ -1079,6 +1186,10 @@ func (r *RoleManager) roleViewFromLocalRole(ctx context.Context, organizationID 
 		genGrants = append(genGrants, scopedGrantToGenRoleGrant(g))
 	}
 
+	return roleViewFromLocalRoleAndGrants(role, genGrants), nil
+}
+
+func roleViewFromLocalRoleAndGrants(role localRole, grants []*gen.RoleGrant) *gen.Role {
 	return &gen.Role{
 		ID:           role.ID,
 		PrincipalUrn: role.PrincipalURN,
@@ -1086,11 +1197,19 @@ func (r *RoleManager) roleViewFromLocalRole(ctx context.Context, organizationID 
 		Slug:         role.Slug,
 		Description:  role.Description,
 		IsSystem:     isSystemRole(role.Slug),
-		Grants:       genGrants,
+		Grants:       grants,
 		MemberCount:  role.MemberCount,
 		CreatedAt:    conv.Default(role.CreatedAt, time.Time{}.UTC().Format(time.RFC3339)),
 		UpdatedAt:    conv.Default(role.UpdatedAt, time.Time{}.UTC().Format(time.RFC3339)),
-	}, nil
+	}
+}
+
+func cloneString(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
 }
 
 // workosTimeOrNow parses a WorkOS RFC3339 timestamp or returns the current UTC time when WorkOS omits or malforms it.

--- a/server/internal/access/role_manager_test.go
+++ b/server/internal/access/role_manager_test.go
@@ -1,6 +1,7 @@
 package access
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -108,6 +109,34 @@ func TestRoleManager_AssignMembersToRoleAcceptsConnectedMemberWithoutAssignment(
 	assigned, _, err := ti.service.roleMgr.assignMembersToRoleTx(ctx, ti.conn, authCtx.ActiveOrganizationID, "custom-builder", []string{"local_user_1"})
 	require.NoError(t, err)
 	require.Equal(t, 1, assigned)
+}
+
+func TestRoleManager_RunWorkOSSyncsDetachesCancellationWithDeadline(t *testing.T) {
+	t.Parallel()
+
+	parent, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	type syncContext struct {
+		err         error
+		hasDeadline bool
+		remaining   time.Duration
+	}
+	observed := make(chan syncContext, 1)
+	(&RoleManager{}).runWorkOSSyncs(parent, []workosSync{func(ctx context.Context) {
+		deadline, hasDeadline := ctx.Deadline()
+		observed <- syncContext{err: ctx.Err(), hasDeadline: hasDeadline, remaining: time.Until(deadline)}
+	}})
+
+	select {
+	case got := <-observed:
+		require.NoError(t, got.err)
+		require.True(t, got.hasDeadline)
+		require.Positive(t, got.remaining)
+		require.LessOrEqual(t, got.remaining, workOSSyncTimeout)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for detached WorkOS sync")
+	}
 }
 
 func TestRoleManager_LocalRoleWritePreservesWorkOSLastEventID(t *testing.T) {

--- a/server/internal/authz/grants.go
+++ b/server/internal/authz/grants.go
@@ -56,6 +56,9 @@ func GrantsSatisfy(grants []Grant, check Check) bool {
 // Read-only projections use this when they need to explain another principal's
 // effective access without replacing the request context's acting principal.
 func GrantsAuthorize(grants []Grant, check Check) (bool, error) {
+	if err := validateInput(check); err != nil {
+		return false, err
+	}
 	evaluation, err := evaluateGrantCheck(grants, check)
 	if err != nil {
 		return false, err

--- a/server/internal/authz/grants.go
+++ b/server/internal/authz/grants.go
@@ -40,13 +40,27 @@ type ScopedGrant struct {
 	Selectors []Selector
 }
 
-// GrantsSatisfy reports whether the loaded grant set authorizes check.
+// GrantsSatisfy reports whether the loaded grant set has an allow grant matching
+// check. It intentionally does not evaluate exclusion scopes; callers answering
+// an effective authorization question should use GrantsAuthorize.
 func GrantsSatisfy(grants []Grant, check Check) bool {
 	if err := validateInput(check); err != nil {
 		return false
 	}
 	grant, _ := matchingGrant(grants, check.expand())
 	return grant != nil
+}
+
+// GrantsAuthorize evaluates one check against already-loaded grants with the
+// same scope expansion, selector matching, and exclusion semantics as Engine.
+// Read-only projections use this when they need to explain another principal's
+// effective access without replacing the request context's acting principal.
+func GrantsAuthorize(grants []Grant, check Check) (bool, error) {
+	evaluation, err := evaluateGrantCheck(grants, check)
+	if err != nil {
+		return false, err
+	}
+	return evaluation.Grant != nil && !evaluation.Denied, nil
 }
 
 // SystemRoleGrants defines the canonical grant sets for the built-in system

--- a/server/internal/authz/grants_authorize_test.go
+++ b/server/internal/authz/grants_authorize_test.go
@@ -1,0 +1,33 @@
+package authz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGrantsAuthorizeAppliesMCPExclusions(t *testing.T) {
+	t.Parallel()
+
+	serverID := "server-1"
+	tool := "delete_tasks"
+	allow := NewSelector(ScopeMCPConnect, serverID)
+	block := NewSelector(ScopeMCPBlockedConnect, serverID)
+	block[SelectorKeyTool] = tool
+	grants := []Grant{
+		{PrincipalUrn: "role:organization:role-1", Scope: ScopeMCPConnect, Selector: allow},
+		{PrincipalUrn: "role:organization:role-1", Scope: ScopeMCPBlockedConnect, Selector: block},
+	}
+
+	allowed, err := GrantsAuthorize(grants, MCPCheck(ScopeMCPConnect, serverID, "project-1"))
+	require.NoError(t, err)
+	require.True(t, allowed)
+
+	allowed, err = GrantsAuthorize(grants, MCPToolCallCheck(serverID, MCPToolCallDimensions{Tool: tool, ProjectID: "project-1"}))
+	require.NoError(t, err)
+	require.False(t, allowed)
+
+	allowed, err = GrantsAuthorize(grants, MCPToolCallCheck(serverID, MCPToolCallDimensions{Tool: "list_tasks", ProjectID: "project-1"}))
+	require.NoError(t, err)
+	require.True(t, allowed)
+}

--- a/server/internal/authz/grants_test.go
+++ b/server/internal/authz/grants_test.go
@@ -1,0 +1,27 @@
+package authz
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGrantsAuthorizeRejectsEmptyResourceID(t *testing.T) {
+	t.Parallel()
+
+	allowed, err := GrantsAuthorize([]Grant{NewGrant(ScopeRoot, WildcardResource)}, Check{
+		Scope: ScopeMCPConnect, ResourceKind: "", ResourceID: "", Dimensions: nil,
+	})
+	require.ErrorIs(t, err, ErrInvalidCheck)
+	require.False(t, allowed)
+}
+
+func TestGrantsAuthorizeRejectsWildcardResourceID(t *testing.T) {
+	t.Parallel()
+
+	allowed, err := GrantsAuthorize([]Grant{NewGrant(ScopeRoot, WildcardResource)}, Check{
+		Scope: ScopeMCPConnect, ResourceKind: "", ResourceID: WildcardResource, Dimensions: nil,
+	})
+	require.ErrorIs(t, err, ErrInvalidCheck)
+	require.False(t, allowed)
+}

--- a/server/internal/feature/flags.go
+++ b/server/internal/feature/flags.go
@@ -46,6 +46,10 @@ const (
 	// replacing a plugin's complete audience assignment set through Platform MCP.
 	// It is evaluated at invocation time and fails closed.
 	FlagPlatformMCPPluginAssignmentMutations Flag = "platform-mcp-plugin-assignment-mutations"
+	// FlagPlatformMCPAccessRoleMutations is the exact-project kill switch for
+	// creating and updating custom MCP-only access roles through Platform MCP.
+	// It is evaluated at invocation time and fails closed.
+	FlagPlatformMCPAccessRoleMutations Flag = "platform-mcp-access-role-mutations"
 
 	// FlagAssistantPlatformMCP grants a project's managed (dashboard)
 	// assistant the Platform MCP read toolset — the "platform" platform

--- a/server/internal/platformmcp/access_reads.go
+++ b/server/internal/platformmcp/access_reads.go
@@ -55,6 +55,8 @@ type MCPConnectSummary struct {
 	ToolRules               int      `json:"tool_rules"`
 	DispositionRules        []string `json:"disposition_rules"`
 	BlockedServers          bool     `json:"blocked_servers"`
+	BlockedProjectRules     int      `json:"blocked_project_rules"`
+	BlockedServerRules      int      `json:"blocked_server_rules"`
 	BlockedToolRules        int      `json:"blocked_tool_rules"`
 	BlockedDispositionRules []string `json:"blocked_disposition_rules"`
 }
@@ -232,59 +234,52 @@ func (s *AccessReadService) ListMembers(ctx context.Context, principal Principal
 		}
 	}
 
-	members, err := s.roles.ListMembers(ctx, principal.OrganizationID)
-	if err != nil {
-		return ListAccessMembersOutput{}, fmt.Errorf("list platform mcp access members: %w", err)
-	}
-	matching := make([]*accessgen.AccessMember, 0, len(members.Members))
-	for _, member := range members.Members {
-		if roleID != "" && !slices.Contains(member.RoleIds, roleID) {
-			continue
-		}
-		if query != "" && !matchesAccessMember(member, query, roleNames) {
-			continue
-		}
-		matching = append(matching, member)
-	}
-
-	count := len(matching)
-	output := ListAccessMembersOutput{
-		Members:      []AccessMember{},
-		TotalMatches: NewSubjectCount(int64(count)),
-		Suppressed:   count > 0 && count < SubjectSuppressionThreshold,
-		Truncated:    false,
-		ExpiresAt:    "",
-	}
-	// Organization-privacy rules do not allow a row-bearing response to reveal
-	// a filtered cohort smaller than five. Return only the suppressed count.
-	if output.Suppressed || count == 0 {
-		return output, nil
-	}
-
 	limit := maxAccessMembers
 	if input.Limit > 0 {
 		limit = min(input.Limit, maxAccessMembers)
 	}
-	if len(matching) > limit {
-		matching = matching[:limit]
-		output.Truncated = true
+	rows, err := platformrepo.New(s.db).SearchPlatformMCPAccessMembers(ctx, platformrepo.SearchPlatformMCPAccessMembersParams{
+		ResultLimit:    int32(limit),
+		OrganizationID: principal.OrganizationID,
+		RoleID:         roleID,
+		Query:          query,
+	})
+	if err != nil {
+		return ListAccessMembersOutput{}, fmt.Errorf("search platform mcp access members: %w", err)
 	}
+	var total int64
+	if len(rows) > 0 {
+		total = rows[0].TotalMatches
+	}
+	output := ListAccessMembersOutput{
+		Members:      []AccessMember{},
+		TotalMatches: NewSubjectCount(total),
+		Suppressed:   total > 0 && total < SubjectSuppressionThreshold,
+		Truncated:    total > int64(len(rows)),
+		ExpiresAt:    "",
+	}
+	// Organization-privacy rules do not allow a row-bearing response to reveal
+	// a filtered cohort smaller than five. Return only the suppressed count.
+	if output.Suppressed || total == 0 {
+		return output, nil
+	}
+
 	now := s.now().UTC()
 	output.ExpiresAt = now.Add(SubjectReferenceTTL).Format(time.RFC3339)
-	for _, member := range matching {
-		reference, err := s.references.Encode(principal, subjectKindAccessMember, member.ID, now)
+	for _, row := range rows {
+		reference, err := s.references.Encode(principal, subjectKindAccessMember, row.ID, now)
 		if err != nil {
 			return ListAccessMembersOutput{}, fmt.Errorf("issue access member reference: %w", err)
 		}
-		names := make([]string, 0, len(member.RoleIds))
-		for _, id := range member.RoleIds {
+		names := make([]string, 0, len(row.RoleIds))
+		for _, id := range row.RoleIds {
 			if name := roleNames[id]; name != "" {
 				names = append(names, name)
 			}
 		}
 		slices.Sort(names)
 		output.Members = append(output.Members, AccessMember{
-			MaskedIdentity: maskAccessMember(member),
+			MaskedIdentity: maskSubject(conv.Default(row.Email, row.DisplayName)),
 			Roles:          slices.Compact(names),
 			Reference:      reference,
 		})
@@ -475,7 +470,7 @@ func accessRoleType(role *accessgen.Role) string {
 }
 
 func summarizeMCPConnect(grants []*accessgen.RoleGrant) MCPConnectSummary {
-	summary := MCPConnectSummary{AllServers: false, ProjectRules: 0, ServerRules: 0, ToolRules: 0, DispositionRules: []string{}, BlockedServers: false, BlockedToolRules: 0, BlockedDispositionRules: []string{}}
+	summary := MCPConnectSummary{AllServers: false, ProjectRules: 0, ServerRules: 0, ToolRules: 0, DispositionRules: []string{}, BlockedServers: false, BlockedProjectRules: 0, BlockedServerRules: 0, BlockedToolRules: 0, BlockedDispositionRules: []string{}}
 	dispositions := map[string]struct{}{}
 	blockedDispositions := map[string]struct{}{}
 	for _, grant := range grants {
@@ -495,11 +490,19 @@ func summarizeMCPConnect(grants []*accessgen.RoleGrant) MCPConnectSummary {
 			if selector == nil {
 				continue
 			}
-			if selector.ProjectID != nil && !blocked {
-				summary.ProjectRules++
+			if selector.ProjectID != nil {
+				if blocked {
+					summary.BlockedProjectRules++
+				} else {
+					summary.ProjectRules++
+				}
 			}
-			if selector.ResourceID != authz.WildcardResource && !blocked {
-				summary.ServerRules++
+			if selector.ResourceID != authz.WildcardResource {
+				if blocked {
+					summary.BlockedServerRules++
+				} else {
+					summary.ServerRules++
+				}
 			}
 			if selector.Tool != nil {
 				if blocked {
@@ -666,13 +669,17 @@ func accessAuthorizationMode(row platformrepo.GetPlatformMCPInventoryItemRow) st
 	if row.Visibility == "disabled" {
 		return "disabled"
 	}
-	if row.Visibility == "public" {
-		return "public_bypass"
-	}
 	if row.UnproxiedMcpServerID.Valid {
 		return "not_served"
 	}
-	return "rbac"
+	switch row.Visibility {
+	case "public":
+		return "public_bypass"
+	case "private":
+		return "rbac"
+	default:
+		return "not_served"
+	}
 }
 
 func accessSummary(row platformrepo.GetPlatformMCPInventoryItemRow) string {
@@ -708,26 +715,4 @@ func knownToolAccess(allowed, total int, catalog string, truncated bool) string 
 
 func normalizeAccessQuery(value string) string {
 	return strings.ToLower(strings.Join(strings.Fields(value), " "))
-}
-
-func matchesAccessMember(member *accessgen.AccessMember, query string, roleNames map[string]string) bool {
-	if strings.Contains(normalizeAccessQuery(member.Name), query) || strings.Contains(normalizeAccessQuery(member.Email), query) {
-		return true
-	}
-	for _, roleID := range member.RoleIds {
-		if strings.Contains(normalizeAccessQuery(roleNames[roleID]), query) {
-			return true
-		}
-	}
-	return false
-}
-
-func maskAccessMember(member *accessgen.AccessMember) string {
-	if member == nil {
-		return ""
-	}
-	if member.Email != "" {
-		return maskSubject(member.Email)
-	}
-	return maskSubject(member.Name)
 }

--- a/server/internal/platformmcp/access_reads.go
+++ b/server/internal/platformmcp/access_reads.go
@@ -1,0 +1,733 @@
+package platformmcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	accessgen "github.com/speakeasy-api/gram/server/gen/access"
+	"github.com/speakeasy-api/gram/server/internal/access"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	"github.com/speakeasy-api/gram/server/internal/mv"
+	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
+	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+)
+
+const (
+	AccessReadsConnectionLimitName   = "platform-mcp-access-reads-connection"
+	AccessReadsOrganizationLimitName = "platform-mcp-access-reads-organization"
+
+	AccessReadQueriesPerConnectionPerMinute   = 30
+	AccessReadQueriesPerOrganizationPerMinute = 300
+
+	maxAccessMembers     = 50
+	maxAccessTools       = 100
+	minAccessQueryLength = 3
+)
+
+const (
+	subjectKindAccessRole   = "access_role"
+	subjectKindAccessMember = "access_member"
+)
+
+var (
+	ErrAccessReferenceNotFound = errors.New("platform mcp access reference not found")
+	ErrAccessMCPNotFound       = errors.New("platform mcp access target not found")
+	ErrAccessQueryRequired     = errors.New("platform mcp access member filter required")
+)
+
+type MCPConnectSummary struct {
+	AllServers              bool     `json:"all_servers"`
+	ProjectRules            int      `json:"project_rules"`
+	ServerRules             int      `json:"server_rules"`
+	ToolRules               int      `json:"tool_rules"`
+	DispositionRules        []string `json:"disposition_rules"`
+	BlockedServers          bool     `json:"blocked_servers"`
+	BlockedToolRules        int      `json:"blocked_tool_rules"`
+	BlockedDispositionRules []string `json:"blocked_disposition_rules"`
+}
+
+type AccessRole struct {
+	Name        string            `json:"name"`
+	Type        string            `json:"type"`
+	MemberCount SubjectCount      `json:"member_count"`
+	MCPAccess   MCPConnectSummary `json:"mcp_access"`
+	Reference   string            `json:"reference"`
+}
+
+type ListAccessRolesOutput struct {
+	Roles     []AccessRole `json:"roles"`
+	ExpiresAt string       `json:"expires_at"`
+}
+
+type ListAccessMembersInput struct {
+	Query         string `json:"query,omitempty" jsonschema:"identity text to search for; required unless role_reference is supplied"`
+	RoleReference string `json:"role_reference,omitempty" jsonschema:"opaque role reference returned by list_access_roles"`
+	Limit         int    `json:"limit,omitempty" jsonschema:"maximum number of matching members to return; server clamps this to 50"`
+}
+
+type AccessMember struct {
+	MaskedIdentity string   `json:"masked_identity"`
+	Roles          []string `json:"roles"`
+	Reference      string   `json:"reference"`
+}
+
+type ListAccessMembersOutput struct {
+	Members      []AccessMember `json:"members"`
+	TotalMatches SubjectCount   `json:"total_matches"`
+	Suppressed   bool           `json:"suppressed"`
+	Truncated    bool           `json:"truncated"`
+	ExpiresAt    string         `json:"expires_at,omitempty"`
+}
+
+type MCPAccessTool struct {
+	Name        string `json:"name"`
+	Disposition string `json:"disposition,omitempty"`
+}
+
+type MCPAccessTarget struct {
+	ID                   string          `json:"id"`
+	Name                 string          `json:"name"`
+	Backend              string          `json:"backend"`
+	Visibility           string          `json:"visibility"`
+	AuthorizationMode    string          `json:"authorization_mode"`
+	AuthorizationSurface string          `json:"authorization_surface"`
+	AccessSummary        string          `json:"access_summary"`
+	ToolCatalog          string          `json:"tool_catalog"`
+	Tools                []MCPAccessTool `json:"tools"`
+	ToolsTruncated       bool            `json:"tools_truncated"`
+}
+
+type MCPRoleCoverage struct {
+	Name                string       `json:"name"`
+	Type                string       `json:"type"`
+	MemberCount         SubjectCount `json:"member_count"`
+	Reference           string       `json:"reference"`
+	CanEnterServer      bool         `json:"can_enter_server"`
+	KnownToolAccess     string       `json:"known_tool_access"`
+	AllowedKnownTools   []string     `json:"allowed_known_tools"`
+	DispositionRules    []string     `json:"disposition_rules"`
+	BlockedDispositions []string     `json:"blocked_dispositions"`
+	UnevaluatedGrants   bool         `json:"unevaluated_grants"`
+}
+
+type GetMCPAccessInput struct {
+	ProjectID string `json:"project_id" jsonschema:"project ID that owns the configured MCP"`
+	MCPID     string `json:"mcp_id" jsonschema:"configured MCP ID returned by find_mcp"`
+}
+
+type GetMCPAccessOutput struct {
+	ProjectID string            `json:"project_id"`
+	MCP       MCPAccessTarget   `json:"mcp"`
+	Roles     []MCPRoleCoverage `json:"roles"`
+	ExpiresAt string            `json:"expires_at"`
+}
+
+// AccessReadService projects the access service's local role/member authority
+// into privacy-safe Platform MCP reads. It never contacts WorkOS or a configured
+// MCP and never accepts raw role, member, principal, or grant identifiers.
+type AccessReadService struct {
+	logger     *slog.Logger
+	db         *pgxpool.Pool
+	roles      *access.RoleManager
+	budget     OperationBudget
+	references *subjectReferenceCodec
+	now        func() time.Time
+}
+
+func NewAccessReadService(logger *slog.Logger, db *pgxpool.Pool, budget OperationBudget, keyMaterial string) *AccessReadService {
+	if logger == nil {
+		return &AccessReadService{logger: nil, db: nil, roles: nil, budget: OperationBudget{Connection: nil, Organization: nil}, references: nil, now: nil}
+	}
+	references, err := newSubjectReferenceCodec(keyMaterial)
+	if err != nil {
+		logger.ErrorContext(context.Background(), "build Platform MCP access reference codec", attr.SlogError(err))
+	}
+	return &AccessReadService{
+		logger:     logger,
+		db:         db,
+		roles:      access.NewRoleManager(logger, db, nil, nil),
+		budget:     budget,
+		references: references,
+		now:        time.Now,
+	}
+}
+
+func (s *AccessReadService) valid() bool {
+	return s != nil && s.db != nil && s.roles != nil && s.budget.valid() && s.references != nil && s.now != nil
+}
+
+func (s *AccessReadService) ListRoles(ctx context.Context, principal Principal) (ListAccessRolesOutput, error) {
+	if !s.valid() {
+		return ListAccessRolesOutput{}, ErrUnavailable
+	}
+	if err := s.budget.Allow(ctx, principal); err != nil {
+		return ListAccessRolesOutput{}, err
+	}
+	roles, err := s.roles.ListRoles(ctx, principal.OrganizationID)
+	if err != nil {
+		return ListAccessRolesOutput{}, fmt.Errorf("list platform mcp access roles: %w", err)
+	}
+	now := s.now().UTC()
+	output := ListAccessRolesOutput{
+		Roles:     make([]AccessRole, 0, len(roles.Roles)),
+		ExpiresAt: now.Add(SubjectReferenceTTL).Format(time.RFC3339),
+	}
+	for _, role := range roles.Roles {
+		reference, err := s.references.Encode(principal, subjectKindAccessRole, role.ID, now)
+		if err != nil {
+			return ListAccessRolesOutput{}, fmt.Errorf("issue access role reference: %w", err)
+		}
+		output.Roles = append(output.Roles, AccessRole{
+			Name:        role.Name,
+			Type:        accessRoleType(role),
+			MemberCount: NewSubjectCount(int64(role.MemberCount)),
+			MCPAccess:   summarizeMCPConnect(role.Grants),
+			Reference:   reference,
+		})
+	}
+	return output, nil
+}
+
+func (s *AccessReadService) ListMembers(ctx context.Context, principal Principal, input ListAccessMembersInput) (ListAccessMembersOutput, error) {
+	if !s.valid() {
+		return ListAccessMembersOutput{}, ErrUnavailable
+	}
+	query := normalizeAccessQuery(input.Query)
+	if input.RoleReference == "" && len([]rune(query)) < minAccessQueryLength {
+		return ListAccessMembersOutput{}, ErrAccessQueryRequired
+	}
+	if err := s.budget.Allow(ctx, principal); err != nil {
+		return ListAccessMembersOutput{}, err
+	}
+	roles, err := s.roles.ListRoles(ctx, principal.OrganizationID)
+	if err != nil {
+		return ListAccessMembersOutput{}, fmt.Errorf("list roles for platform mcp members: %w", err)
+	}
+	roleNames := make(map[string]string, len(roles.Roles))
+	for _, role := range roles.Roles {
+		roleNames[role.ID] = role.Name
+	}
+
+	roleID := ""
+	if input.RoleReference != "" {
+		roleID, err = s.references.Decode(input.RoleReference, principal, subjectKindAccessRole, s.now())
+		if err != nil {
+			return ListAccessMembersOutput{}, ErrAccessReferenceNotFound
+		}
+		if _, ok := roleNames[roleID]; !ok {
+			return ListAccessMembersOutput{}, ErrAccessReferenceNotFound
+		}
+	}
+
+	members, err := s.roles.ListMembers(ctx, principal.OrganizationID)
+	if err != nil {
+		return ListAccessMembersOutput{}, fmt.Errorf("list platform mcp access members: %w", err)
+	}
+	matching := make([]*accessgen.AccessMember, 0, len(members.Members))
+	for _, member := range members.Members {
+		if roleID != "" && !slices.Contains(member.RoleIds, roleID) {
+			continue
+		}
+		if query != "" && !matchesAccessMember(member, query, roleNames) {
+			continue
+		}
+		matching = append(matching, member)
+	}
+
+	count := len(matching)
+	output := ListAccessMembersOutput{
+		Members:      []AccessMember{},
+		TotalMatches: NewSubjectCount(int64(count)),
+		Suppressed:   count > 0 && count < SubjectSuppressionThreshold,
+		Truncated:    false,
+		ExpiresAt:    "",
+	}
+	// Organization-privacy rules do not allow a row-bearing response to reveal
+	// a filtered cohort smaller than five. Return only the suppressed count.
+	if output.Suppressed || count == 0 {
+		return output, nil
+	}
+
+	limit := maxAccessMembers
+	if input.Limit > 0 {
+		limit = min(input.Limit, maxAccessMembers)
+	}
+	if len(matching) > limit {
+		matching = matching[:limit]
+		output.Truncated = true
+	}
+	now := s.now().UTC()
+	output.ExpiresAt = now.Add(SubjectReferenceTTL).Format(time.RFC3339)
+	for _, member := range matching {
+		reference, err := s.references.Encode(principal, subjectKindAccessMember, member.ID, now)
+		if err != nil {
+			return ListAccessMembersOutput{}, fmt.Errorf("issue access member reference: %w", err)
+		}
+		names := make([]string, 0, len(member.RoleIds))
+		for _, id := range member.RoleIds {
+			if name := roleNames[id]; name != "" {
+				names = append(names, name)
+			}
+		}
+		slices.Sort(names)
+		output.Members = append(output.Members, AccessMember{
+			MaskedIdentity: maskAccessMember(member),
+			Roles:          slices.Compact(names),
+			Reference:      reference,
+		})
+	}
+	return output, nil
+}
+
+func (s *AccessReadService) GetMCPAccess(ctx context.Context, principal Principal, input GetMCPAccessInput) (GetMCPAccessOutput, error) {
+	if !s.valid() {
+		return GetMCPAccessOutput{}, ErrUnavailable
+	}
+	if err := s.budget.Allow(ctx, principal); err != nil {
+		return GetMCPAccessOutput{}, err
+	}
+	projectID, err := uuid.Parse(input.ProjectID)
+	if err != nil {
+		return GetMCPAccessOutput{}, ErrAccessMCPNotFound
+	}
+	mcpID, err := uuid.Parse(input.MCPID)
+	if err != nil {
+		return GetMCPAccessOutput{}, ErrAccessMCPNotFound
+	}
+	row, err := platformrepo.New(s.db).GetPlatformMCPInventoryItem(ctx, platformrepo.GetPlatformMCPInventoryItemParams{
+		OrganizationID:       principal.OrganizationID,
+		ConnectionID:         uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		ConnectionGeneration: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		UserID:               inventoryText(principal.UserID),
+		ActingSurface:        inventoryText(string(principal.surface())),
+		McpServerID:          mcpID,
+		ProjectID:            projectID,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return GetMCPAccessOutput{}, ErrAccessMCPNotFound
+	}
+	if err != nil {
+		return GetMCPAccessOutput{}, fmt.Errorf("get platform mcp access target: %w", err)
+	}
+
+	tools, catalog, truncated, err := s.accessTools(ctx, row)
+	if err != nil {
+		return GetMCPAccessOutput{}, err
+	}
+	name := row.McpName.String
+	if name == "" {
+		name = row.McpSlug.String
+	}
+	if name == "" {
+		name = row.McpServerID.String()
+	}
+	target := MCPAccessTarget{
+		ID:                   row.McpServerID.String(),
+		Name:                 name,
+		Backend:              accessBackend(row),
+		Visibility:           row.Visibility,
+		AuthorizationMode:    accessAuthorizationMode(row),
+		AuthorizationSurface: "configured_endpoint",
+		AccessSummary:        accessSummary(row),
+		ToolCatalog:          catalog,
+		Tools:                tools,
+		ToolsTruncated:       truncated,
+	}
+
+	if target.AuthorizationMode != "rbac" {
+		return GetMCPAccessOutput{
+			ProjectID: projectID.String(),
+			MCP:       target,
+			Roles:     []MCPRoleCoverage{},
+			ExpiresAt: "",
+		}, nil
+	}
+
+	roles, err := s.roles.ListRoles(ctx, principal.OrganizationID)
+	if err != nil {
+		return GetMCPAccessOutput{}, fmt.Errorf("list roles for platform mcp access: %w", err)
+	}
+	now := s.now().UTC()
+	output := GetMCPAccessOutput{
+		ProjectID: projectID.String(),
+		MCP:       target,
+		Roles:     make([]MCPRoleCoverage, 0, len(roles.Roles)),
+		ExpiresAt: now.Add(SubjectReferenceTTL).Format(time.RFC3339),
+	}
+	for _, role := range roles.Roles {
+		grants, unevaluated := roleAuthzGrants(role)
+		serverCheck := authz.MCPCheck(authz.ScopeMCPConnect, row.McpServerID.String(), projectID.String())
+		canEnter, err := authz.GrantsAuthorize(grants, serverCheck)
+		if err != nil {
+			return GetMCPAccessOutput{}, fmt.Errorf("evaluate server access for role %q: %w", role.Name, err)
+		}
+		allowedTools := make([]string, 0, len(tools))
+		for _, tool := range tools {
+			allowed, err := authz.GrantsAuthorize(grants, authz.MCPToolCallCheck(row.McpServerID.String(), authz.MCPToolCallDimensions{
+				Tool: tool.Name, Disposition: tool.Disposition, ProjectID: projectID.String(),
+			}))
+			if err != nil {
+				return GetMCPAccessOutput{}, fmt.Errorf("evaluate tool access for role %q: %w", role.Name, err)
+			}
+			if allowed {
+				allowedTools = append(allowedTools, tool.Name)
+			}
+		}
+		dispositions, blockedDispositions := matchingDispositionRules(role.Grants, row.McpServerID.String(), projectID.String())
+		if !canEnter && len(allowedTools) == 0 && len(dispositions) == 0 && len(blockedDispositions) == 0 && !unevaluated {
+			continue
+		}
+		reference, err := s.references.Encode(principal, subjectKindAccessRole, role.ID, now)
+		if err != nil {
+			return GetMCPAccessOutput{}, fmt.Errorf("issue MCP access role reference: %w", err)
+		}
+		output.Roles = append(output.Roles, MCPRoleCoverage{
+			Name:                role.Name,
+			Type:                accessRoleType(role),
+			MemberCount:         NewSubjectCount(int64(role.MemberCount)),
+			Reference:           reference,
+			CanEnterServer:      canEnter,
+			KnownToolAccess:     knownToolAccess(len(allowedTools), len(tools), catalog, truncated),
+			AllowedKnownTools:   allowedTools,
+			DispositionRules:    dispositions,
+			BlockedDispositions: blockedDispositions,
+			UnevaluatedGrants:   unevaluated,
+		})
+	}
+	return output, nil
+}
+
+func (s *AccessReadService) accessTools(ctx context.Context, row platformrepo.GetPlatformMCPInventoryItemRow) ([]MCPAccessTool, string, bool, error) {
+	var tools []MCPAccessTool
+	catalog := "dynamic"
+	switch {
+	case row.ToolsetID.Valid:
+		toolset, err := toolsetsrepo.New(s.db).GetToolsetByIDAndProject(ctx, toolsetsrepo.GetToolsetByIDAndProjectParams{ID: row.ToolsetID.UUID, ProjectID: row.ProjectID})
+		if err != nil {
+			return nil, "", false, fmt.Errorf("get hosted MCP toolset: %w", err)
+		}
+		entries, err := mv.DescribeToolsetEntries(ctx, s.logger, s.db, mv.ProjectID(row.ProjectID), []toolsetsrepo.Toolset{toolset})
+		if err != nil {
+			return nil, "", false, fmt.Errorf("describe hosted MCP tools: %w", err)
+		}
+		catalog = "authoritative"
+		if len(entries) > 0 {
+			for _, tool := range entries[0].Tools {
+				if tool == nil || tool.Name == "" {
+					continue
+				}
+				tools = append(tools, MCPAccessTool{Name: tool.Name, Disposition: conv.DispositionFromAnnotations(tool.Annotations)})
+			}
+		}
+	case row.RemoteMcpServerID.Valid || row.TunneledMcpServerID.Valid:
+		rows, err := mcpserversrepo.New(s.db).ListMCPServerToolMetadata(ctx, mcpserversrepo.ListMCPServerToolMetadataParams{
+			McpServerID: row.McpServerID, ProjectID: row.ProjectID, IncludeDeleted: false,
+		})
+		if err != nil {
+			return nil, "", false, fmt.Errorf("list configured MCP tool metadata: %w", err)
+		}
+		if len(rows) > 0 {
+			catalog = "stored_metadata"
+		}
+		for _, tool := range rows {
+			tools = append(tools, MCPAccessTool{
+				Name: tool.ToolName,
+				Disposition: conv.DispositionFromAnnotations(conv.AnnotationsFromColumns(
+					tool.ReadOnlyHint, tool.DestructiveHint, tool.IdempotentHint, tool.OpenWorldHint,
+				)),
+			})
+		}
+	case row.UnproxiedMcpServerID.Valid:
+		catalog = "unavailable"
+	}
+	sort.Slice(tools, func(i, j int) bool {
+		if tools[i].Name == tools[j].Name {
+			return tools[i].Disposition < tools[j].Disposition
+		}
+		return tools[i].Name < tools[j].Name
+	})
+	tools = omitAmbiguousAccessTools(tools)
+	truncated := len(tools) > maxAccessTools
+	if truncated {
+		tools = tools[:maxAccessTools]
+	}
+	return tools, catalog, truncated, nil
+}
+
+func accessRoleType(role *accessgen.Role) string {
+	if role.IsSystem {
+		return "system"
+	}
+	return "custom"
+}
+
+func summarizeMCPConnect(grants []*accessgen.RoleGrant) MCPConnectSummary {
+	summary := MCPConnectSummary{AllServers: false, ProjectRules: 0, ServerRules: 0, ToolRules: 0, DispositionRules: []string{}, BlockedServers: false, BlockedToolRules: 0, BlockedDispositionRules: []string{}}
+	dispositions := map[string]struct{}{}
+	blockedDispositions := map[string]struct{}{}
+	for _, grant := range grants {
+		if grant == nil || (!scopeMayAllowConnect(grant.Scope) && !scopeMayBlockConnect(grant.Scope)) {
+			continue
+		}
+		blocked := scopeMayBlockConnect(grant.Scope)
+		if grant.Scope == string(authz.ScopeRoot) || grant.Selectors == nil {
+			if blocked {
+				summary.BlockedServers = true
+			} else {
+				summary.AllServers = true
+			}
+			continue
+		}
+		for _, selector := range grant.Selectors {
+			if selector == nil {
+				continue
+			}
+			if selector.ProjectID != nil && !blocked {
+				summary.ProjectRules++
+			}
+			if selector.ResourceID != authz.WildcardResource && !blocked {
+				summary.ServerRules++
+			}
+			if selector.Tool != nil {
+				if blocked {
+					summary.BlockedToolRules++
+				} else {
+					summary.ToolRules++
+				}
+			}
+			if selector.Disposition != nil && *selector.Disposition != "" {
+				if blocked {
+					blockedDispositions[*selector.Disposition] = struct{}{}
+				} else {
+					dispositions[*selector.Disposition] = struct{}{}
+				}
+			}
+			if selector.ResourceID == authz.WildcardResource && selector.ProjectID == nil && selector.Tool == nil && selector.Disposition == nil {
+				if blocked {
+					summary.BlockedServers = true
+				} else {
+					summary.AllServers = true
+				}
+			}
+		}
+	}
+	for disposition := range dispositions {
+		summary.DispositionRules = append(summary.DispositionRules, disposition)
+	}
+	for disposition := range blockedDispositions {
+		summary.BlockedDispositionRules = append(summary.BlockedDispositionRules, disposition)
+	}
+	slices.Sort(summary.DispositionRules)
+	slices.Sort(summary.BlockedDispositionRules)
+	return summary
+}
+
+func roleAuthzGrants(role *accessgen.Role) ([]authz.Grant, bool) {
+	grants := make([]authz.Grant, 0)
+	if role == nil {
+		return grants, false
+	}
+	unevaluated := false
+	for _, grant := range role.Grants {
+		if grant == nil {
+			continue
+		}
+		scope := authz.Scope(grant.Scope)
+		if grant.Selectors == nil {
+			grants = append(grants, authz.Grant{PrincipalUrn: role.PrincipalUrn, Scope: scope, Selector: authz.NewSelector(scope, authz.WildcardResource)})
+			continue
+		}
+		for _, selector := range grant.Selectors {
+			if selector == nil {
+				continue
+			}
+			converted := authz.Selector{
+				authz.SelectorKeyResourceKind: selector.ResourceKind,
+				authz.SelectorKeyResourceID:   selector.ResourceID,
+			}
+			if selector.ProjectID != nil {
+				converted[authz.SelectorKeyProjectID] = *selector.ProjectID
+			}
+			if selector.Tool != nil {
+				converted[authz.SelectorKeyTool] = *selector.Tool
+			}
+			if selector.Disposition != nil {
+				converted[authz.SelectorKeyDisposition] = *selector.Disposition
+			}
+			if err := authz.ValidateSelector(scope, converted); err != nil {
+				unevaluated = true
+				continue
+			}
+			grants = append(grants, authz.Grant{PrincipalUrn: role.PrincipalUrn, Scope: scope, Selector: converted})
+		}
+	}
+	return grants, unevaluated
+}
+
+func matchingDispositionRules(grants []*accessgen.RoleGrant, mcpID, projectID string) ([]string, []string) {
+	found := map[string]struct{}{}
+	blocked := map[string]struct{}{}
+	for _, grant := range grants {
+		if grant == nil || (!scopeMayAllowConnect(grant.Scope) && !scopeMayBlockConnect(grant.Scope)) {
+			continue
+		}
+		for _, selector := range grant.Selectors {
+			if selector == nil || selector.Disposition == nil || *selector.Disposition == "" {
+				continue
+			}
+			if selector.ResourceID != authz.WildcardResource && selector.ResourceID != mcpID {
+				continue
+			}
+			if selector.ProjectID != nil && *selector.ProjectID != authz.WildcardResource && *selector.ProjectID != projectID {
+				continue
+			}
+			if scopeMayBlockConnect(grant.Scope) {
+				blocked[*selector.Disposition] = struct{}{}
+			} else {
+				found[*selector.Disposition] = struct{}{}
+			}
+		}
+	}
+	out := make([]string, 0, len(found))
+	for value := range found {
+		out = append(out, value)
+	}
+	blockedOut := make([]string, 0, len(blocked))
+	for value := range blocked {
+		blockedOut = append(blockedOut, value)
+	}
+	slices.Sort(out)
+	slices.Sort(blockedOut)
+	return out, blockedOut
+}
+
+func scopeMayAllowConnect(scope string) bool {
+	switch authz.Scope(scope) {
+	case authz.ScopeRoot, authz.ScopeMCPConnect, authz.ScopeMCPRead, authz.ScopeMCPWrite:
+		return true
+	default:
+		return false
+	}
+}
+
+func scopeMayBlockConnect(scope string) bool {
+	switch authz.Scope(scope) {
+	case authz.ScopeMCPBlockedConnect, authz.ScopeMCPBlockedRead, authz.ScopeMCPBlockedWrite:
+		return true
+	default:
+		return false
+	}
+}
+
+func omitAmbiguousAccessTools(tools []MCPAccessTool) []MCPAccessTool {
+	result := make([]MCPAccessTool, 0, len(tools))
+	for start := 0; start < len(tools); {
+		end := start + 1
+		for end < len(tools) && tools[end].Name == tools[start].Name {
+			end++
+		}
+		if end-start == 1 {
+			result = append(result, tools[start])
+		}
+		start = end
+	}
+	return result
+}
+
+func accessBackend(row platformrepo.GetPlatformMCPInventoryItemRow) string {
+	switch {
+	case row.RemoteMcpServerID.Valid:
+		return "remote"
+	case row.TunneledMcpServerID.Valid:
+		return "tunneled"
+	case row.ToolsetID.Valid:
+		return "hosted"
+	case row.UnproxiedMcpServerID.Valid:
+		return "unproxied"
+	default:
+		return "legacy"
+	}
+}
+
+func accessAuthorizationMode(row platformrepo.GetPlatformMCPInventoryItemRow) string {
+	if row.Visibility == "disabled" {
+		return "disabled"
+	}
+	if row.Visibility == "public" {
+		return "public_bypass"
+	}
+	if row.UnproxiedMcpServerID.Valid {
+		return "not_served"
+	}
+	return "rbac"
+}
+
+func accessSummary(row platformrepo.GetPlatformMCPInventoryItemRow) string {
+	switch accessAuthorizationMode(row) {
+	case "public_bypass":
+		return "everyone"
+	case "disabled", "not_served":
+		return "nobody"
+	default:
+		return "by_role"
+	}
+}
+
+func knownToolAccess(allowed, total int, catalog string, truncated bool) string {
+	if total == 0 {
+		if catalog == "dynamic" || catalog == "unavailable" {
+			return "not_enumerable"
+		}
+		return "none"
+	}
+	switch allowed {
+	case 0:
+		return "none"
+	case total:
+		if truncated {
+			return "some_known_tools"
+		}
+		return "all"
+	default:
+		return "some"
+	}
+}
+
+func normalizeAccessQuery(value string) string {
+	return strings.ToLower(strings.Join(strings.Fields(value), " "))
+}
+
+func matchesAccessMember(member *accessgen.AccessMember, query string, roleNames map[string]string) bool {
+	if strings.Contains(normalizeAccessQuery(member.Name), query) || strings.Contains(normalizeAccessQuery(member.Email), query) {
+		return true
+	}
+	for _, roleID := range member.RoleIds {
+		if strings.Contains(normalizeAccessQuery(roleNames[roleID]), query) {
+			return true
+		}
+	}
+	return false
+}
+
+func maskAccessMember(member *accessgen.AccessMember) string {
+	if member == nil {
+		return ""
+	}
+	if member.Email != "" {
+		return maskSubject(member.Email)
+	}
+	return maskSubject(member.Name)
+}

--- a/server/internal/platformmcp/access_reads.go
+++ b/server/internal/platformmcp/access_reads.go
@@ -2,6 +2,7 @@ package platformmcp
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -67,6 +68,7 @@ type AccessRole struct {
 	MemberCount SubjectCount      `json:"member_count"`
 	MCPAccess   MCPConnectSummary `json:"mcp_access"`
 	Reference   string            `json:"reference"`
+	Version     string            `json:"version"`
 }
 
 type ListAccessRolesOutput struct {
@@ -117,6 +119,7 @@ type MCPRoleCoverage struct {
 	Type                string       `json:"type"`
 	MemberCount         SubjectCount `json:"member_count"`
 	Reference           string       `json:"reference"`
+	Version             string       `json:"version"`
 	CanEnterServer      bool         `json:"can_enter_server"`
 	KnownToolAccess     string       `json:"known_tool_access"`
 	AllowedKnownTools   []string     `json:"allowed_known_tools"`
@@ -147,16 +150,18 @@ type AccessReadService struct {
 	budget     OperationBudget
 	references *subjectReferenceCodec
 	now        func() time.Time
+	versionKey []byte
 }
 
 func NewAccessReadService(logger *slog.Logger, db *pgxpool.Pool, budget OperationBudget, keyMaterial string) *AccessReadService {
 	if logger == nil {
-		return &AccessReadService{logger: nil, db: nil, roles: nil, budget: OperationBudget{Connection: nil, Organization: nil}, references: nil, now: nil}
+		return &AccessReadService{logger: nil, db: nil, roles: nil, budget: OperationBudget{Connection: nil, Organization: nil}, references: nil, now: nil, versionKey: nil}
 	}
 	references, err := newSubjectReferenceCodec(keyMaterial)
 	if err != nil {
 		logger.ErrorContext(context.Background(), "build Platform MCP access reference codec", attr.SlogError(err))
 	}
+	versionKey := sha256.Sum256([]byte("platform-mcp-access-role-version:" + keyMaterial))
 	return &AccessReadService{
 		logger:     logger,
 		db:         db,
@@ -164,11 +169,12 @@ func NewAccessReadService(logger *slog.Logger, db *pgxpool.Pool, budget Operatio
 		budget:     budget,
 		references: references,
 		now:        time.Now,
+		versionKey: versionKey[:],
 	}
 }
 
 func (s *AccessReadService) valid() bool {
-	return s != nil && s.db != nil && s.roles != nil && s.budget.valid() && s.references != nil && s.now != nil
+	return s != nil && s.db != nil && s.roles != nil && s.budget.valid() && s.references != nil && s.now != nil && len(s.versionKey) == sha256.Size
 }
 
 func (s *AccessReadService) ListRoles(ctx context.Context, principal Principal) (ListAccessRolesOutput, error) {
@@ -192,12 +198,17 @@ func (s *AccessReadService) ListRoles(ctx context.Context, principal Principal) 
 		if err != nil {
 			return ListAccessRolesOutput{}, fmt.Errorf("issue access role reference: %w", err)
 		}
+		version, err := accessRoleVersion(s.versionKey, role)
+		if err != nil {
+			return ListAccessRolesOutput{}, fmt.Errorf("version access role: %w", err)
+		}
 		output.Roles = append(output.Roles, AccessRole{
 			Name:        role.Name,
 			Type:        accessRoleType(role),
 			MemberCount: NewSubjectCount(int64(role.MemberCount)),
 			MCPAccess:   summarizeMCPConnect(role.Grants),
 			Reference:   reference,
+			Version:     version,
 		})
 	}
 	return output, nil
@@ -389,11 +400,16 @@ func (s *AccessReadService) GetMCPAccess(ctx context.Context, principal Principa
 		if err != nil {
 			return GetMCPAccessOutput{}, fmt.Errorf("issue MCP access role reference: %w", err)
 		}
+		version, err := accessRoleVersion(s.versionKey, role)
+		if err != nil {
+			return GetMCPAccessOutput{}, fmt.Errorf("version MCP access role: %w", err)
+		}
 		output.Roles = append(output.Roles, MCPRoleCoverage{
 			Name:                role.Name,
 			Type:                accessRoleType(role),
 			MemberCount:         NewSubjectCount(int64(role.MemberCount)),
 			Reference:           reference,
+			Version:             version,
 			CanEnterServer:      canEnter,
 			KnownToolAccess:     knownToolAccess(len(allowedTools), len(tools), catalog, truncated),
 			AllowedKnownTools:   allowedTools,

--- a/server/internal/platformmcp/access_reads_integration_test.go
+++ b/server/internal/platformmcp/access_reads_integration_test.go
@@ -1,0 +1,130 @@
+package platformmcp
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
+)
+
+func TestAccessReadServiceSuppressesSmallMemberSearchAndReturnsMaskedLargeCohort(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_access_members")
+	require.NoError(t, err)
+	principal, _ := seedRegistrationLifecycle(t, ctx, conn)
+	service := NewAccessReadService(testenv.NewLogger(t), conn, allowBudget(), "access-read-key")
+
+	_, err = service.ListMembers(ctx, principal, ListAccessMembersInput{Query: "o"})
+	require.ErrorIs(t, err, ErrAccessQueryRequired)
+
+	for i := range 5 {
+		seedAccessMember(t, ctx, conn, principal.OrganizationID, fmt.Sprintf("member-%d", i), fmt.Sprintf("operator%d@example.test", i))
+	}
+
+	small, err := service.ListMembers(ctx, principal, ListAccessMembersInput{Query: "operator0"})
+	require.NoError(t, err)
+	require.True(t, small.Suppressed)
+	require.Empty(t, small.Members)
+	require.Empty(t, small.ExpiresAt)
+
+	large, err := service.ListMembers(ctx, principal, ListAccessMembersInput{Query: "operator"})
+	require.NoError(t, err)
+	require.False(t, large.Suppressed)
+	require.Len(t, large.Members, 5)
+	for _, member := range large.Members {
+		require.NotContains(t, member.MaskedIdentity, "example.test")
+		require.NotEmpty(t, member.Reference)
+		decoded, err := service.references.Decode(member.Reference, principal, subjectKindAccessMember, service.now())
+		require.NoError(t, err)
+		require.NotEmpty(t, decoded)
+	}
+}
+
+func TestGetMCPAccessUsesFrontingServerIDAndStoredToolMetadata(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_access_target")
+	require.NoError(t, err)
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	service := NewAccessReadService(testenv.NewLogger(t), conn, allowBudget(), "access-read-key")
+
+	// seedRegistrationLifecycle creates a remote cohort server; select it through
+	// the same tenant-qualified inventory query the service uses.
+	rows, err := platformrepo.New(conn).ListPlatformMCPInventory(ctx, platformrepo.ListPlatformMCPInventoryParams{
+		OrganizationID: principal.OrganizationID, ConnectionID: uuid.NullUUID{}, ConnectionGeneration: uuid.NullUUID{},
+		UserID: inventoryText(principal.UserID), ActingSurface: inventoryText(string(principal.surface())),
+		ProjectID: uuid.NullUUID{UUID: project.ID, Valid: true}, AfterMcpID: uuid.NullUUID{}, QueryText: "", ReadinessState: pgtype.Text{}, LimitValue: 10,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, rows)
+	target := rows[0]
+
+	_, err = mcpserversrepo.New(conn).AddMCPServerToolMetadata(ctx, mcpserversrepo.AddMCPServerToolMetadataParams{
+		ProjectID: target.ProjectID, McpServerID: target.McpServerID,
+		Tools: []byte(`[{"tool_name":"list_tasks","read_only_hint":true}]`),
+	})
+	require.NoError(t, err)
+
+	role := seedAccessRole(t, ctx, conn, principal.OrganizationID, "operators", "Operators")
+	selector := authz.NewSelector(authz.ScopeMCPConnect, target.McpServerID.String())
+	selector[authz.SelectorKeyTool] = "list_tasks"
+	selectorBytes, err := selector.MarshalJSON()
+	require.NoError(t, err)
+	_, err = accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
+		OrganizationID: principal.OrganizationID, PrincipalUrn: role, Scope: string(authz.ScopeMCPConnect), Selectors: selectorBytes,
+	})
+	require.NoError(t, err)
+
+	output, err := service.GetMCPAccess(ctx, principal, GetMCPAccessInput{ProjectID: project.ID.String(), MCPID: target.McpServerID.String()})
+	require.NoError(t, err)
+	require.Equal(t, "remote", output.MCP.Backend)
+	require.Equal(t, "stored_metadata", output.MCP.ToolCatalog)
+	require.Equal(t, []MCPAccessTool{{Name: "list_tasks", Disposition: "read_only"}}, output.MCP.Tools)
+	require.Len(t, output.Roles, 1)
+	require.Equal(t, "Operators", output.Roles[0].Name)
+	require.True(t, output.Roles[0].CanEnterServer)
+	require.Equal(t, "all", output.Roles[0].KnownToolAccess)
+	require.Equal(t, []string{"list_tasks"}, output.Roles[0].AllowedKnownTools)
+}
+
+func seedAccessMember(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID, userID, email string) {
+	t.Helper()
+	_, err := usersrepo.New(conn).UpsertUser(ctx, usersrepo.UpsertUserParams{ID: userID, Email: email, DisplayName: userID, PhotoUrl: pgtype.Text{}, Admin: false})
+	require.NoError(t, err)
+	workosUserID := "workos-" + userID
+	require.NoError(t, usersrepo.New(conn).OverwriteUserWorkosID(ctx, usersrepo.OverwriteUserWorkosIDParams{WorkosID: conv.ToPGText(workosUserID), ID: userID}))
+	require.NoError(t, orgrepo.New(conn).AttachWorkOSUserToOrg(ctx, orgrepo.AttachWorkOSUserToOrgParams{
+		OrganizationID: organizationID, UserID: conv.ToPGText(userID), WorkosMembershipID: conv.PtrToPGText(conv.PtrEmpty("membership-" + userID)),
+	}))
+}
+
+func seedAccessRole(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID, slug, name string) urn.Principal {
+	t.Helper()
+	now := time.Now().UTC()
+	row, err := accessrepo.New(conn).UpsertOrganizationRole(ctx, accessrepo.UpsertOrganizationRoleParams{
+		OrganizationID: organizationID, WorkosSlug: slug, WorkosName: name, WorkosDescription: pgtype.Text{},
+		WorkosCreatedAt: conv.ToPGTimestamptz(now), WorkosUpdatedAt: conv.ToPGTimestamptz(now), WorkosLastEventID: pgtype.Text{},
+	})
+	require.NoError(t, err)
+	principal, err := urn.ParsePrincipal(row.RoleUrn)
+	require.NoError(t, err)
+	return principal
+}

--- a/server/internal/platformmcp/access_reads_integration_test.go
+++ b/server/internal/platformmcp/access_reads_integration_test.go
@@ -3,6 +3,7 @@ package platformmcp
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,8 +35,16 @@ func TestAccessReadServiceSuppressesSmallMemberSearchAndReturnsMaskedLargeCohort
 	_, err = service.ListMembers(ctx, principal, ListAccessMembersInput{Query: "o"})
 	require.ErrorIs(t, err, ErrAccessQueryRequired)
 
+	seedAccessRole(t, ctx, conn, principal.OrganizationID, "operators", "Operators")
 	for i := range 5 {
-		seedAccessMember(t, ctx, conn, principal.OrganizationID, fmt.Sprintf("member-%d", i), fmt.Sprintf("operator%d@example.test", i))
+		userID := fmt.Sprintf("member-%d", i)
+		seedAccessMember(t, ctx, conn, principal.OrganizationID, userID, fmt.Sprintf("operator%d@example.test", i))
+		_, err = accessrepo.New(conn).UpsertOrganizationRoleAssignment(ctx, accessrepo.UpsertOrganizationRoleAssignmentParams{
+			OrganizationID: principal.OrganizationID, WorkosUserID: "workos-" + userID, UserID: conv.ToPGText(userID),
+			WorkosMembershipID: conv.ToPGText("membership-" + userID), WorkosUpdatedAt: conv.ToPGTimestamptz(time.Now().UTC()),
+			WorkosLastEventID: conv.ToPGTextEmpty(""), WorkosRoleSlug: "operators",
+		})
+		require.NoError(t, err)
 	}
 
 	small, err := service.ListMembers(ctx, principal, ListAccessMembersInput{Query: "operator0"})
@@ -44,10 +53,12 @@ func TestAccessReadServiceSuppressesSmallMemberSearchAndReturnsMaskedLargeCohort
 	require.Empty(t, small.Members)
 	require.Empty(t, small.ExpiresAt)
 
-	large, err := service.ListMembers(ctx, principal, ListAccessMembersInput{Query: "operator"})
+	large, err := service.ListMembers(ctx, principal, ListAccessMembersInput{Query: "operator", Limit: 2})
 	require.NoError(t, err)
 	require.False(t, large.Suppressed)
-	require.Len(t, large.Members, 5)
+	require.Equal(t, NewSubjectCount(5), large.TotalMatches)
+	require.True(t, large.Truncated)
+	require.Len(t, large.Members, 2)
 	for _, member := range large.Members {
 		require.NotContains(t, member.MaskedIdentity, "example.test")
 		require.NotEmpty(t, member.Reference)
@@ -55,6 +66,27 @@ func TestAccessReadServiceSuppressesSmallMemberSearchAndReturnsMaskedLargeCohort
 		require.NoError(t, err)
 		require.NotEmpty(t, decoded)
 	}
+
+	roles, err := service.ListRoles(ctx, principal)
+	require.NoError(t, err)
+	var roleReference string
+	for _, candidate := range roles.Roles {
+		if candidate.Name == "Operators" {
+			roleReference = candidate.Reference
+		}
+	}
+	require.NotEmpty(t, roleReference)
+	byRole, err := service.ListMembers(ctx, principal, ListAccessMembersInput{RoleReference: roleReference})
+	require.NoError(t, err)
+	require.Equal(t, NewSubjectCount(5), byRole.TotalMatches)
+	require.Len(t, byRole.Members, 5)
+	for _, member := range byRole.Members {
+		require.Equal(t, []string{"Operators"}, member.Roles)
+	}
+
+	byRoleName, err := service.ListMembers(ctx, principal, ListAccessMembersInput{Query: strings.ToUpper("Operators")})
+	require.NoError(t, err)
+	require.Equal(t, NewSubjectCount(5), byRoleName.TotalMatches)
 }
 
 func TestGetMCPAccessUsesFrontingServerIDAndStoredToolMetadata(t *testing.T) {

--- a/server/internal/platformmcp/access_reads_test.go
+++ b/server/internal/platformmcp/access_reads_test.go
@@ -18,10 +18,10 @@ func TestAccessReadOutputsOnlyAllowlistedFields(t *testing.T) {
 
 	roles := ListAccessRolesOutput{Roles: []AccessRole{{
 		Name: "Operators", Type: "custom", MemberCount: NewSubjectCount(7),
-		MCPAccess: MCPConnectSummary{AllServers: false, ProjectRules: 1, ServerRules: 1, ToolRules: 1, DispositionRules: []string{"read_only"}, BlockedServers: false, BlockedToolRules: 0, BlockedDispositionRules: []string{}},
+		MCPAccess: MCPConnectSummary{AllServers: false, ProjectRules: 1, ServerRules: 1, ToolRules: 1, DispositionRules: []string{"read_only"}, BlockedServers: false, BlockedProjectRules: 1, BlockedServerRules: 1, BlockedToolRules: 0, BlockedDispositionRules: []string{}},
 		Reference: "opaque-role",
 	}}, ExpiresAt: "2026-09-04T12:10:00Z"}
-	require.ElementsMatch(t, []string{"roles", "name", "type", "member_count", "mcp_access", "all_servers", "project_rules", "server_rules", "tool_rules", "disposition_rules", "blocked_servers", "blocked_tool_rules", "blocked_disposition_rules", "reference", "expires_at"}, decodeKeys(t, roles))
+	require.ElementsMatch(t, []string{"roles", "name", "type", "member_count", "mcp_access", "all_servers", "project_rules", "server_rules", "tool_rules", "disposition_rules", "blocked_servers", "blocked_project_rules", "blocked_server_rules", "blocked_tool_rules", "blocked_disposition_rules", "reference", "expires_at"}, decodeKeys(t, roles))
 
 	members := ListAccessMembersOutput{
 		Members:      []AccessMember{{MaskedIdentity: "a***@e***", Roles: []string{"Operators"}, Reference: "opaque-member"}},
@@ -47,17 +47,6 @@ func TestAccessReadOutputsOnlyAllowlistedFields(t *testing.T) {
 	}
 }
 
-func TestAccessMemberFiltersAndMasks(t *testing.T) {
-	t.Parallel()
-
-	roleNames := map[string]string{"role-a": "Operators"}
-	member := &accessgen.AccessMember{ID: "user-internal", PrincipalUrn: "user:user-internal", Name: "Ada Lovelace", Email: "ada@example.test", RoleIds: []string{"role-a"}}
-	require.True(t, matchesAccessMember(member, "ada", roleNames))
-	require.True(t, matchesAccessMember(member, "operators", roleNames))
-	require.False(t, matchesAccessMember(member, "finance", roleNames))
-	require.Equal(t, "a**@e***", maskAccessMember(member))
-}
-
 func TestAccessRoleProjectionSummarizesWithoutSelectors(t *testing.T) {
 	t.Parallel()
 
@@ -79,6 +68,11 @@ func TestAccessRoleProjectionSummarizesWithoutSelectors(t *testing.T) {
 	require.False(t, summary.BlockedServers)
 	require.Equal(t, 1, summary.BlockedToolRules)
 	require.Equal(t, []string{"destructive"}, summary.BlockedDispositionRules)
+
+	project = uuid.NewString()
+	summary = summarizeMCPConnect([]*accessgen.RoleGrant{{Scope: string(authz.ScopeMCPBlockedConnect), Selectors: []*accessgen.Selector{{ResourceKind: "mcp", ResourceID: server, ProjectID: &project}}}})
+	require.Equal(t, 1, summary.BlockedProjectRules)
+	require.Equal(t, 1, summary.BlockedServerRules)
 }
 
 func TestRoleAuthzGrantsUseEffectiveExclusions(t *testing.T) {
@@ -108,6 +102,8 @@ func TestAccessSummaryAndKnownToolCoverageCannotOverclaim(t *testing.T) {
 	require.Equal(t, "everyone", accessSummary(platformrepo.GetPlatformMCPInventoryItemRow{Visibility: "public"}))
 	require.Equal(t, "nobody", accessSummary(platformrepo.GetPlatformMCPInventoryItemRow{Visibility: "disabled"}))
 	require.Equal(t, "nobody", accessSummary(platformrepo.GetPlatformMCPInventoryItemRow{Visibility: "private", UnproxiedMcpServerID: uuid.NullUUID{UUID: uuid.New(), Valid: true}}))
+	require.Equal(t, "nobody", accessSummary(platformrepo.GetPlatformMCPInventoryItemRow{Visibility: "public", UnproxiedMcpServerID: uuid.NullUUID{UUID: uuid.New(), Valid: true}}))
+	require.Equal(t, "nobody", accessSummary(platformrepo.GetPlatformMCPInventoryItemRow{Visibility: "future_value"}))
 	require.Equal(t, "by_role", accessSummary(platformrepo.GetPlatformMCPInventoryItemRow{Visibility: "private"}))
 
 	require.Equal(t, "all", knownToolAccess(2, 2, "authoritative", false))

--- a/server/internal/platformmcp/access_reads_test.go
+++ b/server/internal/platformmcp/access_reads_test.go
@@ -1,0 +1,161 @@
+package platformmcp
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	accessgen "github.com/speakeasy-api/gram/server/gen/access"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
+)
+
+func TestAccessReadOutputsOnlyAllowlistedFields(t *testing.T) {
+	t.Parallel()
+
+	roles := ListAccessRolesOutput{Roles: []AccessRole{{
+		Name: "Operators", Type: "custom", MemberCount: NewSubjectCount(7),
+		MCPAccess: MCPConnectSummary{AllServers: false, ProjectRules: 1, ServerRules: 1, ToolRules: 1, DispositionRules: []string{"read_only"}, BlockedServers: false, BlockedToolRules: 0, BlockedDispositionRules: []string{}},
+		Reference: "opaque-role",
+	}}, ExpiresAt: "2026-09-04T12:10:00Z"}
+	require.ElementsMatch(t, []string{"roles", "name", "type", "member_count", "mcp_access", "all_servers", "project_rules", "server_rules", "tool_rules", "disposition_rules", "blocked_servers", "blocked_tool_rules", "blocked_disposition_rules", "reference", "expires_at"}, decodeKeys(t, roles))
+
+	members := ListAccessMembersOutput{
+		Members:      []AccessMember{{MaskedIdentity: "a***@e***", Roles: []string{"Operators"}, Reference: "opaque-member"}},
+		TotalMatches: NewSubjectCount(7), Suppressed: false, Truncated: false, ExpiresAt: "2026-09-04T12:10:00Z",
+	}
+	require.ElementsMatch(t, []string{"members", "masked_identity", "roles", "reference", "total_matches", "suppressed", "truncated", "expires_at"}, decodeKeys(t, members))
+
+	access := GetMCPAccessOutput{
+		ProjectID: uuid.NewString(),
+		MCP:       MCPAccessTarget{ID: uuid.NewString(), Name: "Tasks", Backend: "remote", Visibility: "private", AuthorizationMode: "rbac", AuthorizationSurface: "configured_endpoint", AccessSummary: "by_role", ToolCatalog: "stored_metadata", Tools: []MCPAccessTool{{Name: "list_tasks", Disposition: "read_only"}}},
+		Roles:     []MCPRoleCoverage{{Name: "Operators", Type: "custom", MemberCount: NewSubjectCount(7), Reference: "opaque-role", CanEnterServer: true, KnownToolAccess: "all", AllowedKnownTools: []string{"list_tasks"}, DispositionRules: []string{"read_only"}, BlockedDispositions: []string{}, UnevaluatedGrants: false}},
+		ExpiresAt: "2026-09-04T12:10:00Z",
+	}
+	keys := decodeKeys(t, access)
+	require.ElementsMatch(t, []string{
+		"project_id", "mcp", "id", "name", "backend", "visibility", "authorization_mode", "authorization_surface", "access_summary", "tool_catalog", "tools", "name", "tools_truncated", "disposition",
+		"roles", "name", "type", "member_count", "reference", "can_enter_server", "known_tool_access", "allowed_known_tools", "disposition_rules", "blocked_dispositions", "unevaluated_grants", "expires_at",
+	}, keys)
+	encoded, err := json.Marshal(access)
+	require.NoError(t, err)
+	for _, forbidden := range []string{"principal_urn", "user_id", "role_id", "email", "selector", "resource_id"} {
+		require.NotContains(t, string(encoded), forbidden)
+	}
+}
+
+func TestAccessMemberFiltersAndMasks(t *testing.T) {
+	t.Parallel()
+
+	roleNames := map[string]string{"role-a": "Operators"}
+	member := &accessgen.AccessMember{ID: "user-internal", PrincipalUrn: "user:user-internal", Name: "Ada Lovelace", Email: "ada@example.test", RoleIds: []string{"role-a"}}
+	require.True(t, matchesAccessMember(member, "ada", roleNames))
+	require.True(t, matchesAccessMember(member, "operators", roleNames))
+	require.False(t, matchesAccessMember(member, "finance", roleNames))
+	require.Equal(t, "a**@e***", maskAccessMember(member))
+}
+
+func TestAccessRoleProjectionSummarizesWithoutSelectors(t *testing.T) {
+	t.Parallel()
+
+	readOnly := "read_only"
+	project := uuid.NewString()
+	server := uuid.NewString()
+	summary := summarizeMCPConnect([]*accessgen.RoleGrant{
+		{Scope: string(authz.ScopeMCPConnect), Selectors: []*accessgen.Selector{{ResourceKind: "mcp", ResourceID: server, Tool: new("list_tasks")}}},
+		{Scope: string(authz.ScopeMCPRead), Selectors: []*accessgen.Selector{{ResourceKind: "mcp", ResourceID: authz.WildcardResource, ProjectID: &project, Disposition: &readOnly}}},
+	})
+	require.False(t, summary.AllServers)
+	require.Equal(t, 1, summary.ProjectRules)
+	require.Equal(t, 1, summary.ServerRules)
+	require.Equal(t, 1, summary.ToolRules)
+	require.Equal(t, []string{"read_only"}, summary.DispositionRules)
+
+	blocked := "destructive"
+	summary = summarizeMCPConnect([]*accessgen.RoleGrant{{Scope: string(authz.ScopeMCPBlockedConnect), Selectors: []*accessgen.Selector{{ResourceKind: "mcp", ResourceID: authz.WildcardResource, Tool: new("delete_tasks"), Disposition: &blocked}}}})
+	require.False(t, summary.BlockedServers)
+	require.Equal(t, 1, summary.BlockedToolRules)
+	require.Equal(t, []string{"destructive"}, summary.BlockedDispositionRules)
+}
+
+func TestRoleAuthzGrantsUseEffectiveExclusions(t *testing.T) {
+	t.Parallel()
+
+	server := uuid.NewString()
+	tool := "delete_tasks"
+	role := &accessgen.Role{PrincipalUrn: "role:organization:" + uuid.NewString(), Grants: []*accessgen.RoleGrant{
+		{Scope: string(authz.ScopeMCPConnect), Selectors: []*accessgen.Selector{{ResourceKind: "mcp", ResourceID: server}}},
+		{Scope: string(authz.ScopeMCPBlockedConnect), Selectors: []*accessgen.Selector{{ResourceKind: "mcp", ResourceID: server, Tool: &tool}}},
+	}}
+	grants, unevaluated := roleAuthzGrants(role)
+	require.False(t, unevaluated)
+
+	serverAllowed, err := authz.GrantsAuthorize(grants, authz.MCPCheck(authz.ScopeMCPConnect, server, uuid.NewString()))
+	require.NoError(t, err)
+	require.True(t, serverAllowed, "a tool-specific exclusion does not block the server-level check")
+
+	toolAllowed, err := authz.GrantsAuthorize(grants, authz.MCPToolCallCheck(server, authz.MCPToolCallDimensions{Tool: tool}))
+	require.NoError(t, err)
+	require.False(t, toolAllowed)
+}
+
+func TestAccessSummaryAndKnownToolCoverageCannotOverclaim(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "everyone", accessSummary(platformrepo.GetPlatformMCPInventoryItemRow{Visibility: "public"}))
+	require.Equal(t, "nobody", accessSummary(platformrepo.GetPlatformMCPInventoryItemRow{Visibility: "disabled"}))
+	require.Equal(t, "nobody", accessSummary(platformrepo.GetPlatformMCPInventoryItemRow{Visibility: "private", UnproxiedMcpServerID: uuid.NullUUID{UUID: uuid.New(), Valid: true}}))
+	require.Equal(t, "by_role", accessSummary(platformrepo.GetPlatformMCPInventoryItemRow{Visibility: "private"}))
+
+	require.Equal(t, "all", knownToolAccess(2, 2, "authoritative", false))
+	require.Equal(t, "some_known_tools", knownToolAccess(100, 100, "authoritative", true))
+	require.Equal(t, "not_enumerable", knownToolAccess(0, 0, "dynamic", false))
+}
+
+func TestAmbiguousAccessToolsAreOmitted(t *testing.T) {
+	t.Parallel()
+
+	tools := omitAmbiguousAccessTools([]MCPAccessTool{
+		{Name: "alpha", Disposition: "read_only"},
+		{Name: "shared", Disposition: "destructive"},
+		{Name: "shared", Disposition: "read_only"},
+		{Name: "zeta", Disposition: ""},
+	})
+	require.Equal(t, []MCPAccessTool{{Name: "alpha", Disposition: "read_only"}, {Name: "zeta", Disposition: ""}}, tools)
+}
+
+func TestRoleAuthzGrantsSkipsLegacyMalformedSelectors(t *testing.T) {
+	t.Parallel()
+
+	role := &accessgen.Role{PrincipalUrn: "role:organization:" + uuid.NewString(), Grants: []*accessgen.RoleGrant{{
+		Scope: string(authz.ScopeMCPConnect), Selectors: []*accessgen.Selector{{ResourceKind: "project", ResourceID: uuid.NewString()}},
+	}}}
+	grants, unevaluated := roleAuthzGrants(role)
+	require.True(t, unevaluated)
+	require.Empty(t, grants)
+}
+
+func TestAccessReferencesAreBoundByKindPrincipalAndExpiry(t *testing.T) {
+	t.Parallel()
+
+	codec, err := newSubjectReferenceCodec("access-read-test-key")
+	require.NoError(t, err)
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	principal := Principal{UserID: "user-a", OrganizationID: "org-a", ConnectionID: "connection-a", Generation: "generation-a"}
+	reference, err := codec.Encode(principal, subjectKindAccessMember, "internal-user-id", now)
+	require.NoError(t, err)
+	require.NotContains(t, reference, "internal-user-id")
+
+	value, err := codec.Decode(reference, principal, subjectKindAccessMember, now)
+	require.NoError(t, err)
+	require.Equal(t, "internal-user-id", value)
+	_, err = codec.Decode(reference, principal, subjectKindAccessRole, now)
+	require.ErrorIs(t, err, ErrSubjectReferenceNotFound)
+	_, err = codec.Decode(reference, Principal{UserID: "user-b", OrganizationID: "org-a", ConnectionID: "connection-b", Generation: "generation-b"}, subjectKindAccessMember, now)
+	require.ErrorIs(t, err, ErrSubjectReferenceNotFound)
+	_, err = codec.Decode(reference, principal, subjectKindAccessMember, now.Add(SubjectReferenceTTL))
+	require.ErrorIs(t, err, ErrSubjectReferenceNotFound)
+}

--- a/server/internal/platformmcp/access_reads_test.go
+++ b/server/internal/platformmcp/access_reads_test.go
@@ -19,9 +19,9 @@ func TestAccessReadOutputsOnlyAllowlistedFields(t *testing.T) {
 	roles := ListAccessRolesOutput{Roles: []AccessRole{{
 		Name: "Operators", Type: "custom", MemberCount: NewSubjectCount(7),
 		MCPAccess: MCPConnectSummary{AllServers: false, ProjectRules: 1, ServerRules: 1, ToolRules: 1, DispositionRules: []string{"read_only"}, BlockedServers: false, BlockedProjectRules: 1, BlockedServerRules: 1, BlockedToolRules: 0, BlockedDispositionRules: []string{}},
-		Reference: "opaque-role",
+		Reference: "opaque-role", Version: "opaque-version",
 	}}, ExpiresAt: "2026-09-04T12:10:00Z"}
-	require.ElementsMatch(t, []string{"roles", "name", "type", "member_count", "mcp_access", "all_servers", "project_rules", "server_rules", "tool_rules", "disposition_rules", "blocked_servers", "blocked_project_rules", "blocked_server_rules", "blocked_tool_rules", "blocked_disposition_rules", "reference", "expires_at"}, decodeKeys(t, roles))
+	require.ElementsMatch(t, []string{"roles", "name", "type", "member_count", "mcp_access", "all_servers", "project_rules", "server_rules", "tool_rules", "disposition_rules", "blocked_servers", "blocked_project_rules", "blocked_server_rules", "blocked_tool_rules", "blocked_disposition_rules", "reference", "version", "expires_at"}, decodeKeys(t, roles))
 
 	members := ListAccessMembersOutput{
 		Members:      []AccessMember{{MaskedIdentity: "a***@e***", Roles: []string{"Operators"}, Reference: "opaque-member"}},
@@ -32,13 +32,13 @@ func TestAccessReadOutputsOnlyAllowlistedFields(t *testing.T) {
 	access := GetMCPAccessOutput{
 		ProjectID: uuid.NewString(),
 		MCP:       MCPAccessTarget{ID: uuid.NewString(), Name: "Tasks", Backend: "remote", Visibility: "private", AuthorizationMode: "rbac", AuthorizationSurface: "configured_endpoint", AccessSummary: "by_role", ToolCatalog: "stored_metadata", Tools: []MCPAccessTool{{Name: "list_tasks", Disposition: "read_only"}}},
-		Roles:     []MCPRoleCoverage{{Name: "Operators", Type: "custom", MemberCount: NewSubjectCount(7), Reference: "opaque-role", CanEnterServer: true, KnownToolAccess: "all", AllowedKnownTools: []string{"list_tasks"}, DispositionRules: []string{"read_only"}, BlockedDispositions: []string{}, UnevaluatedGrants: false}},
+		Roles:     []MCPRoleCoverage{{Name: "Operators", Type: "custom", MemberCount: NewSubjectCount(7), Reference: "opaque-role", Version: "opaque-version", CanEnterServer: true, KnownToolAccess: "all", AllowedKnownTools: []string{"list_tasks"}, DispositionRules: []string{"read_only"}, BlockedDispositions: []string{}, UnevaluatedGrants: false}},
 		ExpiresAt: "2026-09-04T12:10:00Z",
 	}
 	keys := decodeKeys(t, access)
 	require.ElementsMatch(t, []string{
 		"project_id", "mcp", "id", "name", "backend", "visibility", "authorization_mode", "authorization_surface", "access_summary", "tool_catalog", "tools", "name", "tools_truncated", "disposition",
-		"roles", "name", "type", "member_count", "reference", "can_enter_server", "known_tool_access", "allowed_known_tools", "disposition_rules", "blocked_dispositions", "unevaluated_grants", "expires_at",
+		"roles", "name", "type", "member_count", "reference", "version", "can_enter_server", "known_tool_access", "allowed_known_tools", "disposition_rules", "blocked_dispositions", "unevaluated_grants", "expires_at",
 	}, keys)
 	encoded, err := json.Marshal(access)
 	require.NoError(t, err)

--- a/server/internal/platformmcp/access_role_mutation_receipt.go
+++ b/server/internal/platformmcp/access_role_mutation_receipt.go
@@ -63,11 +63,15 @@ func (s *AccessRoleMutationReceiptStore) execute(ctx context.Context, principal 
 		Invalid: func(cause error) error {
 			return &AccessRoleMutationError{Code: "invalid_request", Message: "The access role mutation caller identity is invalid.", Cause: fmt.Errorf("%w: %w", ErrAccessRoleMutationInvalid, cause)}
 		},
-		Conflict:       accessRoleMutationConflict,
-		Unavailable:    accessRoleMutationUnavailable,
-		ValidateReplay: validAccessRoleMutationReceiptPayload,
-		EncodeResult:   encodeAccessRoleMutationReceipt,
-		Mutate:         mutate,
+		Conflict:    accessRoleMutationConflict,
+		Unavailable: accessRoleMutationUnavailable,
+		ValidateReplay: func(payload []byte) bool {
+			return validAccessRoleMutationReceiptPayload(operation, payload)
+		},
+		EncodeResult: func(result AccessRoleMutationReceiptResult) ([]byte, error) {
+			return encodeAccessRoleMutationReceipt(operation, result)
+		},
+		Mutate: mutate,
 	})
 }
 
@@ -87,8 +91,8 @@ func accessRoleMutationOperation(operation string) bool {
 	return operation == operationCreateMCPAccessRole || operation == operationUpdateMCPAccessRole
 }
 
-func encodeAccessRoleMutationReceipt(result AccessRoleMutationReceiptResult) ([]byte, error) {
-	if !validAccessRoleMutationReceiptResult(result) {
+func encodeAccessRoleMutationReceipt(operation string, result AccessRoleMutationReceiptResult) ([]byte, error) {
+	if !validAccessRoleMutationReceiptResult(operation, result) {
 		return nil, accessRoleMutationUnavailable(errors.New("unsafe access role mutation receipt result"))
 	}
 	payload, err := json.Marshal(result)
@@ -101,9 +105,9 @@ func encodeAccessRoleMutationReceipt(result AccessRoleMutationReceiptResult) ([]
 	return payload, nil
 }
 
-func decodeAccessRoleMutationReceipt(payload []byte) (AccessRoleMutationReceiptResult, error) {
+func decodeAccessRoleMutationReceipt(operation string, payload []byte) (AccessRoleMutationReceiptResult, error) {
 	var result AccessRoleMutationReceiptResult
-	if !validAccessRoleMutationReceiptPayload(payload) {
+	if !validAccessRoleMutationReceiptPayload(operation, payload) {
 		return result, accessRoleMutationUnavailable(errors.New("invalid access role mutation replay payload"))
 	}
 	decoder := json.NewDecoder(bytes.NewReader(payload))
@@ -114,24 +118,33 @@ func decodeAccessRoleMutationReceipt(payload []byte) (AccessRoleMutationReceiptR
 	return result, nil
 }
 
-func validAccessRoleMutationReceiptPayload(payload []byte) bool {
+func validAccessRoleMutationReceiptPayload(operation string, payload []byte) bool {
 	if len(payload) == 0 || len(payload) > maxAccessRoleMutationReceiptPayloadBytes {
 		return false
 	}
 	decoder := json.NewDecoder(bytes.NewReader(payload))
 	decoder.DisallowUnknownFields()
 	var result AccessRoleMutationReceiptResult
-	if decoder.Decode(&result) != nil || !validAccessRoleMutationReceiptResult(result) {
+	if decoder.Decode(&result) != nil || !validAccessRoleMutationReceiptResult(operation, result) {
 		return false
 	}
 	return decoder.Decode(&struct{}{}) == io.EOF
 }
 
-func validAccessRoleMutationReceiptResult(result AccessRoleMutationReceiptResult) bool {
+func validAccessRoleMutationReceiptResult(operation string, result AccessRoleMutationReceiptResult) bool {
 	if uuid.Validate(result.RoleID) != nil || result.RoleSlug == "" || strings.TrimSpace(result.Name) == "" || !validAccessRoleVersion(result.Version) {
 		return false
 	}
-	if result.ResultCategory != "created" && result.ResultCategory != "updated" {
+	expectedCategory := ""
+	switch operation {
+	case operationCreateMCPAccessRole:
+		expectedCategory = "created"
+	case operationUpdateMCPAccessRole:
+		expectedCategory = "updated"
+	default:
+		return false
+	}
+	if result.ResultCategory != expectedCategory {
 		return false
 	}
 	return result.Reconciliation == "complete" || result.Reconciliation == "pending"

--- a/server/internal/platformmcp/access_role_mutation_receipt.go
+++ b/server/internal/platformmcp/access_role_mutation_receipt.go
@@ -1,0 +1,138 @@
+package platformmcp
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const maxAccessRoleMutationReceiptPayloadBytes = 16 << 10
+
+type AccessRoleMutationReceiptResult struct {
+	RoleID         string            `json:"role_id"`
+	RoleSlug       string            `json:"role_slug"`
+	Name           string            `json:"name"`
+	Description    string            `json:"description,omitempty"`
+	Version        string            `json:"version"`
+	MCPAccess      MCPConnectSummary `json:"mcp_access"`
+	ResultCategory string            `json:"result_category"`
+	Reconciliation string            `json:"reconciliation"`
+}
+
+type AccessRoleMutationTransaction func(context.Context, pgx.Tx) (AccessRoleMutationReceiptResult, error)
+
+type AccessRoleMutationReceiptStore struct {
+	db  *pgxpool.Pool
+	now func() time.Time
+}
+
+func NewAccessRoleMutationReceiptStore(db *pgxpool.Pool) *AccessRoleMutationReceiptStore {
+	return &AccessRoleMutationReceiptStore{db: db, now: time.Now}
+}
+
+func (s *AccessRoleMutationReceiptStore) ExecuteCreate(ctx context.Context, principal Principal, project ResolvedProject, idempotencyKey string, normalized normalizedCreateMCPAccessRole, mutate AccessRoleMutationTransaction) (OperationReceipt, error) {
+	return s.execute(ctx, principal, project, operationCreateMCPAccessRole, idempotencyKey, normalized, mutate)
+}
+
+func (s *AccessRoleMutationReceiptStore) ExecuteUpdate(ctx context.Context, principal Principal, project ResolvedProject, idempotencyKey string, normalized normalizedUpdateMCPAccessRole, mutate AccessRoleMutationTransaction) (OperationReceipt, error) {
+	return s.execute(ctx, principal, project, operationUpdateMCPAccessRole, idempotencyKey, normalized, mutate)
+}
+
+func (s *AccessRoleMutationReceiptStore) execute(ctx context.Context, principal Principal, project ResolvedProject, operation, idempotencyKey string, normalized any, mutate AccessRoleMutationTransaction) (OperationReceipt, error) {
+	if s == nil || s.db == nil || s.now == nil || mutate == nil || !accessRoleMutationOperation(operation) || idempotencyKey == "" || len(idempotencyKey) > 128 {
+		return OperationReceipt{}, accessRoleMutationInvalid("The access role receipt request is invalid.")
+	}
+	inputHash, err := accessRoleMutationInputHash(operation, normalized)
+	if err != nil {
+		return OperationReceipt{}, accessRoleMutationInvalid("The access role mutation could not be normalized.")
+	}
+	return executeMutationReceipt(ctx, mutationReceiptExecution[AccessRoleMutationReceiptResult]{
+		DB: s.db, Now: s.now, Principal: principal, Project: project, Operation: operation,
+		IdempotencyKey: idempotencyKey, InputHash: inputHash, Label: "access role",
+		Invalid: func(cause error) error {
+			return &AccessRoleMutationError{Code: "invalid_request", Message: "The access role mutation caller identity is invalid.", Cause: fmt.Errorf("%w: %w", ErrAccessRoleMutationInvalid, cause)}
+		},
+		Conflict:       accessRoleMutationConflict,
+		Unavailable:    accessRoleMutationUnavailable,
+		ValidateReplay: validAccessRoleMutationReceiptPayload,
+		EncodeResult:   encodeAccessRoleMutationReceipt,
+		Mutate:         mutate,
+	})
+}
+
+func accessRoleMutationInputHash(operation string, normalized any) (string, error) {
+	if !accessRoleMutationOperation(operation) || normalized == nil {
+		return "", ErrAccessRoleMutationInvalid
+	}
+	payload, err := json.Marshal(normalized)
+	if err != nil {
+		return "", fmt.Errorf("encode normalized access role mutation input: %w", err)
+	}
+	digest := sha256.Sum256(append([]byte("platform-mcp-access-role-mutation-v1\x00"+operation+"\x00"), payload...))
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func accessRoleMutationOperation(operation string) bool {
+	return operation == operationCreateMCPAccessRole || operation == operationUpdateMCPAccessRole
+}
+
+func encodeAccessRoleMutationReceipt(result AccessRoleMutationReceiptResult) ([]byte, error) {
+	if !validAccessRoleMutationReceiptResult(result) {
+		return nil, accessRoleMutationUnavailable(errors.New("unsafe access role mutation receipt result"))
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("encode access role mutation receipt: %w", err)
+	}
+	if len(payload) == 0 || len(payload) > maxAccessRoleMutationReceiptPayloadBytes {
+		return nil, accessRoleMutationUnavailable(errors.New("access role mutation receipt result is too large"))
+	}
+	return payload, nil
+}
+
+func decodeAccessRoleMutationReceipt(payload []byte) (AccessRoleMutationReceiptResult, error) {
+	var result AccessRoleMutationReceiptResult
+	if !validAccessRoleMutationReceiptPayload(payload) {
+		return result, accessRoleMutationUnavailable(errors.New("invalid access role mutation replay payload"))
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&result); err != nil {
+		return AccessRoleMutationReceiptResult{}, accessRoleMutationUnavailable(err)
+	}
+	return result, nil
+}
+
+func validAccessRoleMutationReceiptPayload(payload []byte) bool {
+	if len(payload) == 0 || len(payload) > maxAccessRoleMutationReceiptPayloadBytes {
+		return false
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	var result AccessRoleMutationReceiptResult
+	if decoder.Decode(&result) != nil || !validAccessRoleMutationReceiptResult(result) {
+		return false
+	}
+	return decoder.Decode(&struct{}{}) == io.EOF
+}
+
+func validAccessRoleMutationReceiptResult(result AccessRoleMutationReceiptResult) bool {
+	if uuid.Validate(result.RoleID) != nil || result.RoleSlug == "" || strings.TrimSpace(result.Name) == "" || !validAccessRoleVersion(result.Version) {
+		return false
+	}
+	if result.ResultCategory != "created" && result.ResultCategory != "updated" {
+		return false
+	}
+	return result.Reconciliation == "complete" || result.Reconciliation == "pending"
+}

--- a/server/internal/platformmcp/access_role_mutations.go
+++ b/server/internal/platformmcp/access_role_mutations.go
@@ -1,0 +1,613 @@
+package platformmcp
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	accessgen "github.com/speakeasy-api/gram/server/gen/access"
+	"github.com/speakeasy-api/gram/server/internal/access"
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	organizationsrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+const (
+	operationCreateMCPAccessRole = "create_mcp_access_role"
+	operationUpdateMCPAccessRole = "update_mcp_access_role"
+
+	maxAccessRoleMutationRules       = 100
+	maxAccessRoleMutationNameRunes   = 128
+	maxAccessRoleMutationDescription = 1000
+)
+
+var (
+	ErrAccessRoleMutationUnavailable = errors.New("platform mcp access role mutations unavailable")
+	ErrAccessRoleMutationInvalid     = errors.New("invalid platform mcp access role mutation")
+	ErrAccessRoleMutationNotFound    = errors.New("platform mcp access role mutation target not found")
+	ErrAccessRoleMutationConflict    = errors.New("platform mcp access role mutation conflict")
+)
+
+// AccessRoleMutationError is safe to return through Platform MCP. It never
+// includes a role ID, principal, grant selector, or configured MCP ID.
+type AccessRoleMutationError struct {
+	Code    string
+	Message string
+	Cause   error
+}
+
+func (e *AccessRoleMutationError) Error() string { return e.Message }
+func (e *AccessRoleMutationError) Unwrap() error { return e.Cause }
+
+// MCPAccessRoleRule is a caller-facing request for one server-generated
+// mcp:connect selector. MCPID must be a configured MCP returned for the explicit
+// project. Tool, when present, is accepted only from an enumerable current
+// catalog. Disposition is a closed annotation class, never an open selector.
+type MCPAccessRoleRule struct {
+	MCPID       string `json:"mcp_id" jsonschema:"configured MCP ID returned by find_mcp for the explicit project"`
+	Tool        string `json:"tool,omitempty" jsonschema:"optional exact tool name currently returned by get_mcp_access"`
+	Disposition string `json:"disposition,omitempty" jsonschema:"optional closed tool disposition: read_only, destructive, idempotent, or open_world"`
+}
+
+type CreateMCPAccessRoleInput struct {
+	ProjectID      string              `json:"project_id" jsonschema:"explicit project ID that owns every configured MCP in rules"`
+	Name           string              `json:"name" jsonschema:"display name for the new custom role"`
+	Description    string              `json:"description,omitempty" jsonschema:"optional description for the new custom role"`
+	Rules          []MCPAccessRoleRule `json:"rules" jsonschema:"MCP access rules generated only for configured MCP IDs in this project"`
+	IdempotencyKey string              `json:"idempotency_key" jsonschema:"stable unique key for safely retrying this exact write"`
+	Confirmed      bool                `json:"confirmed" jsonschema:"set true only after the user confirms this exact project, role, and MCP access delta"`
+}
+
+type UpdateMCPAccessRoleInput struct {
+	ProjectID       string              `json:"project_id" jsonschema:"explicit project ID that owns every configured MCP in the delta"`
+	RoleReference   string              `json:"role_reference" jsonschema:"opaque role reference returned by list_access_roles, get_mcp_access, or a role mutation"`
+	ExpectedVersion string              `json:"expected_version" jsonschema:"opaque role version returned by the preceding role mutation"`
+	AddRules        []MCPAccessRoleRule `json:"add_rules,omitempty" jsonschema:"MCP access rules to add without replacing other grants"`
+	RemoveRules     []MCPAccessRoleRule `json:"remove_rules,omitempty" jsonschema:"MCP access rules to remove without replacing other grants"`
+	IdempotencyKey  string              `json:"idempotency_key" jsonschema:"stable unique key for safely retrying this exact write"`
+	Confirmed       bool                `json:"confirmed" jsonschema:"set true only after the user confirms this exact project, role, and MCP access delta"`
+}
+
+type AccessRoleMutationSummary struct {
+	Name        string            `json:"name"`
+	Description string            `json:"description,omitempty"`
+	Reference   string            `json:"reference"`
+	Version     string            `json:"version"`
+	MCPAccess   MCPConnectSummary `json:"mcp_access"`
+}
+
+type CreateMCPAccessRoleOutput struct {
+	Role           AccessRoleMutationSummary `json:"role"`
+	Reconciliation string                    `json:"reconciliation"`
+	Receipt        RiskMutationToolReceipt   `json:"receipt"`
+}
+
+type UpdateMCPAccessRoleOutput struct {
+	Role           AccessRoleMutationSummary `json:"role"`
+	Reconciliation string                    `json:"reconciliation"`
+	Receipt        RiskMutationToolReceipt   `json:"receipt"`
+}
+
+// AccessRoleMutationBackend matches the transaction-scoped access manager API.
+type AccessRoleMutationBackend interface {
+	MutationReady() bool
+	GetRoleByIDTx(context.Context, pgx.Tx, string, string) (*accessgen.Role, error)
+	CreateRoleTx(context.Context, pgx.Tx, string, string, access.RoleAuditActor, *accessgen.CreateRolePayload) (access.RoleCreateResult, access.RoleReconciliation, error)
+	UpdateRoleTx(context.Context, pgx.Tx, string, string, access.RoleAuditActor, *accessgen.UpdateRolePayload) (access.RoleUpdateResult, access.RoleReconciliation, error)
+	ReconcileRoleIdentity(context.Context, string, string, string, string, bool)
+}
+
+type normalizedMCPAccessRoleRule struct {
+	MCPID       string `json:"mcp_id"`
+	Tool        string `json:"tool,omitempty"`
+	Disposition string `json:"disposition,omitempty"`
+}
+
+type normalizedCreateMCPAccessRole struct {
+	ProjectID   string                        `json:"project_id"`
+	Name        string                        `json:"name"`
+	Description string                        `json:"description,omitempty"`
+	Rules       []normalizedMCPAccessRoleRule `json:"rules"`
+}
+
+type normalizedUpdateMCPAccessRole struct {
+	ProjectID       string                        `json:"project_id"`
+	RoleID          string                        `json:"role_id"`
+	ExpectedVersion string                        `json:"expected_version"`
+	AddRules        []normalizedMCPAccessRoleRule `json:"add_rules"`
+	RemoveRules     []normalizedMCPAccessRoleRule `json:"remove_rules"`
+}
+
+type AccessRoleMutationService struct {
+	reads      *AccessReadService
+	flags      feature.Provider
+	budget     OperationBudget
+	backend    AccessRoleMutationBackend
+	receipts   *AccessRoleMutationReceiptStore
+	versionKey []byte
+}
+
+func NewAccessRoleMutationService(reads *AccessReadService, flags feature.Provider, budget OperationBudget, keyMaterial string, backend AccessRoleMutationBackend) (*AccessRoleMutationService, error) {
+	if reads == nil || reads.db == nil || reads.references == nil || reads.now == nil || flags == nil || !budget.valid() || keyMaterial == "" || backend == nil || !backend.MutationReady() {
+		return nil, ErrAccessRoleMutationUnavailable
+	}
+	key := sha256.Sum256([]byte("platform-mcp-access-role-version:" + keyMaterial))
+	return &AccessRoleMutationService{
+		reads: reads, flags: flags, budget: budget, backend: backend,
+		receipts: NewAccessRoleMutationReceiptStore(reads.db), versionKey: key[:],
+	}, nil
+}
+
+func (s *AccessRoleMutationService) valid() bool {
+	return s != nil && s.reads != nil && s.reads.valid() && s.flags != nil && s.budget.valid() && s.backend != nil && s.receipts != nil && len(s.versionKey) == sha256.Size
+}
+
+func (s *AccessRoleMutationService) Create(ctx context.Context, principal Principal, input CreateMCPAccessRoleInput) (CreateMCPAccessRoleOutput, error) {
+	if !input.Confirmed {
+		return CreateMCPAccessRoleOutput{}, accessRoleMutationConfirmationRequired()
+	}
+	if !s.valid() {
+		return CreateMCPAccessRoleOutput{}, accessRoleMutationUnavailable(nil)
+	}
+	name, description, idempotencyKey, err := normalizeAccessRoleIdentity(input.Name, input.Description, input.IdempotencyKey)
+	if err != nil {
+		return CreateMCPAccessRoleOutput{}, err
+	}
+	project, workosOrgID, err := s.admit(ctx, principal, input.ProjectID)
+	if err != nil {
+		return CreateMCPAccessRoleOutput{}, err
+	}
+	rules, err := s.resolveRules(ctx, principal, project, input.Rules, true, make(map[uuid.UUID]accessRoleRuleTarget))
+	if err != nil {
+		return CreateMCPAccessRoleOutput{}, err
+	}
+	if len(rules) == 0 {
+		return CreateMCPAccessRoleOutput{}, accessRoleMutationInvalid("At least one MCP access rule is required to create an MCP access role.")
+	}
+	normalized := normalizedCreateMCPAccessRole{ProjectID: project.ID.String(), Name: name, Description: description, Rules: rules}
+	receipt, err := s.receipts.ExecuteCreate(ctx, principal, project, idempotencyKey, normalized, func(ctx context.Context, tx pgx.Tx) (AccessRoleMutationReceiptResult, error) {
+		result, _, err := s.backend.CreateRoleTx(ctx, tx, principal.OrganizationID, workosOrgID, access.RoleAuditActor{Principal: urn.NewPrincipal(urn.PrincipalTypeUser, principal.UserID), DisplayName: nil}, &accessgen.CreateRolePayload{ApikeyToken: nil, SessionToken: nil, Name: name, Description: conv.PtrEmpty(description), Grants: accessRoleRulesToGenGrants(rules, project.ID), MemberIds: nil})
+		if err != nil {
+			return AccessRoleMutationReceiptResult{}, classifyAccessRoleBackendError(err)
+		}
+		return s.receiptResult(result.Role, result.Slug, "created", "pending")
+	})
+	if err != nil {
+		return CreateMCPAccessRoleOutput{}, err
+	}
+	result, err := decodeAccessRoleMutationReceipt(receipt.ResultPayload)
+	if err != nil {
+		return CreateMCPAccessRoleOutput{}, err
+	}
+	s.backend.ReconcileRoleIdentity(ctx, workosOrgID, result.RoleSlug, result.Name, result.Description, true)
+	summary, err := s.outputSummary(principal, result)
+	if err != nil {
+		return CreateMCPAccessRoleOutput{}, err
+	}
+	return CreateMCPAccessRoleOutput{Role: summary, Reconciliation: result.Reconciliation, Receipt: riskMutationToolReceipt(receipt)}, nil
+}
+
+func (s *AccessRoleMutationService) Update(ctx context.Context, principal Principal, input UpdateMCPAccessRoleInput) (UpdateMCPAccessRoleOutput, error) {
+	if !input.Confirmed {
+		return UpdateMCPAccessRoleOutput{}, accessRoleMutationConfirmationRequired()
+	}
+	if !s.valid() {
+		return UpdateMCPAccessRoleOutput{}, accessRoleMutationUnavailable(nil)
+	}
+	input.ProjectID = strings.TrimSpace(input.ProjectID)
+	input.RoleReference = strings.TrimSpace(input.RoleReference)
+	input.ExpectedVersion = strings.TrimSpace(input.ExpectedVersion)
+	input.IdempotencyKey = strings.TrimSpace(input.IdempotencyKey)
+	if principal.UserID == "" || input.RoleReference == "" || !validAccessRoleVersion(input.ExpectedVersion) || input.IdempotencyKey == "" || len(input.IdempotencyKey) > 128 {
+		return UpdateMCPAccessRoleOutput{}, accessRoleMutationInvalid("The access role update request is invalid.")
+	}
+	if len(input.AddRules) == 0 && len(input.RemoveRules) == 0 {
+		return UpdateMCPAccessRoleOutput{}, accessRoleMutationInvalid("Supply at least one MCP access rule to add or remove.")
+	}
+	project, workosOrgID, err := s.admit(ctx, principal, input.ProjectID)
+	if err != nil {
+		return UpdateMCPAccessRoleOutput{}, err
+	}
+	roleID, err := s.reads.references.Decode(input.RoleReference, principal, subjectKindAccessRole, s.reads.now().UTC())
+	if err != nil {
+		return UpdateMCPAccessRoleOutput{}, accessRoleMutationNotFound()
+	}
+	targets := make(map[uuid.UUID]accessRoleRuleTarget)
+	addRules, err := s.resolveRules(ctx, principal, project, input.AddRules, true, targets)
+	if err != nil {
+		return UpdateMCPAccessRoleOutput{}, err
+	}
+	// Removal only narrows access. Validate its closed shape, but do not require
+	// the server or tool to remain in today's catalog: stale grants must stay
+	// removable after a server is deleted or its dynamic catalog changes.
+	removeRules, err := s.resolveRules(ctx, principal, project, input.RemoveRules, false, targets)
+	if err != nil {
+		return UpdateMCPAccessRoleOutput{}, err
+	}
+	if overlappingAccessRoleRules(addRules, removeRules) {
+		return UpdateMCPAccessRoleOutput{}, accessRoleMutationInvalid("The same MCP access rule cannot be both added and removed.")
+	}
+	normalized := normalizedUpdateMCPAccessRole{
+		ProjectID: project.ID.String(), RoleID: roleID, ExpectedVersion: input.ExpectedVersion,
+		AddRules: addRules, RemoveRules: removeRules,
+	}
+	receipt, err := s.receipts.ExecuteUpdate(ctx, principal, project, input.IdempotencyKey, normalized, func(ctx context.Context, tx pgx.Tx) (AccessRoleMutationReceiptResult, error) {
+		roleUUID, parseErr := uuid.Parse(roleID)
+		if parseErr != nil || roleUUID == uuid.Nil {
+			return AccessRoleMutationReceiptResult{}, accessRoleMutationNotFound()
+		}
+		if _, lockErr := accessrepo.New(tx).LockOrganizationRoleByID(ctx, accessrepo.LockOrganizationRoleByIDParams{OrganizationID: principal.OrganizationID, ID: roleUUID}); errors.Is(lockErr, pgx.ErrNoRows) {
+			return AccessRoleMutationReceiptResult{}, accessRoleMutationNotFound()
+		} else if lockErr != nil {
+			return AccessRoleMutationReceiptResult{}, accessRoleMutationUnavailable(lockErr)
+		}
+		current, readErr := s.backend.GetRoleByIDTx(ctx, tx, principal.OrganizationID, roleID)
+		if readErr != nil {
+			return AccessRoleMutationReceiptResult{}, classifyAccessRoleBackendError(readErr)
+		}
+		if current == nil || current.IsSystem {
+			return AccessRoleMutationReceiptResult{}, accessRoleMutationNotFound()
+		}
+		version, versionErr := s.roleVersion(current)
+		if versionErr != nil || !hmac.Equal([]byte(version), []byte(input.ExpectedVersion)) {
+			return AccessRoleMutationReceiptResult{}, accessRoleMutationConflict("The access role changed after it was read. Read it again and retry with the new version.")
+		}
+		result, _, err := s.backend.UpdateRoleTx(ctx, tx, principal.OrganizationID, workosOrgID, access.RoleAuditActor{Principal: urn.NewPrincipal(urn.PrincipalTypeUser, principal.UserID), DisplayName: nil}, &accessgen.UpdateRolePayload{ApikeyToken: nil, SessionToken: nil, ID: roleID, Name: nil, Description: nil, AddGrants: accessRoleRulesToGenGrants(addRules, project.ID), RemoveGrants: accessRoleRulesToGenGrants(removeRules, project.ID), MemberIds: nil})
+		if err != nil {
+			return AccessRoleMutationReceiptResult{}, classifyAccessRoleBackendError(err)
+		}
+		if result.After == nil {
+			return AccessRoleMutationReceiptResult{}, accessRoleMutationNotFound()
+		}
+		return s.receiptResult(result.After, result.Slug, "updated", "complete")
+	})
+	if err != nil {
+		return UpdateMCPAccessRoleOutput{}, err
+	}
+	result, err := decodeAccessRoleMutationReceipt(receipt.ResultPayload)
+	if err != nil {
+		return UpdateMCPAccessRoleOutput{}, err
+	}
+	summary, err := s.outputSummary(principal, result)
+	if err != nil {
+		return UpdateMCPAccessRoleOutput{}, err
+	}
+	return UpdateMCPAccessRoleOutput{Role: summary, Reconciliation: result.Reconciliation, Receipt: riskMutationToolReceipt(receipt)}, nil
+}
+
+func (s *AccessRoleMutationService) admit(ctx context.Context, principal Principal, projectID string) (ResolvedProject, string, error) {
+	if principal.OrganizationID == "" || principal.UserID == "" {
+		return ResolvedProject{}, "", accessRoleMutationInvalid("An explicit project and attributable user are required for access role mutations.")
+	}
+	parsed, err := uuid.Parse(strings.TrimSpace(projectID))
+	if err != nil || parsed == uuid.Nil {
+		return ResolvedProject{}, "", accessRoleMutationNotFound()
+	}
+	row, err := platformrepo.New(s.reads.db).ResolvePlatformMCPProjectByID(ctx, platformrepo.ResolvePlatformMCPProjectByIDParams{OrganizationID: principal.OrganizationID, ProjectID: parsed})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ResolvedProject{}, "", accessRoleMutationNotFound()
+	}
+	if err != nil {
+		return ResolvedProject{}, "", accessRoleMutationUnavailable(err)
+	}
+	project := ResolvedProject{ID: row.ID, Name: row.Name, Slug: row.Slug}
+	organization, err := organizationsrepo.New(s.reads.db).GetOrganizationMetadata(ctx, principal.OrganizationID)
+	if err != nil {
+		return ResolvedProject{}, "", accessRoleMutationUnavailable(err)
+	}
+	if !organization.WorkosID.Valid || organization.WorkosID.String == "" || organization.Slug == "" {
+		return ResolvedProject{}, "", accessRoleMutationUnavailable(errors.New("organization role provider metadata is unavailable"))
+	}
+	evaluation, err := feature.EvaluateFlag(ctx, s.flags, feature.FlagPlatformMCPAccessRoleMutations, principal.OrganizationID, feature.OrgProjectGroups(organization.Slug, project.Slug))
+	if err != nil || evaluation != feature.EvaluationEnabled {
+		return ResolvedProject{}, "", accessRoleMutationUnavailable(err)
+	}
+	if err := s.budget.AllowConnectionOrOrganization(ctx, principal); err != nil {
+		if errors.Is(err, ErrOperationRateLimited) {
+			return ResolvedProject{}, "", &AccessRoleMutationError{Code: "rate_limited", Message: "The access role mutation rate limit was reached.", Cause: err}
+		}
+		return ResolvedProject{}, "", accessRoleMutationUnavailable(err)
+	}
+	return project, organization.WorkosID.String, nil
+}
+
+type accessRoleRuleTarget struct {
+	catalog   string
+	tools     []MCPAccessTool
+	truncated bool
+}
+
+func (s *AccessRoleMutationService) resolveRules(ctx context.Context, principal Principal, project ResolvedProject, raw []MCPAccessRoleRule, requireCurrentTarget bool, targets map[uuid.UUID]accessRoleRuleTarget) ([]normalizedMCPAccessRoleRule, error) {
+	if len(raw) > maxAccessRoleMutationRules {
+		return nil, accessRoleMutationInvalid("Too many MCP access rules were supplied.")
+	}
+	result := make([]normalizedMCPAccessRoleRule, 0, len(raw))
+	for _, requested := range raw {
+		mcpID, err := uuid.Parse(strings.TrimSpace(requested.MCPID))
+		if err != nil || mcpID == uuid.Nil {
+			return nil, accessRoleMutationNotFound()
+		}
+		tool := strings.TrimSpace(requested.Tool)
+		disposition := strings.ToLower(strings.TrimSpace(requested.Disposition))
+		if tool != "" && (len(tool) > 256 || strings.ContainsAny(tool, "\x00\r\n")) {
+			return nil, accessRoleMutationInvalid("A requested exact tool name is invalid.")
+		}
+		if disposition != "" && !validAccessRoleDisposition(disposition) {
+			return nil, accessRoleMutationInvalid("Rule disposition must be read_only, destructive, idempotent, or open_world.")
+		}
+		if !requireCurrentTarget {
+			result = append(result, normalizedMCPAccessRoleRule{MCPID: mcpID.String(), Tool: tool, Disposition: disposition})
+			continue
+		}
+		target, checked := targets[mcpID]
+		if !checked {
+			target, err = s.resolveRuleTarget(ctx, principal, project, mcpID)
+			if err != nil {
+				return nil, err
+			}
+			targets[mcpID] = target
+		}
+		if tool != "" {
+			if target.catalog == "dynamic" || target.catalog == "unavailable" || target.truncated {
+				return nil, accessRoleMutationInvalid("Exact tool rules require a complete enumerable tool catalog. Use a server or disposition rule instead.")
+			}
+			if !slices.ContainsFunc(target.tools, func(candidate MCPAccessTool) bool { return candidate.Name == tool }) {
+				return nil, accessRoleMutationInvalid("The exact tool is not in the configured MCP's current catalog. Read its access details again rather than guessing a tool name.")
+			}
+		}
+		result = append(result, normalizedMCPAccessRoleRule{MCPID: mcpID.String(), Tool: tool, Disposition: disposition})
+	}
+	slices.SortFunc(result, compareNormalizedAccessRoleRule)
+	return slices.Compact(result), nil
+}
+
+func (s *AccessRoleMutationService) resolveRuleTarget(ctx context.Context, principal Principal, project ResolvedProject, mcpID uuid.UUID) (accessRoleRuleTarget, error) {
+	row, err := platformrepo.New(s.reads.db).GetPlatformMCPInventoryItem(ctx, platformrepo.GetPlatformMCPInventoryItemParams{
+		OrganizationID: principal.OrganizationID, ConnectionID: uuid.NullUUID{UUID: uuid.Nil, Valid: false}, ConnectionGeneration: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+		UserID: inventoryText(principal.UserID), ActingSurface: inventoryText(string(principal.surface())),
+		McpServerID: mcpID, ProjectID: project.ID,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return accessRoleRuleTarget{}, accessRoleMutationNotFound()
+	}
+	if err != nil {
+		return accessRoleRuleTarget{}, accessRoleMutationUnavailable(err)
+	}
+	if accessAuthorizationMode(row) != "rbac" {
+		return accessRoleRuleTarget{}, accessRoleMutationInvalid("MCP access roles can target only active private MCP servers that use role-based access.")
+	}
+	tools, catalog, truncated, err := s.reads.accessTools(ctx, row)
+	if err != nil {
+		return accessRoleRuleTarget{}, accessRoleMutationUnavailable(err)
+	}
+	return accessRoleRuleTarget{catalog: catalog, tools: tools, truncated: truncated}, nil
+}
+
+func accessRoleRulesToGenGrants(rules []normalizedMCPAccessRoleRule, projectID uuid.UUID) []*accessgen.RoleGrant {
+	grants := make([]*accessgen.RoleGrant, 0, len(rules))
+	for _, rule := range rules {
+		scope := authz.ScopeMCPConnect
+		selector := authz.NewSelector(scope, rule.MCPID)
+		selector[authz.SelectorKeyProjectID] = projectID.String()
+		if rule.Tool != "" {
+			selector[authz.SelectorKeyTool] = rule.Tool
+		}
+		if rule.Disposition != "" {
+			selector[authz.SelectorKeyDisposition] = rule.Disposition
+		}
+		generated := &accessgen.Selector{ResourceKind: selector[authz.SelectorKeyResourceKind], ResourceID: selector[authz.SelectorKeyResourceID], Disposition: nil, Tool: nil, ProjectID: nil, ServerURL: nil}
+		if value := selector[authz.SelectorKeyProjectID]; value != "" {
+			generated.ProjectID = &value
+		}
+		if value := selector[authz.SelectorKeyTool]; value != "" {
+			generated.Tool = &value
+		}
+		if value := selector[authz.SelectorKeyDisposition]; value != "" {
+			generated.Disposition = &value
+		}
+		grants = append(grants, &accessgen.RoleGrant{Scope: string(scope), Selectors: []*accessgen.Selector{generated}})
+	}
+	return grants
+}
+
+func (s *AccessRoleMutationService) receiptResult(state *accessgen.Role, roleSlug, category, reconciliation string) (AccessRoleMutationReceiptResult, error) {
+	if state == nil || state.IsSystem || uuid.Validate(state.ID) != nil || roleSlug == "" {
+		return AccessRoleMutationReceiptResult{}, accessRoleMutationUnavailable(errors.New("unsafe role backend result"))
+	}
+	version, err := s.roleVersion(state)
+	if err != nil {
+		return AccessRoleMutationReceiptResult{}, accessRoleMutationUnavailable(err)
+	}
+	return AccessRoleMutationReceiptResult{
+		RoleID: state.ID, RoleSlug: roleSlug, Name: state.Name, Description: state.Description, Version: version,
+		MCPAccess: summarizeMCPConnect(state.Grants), ResultCategory: category, Reconciliation: reconciliation,
+	}, nil
+}
+
+func (s *AccessRoleMutationService) outputSummary(principal Principal, result AccessRoleMutationReceiptResult) (AccessRoleMutationSummary, error) {
+	reference, err := s.reads.references.Encode(principal, subjectKindAccessRole, result.RoleID, s.reads.now().UTC())
+	if err != nil {
+		return AccessRoleMutationSummary{}, accessRoleMutationUnavailable(err)
+	}
+	return AccessRoleMutationSummary{Name: result.Name, Description: result.Description, Reference: reference, Version: result.Version, MCPAccess: result.MCPAccess}, nil
+}
+
+type canonicalAccessRoleVersion struct {
+	RoleID      string                     `json:"role_id"`
+	Name        string                     `json:"name"`
+	Description string                     `json:"description"`
+	Grants      []canonicalAccessRoleGrant `json:"grants"`
+}
+
+type canonicalAccessRoleGrant struct {
+	Scope        string `json:"scope"`
+	ResourceKind string `json:"resource_kind"`
+	ResourceID   string `json:"resource_id"`
+	ProjectID    string `json:"project_id,omitempty"`
+	Tool         string `json:"tool,omitempty"`
+	Disposition  string `json:"disposition,omitempty"`
+	ServerURL    string `json:"server_url,omitempty"`
+}
+
+func (s *AccessRoleMutationService) roleVersion(state *accessgen.Role) (string, error) {
+	return accessRoleVersion(s.versionKey, state)
+}
+
+func accessRoleVersion(versionKey []byte, state *accessgen.Role) (string, error) {
+	if state == nil || len(versionKey) != sha256.Size || uuid.Validate(state.ID) != nil || state.Name == "" {
+		return "", ErrAccessRoleMutationInvalid
+	}
+	canonical := canonicalAccessRoleVersion{RoleID: state.ID, Name: state.Name, Description: state.Description, Grants: canonicalAccessRoleGrants(state.Grants)}
+	payload, err := json.Marshal(canonical)
+	if err != nil {
+		return "", fmt.Errorf("encode access role version: %w", err)
+	}
+	mac := hmac.New(sha256.New, versionKey)
+	_, _ = mac.Write([]byte("platform-mcp-access-role-version-v1\x00"))
+	_, _ = mac.Write(payload)
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil)), nil
+}
+
+func canonicalAccessRoleGrants(grants []*accessgen.RoleGrant) []canonicalAccessRoleGrant {
+	result := make([]canonicalAccessRoleGrant, 0)
+	for _, grant := range grants {
+		if grant == nil {
+			continue
+		}
+		if grant.Selectors == nil {
+			result = append(result, canonicalAccessRoleGrant{Scope: grant.Scope, ResourceKind: "", ResourceID: authz.WildcardResource, ProjectID: "", Tool: "", Disposition: "", ServerURL: ""})
+			continue
+		}
+		for _, selector := range grant.Selectors {
+			if selector == nil {
+				continue
+			}
+			item := canonicalAccessRoleGrant{Scope: grant.Scope, ResourceKind: selector.ResourceKind, ResourceID: selector.ResourceID, ProjectID: "", Tool: "", Disposition: "", ServerURL: ""}
+			if selector.ProjectID != nil {
+				item.ProjectID = *selector.ProjectID
+			}
+			if selector.Tool != nil {
+				item.Tool = *selector.Tool
+			}
+			if selector.Disposition != nil {
+				item.Disposition = *selector.Disposition
+			}
+			if selector.ServerURL != nil {
+				item.ServerURL = *selector.ServerURL
+			}
+			result = append(result, item)
+		}
+	}
+	slices.SortFunc(result, func(a, b canonicalAccessRoleGrant) int {
+		return strings.Compare(a.Scope+"\x00"+a.ResourceKind+"\x00"+a.ResourceID+"\x00"+a.ProjectID+"\x00"+a.Tool+"\x00"+a.Disposition+"\x00"+a.ServerURL,
+			b.Scope+"\x00"+b.ResourceKind+"\x00"+b.ResourceID+"\x00"+b.ProjectID+"\x00"+b.Tool+"\x00"+b.Disposition+"\x00"+b.ServerURL)
+	})
+	return slices.Compact(result)
+}
+
+func normalizeAccessRoleIdentity(rawName, rawDescription, rawKey string) (string, string, string, error) {
+	name := strings.TrimSpace(rawName)
+	description := strings.TrimSpace(rawDescription)
+	key := strings.TrimSpace(rawKey)
+	if !validAccessRoleName(name) || len(description) > maxAccessRoleMutationDescription || key == "" || len(key) > 128 {
+		return "", "", "", accessRoleMutationInvalid("The access role create request is invalid.")
+	}
+	return name, description, key, nil
+}
+
+func validAccessRoleName(value string) bool {
+	if value == "" || len([]rune(value)) > maxAccessRoleMutationNameRunes {
+		return false
+	}
+	for _, r := range value {
+		if (r < 'A' || r > 'Z') && (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != ' ' && r != '_' && r != '-' {
+			return false
+		}
+	}
+	return true
+}
+
+func validAccessRoleDisposition(value string) bool {
+	switch value {
+	case authz.DispositionReadOnly, authz.DispositionDestructive, authz.DispositionIdempotent, authz.DispositionOpenWorld:
+		return true
+	default:
+		return false
+	}
+}
+
+func compareNormalizedAccessRoleRule(a, b normalizedMCPAccessRoleRule) int {
+	return strings.Compare(a.MCPID+"\x00"+a.Tool+"\x00"+a.Disposition, b.MCPID+"\x00"+b.Tool+"\x00"+b.Disposition)
+}
+
+func overlappingAccessRoleRules(add, remove []normalizedMCPAccessRoleRule) bool {
+	for _, rule := range add {
+		if _, found := slices.BinarySearchFunc(remove, rule, compareNormalizedAccessRoleRule); found {
+			return true
+		}
+	}
+	return false
+}
+
+func validAccessRoleVersion(value string) bool {
+	if len(value) != base64.RawURLEncoding.EncodedLen(sha256.Size) {
+		return false
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(value)
+	return err == nil && len(decoded) == sha256.Size
+}
+
+func classifyAccessRoleBackendError(err error) error {
+	var shareable *oops.ShareableError
+	switch {
+	case errors.Is(err, access.ErrRoleNotFound), errors.Is(err, ErrAccessRoleMutationNotFound):
+		return accessRoleMutationNotFound()
+	case errors.Is(err, ErrAccessRoleMutationConflict):
+		return accessRoleMutationConflict("The access role changed before the mutation completed. Read it again and retry.")
+	case errors.Is(err, ErrAccessRoleMutationInvalid):
+		return accessRoleMutationInvalid("The access role mutation is no longer valid.")
+	case errors.As(err, &shareable) && shareable.Code == oops.CodeConflict:
+		return accessRoleMutationConflict("A custom role with that name already exists. Choose another name.")
+	case errors.As(err, &shareable) && (shareable.Code == oops.CodeBadRequest || shareable.Code == oops.CodeInvalid):
+		return accessRoleMutationInvalid("The access role mutation is no longer valid.")
+	default:
+		return accessRoleMutationUnavailable(err)
+	}
+}
+
+func accessRoleMutationConfirmationRequired() error {
+	return &AccessRoleMutationError{Code: "confirmation_required", Message: "Show the exact project, role name or reference, and complete MCP access delta; ask the user to confirm it, then retry with confirmed: true.", Cause: ErrAccessRoleMutationInvalid}
+}
+
+func accessRoleMutationInvalid(message string) error {
+	return &AccessRoleMutationError{Code: "invalid_request", Message: message, Cause: ErrAccessRoleMutationInvalid}
+}
+
+func accessRoleMutationNotFound() error {
+	return &AccessRoleMutationError{Code: "not_found", Message: "The selected project, role, or configured MCP is unavailable. Read the current access state and choose from that result.", Cause: ErrAccessRoleMutationNotFound}
+}
+
+func accessRoleMutationConflict(message string) error {
+	return &AccessRoleMutationError{Code: "conflict", Message: message, Cause: ErrAccessRoleMutationConflict}
+}
+
+func accessRoleMutationUnavailable(cause error) error {
+	if cause == nil {
+		return &AccessRoleMutationError{Code: unavailableCode, Message: "Access role mutations are not enabled for this project.", Cause: ErrAccessRoleMutationUnavailable}
+	}
+	return &AccessRoleMutationError{Code: unavailableCode, Message: "Access role mutations are temporarily unavailable.", Cause: fmt.Errorf("%w: %w", ErrAccessRoleMutationUnavailable, cause)}
+}

--- a/server/internal/platformmcp/access_role_mutations.go
+++ b/server/internal/platformmcp/access_role_mutations.go
@@ -189,7 +189,7 @@ func (s *AccessRoleMutationService) Create(ctx context.Context, principal Princi
 	if err != nil {
 		return CreateMCPAccessRoleOutput{}, err
 	}
-	result, err := decodeAccessRoleMutationReceipt(receipt.ResultPayload)
+	result, err := decodeAccessRoleMutationReceipt(operationCreateMCPAccessRole, receipt.ResultPayload)
 	if err != nil {
 		return CreateMCPAccessRoleOutput{}, err
 	}
@@ -278,7 +278,7 @@ func (s *AccessRoleMutationService) Update(ctx context.Context, principal Princi
 	if err != nil {
 		return UpdateMCPAccessRoleOutput{}, err
 	}
-	result, err := decodeAccessRoleMutationReceipt(receipt.ResultPayload)
+	result, err := decodeAccessRoleMutationReceipt(operationUpdateMCPAccessRole, receipt.ResultPayload)
 	if err != nil {
 		return UpdateMCPAccessRoleOutput{}, err
 	}

--- a/server/internal/platformmcp/access_role_mutations_integration_test.go
+++ b/server/internal/platformmcp/access_role_mutations_integration_test.go
@@ -1,0 +1,162 @@
+package platformmcp
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/access"
+	accessrepo "github.com/speakeasy-api/gram/server/internal/access/repo"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	organizationsrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+func TestAccessRoleMutationsCommitReplayAndPreserveOtherGrants(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_access_role_mutations")
+	require.NoError(t, err)
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+
+	organization, err := organizationsrepo.New(conn).GetOrganizationMetadata(ctx, principal.OrganizationID)
+	require.NoError(t, err)
+	_, err = organizationsrepo.New(conn).UpsertOrganizationMetadata(ctx, organizationsrepo.UpsertOrganizationMetadataParams{
+		ID: principal.OrganizationID, Name: organization.Name, Slug: organization.Slug,
+		WorkosID: conv.ToPGText("workos-" + uuid.NewString()), Whitelisted: pgtype.Bool{},
+	})
+	require.NoError(t, err)
+
+	rows, err := platformrepo.New(conn).ListPlatformMCPInventory(ctx, platformrepo.ListPlatformMCPInventoryParams{
+		OrganizationID: principal.OrganizationID, ConnectionID: uuid.NullUUID{}, ConnectionGeneration: uuid.NullUUID{},
+		UserID: inventoryText(principal.UserID), ActingSurface: inventoryText(string(principal.surface())),
+		ProjectID: uuid.NullUUID{UUID: project.ID, Valid: true}, AfterMcpID: uuid.NullUUID{}, QueryText: "", ReadinessState: pgtype.Text{}, LimitValue: 10,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, rows)
+	targetID := rows[0].McpServerID.String()
+
+	flags := &feature.InMemory{}
+	flags.SetFlag(feature.FlagPlatformMCPAccessRoleMutations, principal.OrganizationID, true)
+	logger := testenv.NewLogger(t)
+	reads := NewAccessReadService(logger, conn, allowBudget(), "access-role-integration-key")
+	manager := access.NewRoleManager(logger, conn, workos.NewStubClient(), audit.NewLogger())
+	service, err := NewAccessRoleMutationService(reads, flags, allowBudget(), "access-role-integration-key", manager)
+	require.NoError(t, err)
+
+	createAuditsBefore, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionAccessRoleCreate)
+	require.NoError(t, err)
+	createInput := CreateMCPAccessRoleInput{
+		ProjectID: project.ID.String(), Name: "MCP Operators", Description: "Uses selected MCP servers",
+		Rules: []MCPAccessRoleRule{{MCPID: targetID}}, IdempotencyKey: "create-mcp-operators", Confirmed: true,
+	}
+	created, err := service.Create(ctx, principal, createInput)
+	require.NoError(t, err)
+	require.Equal(t, "MCP Operators", created.Role.Name)
+	require.NotEmpty(t, created.Role.Reference)
+	require.NotEmpty(t, created.Role.Version)
+	require.False(t, created.Receipt.Replayed)
+	require.Equal(t, "pending", created.Reconciliation)
+
+	roleID, err := reads.references.Decode(created.Role.Reference, principal, subjectKindAccessRole, reads.now())
+	require.NoError(t, err)
+	stored, err := manager.GetRoleByID(ctx, principal.OrganizationID, roleID)
+	require.NoError(t, err)
+	require.False(t, stored.IsSystem)
+	require.Len(t, stored.Grants, 1)
+	require.Equal(t, string(authz.ScopeMCPConnect), stored.Grants[0].Scope)
+
+	createAuditsAfter, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionAccessRoleCreate)
+	require.NoError(t, err)
+	require.Equal(t, createAuditsBefore+1, createAuditsAfter)
+	receipt, err := platformrepo.New(conn).GetPlatformMCPOperationReceipt(ctx, platformrepo.GetPlatformMCPOperationReceiptParams{
+		OrganizationID: principal.OrganizationID, ProjectID: project.ID, Operation: operationCreateMCPAccessRole,
+		IdempotencyKey: createInput.IdempotencyKey, UserID: conv.ToPGText(principal.UserID), SubjectUrn: userSubjectURN(principal.UserID),
+	})
+	require.NoError(t, err)
+	require.Equal(t, created.Receipt.ID, receipt.ID.String())
+
+	replayed, err := service.Create(ctx, principal, createInput)
+	require.NoError(t, err)
+	require.True(t, replayed.Receipt.Replayed)
+	require.Equal(t, created.Receipt.ID, replayed.Receipt.ID)
+	createAuditsReplayed, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionAccessRoleCreate)
+	require.NoError(t, err)
+	require.Equal(t, createAuditsAfter, createAuditsReplayed)
+
+	projectSelector := authz.NewSelector(authz.ScopeProjectRead, project.ID.String())
+	encodedProjectSelector, err := projectSelector.MarshalJSON()
+	require.NoError(t, err)
+	_, err = accessrepo.New(conn).UpsertPrincipalGrant(ctx, accessrepo.UpsertPrincipalGrantParams{
+		OrganizationID: principal.OrganizationID,
+		PrincipalUrn:   urn.NewPrincipal(urn.PrincipalTypeRole, "organization:"+roleID),
+		Scope:          string(authz.ScopeProjectRead),
+		Selectors:      encodedProjectSelector,
+	})
+	require.NoError(t, err)
+
+	roles, err := reads.ListRoles(ctx, principal)
+	require.NoError(t, err)
+	var current AccessRole
+	for _, role := range roles.Roles {
+		if role.Name == "MCP Operators" {
+			current = role
+			break
+		}
+	}
+	require.NotEmpty(t, current.Reference)
+	require.NotEmpty(t, current.Version)
+
+	updateAuditsBefore, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionAccessRoleUpdate)
+	require.NoError(t, err)
+	updated, err := service.Update(ctx, principal, UpdateMCPAccessRoleInput{
+		ProjectID: project.ID.String(), RoleReference: current.Reference, ExpectedVersion: current.Version,
+		AddRules:       []MCPAccessRoleRule{{MCPID: targetID, Disposition: authz.DispositionReadOnly}},
+		RemoveRules:    []MCPAccessRoleRule{{MCPID: targetID}},
+		IdempotencyKey: "update-mcp-operators", Confirmed: true,
+	})
+	require.NoError(t, err)
+	require.False(t, updated.Receipt.Replayed)
+	require.Equal(t, "complete", updated.Reconciliation)
+	require.NotEqual(t, current.Version, updated.Role.Version)
+
+	stored, err = manager.GetRoleByID(ctx, principal.OrganizationID, roleID)
+	require.NoError(t, err)
+	require.Len(t, stored.Grants, 2)
+	var preservedProjectRead, updatedMCPRule bool
+	for _, grant := range stored.Grants {
+		switch grant.Scope {
+		case string(authz.ScopeProjectRead):
+			preservedProjectRead = true
+		case string(authz.ScopeMCPConnect):
+			require.Len(t, grant.Selectors, 1)
+			require.NotNil(t, grant.Selectors[0].Disposition)
+			require.Equal(t, authz.DispositionReadOnly, *grant.Selectors[0].Disposition)
+			updatedMCPRule = true
+		}
+	}
+	require.True(t, preservedProjectRead)
+	require.True(t, updatedMCPRule)
+	updateAuditsAfter, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionAccessRoleUpdate)
+	require.NoError(t, err)
+	require.Equal(t, updateAuditsBefore+1, updateAuditsAfter)
+
+	_, err = service.Update(ctx, principal, UpdateMCPAccessRoleInput{
+		ProjectID: project.ID.String(), RoleReference: current.Reference, ExpectedVersion: current.Version,
+		AddRules: []MCPAccessRoleRule{{MCPID: targetID}}, IdempotencyKey: "stale-mcp-operators", Confirmed: true,
+	})
+	require.ErrorIs(t, err, ErrAccessRoleMutationConflict)
+	updateAuditsStale, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionAccessRoleUpdate)
+	require.NoError(t, err)
+	require.Equal(t, updateAuditsAfter, updateAuditsStale)
+}

--- a/server/internal/platformmcp/access_role_mutations_test.go
+++ b/server/internal/platformmcp/access_role_mutations_test.go
@@ -96,24 +96,32 @@ func TestAccessRoleReceiptRejectsUnknownOrUnsafePayloads(t *testing.T) {
 		MCPAccess:      MCPConnectSummary{DispositionRules: []string{}, BlockedDispositionRules: []string{}},
 		ResultCategory: "created", Reconciliation: "pending",
 	}
-	payload, err := encodeAccessRoleMutationReceipt(result)
+	payload, err := encodeAccessRoleMutationReceipt(operationCreateMCPAccessRole, result)
 	require.NoError(t, err)
-	require.True(t, validAccessRoleMutationReceiptPayload(payload))
+	require.True(t, validAccessRoleMutationReceiptPayload(operationCreateMCPAccessRole, payload))
+	require.False(t, validAccessRoleMutationReceiptPayload(operationUpdateMCPAccessRole, payload))
+
+	_, err = encodeAccessRoleMutationReceipt(operationUpdateMCPAccessRole, result)
+	require.Error(t, err)
 
 	var decoded map[string]any
 	require.NoError(t, json.Unmarshal(payload, &decoded))
 	decoded["principal_urn"] = "role:organization:hidden"
 	unsafe, err := json.Marshal(decoded)
 	require.NoError(t, err)
-	require.False(t, validAccessRoleMutationReceiptPayload(unsafe))
+	require.False(t, validAccessRoleMutationReceiptPayload(operationCreateMCPAccessRole, unsafe))
 
 	result.Reconciliation = "scheduled"
-	require.False(t, validAccessRoleMutationReceiptResult(result))
+	require.False(t, validAccessRoleMutationReceiptResult(operationCreateMCPAccessRole, result))
 
 	result.Reconciliation = "pending"
 	result.Name = "Support (EU)"
 	result.MCPAccess = MCPConnectSummary{ServerRules: maxAccessRoleMutationRules * 4, DispositionRules: []string{"future_annotation"}, BlockedDispositionRules: []string{}}
-	require.True(t, validAccessRoleMutationReceiptResult(result), "receipt validation must accept legitimate pre-existing dashboard role state")
+	require.True(t, validAccessRoleMutationReceiptResult(operationCreateMCPAccessRole, result), "receipt validation must accept legitimate pre-existing dashboard role state")
+
+	result.ResultCategory = "updated"
+	require.True(t, validAccessRoleMutationReceiptResult(operationUpdateMCPAccessRole, result))
+	require.False(t, validAccessRoleMutationReceiptResult(operationCreateMCPAccessRole, result))
 }
 
 func TestAccessRoleRemovalDoesNotRequireCurrentCatalog(t *testing.T) {

--- a/server/internal/platformmcp/access_role_mutations_test.go
+++ b/server/internal/platformmcp/access_role_mutations_test.go
@@ -1,0 +1,152 @@
+package platformmcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	accessgen "github.com/speakeasy-api/gram/server/gen/access"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+)
+
+func TestAccessRoleMutationRequiresConfirmationBeforeServiceValidation(t *testing.T) {
+	t.Parallel()
+
+	_, err := (*AccessRoleMutationService)(nil).Create(t.Context(), Principal{}, CreateMCPAccessRoleInput{})
+	var mutation *AccessRoleMutationError
+	require.ErrorAs(t, err, &mutation)
+	require.Equal(t, "confirmation_required", mutation.Code)
+}
+
+func TestAccessRoleRuleGrantsAreServerGeneratedAndProjectScoped(t *testing.T) {
+	t.Parallel()
+
+	projectID := uuid.New()
+	mcpID := uuid.NewString()
+	grants := accessRoleRulesToGenGrants([]normalizedMCPAccessRoleRule{{
+		MCPID: mcpID, Tool: "list_tasks", Disposition: authz.DispositionReadOnly,
+	}}, projectID)
+	require.Len(t, grants, 1)
+	require.Equal(t, string(authz.ScopeMCPConnect), grants[0].Scope)
+	require.Len(t, grants[0].Selectors, 1)
+	selector := grants[0].Selectors[0]
+	require.Equal(t, authz.ResourceKindMCP, selector.ResourceKind)
+	require.Equal(t, mcpID, selector.ResourceID)
+	require.Equal(t, projectID.String(), *selector.ProjectID)
+	require.Equal(t, "list_tasks", *selector.Tool)
+	require.Equal(t, authz.DispositionReadOnly, *selector.Disposition)
+}
+
+func TestAccessRoleVersionIsCanonicalAndCoversNonMCPGrants(t *testing.T) {
+	t.Parallel()
+
+	service := &AccessRoleMutationService{versionKey: make([]byte, 32)}
+	projectID := uuid.NewString()
+	mcpID := uuid.NewString()
+	project := &accessgen.RoleGrant{Scope: string(authz.ScopeProjectRead), Selectors: []*accessgen.Selector{{ResourceKind: authz.ResourceKindProject, ResourceID: projectID}}}
+	mcp := &accessgen.RoleGrant{Scope: string(authz.ScopeMCPConnect), Selectors: []*accessgen.Selector{{ResourceKind: authz.ResourceKindMCP, ResourceID: mcpID, ProjectID: &projectID}}}
+	roleID := uuid.NewString()
+
+	first, err := service.roleVersion(&accessgen.Role{ID: roleID, Name: "Operators", Grants: []*accessgen.RoleGrant{project, mcp}})
+	require.NoError(t, err)
+	second, err := service.roleVersion(&accessgen.Role{ID: roleID, Name: "Operators", Grants: []*accessgen.RoleGrant{mcp, project}})
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+
+	changed, err := service.roleVersion(&accessgen.Role{ID: roleID, Name: "Operators", Grants: []*accessgen.RoleGrant{mcp}})
+	require.NoError(t, err)
+	require.NotEqual(t, first, changed, "non-MCP grants must participate in optimistic concurrency")
+}
+
+func TestAccessRoleMutationInputHashCanonicalizesRuleOrder(t *testing.T) {
+	t.Parallel()
+
+	a := normalizedMCPAccessRoleRule{MCPID: uuid.NewString()}
+	b := normalizedMCPAccessRoleRule{MCPID: uuid.NewString(), Disposition: authz.DispositionDestructive}
+	ordered := []normalizedMCPAccessRoleRule{a, b}
+	reversed := []normalizedMCPAccessRoleRule{b, a}
+	if compareNormalizedAccessRoleRule(ordered[0], ordered[1]) > 0 {
+		ordered[0], ordered[1] = ordered[1], ordered[0]
+	}
+	if compareNormalizedAccessRoleRule(reversed[0], reversed[1]) > 0 {
+		reversed[0], reversed[1] = reversed[1], reversed[0]
+	}
+
+	first, err := accessRoleMutationInputHash(operationCreateMCPAccessRole, normalizedCreateMCPAccessRole{ProjectID: uuid.NewString(), Name: "Operators", Rules: ordered})
+	require.NoError(t, err)
+	second, err := accessRoleMutationInputHash(operationCreateMCPAccessRole, normalizedCreateMCPAccessRole{ProjectID: uuid.NewString(), Name: "Operators", Rules: reversed})
+	require.NoError(t, err)
+	require.NotEqual(t, first, second, "the explicit project must bind the input hash")
+
+	projectID := uuid.NewString()
+	first, err = accessRoleMutationInputHash(operationCreateMCPAccessRole, normalizedCreateMCPAccessRole{ProjectID: projectID, Name: "Operators", Rules: ordered})
+	require.NoError(t, err)
+	second, err = accessRoleMutationInputHash(operationCreateMCPAccessRole, normalizedCreateMCPAccessRole{ProjectID: projectID, Name: "Operators", Rules: reversed})
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+}
+
+func TestAccessRoleReceiptRejectsUnknownOrUnsafePayloads(t *testing.T) {
+	t.Parallel()
+
+	result := AccessRoleMutationReceiptResult{
+		RoleID: uuid.NewString(), RoleSlug: "org-operators", Name: "Operators", Version: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		MCPAccess:      MCPConnectSummary{DispositionRules: []string{}, BlockedDispositionRules: []string{}},
+		ResultCategory: "created", Reconciliation: "pending",
+	}
+	payload, err := encodeAccessRoleMutationReceipt(result)
+	require.NoError(t, err)
+	require.True(t, validAccessRoleMutationReceiptPayload(payload))
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(payload, &decoded))
+	decoded["principal_urn"] = "role:organization:hidden"
+	unsafe, err := json.Marshal(decoded)
+	require.NoError(t, err)
+	require.False(t, validAccessRoleMutationReceiptPayload(unsafe))
+
+	result.Reconciliation = "scheduled"
+	require.False(t, validAccessRoleMutationReceiptResult(result))
+
+	result.Reconciliation = "pending"
+	result.Name = "Support (EU)"
+	result.MCPAccess = MCPConnectSummary{ServerRules: maxAccessRoleMutationRules * 4, DispositionRules: []string{"future_annotation"}, BlockedDispositionRules: []string{}}
+	require.True(t, validAccessRoleMutationReceiptResult(result), "receipt validation must accept legitimate pre-existing dashboard role state")
+}
+
+func TestAccessRoleRemovalDoesNotRequireCurrentCatalog(t *testing.T) {
+	t.Parallel()
+
+	service := &AccessRoleMutationService{}
+	mcpID := uuid.NewString()
+	rules, err := service.resolveRules(t.Context(), Principal{}, ResolvedProject{}, []MCPAccessRoleRule{{MCPID: mcpID, Tool: "retired_tool"}}, false, make(map[uuid.UUID]accessRoleRuleTarget))
+	require.NoError(t, err)
+	require.Equal(t, []normalizedMCPAccessRoleRule{{MCPID: mcpID, Tool: "retired_tool", Disposition: ""}}, rules)
+}
+
+func TestAccessRoleMutationOutputsExposeNoRawIdentifiersOrSelectors(t *testing.T) {
+	t.Parallel()
+
+	output := CreateMCPAccessRoleOutput{Role: AccessRoleMutationSummary{
+		Name: "Operators", Description: "MCP operators", Reference: "opaque-role", Version: "opaque-version",
+		MCPAccess: MCPConnectSummary{ServerRules: 1, DispositionRules: []string{}, BlockedDispositionRules: []string{}},
+	}, Reconciliation: "pending", Receipt: RiskMutationToolReceipt{ID: uuid.NewString()}}
+	payload, err := json.Marshal(output)
+	require.NoError(t, err)
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(payload, &raw))
+	keys := make([]string, 0, len(raw))
+	for key := range raw {
+		keys = append(keys, key)
+	}
+	require.ElementsMatch(t, []string{"role", "reconciliation", "receipt"}, keys)
+	var role map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw["role"], &role))
+	roleKeys := make([]string, 0, len(role))
+	for key := range role {
+		roleKeys = append(roleKeys, key)
+	}
+	require.ElementsMatch(t, []string{"name", "description", "reference", "version", "mcp_access"}, roleKeys)
+}

--- a/server/internal/platformmcp/operation_budget.go
+++ b/server/internal/platformmcp/operation_budget.go
@@ -280,5 +280,5 @@ func (b DrilldownVolumeBudget) allow(ctx context.Context, principal Principal, l
 }
 
 func (b OperationBudgets) Valid() bool {
-	return b.Catalog.valid() && b.Registration.valid() && b.Handoff.valid() && b.SetupStart.valid() && b.Repair.valid() && b.Docs.valid() && b.Skills.valid() && b.LifecycleMetadata.valid() && b.Diagnostics.valid() && b.SensitiveDiagnostics.valid() && b.SensitiveSessionRecall.valid() && b.RiskMutations.valid() && b.DrilldownVolume.valid()
+	return b.Catalog.valid() && b.Registration.valid() && b.Handoff.valid() && b.SetupStart.valid() && b.Repair.valid() && b.Docs.valid() && b.Skills.valid() && b.LifecycleMetadata.valid() && b.Plugins.valid() && b.AccessReads.valid() && b.Diagnostics.valid() && b.SensitiveDiagnostics.valid() && b.SensitiveSessionRecall.valid() && b.RiskMutations.valid() && b.DrilldownVolume.valid()
 }

--- a/server/internal/platformmcp/operation_budget.go
+++ b/server/internal/platformmcp/operation_budget.go
@@ -207,6 +207,9 @@ type OperationBudgets struct {
 	// an administrator walking the inventory does not spend the allowance the
 	// failure diagnosis it leads to will need.
 	Plugins OperationBudget
+	// AccessReads meters role/member access inspection separately. Member search
+	// returns masked personal data and must not be fundable by another read lane.
+	AccessReads OperationBudget
 	// Diagnostics meters the observability reads. They are bounded aggregate
 	// queries over Gram-owned telemetry, so the cost being metered is the
 	// ClickHouse scan, not an external egress.

--- a/server/internal/platformmcp/operation_budget.go
+++ b/server/internal/platformmcp/operation_budget.go
@@ -35,6 +35,8 @@ const (
 const (
 	PluginAssignmentMutationConnectionLimitName   = "platform-mcp-plugin-assignment-mutation-connection"
 	PluginAssignmentMutationOrganizationLimitName = "platform-mcp-plugin-assignment-mutation-organization"
+	AccessRoleMutationConnectionLimitName         = "platform-mcp-access-role-mutation-connection"
+	AccessRoleMutationOrganizationLimitName       = "platform-mcp-access-role-mutation-organization"
 )
 
 const (
@@ -69,6 +71,8 @@ const (
 	// plugin's complete assignment set on an independent allowance.
 	PluginAssignmentMutationsPerConnectionPerMinute   = 5
 	PluginAssignmentMutationsPerOrganizationPerMinute = 50
+	AccessRoleMutationsPerConnectionPerMinute         = 5
+	AccessRoleMutationsPerOrganizationPerMinute       = 50
 
 	// DrilldownRowsPerConnectionPerWindow and
 	// DrilldownMetricQueriesPerConnectionPerWindow are the second cap the
@@ -210,6 +214,8 @@ type OperationBudgets struct {
 	// AccessReads meters role/member access inspection separately. Member search
 	// returns masked personal data and must not be fundable by another read lane.
 	AccessReads OperationBudget
+	// AccessRoleMutations independently meters custom MCP access-role writes.
+	AccessRoleMutations OperationBudget
 	// Diagnostics meters the observability reads. They are bounded aggregate
 	// queries over Gram-owned telemetry, so the cost being metered is the
 	// ClickHouse scan, not an external egress.
@@ -280,5 +286,5 @@ func (b DrilldownVolumeBudget) allow(ctx context.Context, principal Principal, l
 }
 
 func (b OperationBudgets) Valid() bool {
-	return b.Catalog.valid() && b.Registration.valid() && b.Handoff.valid() && b.SetupStart.valid() && b.Repair.valid() && b.Docs.valid() && b.Skills.valid() && b.LifecycleMetadata.valid() && b.Plugins.valid() && b.AccessReads.valid() && b.Diagnostics.valid() && b.SensitiveDiagnostics.valid() && b.SensitiveSessionRecall.valid() && b.RiskMutations.valid() && b.DrilldownVolume.valid()
+	return b.Catalog.valid() && b.Registration.valid() && b.Handoff.valid() && b.SetupStart.valid() && b.Repair.valid() && b.Docs.valid() && b.Skills.valid() && b.LifecycleMetadata.valid() && b.Plugins.valid() && b.AccessReads.valid() && b.AccessRoleMutations.valid() && b.Diagnostics.valid() && b.SensitiveDiagnostics.valid() && b.SensitiveSessionRecall.valid() && b.RiskMutations.valid() && b.DrilldownVolume.valid()
 }

--- a/server/internal/platformmcp/operation_budget_test.go
+++ b/server/internal/platformmcp/operation_budget_test.go
@@ -10,6 +10,32 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/ratelimit"
 )
 
+func TestOperationBudgetsValidRequiresAccessReads(t *testing.T) {
+	t.Parallel()
+
+	budget := allowBudget()
+	budgets := OperationBudgets{
+		Catalog: budget, Registration: budget, Handoff: budget, SetupStart: budget,
+		Repair: budget, Docs: budget, Skills: budget, LifecycleMetadata: budget,
+		Plugins: budget, AccessReads: budget, Diagnostics: budget,
+		SensitiveDiagnostics: budget, SensitiveSessionRecall: budget, RiskMutations: budget,
+		DrilldownVolume: DrilldownVolumeBudget{Rows: allowOperationLimiter{}, MetricQueries: allowOperationLimiter{}},
+	}
+	require.True(t, budgets.Valid())
+
+	budgets.AccessReads.Connection = nil
+	require.False(t, budgets.Valid())
+	budgets.AccessReads.Connection = allowOperationLimiter{}
+	budgets.AccessReads.Organization = nil
+	require.False(t, budgets.Valid())
+	budgets.AccessReads = budget
+	budgets.Plugins.Connection = nil
+	require.False(t, budgets.Valid())
+	budgets.Plugins.Connection = allowOperationLimiter{}
+	budgets.Plugins.Organization = nil
+	require.False(t, budgets.Valid())
+}
+
 func TestOperationBudgetChargesConnectionBeforeOrganization(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/platformmcp/operation_budget_test.go
+++ b/server/internal/platformmcp/operation_budget_test.go
@@ -17,7 +17,7 @@ func TestOperationBudgetsValidRequiresAccessReads(t *testing.T) {
 	budgets := OperationBudgets{
 		Catalog: budget, Registration: budget, Handoff: budget, SetupStart: budget,
 		Repair: budget, Docs: budget, Skills: budget, LifecycleMetadata: budget,
-		Plugins: budget, AccessReads: budget, Diagnostics: budget,
+		Plugins: budget, AccessReads: budget, AccessRoleMutations: budget, Diagnostics: budget,
 		SensitiveDiagnostics: budget, SensitiveSessionRecall: budget, RiskMutations: budget,
 		DrilldownVolume: DrilldownVolumeBudget{Rows: allowOperationLimiter{}, MetricQueries: allowOperationLimiter{}},
 	}

--- a/server/internal/platformmcp/operation_budget_test.go
+++ b/server/internal/platformmcp/operation_budget_test.go
@@ -34,6 +34,12 @@ func TestOperationBudgetsValidRequiresAccessReads(t *testing.T) {
 	budgets.Plugins.Connection = allowOperationLimiter{}
 	budgets.Plugins.Organization = nil
 	require.False(t, budgets.Valid())
+	budgets.Plugins = budget
+	budgets.AccessRoleMutations.Connection = nil
+	require.False(t, budgets.Valid())
+	budgets.AccessRoleMutations.Connection = allowOperationLimiter{}
+	budgets.AccessRoleMutations.Organization = nil
+	require.False(t, budgets.Valid())
 }
 
 func TestOperationBudgetChargesConnectionBeforeOrganization(t *testing.T) {

--- a/server/internal/platformmcp/queries.sql
+++ b/server/internal/platformmcp/queries.sql
@@ -2894,6 +2894,39 @@ WHERE p.project_id = @project_id
 ORDER BY p.id ASC
 LIMIT 2;
 
+-- name: SearchPlatformMCPAccessMembers :many
+-- Count distinct members and return only a bounded page from the same snapshot.
+-- Active local role assignments follow the access roster's WorkOS identity join.
+WITH member_roles AS (
+  SELECT ora.workos_user_id,
+    array_agg(DISTINCT COALESCE(r.id::text, g.id::text)) AS role_ids,
+    array_agg(DISTINCT COALESCE(r.workos_name, g.workos_name)) AS role_names
+  FROM organization_role_assignments ora
+  LEFT JOIN organization_roles r ON ora.role_urn = 'role:organization:' || r.id::text
+    AND r.organization_id = @organization_id AND r.deleted IS FALSE AND r.workos_deleted IS FALSE
+  LEFT JOIN global_roles g ON ora.role_urn = 'role:global:' || g.id::text
+    AND g.deleted IS FALSE AND g.workos_deleted IS FALSE
+  WHERE ora.organization_id = @organization_id AND ora.deleted_at IS NULL
+    AND COALESCE(r.id, g.id) IS NOT NULL
+  GROUP BY ora.workos_user_id
+), matching AS (
+  SELECT DISTINCT u.id, u.display_name, u.email, COALESCE(m.role_ids, '{}'::text[])::text[] AS role_ids
+  FROM organization_user_relationships rel
+  JOIN users u ON u.id = rel.user_id AND u.deleted_at IS NULL
+  LEFT JOIN member_roles m ON m.workos_user_id = u.workos_id
+  WHERE rel.organization_id = @organization_id AND rel.deleted IS FALSE
+    AND (@role_id::text = '' OR @role_id::text = ANY(m.role_ids))
+    AND (@query::text = ''
+      OR strpos(lower(trim(regexp_replace(u.display_name, '[[:space:]]+', ' ', 'g'))), @query::text) > 0
+      OR strpos(lower(trim(regexp_replace(u.email, '[[:space:]]+', ' ', 'g'))), @query::text) > 0
+      OR EXISTS (SELECT 1 FROM unnest(m.role_names) AS role_name
+        WHERE strpos(lower(trim(regexp_replace(role_name, '[[:space:]]+', ' ', 'g'))), @query::text) > 0))
+)
+SELECT id, display_name, email, role_ids, count(*) OVER ()::bigint AS total_matches
+FROM matching
+ORDER BY email, id
+LIMIT @result_limit;
+
 -- name: GetPlatformMCPPluginForUpdate :one
 -- Serializes an MCP distribution write against concurrent deletion of the
 -- exact plugin the caller named. A deleted plugin deliberately returns no row,

--- a/server/internal/platformmcp/repo/queries.sql.go
+++ b/server/internal/platformmcp/repo/queries.sql.go
@@ -6427,6 +6427,86 @@ func (q *Queries) RotatePlatformMCPSession(ctx context.Context, arg RotatePlatfo
 	return i, err
 }
 
+const searchPlatformMCPAccessMembers = `-- name: SearchPlatformMCPAccessMembers :many
+WITH member_roles AS (
+  SELECT ora.workos_user_id,
+    array_agg(DISTINCT COALESCE(r.id::text, g.id::text)) AS role_ids,
+    array_agg(DISTINCT COALESCE(r.workos_name, g.workos_name)) AS role_names
+  FROM organization_role_assignments ora
+  LEFT JOIN organization_roles r ON ora.role_urn = 'role:organization:' || r.id::text
+    AND r.organization_id = $2 AND r.deleted IS FALSE AND r.workos_deleted IS FALSE
+  LEFT JOIN global_roles g ON ora.role_urn = 'role:global:' || g.id::text
+    AND g.deleted IS FALSE AND g.workos_deleted IS FALSE
+  WHERE ora.organization_id = $2 AND ora.deleted_at IS NULL
+    AND COALESCE(r.id, g.id) IS NOT NULL
+  GROUP BY ora.workos_user_id
+), matching AS (
+  SELECT DISTINCT u.id, u.display_name, u.email, COALESCE(m.role_ids, '{}'::text[])::text[] AS role_ids
+  FROM organization_user_relationships rel
+  JOIN users u ON u.id = rel.user_id AND u.deleted_at IS NULL
+  LEFT JOIN member_roles m ON m.workos_user_id = u.workos_id
+  WHERE rel.organization_id = $2 AND rel.deleted IS FALSE
+    AND ($3::text = '' OR $3::text = ANY(m.role_ids))
+    AND ($4::text = ''
+      OR strpos(lower(trim(regexp_replace(u.display_name, '[[:space:]]+', ' ', 'g'))), $4::text) > 0
+      OR strpos(lower(trim(regexp_replace(u.email, '[[:space:]]+', ' ', 'g'))), $4::text) > 0
+      OR EXISTS (SELECT 1 FROM unnest(m.role_names) AS role_name
+        WHERE strpos(lower(trim(regexp_replace(role_name, '[[:space:]]+', ' ', 'g'))), $4::text) > 0))
+)
+SELECT id, display_name, email, role_ids, count(*) OVER ()::bigint AS total_matches
+FROM matching
+ORDER BY email, id
+LIMIT $1
+`
+
+type SearchPlatformMCPAccessMembersParams struct {
+	ResultLimit    int32
+	OrganizationID string
+	RoleID         string
+	Query          string
+}
+
+type SearchPlatformMCPAccessMembersRow struct {
+	ID           string
+	DisplayName  string
+	Email        string
+	RoleIds      []string
+	TotalMatches int64
+}
+
+// Count distinct members and return only a bounded page from the same snapshot.
+// Active local role assignments follow the access roster's WorkOS identity join.
+func (q *Queries) SearchPlatformMCPAccessMembers(ctx context.Context, arg SearchPlatformMCPAccessMembersParams) ([]SearchPlatformMCPAccessMembersRow, error) {
+	rows, err := q.db.Query(ctx, searchPlatformMCPAccessMembers,
+		arg.ResultLimit,
+		arg.OrganizationID,
+		arg.RoleID,
+		arg.Query,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SearchPlatformMCPAccessMembersRow
+	for rows.Next() {
+		var i SearchPlatformMCPAccessMembersRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.DisplayName,
+			&i.Email,
+			&i.RoleIds,
+			&i.TotalMatches,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const softDeletePendingPlatformMCPCatalogRegistration = `-- name: SoftDeletePendingPlatformMCPCatalogRegistration :exec
 UPDATE platform_mcp_catalog_registrations
 SET deleted_at = clock_timestamp()

--- a/server/internal/platformmcp/runtime.go
+++ b/server/internal/platformmcp/runtime.go
@@ -127,14 +127,14 @@ func NewRuntimeWithFeedback(logger *slog.Logger, authenticator Authenticator, ga
 // identities and declared configuration fields, never an arbitrary endpoint or
 // provider credential.
 func NewRuntimeWithLifecycle(logger *slog.Logger, authenticator Authenticator, gate Gate, authorizer Authorizer, protectedResourceURL, cursorKeyMaterial string, reader Reader, catalog Catalog, registrations *RegistrationService, readiness ReadinessRecorder, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, candidate CatalogDescriptor) *Runtime {
-	return NewRuntimeWithRiskMutations(logger, authenticator, gate, authorizer, protectedResourceURL, cursorKeyMaterial, reader, catalog, registrations, readiness, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, nil, candidate)
+	return NewRuntimeWithRiskMutations(logger, authenticator, gate, authorizer, protectedResourceURL, cursorKeyMaterial, reader, catalog, registrations, readiness, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, nil, candidate, nil)
 }
 
-func NewRuntimeWithRiskMutations(logger *slog.Logger, authenticator Authenticator, gate Gate, authorizer Authorizer, protectedResourceURL, cursorKeyMaterial string, reader Reader, catalog Catalog, registrations *RegistrationService, readiness ReadinessRecorder, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, riskMutations *RiskMutationHandlers, candidate CatalogDescriptor) *Runtime {
+func NewRuntimeWithRiskMutations(logger *slog.Logger, authenticator Authenticator, gate Gate, authorizer Authorizer, protectedResourceURL, cursorKeyMaterial string, reader Reader, catalog Catalog, registrations *RegistrationService, readiness ReadinessRecorder, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, riskMutations *RiskMutationHandlers, candidate CatalogDescriptor, accessReads *AccessReadService) *Runtime {
 	if postgresReader, ok := reader.(*PostgresReader); ok {
 		postgresReader.setInventoryCursorKey(cursorKeyMaterial)
 	}
-	server, registrar := newServerWithRiskMutations(reader, catalog, registrations, cursorKeyMaterial, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, riskMutations, candidate)
+	server, registrar := newServerWithRiskMutations(reader, catalog, registrations, cursorKeyMaterial, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, riskMutations, candidate, accessReads)
 	runtime := &Runtime{
 		authenticator:        authenticator,
 		gate:                 gate,

--- a/server/internal/platformmcp/runtime.go
+++ b/server/internal/platformmcp/runtime.go
@@ -127,14 +127,14 @@ func NewRuntimeWithFeedback(logger *slog.Logger, authenticator Authenticator, ga
 // identities and declared configuration fields, never an arbitrary endpoint or
 // provider credential.
 func NewRuntimeWithLifecycle(logger *slog.Logger, authenticator Authenticator, gate Gate, authorizer Authorizer, protectedResourceURL, cursorKeyMaterial string, reader Reader, catalog Catalog, registrations *RegistrationService, readiness ReadinessRecorder, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, candidate CatalogDescriptor) *Runtime {
-	return NewRuntimeWithRiskMutations(logger, authenticator, gate, authorizer, protectedResourceURL, cursorKeyMaterial, reader, catalog, registrations, readiness, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, nil, candidate, nil)
+	return NewRuntimeWithRiskMutations(logger, authenticator, gate, authorizer, protectedResourceURL, cursorKeyMaterial, reader, catalog, registrations, readiness, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, nil, candidate, nil, nil)
 }
 
-func NewRuntimeWithRiskMutations(logger *slog.Logger, authenticator Authenticator, gate Gate, authorizer Authorizer, protectedResourceURL, cursorKeyMaterial string, reader Reader, catalog Catalog, registrations *RegistrationService, readiness ReadinessRecorder, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, riskMutations *RiskMutationHandlers, candidate CatalogDescriptor, accessReads *AccessReadService) *Runtime {
+func NewRuntimeWithRiskMutations(logger *slog.Logger, authenticator Authenticator, gate Gate, authorizer Authorizer, protectedResourceURL, cursorKeyMaterial string, reader Reader, catalog Catalog, registrations *RegistrationService, readiness ReadinessRecorder, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, riskMutations *RiskMutationHandlers, candidate CatalogDescriptor, accessReads *AccessReadService, accessRoleMutations *AccessRoleMutationService) *Runtime {
 	if postgresReader, ok := reader.(*PostgresReader); ok {
 		postgresReader.setInventoryCursorKey(cursorKeyMaterial)
 	}
-	server, registrar := newServerWithRiskMutations(reader, catalog, registrations, cursorKeyMaterial, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, riskMutations, candidate, accessReads)
+	server, registrar := newServerWithRiskMutations(reader, catalog, registrations, cursorKeyMaterial, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, riskMutations, candidate, accessReads, accessRoleMutations)
 	runtime := &Runtime{
 		authenticator:        authenticator,
 		gate:                 gate,

--- a/server/internal/platformmcp/tool_access_reads.go
+++ b/server/internal/platformmcp/tool_access_reads.go
@@ -21,7 +21,7 @@ func registerAccessReadTools(reg *Registrar, accessReads *AccessReadService) {
 		Description: "List the organization's roles and summarize the MCP access each role carries. Member counts are withheld for small groups, and each role is represented by a short-lived opaque reference rather than a role ID or principal.",
 		Annotations: readOnlyAnnotations(),
 	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeNone}, func(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, ListAccessRolesOutput, error) {
-		return accessReadToolCall(ctx, func(principal Principal) (ListAccessRolesOutput, error) {
+		return principalToolCall(ctx, accessReadToolResult, func(principal Principal) (ListAccessRolesOutput, error) {
 			return accessReads.ListRoles(ctx, principal)
 		})
 	})
@@ -32,7 +32,7 @@ func registerAccessReadTools(reg *Registrar, accessReads *AccessReadService) {
 		Description: "Find organization members by an explicit identity query of at least three characters or a role reference. Returns masked identities, role names, and short-lived opaque member references only when at least five people match; smaller result sets are withheld rather than enumerated.",
 		Annotations: readOnlyAnnotations(),
 	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeNone}, func(ctx context.Context, _ *mcp.CallToolRequest, input ListAccessMembersInput) (*mcp.CallToolResult, ListAccessMembersOutput, error) {
-		return accessReadToolCall(ctx, func(principal Principal) (ListAccessMembersOutput, error) {
+		return principalToolCall(ctx, accessReadToolResult, func(principal Principal) (ListAccessMembersOutput, error) {
 			return accessReads.ListMembers(ctx, principal, input)
 		})
 	})
@@ -43,7 +43,7 @@ func registerAccessReadTools(reg *Registrar, accessReads *AccessReadService) {
 		Description: "Inspect which roles can enter one exact configured MCP server through its configured endpoint and which known tools or behavior classes they can use. Uses the same authorization resource and selector semantics as that endpoint; dynamic servers may not have an enumerable tool catalog.",
 		Annotations: readOnlyAnnotations(),
 	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input GetMCPAccessInput) (*mcp.CallToolResult, GetMCPAccessOutput, error) {
-		return accessReadToolCall(ctx, func(principal Principal) (GetMCPAccessOutput, error) {
+		return principalToolCall(ctx, accessReadToolResult, func(principal Principal) (GetMCPAccessOutput, error) {
 			return accessReads.GetMCPAccess(ctx, principal, input)
 		})
 	})
@@ -67,22 +67,6 @@ func registerUnavailableAccessReadTools(reg *Registrar) {
 			Annotations: readOnlyAnnotations(),
 		}, ToolMeta{Audiences: externalOnly, ProjectScope: tool.projectScope}, unavailableTool("mcp_access_reads"))
 	}
-}
-
-func accessReadToolCall[Out any](ctx context.Context, call func(principal Principal) (Out, error)) (*mcp.CallToolResult, Out, error) {
-	var zero Out
-	principal, err := principalFromToolContext(ctx)
-	if err != nil {
-		return nil, zero, err
-	}
-	output, err := call(principal)
-	if err != nil {
-		if refusal, ok := accessReadToolResult(err); ok {
-			return refusal, zero, nil
-		}
-		return nil, zero, err
-	}
-	return nil, output, nil
 }
 
 func accessReadToolResult(err error) (*mcp.CallToolResult, bool) {

--- a/server/internal/platformmcp/tool_access_reads.go
+++ b/server/internal/platformmcp/tool_access_reads.go
@@ -1,0 +1,108 @@
+//nolint:exhaustruct // MCP SDK manifests intentionally rely on documented zero-value optional fields.
+package platformmcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type accessReadRefusalResult struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func registerAccessReadTools(reg *Registrar, accessReads *AccessReadService) {
+	addTool(reg, &mcp.Tool{
+		Name:        "list_access_roles",
+		Title:       "List MCP Access Roles",
+		Description: "List the organization's roles and summarize the MCP access each role carries. Member counts are withheld for small groups, and each role is represented by a short-lived opaque reference rather than a role ID or principal.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeNone}, func(ctx context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, ListAccessRolesOutput, error) {
+		return accessReadToolCall(ctx, func(principal Principal) (ListAccessRolesOutput, error) {
+			return accessReads.ListRoles(ctx, principal)
+		})
+	})
+
+	addTool(reg, &mcp.Tool{
+		Name:        "list_access_members",
+		Title:       "Find Organization Members for MCP Access",
+		Description: "Find organization members by an explicit identity query of at least three characters or a role reference. Returns masked identities, role names, and short-lived opaque member references only when at least five people match; smaller result sets are withheld rather than enumerated.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeNone}, func(ctx context.Context, _ *mcp.CallToolRequest, input ListAccessMembersInput) (*mcp.CallToolResult, ListAccessMembersOutput, error) {
+		return accessReadToolCall(ctx, func(principal Principal) (ListAccessMembersOutput, error) {
+			return accessReads.ListMembers(ctx, principal, input)
+		})
+	})
+
+	addTool(reg, &mcp.Tool{
+		Name:        "get_mcp_access",
+		Title:       "Inspect Access to One MCP Server",
+		Description: "Inspect which roles can enter one exact configured MCP server through its configured endpoint and which known tools or behavior classes they can use. Uses the same authorization resource and selector semantics as that endpoint; dynamic servers may not have an enumerable tool catalog.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input GetMCPAccessInput) (*mcp.CallToolResult, GetMCPAccessOutput, error) {
+		return accessReadToolCall(ctx, func(principal Principal) (GetMCPAccessOutput, error) {
+			return accessReads.GetMCPAccess(ctx, principal, input)
+		})
+	})
+}
+
+func registerUnavailableAccessReadTools(reg *Registrar) {
+	for _, tool := range []struct {
+		name         string
+		title        string
+		description  string
+		projectScope ProjectScope
+	}{
+		{"list_access_roles", "List MCP Access Roles", "List MCP access roles. This is not switched on for your organization yet.", ProjectScopeNone},
+		{"list_access_members", "Find Organization Members for MCP Access", "Find organization members for MCP access. This is not switched on for your organization yet.", ProjectScopeNone},
+		{"get_mcp_access", "Inspect Access to One MCP Server", "Inspect access to one MCP server. This is not switched on for your organization yet.", ProjectScopeExplicit},
+	} {
+		addTool(reg, &mcp.Tool{
+			Name:        tool.name,
+			Title:       tool.title,
+			Description: tool.description,
+			Annotations: readOnlyAnnotations(),
+		}, ToolMeta{Audiences: externalOnly, ProjectScope: tool.projectScope}, unavailableTool("mcp_access_reads"))
+	}
+}
+
+func accessReadToolCall[Out any](ctx context.Context, call func(principal Principal) (Out, error)) (*mcp.CallToolResult, Out, error) {
+	var zero Out
+	principal, err := principalFromToolContext(ctx)
+	if err != nil {
+		return nil, zero, err
+	}
+	output, err := call(principal)
+	if err != nil {
+		if refusal, ok := accessReadToolResult(err); ok {
+			return refusal, zero, nil
+		}
+		return nil, zero, err
+	}
+	return nil, output, nil
+}
+
+func accessReadToolResult(err error) (*mcp.CallToolResult, bool) {
+	var result accessReadRefusalResult
+	switch {
+	case errors.Is(err, ErrAccessQueryRequired):
+		result = accessReadRefusalResult{Code: "invalid_request", Message: "Supply an identity query of at least three characters or choose one of the role references returned by list_access_roles; the full employee directory is not exposed."}
+	case errors.Is(err, ErrAccessReferenceNotFound):
+		result = accessReadRefusalResult{Code: "not_found", Message: "That access reference is not available here. List the roles or members again and use a reference from the new result."}
+	case errors.Is(err, ErrAccessMCPNotFound):
+		result = accessReadRefusalResult{Code: "not_found", Message: "That MCP server is not in the selected project. Choose one returned by find_mcp."}
+	default:
+		if budgetResult, ok := operationBudgetToolResult(err); ok {
+			return budgetResult, true
+		}
+		return nil, false
+	}
+	content, marshalErr := json.Marshal(result)
+	if marshalErr != nil {
+		return nil, false
+	}
+	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(content)}}, IsError: true}, true
+}

--- a/server/internal/platformmcp/tool_access_reads_test.go
+++ b/server/internal/platformmcp/tool_access_reads_test.go
@@ -1,0 +1,64 @@
+package platformmcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccessReadToolsAreExternalReadOnlyTools(t *testing.T) {
+	t.Parallel()
+
+	_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, nil, nil, nil, CatalogDescriptor{})
+	wanted := map[string]ProjectScope{
+		"list_access_roles":   ProjectScopeNone,
+		"list_access_members": ProjectScopeNone,
+		"get_mcp_access":      ProjectScopeExplicit,
+	}
+	for _, descriptor := range registrar.Descriptors() {
+		projectScope, ok := wanted[descriptor.Name]
+		if !ok {
+			continue
+		}
+		require.Equal(t, projectScope, descriptor.Meta.ProjectScope)
+		require.Equal(t, externalOnly, descriptor.Meta.Audiences)
+		require.NotEmpty(t, descriptor.InputSchema)
+		delete(wanted, descriptor.Name)
+	}
+	require.Empty(t, wanted)
+
+	tools := registrar.For(AudienceAssistant)
+	for _, descriptor := range tools {
+		require.NotContains(t, []string{"list_access_roles", "list_access_members", "get_mcp_access"}, descriptor.Name)
+	}
+}
+
+func TestAccessReadToolRefusalsAreStructured(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name string
+		err  error
+		code string
+	}{
+		{name: "query", err: ErrAccessQueryRequired, code: "invalid_request"},
+		{name: "reference", err: ErrAccessReferenceNotFound, code: "not_found"},
+		{name: "mcp", err: ErrAccessMCPNotFound, code: "not_found"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result, ok := accessReadToolResult(test.err)
+			require.True(t, ok)
+			require.True(t, result.IsError)
+			require.Len(t, result.Content, 1)
+			text, ok := result.Content[0].(*mcp.TextContent)
+			require.True(t, ok)
+			var refusal accessReadRefusalResult
+			require.NoError(t, json.Unmarshal([]byte(text.Text), &refusal))
+			require.Equal(t, test.code, refusal.Code)
+			require.NotEmpty(t, refusal.Message)
+		})
+	}
+}

--- a/server/internal/platformmcp/tool_access_reads_test.go
+++ b/server/internal/platformmcp/tool_access_reads_test.go
@@ -2,6 +2,7 @@ package platformmcp
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -12,6 +13,20 @@ func TestAccessReadToolsAreExternalReadOnlyTools(t *testing.T) {
 	t.Parallel()
 
 	_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, nil, nil, nil, CatalogDescriptor{})
+	requireAccessReadToolDescriptors(t, registrar)
+}
+
+func TestAvailableAccessReadToolsAreExternalReadOnlyTools(t *testing.T) {
+	t.Parallel()
+
+	registrar := newRegistrar(mcp.NewServer(&mcp.Implementation{Name: "test", Version: "test"}, nil))
+	registerAccessReadTools(registrar, nil)
+	requireAccessReadToolDescriptors(t, registrar)
+}
+
+func requireAccessReadToolDescriptors(t *testing.T, registrar *Registrar) {
+	t.Helper()
+
 	wanted := map[string]ProjectScope{
 		"list_access_roles":   ProjectScopeNone,
 		"list_access_members": ProjectScopeNone,
@@ -22,6 +37,8 @@ func TestAccessReadToolsAreExternalReadOnlyTools(t *testing.T) {
 		if !ok {
 			continue
 		}
+		require.NotNil(t, descriptor.Annotations)
+		require.True(t, descriptor.Annotations.ReadOnlyHint)
 		require.Equal(t, projectScope, descriptor.Meta.ProjectScope)
 		require.Equal(t, externalOnly, descriptor.Meta.Audiences)
 		require.NotEmpty(t, descriptor.InputSchema)
@@ -32,6 +49,82 @@ func TestAccessReadToolsAreExternalReadOnlyTools(t *testing.T) {
 	tools := registrar.For(AudienceAssistant)
 	for _, descriptor := range tools {
 		require.NotContains(t, []string{"list_access_roles", "list_access_members", "get_mcp_access"}, descriptor.Name)
+	}
+}
+
+func TestPrincipalToolCallRequiresPrincipal(t *testing.T) {
+	t.Parallel()
+
+	result, output, err := principalToolCall(t.Context(), func(error) (*mcp.CallToolResult, bool) {
+		t.Fatal("principal errors must not be translated")
+		return nil, false
+	}, func(Principal) (string, error) {
+		t.Fatal("call must not run without a principal")
+		return "", nil
+	})
+	require.ErrorIs(t, err, ErrUnauthorized)
+	require.Nil(t, result)
+	require.Empty(t, output)
+}
+
+func TestPrincipalToolCallReturnsSuccessfulOutput(t *testing.T) {
+	t.Parallel()
+
+	principal := registrationServicePrincipal()
+	ctx := contextWithPrincipal(t.Context(), principal)
+	result, output, err := principalToolCall(ctx, accessReadToolResult, func(actual Principal) (string, error) {
+		require.Equal(t, principal, actual)
+		return "output", nil
+	})
+	require.NoError(t, err)
+	require.Nil(t, result)
+	require.Equal(t, "output", output)
+}
+
+func TestPrincipalToolCallPreservesUnexpectedErrors(t *testing.T) {
+	t.Parallel()
+
+	unexpected := errors.New("unexpected service failure")
+	ctx := contextWithPrincipal(t.Context(), registrationServicePrincipal())
+	for _, refusalResult := range []func(error) (*mcp.CallToolResult, bool){accessReadToolResult, pluginToolResult} {
+		result, output, err := principalToolCall(ctx, refusalResult, func(Principal) (string, error) {
+			return "partial output", unexpected
+		})
+		require.ErrorIs(t, err, unexpected)
+		require.Nil(t, result)
+		require.Empty(t, output)
+	}
+}
+
+func TestPrincipalToolCallTranslatesKnownRefusals(t *testing.T) {
+	t.Parallel()
+
+	ctx := contextWithPrincipal(t.Context(), registrationServicePrincipal())
+	for _, test := range []struct {
+		refusalResult func(error) (*mcp.CallToolResult, bool)
+		err           error
+	}{
+		{accessReadToolResult, ErrAccessQueryRequired},
+		{accessReadToolResult, ErrAccessReferenceNotFound},
+		{accessReadToolResult, ErrAccessMCPNotFound},
+		{accessReadToolResult, ErrOperationRateLimited},
+		{accessReadToolResult, ErrOperationBudgetUnavailable},
+		{pluginToolResult, ErrPluginProjectNotFound},
+		{pluginToolResult, ErrPluginNotFound},
+		{pluginToolResult, ErrPluginAmbiguous},
+		{pluginToolResult, ErrPluginCursorInvalid},
+		{pluginToolResult, ErrOperationRateLimited},
+		{pluginToolResult, ErrOperationBudgetUnavailable},
+	} {
+		result, output, err := principalToolCall(ctx, test.refusalResult, func(Principal) (string, error) {
+			return "partial output", test.err
+		})
+		require.NoError(t, err)
+		require.Empty(t, output)
+		expected, ok := test.refusalResult(test.err)
+		require.True(t, ok)
+		require.Equal(t, expected, result)
+		require.True(t, result.IsError)
 	}
 }
 

--- a/server/internal/platformmcp/tool_access_role_mutations.go
+++ b/server/internal/platformmcp/tool_access_role_mutations.go
@@ -1,0 +1,67 @@
+//nolint:exhaustruct // MCP SDK manifests intentionally rely on documented zero-value optional fields.
+package platformmcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type accessRoleMutationRefusal struct {
+	Code    string `json:"code"`
+	Feature string `json:"feature"`
+	Message string `json:"message"`
+}
+
+func registerAccessRoleMutationTools(reg *Registrar, mutations *AccessRoleMutationService) {
+	create := unavailableAccessRoleMutationHandler[CreateMCPAccessRoleInput, CreateMCPAccessRoleOutput]()
+	update := unavailableAccessRoleMutationHandler[UpdateMCPAccessRoleInput, UpdateMCPAccessRoleOutput]()
+	if mutations != nil && mutations.valid() {
+		create = func(ctx context.Context, _ *mcp.CallToolRequest, input CreateMCPAccessRoleInput) (*mcp.CallToolResult, CreateMCPAccessRoleOutput, error) {
+			return principalToolCall(ctx, accessRoleMutationToolResult, func(principal Principal) (CreateMCPAccessRoleOutput, error) {
+				return mutations.Create(ctx, principal, input)
+			})
+		}
+		update = func(ctx context.Context, _ *mcp.CallToolRequest, input UpdateMCPAccessRoleInput) (*mcp.CallToolResult, UpdateMCPAccessRoleOutput, error) {
+			return principalToolCall(ctx, accessRoleMutationToolResult, func(principal Principal) (UpdateMCPAccessRoleOutput, error) {
+				return mutations.Update(ctx, principal, input)
+			})
+		}
+	}
+	meta := ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}
+	addTool(reg, &mcp.Tool{
+		Name: "create_mcp_access_role", Title: "Create MCP Access Role",
+		Description: "Create a custom role in one explicit project with only server-generated MCP access selectors. Requires explicit confirmation and an idempotency key. An exact replay returns the stored committed role snapshot; use list_access_roles for current state before a later update.",
+		Annotations: &mcp.ToolAnnotations{IdempotentHint: true, DestructiveHint: new(false)},
+	}, meta, create)
+	addTool(reg, &mcp.Tool{
+		Name: "update_mcp_access_role", Title: "Update MCP Access Role",
+		Description: "Update a custom role through an opaque reference and expected version. Adds or removes exact MCP access rules while preserving every non-MCP grant. Requires explicit confirmation and an idempotency key.",
+		Annotations: &mcp.ToolAnnotations{IdempotentHint: true, DestructiveHint: new(true)},
+	}, meta, update)
+}
+
+func unavailableAccessRoleMutationHandler[In, Out any]() mcp.ToolHandlerFor[In, Out] {
+	return func(_ context.Context, _ *mcp.CallToolRequest, _ In) (*mcp.CallToolResult, Out, error) {
+		var zero Out
+		payload, err := json.Marshal(accessRoleMutationRefusal{Code: unavailableCode, Feature: "access_role_mutations", Message: "This Platform MCP capability is not enabled for the current rollout."})
+		if err != nil {
+			return nil, zero, errors.Join(errors.New("encode access role mutation refusal"), err)
+		}
+		return nil, zero, &ToolRefusalError{Code: unavailableCode, Payload: string(payload)}
+	}
+}
+
+func accessRoleMutationToolResult(err error) (*mcp.CallToolResult, bool) {
+	var mutation *AccessRoleMutationError
+	if !errors.As(err, &mutation) {
+		return nil, false
+	}
+	payload, marshalErr := json.Marshal(accessRoleMutationRefusal{Code: mutation.Code, Feature: "access_role_mutations", Message: mutation.Message})
+	if marshalErr != nil {
+		return nil, false
+	}
+	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(payload)}}, IsError: true}, true
+}

--- a/server/internal/platformmcp/tool_access_role_mutations_test.go
+++ b/server/internal/platformmcp/tool_access_role_mutations_test.go
@@ -1,0 +1,33 @@
+package platformmcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccessRoleMutationToolsAreStableExternalOnlyMutations(t *testing.T) {
+	t.Parallel()
+
+	_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, nil, nil, nil, CatalogDescriptor{})
+	for _, name := range []string{operationCreateMCPAccessRole, operationUpdateMCPAccessRole} {
+		descriptor := descriptorByName(t, registrar, name)
+		require.Equal(t, externalOnly, descriptor.Meta.Audiences)
+		require.Equal(t, ProjectScopeExplicit, descriptor.Meta.ProjectScope)
+		require.NotNil(t, descriptor.Annotations)
+		require.False(t, descriptor.Annotations.ReadOnlyHint)
+		require.True(t, descriptor.Annotations.IdempotentHint)
+		require.NotNil(t, descriptor.Annotations.DestructiveHint)
+		require.Equal(t, name == operationUpdateMCPAccessRole, *descriptor.Annotations.DestructiveHint)
+
+		arguments := json.RawMessage(`{"project_id":"00000000-0000-0000-0000-000000000001","role_reference":"opaque","expected_version":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","add_rules":[],"remove_rules":[],"idempotency_key":"key","confirmed":true}`)
+		if name == operationCreateMCPAccessRole {
+			arguments = json.RawMessage(`{"project_id":"00000000-0000-0000-0000-000000000001","name":"Operators","rules":[],"idempotency_key":"key","confirmed":true}`)
+		}
+		_, err := descriptor.Invoke(ContextWithPrincipal(t.Context(), registrationServicePrincipal()), arguments)
+		var refusal *ToolRefusalError
+		require.ErrorAs(t, err, &refusal)
+		require.JSONEq(t, `{"code":"feature_unavailable","feature":"access_role_mutations","message":"This Platform MCP capability is not enabled for the current rollout."}`, refusal.Payload)
+	}
+}

--- a/server/internal/platformmcp/tool_call.go
+++ b/server/internal/platformmcp/tool_call.go
@@ -1,0 +1,25 @@
+package platformmcp
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// principalToolCall shares caller extraction and refusal handling while leaving
+// each tool family responsible for its own safe error projection.
+func principalToolCall[Out any](ctx context.Context, refusalFor func(error) (*mcp.CallToolResult, bool), call func(Principal) (Out, error)) (*mcp.CallToolResult, Out, error) {
+	var zero Out
+	principal, err := principalFromToolContext(ctx)
+	if err != nil {
+		return nil, zero, err
+	}
+	output, err := call(principal)
+	if err != nil {
+		if refusal, ok := refusalFor(err); ok {
+			return refusal, zero, nil
+		}
+		return nil, zero, err
+	}
+	return nil, output, nil
+}

--- a/server/internal/platformmcp/tool_plugins.go
+++ b/server/internal/platformmcp/tool_plugins.go
@@ -25,7 +25,7 @@ func registerPluginTools(reg *Registrar, plugins *PluginsService) {
 		Title:       "Set Plugin Assignments",
 		Description: setDescription,
 	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input SetPluginAssignmentsInput) (*mcp.CallToolResult, SetPluginAssignmentsOutput, error) {
-		return pluginToolCall(ctx, func(principal Principal) (SetPluginAssignmentsOutput, error) {
+		return principalToolCall(ctx, pluginToolResult, func(principal Principal) (SetPluginAssignmentsOutput, error) {
 			return plugins.SetPluginAssignments(ctx, principal, input)
 		})
 	})
@@ -36,7 +36,7 @@ func registerPluginTools(reg *Registrar, plugins *PluginsService) {
 		Description: "List up to 100 existing roles and directory assignment targets that can receive plugins in an explicit project. Each assignment has a short-lived opaque reference and, where available, a privacy-safe member count; Everyone has no member count. Raw principal identifiers are never returned. If truncated is true, use the dashboard to choose from the complete assignment set.",
 		Annotations: readOnlyAnnotations(),
 	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input ListPluginAssignmentsInput) (*mcp.CallToolResult, ListPluginAssignmentsOutput, error) {
-		return pluginToolCall(ctx, func(principal Principal) (ListPluginAssignmentsOutput, error) {
+		return principalToolCall(ctx, pluginToolResult, func(principal Principal) (ListPluginAssignmentsOutput, error) {
 			return plugins.ListPluginAssignments(ctx, principal, input)
 		})
 	})

--- a/server/internal/platformmcp/tool_plugins.go
+++ b/server/internal/platformmcp/tool_plugins.go
@@ -47,7 +47,7 @@ func registerPluginTools(reg *Registrar, plugins *PluginsService) {
 		Description: "List the plugins in a named project. A plugin is the bundle of MCP servers and skills an administrator shares with people, so this is the level to answer \"what do we ship\" at, rather than adding up individual servers. Each entry reports how much the plugin carries, who receives it, and whether it has been published — that is, whether the people it is shared with have it yet.",
 		Annotations: readOnlyAnnotations(),
 	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input ListPluginsInput) (*mcp.CallToolResult, ListPluginsOutput, error) {
-		return pluginToolCall(ctx, func(principal Principal) (ListPluginsOutput, error) {
+		return principalToolCall(ctx, pluginToolResult, func(principal Principal) (ListPluginsOutput, error) {
 			return plugins.ListPlugins(ctx, principal, input)
 		})
 	})
@@ -58,7 +58,7 @@ func registerPluginTools(reg *Registrar, plugins *PluginsService) {
 		Description: "Get one plugin — the bundle of MCP servers and skills you share with people — and what it carries: its MCP servers, skills, up to 100 current assignments, and an assignment version for safe follow-up edits. Assignment references expire at the returned time; if assignments_truncated is true or assignment_details_complete is false, use the dashboard before editing assignments. The general truncated field applies only to MCP servers and skills. Constraints: name the plugin exactly by ID, slug, or name; a name matching nothing is refused as not_found and a name matching more than one plugin as ambiguous_target, never silently answered with the default plugin.",
 		Annotations: readOnlyAnnotations(),
 	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input GetPluginInput) (*mcp.CallToolResult, GetPluginOutput, error) {
-		return pluginToolCall(ctx, func(principal Principal) (GetPluginOutput, error) {
+		return principalToolCall(ctx, pluginToolResult, func(principal Principal) (GetPluginOutput, error) {
 			return plugins.GetPlugin(ctx, principal, input)
 		})
 	})
@@ -82,25 +82,6 @@ func registerUnavailablePluginTools(reg *Registrar) {
 		}
 		addTool(reg, manifest, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, unavailableTool("plugins"))
 	}
-}
-
-// pluginToolCall runs one plugin call and turns a refusal into a structured
-// error result rather than a transport error, so the reason survives to the
-// model that has to act on it.
-func pluginToolCall[Out any](ctx context.Context, call func(principal Principal) (Out, error)) (*mcp.CallToolResult, Out, error) {
-	var zero Out
-	principal, err := principalFromToolContext(ctx)
-	if err != nil {
-		return nil, zero, err
-	}
-	output, err := call(principal)
-	if err != nil {
-		if refusal, ok := pluginToolResult(err); ok {
-			return refusal, zero, nil
-		}
-		return nil, zero, err
-	}
-	return nil, output, nil
 }
 
 func pluginToolResult(err error) (*mcp.CallToolResult, bool) {

--- a/server/internal/platformmcp/tools.go
+++ b/server/internal/platformmcp/tools.go
@@ -151,10 +151,10 @@ type operationBudgetResult struct {
 // assistant — can be composed from the same registration pass rather than from
 // a second list that would drift.
 func newServer(reader Reader, catalog Catalog, registrations *RegistrationService, cursorKeyMaterial string, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, candidate CatalogDescriptor) (*mcp.Server, *Registrar) {
-	return newServerWithRiskMutations(reader, catalog, registrations, cursorKeyMaterial, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, nil, candidate)
+	return newServerWithRiskMutations(reader, catalog, registrations, cursorKeyMaterial, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, nil, candidate, nil)
 }
 
-func newServerWithRiskMutations(reader Reader, catalog Catalog, registrations *RegistrationService, cursorKeyMaterial string, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, riskMutations *RiskMutationHandlers, candidate CatalogDescriptor) (*mcp.Server, *Registrar) {
+func newServerWithRiskMutations(reader Reader, catalog Catalog, registrations *RegistrationService, cursorKeyMaterial string, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, riskMutations *RiskMutationHandlers, candidate CatalogDescriptor, accessRead *AccessReadService) (*mcp.Server, *Registrar) {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "platform-mcp",
 		Title:   "Platform MCP",
@@ -296,6 +296,11 @@ func newServerWithRiskMutations(reader Reader, catalog Catalog, registrations *R
 		registerUnavailablePluginTools(reg)
 	} else {
 		registerPluginTools(reg, plugins)
+	}
+	if !accessRead.valid() {
+		registerUnavailableAccessReadTools(reg)
+	} else {
+		registerAccessReadTools(reg, accessRead)
 	}
 	if !sessionRecall.valid() {
 		registerUnavailableSessionRecallTools(reg)

--- a/server/internal/platformmcp/tools.go
+++ b/server/internal/platformmcp/tools.go
@@ -151,10 +151,10 @@ type operationBudgetResult struct {
 // assistant — can be composed from the same registration pass rather than from
 // a second list that would drift.
 func newServer(reader Reader, catalog Catalog, registrations *RegistrationService, cursorKeyMaterial string, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, candidate CatalogDescriptor) (*mcp.Server, *Registrar) {
-	return newServerWithRiskMutations(reader, catalog, registrations, cursorKeyMaterial, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, nil, candidate, nil)
+	return newServerWithRiskMutations(reader, catalog, registrations, cursorKeyMaterial, setupResources, feedback, onboarding, distributions, skills, diagnostics, plugins, sessionRecall, nil, candidate, nil, nil)
 }
 
-func newServerWithRiskMutations(reader Reader, catalog Catalog, registrations *RegistrationService, cursorKeyMaterial string, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, riskMutations *RiskMutationHandlers, candidate CatalogDescriptor, accessRead *AccessReadService) (*mcp.Server, *Registrar) {
+func newServerWithRiskMutations(reader Reader, catalog Catalog, registrations *RegistrationService, cursorKeyMaterial string, setupResources []SetupResource, feedback *FeedbackService, onboarding *OnboardingService, distributions *DistributionService, skills *SkillsService, diagnostics *DiagnosticsService, plugins *PluginsService, sessionRecall *SessionRecallService, riskMutations *RiskMutationHandlers, candidate CatalogDescriptor, accessRead *AccessReadService, accessRoleMutations *AccessRoleMutationService) (*mcp.Server, *Registrar) {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "platform-mcp",
 		Title:   "Platform MCP",
@@ -302,6 +302,7 @@ func newServerWithRiskMutations(reader Reader, catalog Catalog, registrations *R
 	} else {
 		registerAccessReadTools(reg, accessRead)
 	}
+	registerAccessRoleMutationTools(reg, accessRoleMutations)
 	if !sessionRecall.valid() {
 		registerUnavailableSessionRecallTools(reg)
 	} else {


### PR DESCRIPTION
## Linear

- [AIM-223](https://linear.app/speakeasy/issue/AIM-223)

## Why

Platform MCP operators can inspect access roles today, but cannot safely create or update the custom roles that govern MCP connectivity and tool access. This adds the mutation half of that workflow while keeping project scope, role type, and grant shape tightly constrained.

## What changed

- Add external-only `create_mcp_access_role` and `update_mcp_access_role` tools with explicit project targeting and confirmation.
- Restrict mutations to custom roles and server-generated `mcp:connect` selectors for MCP servers and exact tools.
- Preserve unrelated non-MCP grants during updates, while allowing stale MCP grants to be removed when the catalog has changed or is unavailable.
- Persist role changes, grant changes, audit records, and idempotency receipts atomically; make post-commit WorkOS reconciliation replay-safe.
- Add a dedicated feature flag and connection/organization operation budget, opaque role references, version checks, and safe unavailable handlers when dependencies are absent.
- Add focused unit and integration coverage plus a changelog entry.

## Review notes

This is stacked on #6075 (`feat/platform-mcp-inspect-access`) because it extends the access-role read contracts introduced there.

## Validation

- [x] `mise lint:server`
- [x] `mise run test:server ./internal/platformmcp ./internal/access ./internal/authz ./internal/mcp ./internal/remotemcp ./cmd/gram` (2,124 tests)
- [x] `mise build:server`
- [x] `mise run gen:sqlc-server`
- [x] `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds confirmed, idempotent Platform MCP tools for creating and updating custom MCP access roles. Operators could previously only inspect access roles; they can now manage the custom roles that govern MCP connectivity. Read results now return an opaque revision so updates can carry an optimistic version check, and post-commit WorkOS reconciliation runs with its own deadline detached from the caller's cancellation.

**New Features**
- Adds external-only `create_mcp_access_role` and `update_mcp_access_role` tools gated by the new `platform-mcp-access-role-mutations` feature flag.
- Restricts mutations to custom roles and server-generated `mcp:connect` selectors for MCP servers and exact tools.
- Preserves unrelated non-MCP grants on update while allowing stale MCP grants to be removed.
- Persists role, grant, audit, and idempotency receipts atomically; post-commit reconciliation is replay-safe.
- Enforces confirmation, opaque role references, optimistic version checks, and per-connection/organization rate limits.

<sup>Written for commit ddaae9f7c020442263d8c7c074b7b0a0291beb93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


