### PR TITLE
fix: restore hosted MCP project context for organization-wide keys

### DIFF
--- a/.changeset/age-3398-mcp-project-context.md
+++ b/.changeset/age-3398-mcp-project-context.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Provide authorized hosted MCP project context for organization-wide API keys when executing platform tools, while rejecting conflicting project bindings.

--- a/server/internal/mcp/hosted_project_context_test.go
+++ b/server/internal/mcp/hosted_project_context_test.go
@@ -1,0 +1,117 @@
+package mcp_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	platformusersessions "github.com/speakeasy-api/gram/server/internal/platformtools/usersessions"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+func TestHostedPlatformTool_ProjectContext(t *testing.T) {
+	t.Parallel()
+
+	for _, visibility := range []string{"public", "private"} {
+		for _, binding := range []string{"organization", "matching", "conflicting", "foreign organization", "anonymous"} {
+			t.Run(visibility+"/"+binding, func(t *testing.T) {
+				t.Parallel()
+				ctx, ti := newTestMCPService(t)
+				owner, ok := contextvalues.GetAuthContext(ctx)
+				require.True(t, ok)
+				require.NotNil(t, owner.ProjectID)
+
+				target := *owner
+				if binding == "foreign organization" {
+					target.ActiveOrganizationID = "test-foreign-organization"
+					_, err := orgrepo.New(ti.conn).UpsertOrganizationMetadata(ctx, orgrepo.UpsertOrganizationMetadataParams{
+						ID: target.ActiveOrganizationID, Name: "Foreign organization", Slug: "foreign-organization",
+						WorkosID: pgtype.Text{}, Whitelisted: pgtype.Bool{},
+					})
+					require.NoError(t, err)
+					project, err := projectsrepo.New(ti.conn).CreateProject(ctx, projectsrepo.CreateProjectParams{
+						Name: "Foreign project", Slug: "foreign-project", OrganizationID: target.ActiveOrganizationID,
+					})
+					require.NoError(t, err)
+					target.ProjectID = &project.ID
+				}
+
+				toolsets := toolsetsrepo.New(ti.conn)
+				toolset := createPublicMCPToolset(t, ctx, toolsets, &target, "project-context")
+				descriptor := platformusersessions.NewListUserSessionsTool(ti.conn).Descriptor()
+				_, err := toolsets.CreateToolsetVersion(ctx, toolsetsrepo.CreateToolsetVersionParams{
+					ToolsetID: toolset.ID, Version: 1,
+					ToolUrns:     []urn.Tool{descriptor.ToolURN()},
+					ResourceUrns: []urn.Resource{}, PredecessorID: uuid.NullUUID{},
+				})
+				require.NoError(t, err)
+				createToolsetMcpEndpoint(t, ctx, ti.conn, *target.ProjectID, toolset.ID, "project-context", visibility, uuid.NullUUID{}, uuid.Nil)
+
+				keyOwner := *owner
+				keyOwner.ProjectID = nil
+				keyOwner.ProjectSlug = nil
+				switch binding {
+				case "matching":
+					keyOwner.ProjectID = owner.ProjectID
+				case "conflicting":
+					other, err := projectsrepo.New(ti.conn).CreateProject(ctx, projectsrepo.CreateProjectParams{
+						Name: "Other project", Slug: "other-project", OrganizationID: owner.ActiveOrganizationID,
+					})
+					require.NoError(t, err)
+					keyOwner.ProjectID = &other.ID
+				}
+
+				requestCtx := t.Context()
+				var key string
+				if binding != "anonymous" {
+					key = ti.createTestAPIKey(contextvalues.SetAuthContext(ctx, &keyOwner), t)
+					request := httptest.NewRequest(http.MethodPost, "/mcp/project-context", nil)
+					request.Header.Set("Authorization", "Bearer "+key)
+					requestCtx, err = ti.service.TryPublicIdentityAuth(requestCtx, request, false, toolset.ID)
+					require.NoError(t, err)
+				}
+				caller, _ := contextvalues.GetAuthContext(requestCtx)
+
+				// Public requests exercise an already-authenticated context shared
+				// with the caller; private requests authenticate the actual key.
+				if visibility == "public" {
+					key = ""
+				}
+				response, err := servePublicHTTP(t, requestCtx, ti, "project-context", makeToolsCallBody(descriptor.Name), key, nil)
+				if binding == "conflicting" {
+					require.ErrorContains(t, err, "api key project does not match toolset project")
+				} else if visibility == "private" && (binding == "anonymous" || binding == "foreign organization") {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, http.StatusOK, response.Code)
+					var rpc struct {
+						Result json.RawMessage `json:"result"`
+						Error  json.RawMessage `json:"error"`
+					}
+					require.NoError(t, json.Unmarshal(response.Body.Bytes(), &rpc))
+					if binding == "anonymous" || binding == "foreign organization" {
+						require.NotEmpty(t, rpc.Error)
+						require.Empty(t, rpc.Result)
+					} else {
+						require.Empty(t, rpc.Error, "platform execution failed: %s", response.Body.String())
+						require.Contains(t, string(rpc.Result), "items")
+						require.NotContains(t, string(rpc.Result), `"isError":true`)
+					}
+				}
+				if caller != nil {
+					require.Equal(t, keyOwner.ProjectID, caller.ProjectID, "request must not mutate the caller's project binding")
+				}
+			})
+		}
+	}
+}

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -1059,6 +1059,19 @@ func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, t
 			}
 		}
 
+		if authCtx, ok := contextvalues.GetAuthContext(ctx); ok && authCtx != nil && authCtx.APIKeyID != "" {
+			if authCtx.ProjectID != nil && *authCtx.ProjectID != toolset.ProjectID {
+				return oops.E(oops.CodeForbidden, nil, "api key project does not match toolset project")
+			}
+			if authCtx.ProjectID == nil {
+				// Organization-wide keys gain execution context only after project
+				// access is authorized. Copy the context so sibling calls cannot
+				// inherit this request's project binding.
+				projectAuth := *authCtx
+				projectAuth.ProjectID = &toolset.ProjectID
+				ctx = contextvalues.SetAuthContext(ctx, &projectAuth)
+			}
+		}
 	}
 
 	// Decode the raw body first to check for batch requests


### PR DESCRIPTION
## Summary

Fixes AGE-3398.

Bind organization-wide API-key calls to the hosted collection's project after access authorization. Preserve matching bindings and reject conflicting bindings without mutating shared authentication context.

## Motivation

Hosted platform tools require project-bound execution context even when an organization-wide consumer key is valid. Supplying that missing context allows authorized tool calls to execute while retaining organization membership checks and the platform runtime's project guard.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AGE-3398: hosted MCP platform tool calls with organization-wide consumer API keys now execute by supplying the authorized toolset's project ID as auth context, instead of failing with `platform tool requires project auth context`.

- Rejects API keys bound to a different project than the toolset's project.
- Copies the auth context before injecting the project ID so sibling calls can't inherit the temporary binding.

<sup>Written for commit baa941e371b1f00442c600142a7b84ba48545c2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

