### PR TITLE
feat: allow optional project binding for API keys

### DIFF
--- a/.changeset/age-3399-key-project-binding.md
+++ b/.changeset/age-3399-key-project-binding.md
@@ -1,0 +1,6 @@
+---
+"dashboard": patch
+"server": patch
+---
+
+Allow API keys to be bound to an authorized project during creation, while keeping organization-wide keys as the default. Display project bindings separately from permission scopes.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -66271,6 +66271,10 @@ components:
         name:
           type: string
           description: The name of the key
+        project_id:
+          type: string
+          description: Optional project binding. Omit for an organization-wide key; independent of permission scopes and the Gram-Project header.
+          format: uuid
         scopes:
           type: array
           items:

--- a/client/dashboard/src/pages/org/OrgApiKeys.test.tsx
+++ b/client/dashboard/src/pages/org/OrgApiKeys.test.tsx
@@ -1,0 +1,256 @@
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import OrgApiKeys from "./OrgApiKeys";
+import { createKeyFormToJSON } from "@gram/client/models/components/createkeyform.js";
+
+const mocks = vi.hoisted(() => ({
+  organization: {
+    id: "org_test",
+    projects: [
+      {
+        id: "11111111-1111-4111-8111-111111111111",
+        name: "Test project",
+        slug: "test-project",
+      },
+    ],
+  },
+  mutate: vi.fn(),
+  onCreated: async (_key: object) => {},
+  keys: [] as object[],
+  admin: true,
+}));
+vi.mock("@/contexts/Auth", () => ({
+  useOrganization: () => mocks.organization,
+}));
+vi.mock("@/components/require-scope", () => ({
+  RequireScope: ({ children }: { children: ReactNode }) =>
+    mocks.admin ? children : null,
+}));
+vi.mock("@/components/page-templates", () => ({
+  ResourceListPage: ({
+    children,
+    primaryAction,
+  }: {
+    children: ReactNode;
+    primaryAction: ReactNode;
+  }) => (
+    <>
+      {primaryAction}
+      {children}
+    </>
+  ),
+}));
+vi.mock("@gram/client/react-query/createAPIKey", () => ({
+  useCreateAPIKeyMutation: (options: {
+    onSuccess: (key: object) => Promise<void>;
+  }) => {
+    mocks.onCreated = options.onSuccess;
+    return { mutate: mocks.mutate, isPending: false };
+  },
+}));
+vi.mock("@gram/client/react-query/listAPIKeys", () => ({
+  useListAPIKeysSuspense: () => ({ data: { keys: mocks.keys } }),
+  invalidateListAPIKeys: vi.fn(),
+}));
+vi.mock("@gram/client/react-query/revokeAPIKey", () => ({
+  useRevokeAPIKeyMutation: () => ({ mutate: vi.fn() }),
+}));
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ refetchQueries: vi.fn() }),
+}));
+
+beforeEach(() => {
+  mocks.mutate.mockClear();
+  mocks.keys = [];
+  mocks.admin = true;
+  mocks.organization = {
+    id: "org_test",
+    projects: [
+      {
+        id: "11111111-1111-4111-8111-111111111111",
+        name: "Test project",
+        slug: "test-project",
+      },
+    ],
+  };
+  // Radix scrolls the selected option into view in browsers.
+  Element.prototype.scrollIntoView = vi.fn<() => void>();
+});
+afterEach(cleanup);
+
+async function openForm() {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: "New API Key" }));
+  await user.type(screen.getByLabelText("Key name"), "Test key");
+  return user;
+}
+async function selectProject(
+  user: ReturnType<typeof userEvent.setup>,
+  name: string,
+) {
+  await user.click(
+    screen.getByRole("combobox", { name: "Project binding (optional)" }),
+  );
+  await user.click(screen.getByRole("option", { name }));
+}
+
+describe("API key project binding", () => {
+  it("defaults to organization-wide and preserves permission scope", async () => {
+    render(<OrgApiKeys />);
+    const user = await openForm();
+    await user.click(screen.getByRole("radio", { name: /^Producer:/ }));
+    await user.click(screen.getByRole("button", { name: "Create" }));
+    expect(
+      JSON.parse(
+        createKeyFormToJSON(
+          mocks.mutate.mock.calls[0]?.[0].request.createKeyForm,
+        ),
+      ),
+    ).toEqual({ name: "Test key", scopes: ["producer"] });
+    expect(mocks.mutate.mock.calls[0]?.[0]).toEqual({
+      security: { sessionHeaderGramSession: "" },
+      request: {
+        createKeyForm: {
+          name: "Test key",
+          scopes: ["producer"],
+          projectId: undefined,
+        },
+      },
+    });
+  });
+
+  it("sends the selected project ID in the body, not a project header", async () => {
+    render(<OrgApiKeys />);
+    const user = await openForm();
+    await selectProject(user, "Test project");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+    expect(
+      JSON.parse(
+        createKeyFormToJSON(
+          mocks.mutate.mock.calls[0]?.[0].request.createKeyForm,
+        ),
+      ),
+    ).toEqual({
+      name: "Test key",
+      scopes: ["consumer"],
+      project_id: mocks.organization.projects[0]!.id,
+    });
+    expect(mocks.mutate.mock.calls[0]?.[0].request).toEqual({
+      createKeyForm: {
+        name: "Test key",
+        scopes: ["consumer"],
+        projectId: mocks.organization.projects[0]!.id,
+      },
+    });
+  });
+
+  it("can explicitly switch back to organization-wide", async () => {
+    render(<OrgApiKeys />);
+    const user = await openForm();
+    await selectProject(user, "Test project");
+    await selectProject(user, "Organization-wide (no project)");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+    expect(
+      mocks.mutate.mock.calls[0]?.[0].request.createKeyForm.projectId,
+    ).toBeUndefined();
+  });
+
+  it("clears selection on cancel and organization changes", async () => {
+    const view = render(<OrgApiKeys />);
+    const user = await openForm();
+    await selectProject(user, "Test project");
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    await openForm();
+    expect(screen.getByRole("combobox").textContent).toContain(
+      "Organization-wide",
+    );
+    await selectProject(user, "Test project");
+    mocks.organization = { id: "org_other", projects: [] };
+    view.rerender(<OrgApiKeys />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+    await openForm();
+    expect(screen.getByRole("combobox").textContent).toContain(
+      "Organization-wide",
+    );
+    await user.click(screen.getByRole("button", { name: "Create" }));
+    expect(
+      mocks.mutate.mock.calls[0]?.[0].request.createKeyForm.projectId,
+    ).toBeUndefined();
+  });
+
+  it("does not silently broaden a no-longer-authorized project selection", async () => {
+    const view = render(<OrgApiKeys />);
+    const user = await openForm();
+    await selectProject(user, "Test project");
+    mocks.organization = { ...mocks.organization, projects: [] };
+    view.rerender(<OrgApiKeys />);
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Create",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+    fireEvent.submit(screen.getByLabelText("Key name").closest("form")!);
+    expect(mocks.mutate).not.toHaveBeenCalled();
+  });
+
+  it("shows binding separately from permission scopes in the list", () => {
+    mocks.keys = [
+      {
+        id: "key_test",
+        name: "Bound key",
+        keyPrefix: "test-prefix",
+        scopes: ["consumer"],
+        projectId: mocks.organization.projects[0]!.id,
+        createdAt: new Date(),
+      },
+      {
+        id: "key_org",
+        name: "Org key",
+        keyPrefix: "test-prefix",
+        scopes: ["consumer"],
+        createdAt: new Date(),
+      },
+    ];
+    render(<OrgApiKeys />);
+    expect(screen.getByText("Project binding")).toBeTruthy();
+    expect(screen.getByText("Test project")).toBeTruthy();
+    expect(screen.getByText("Organization-wide")).toBeTruthy();
+  });
+
+  it("shows the returned binding with the one-time secret and clears both on close", async () => {
+    render(<OrgApiKeys />);
+    const user = await openForm();
+    await act(() =>
+      mocks.onCreated({
+        id: "key_created",
+        name: "Test key",
+        key: "synthetic-test-secret",
+        projectId: mocks.organization.projects[0]!.id,
+      }),
+    );
+    expect(screen.getByText("Project binding: Test project")).toBeTruthy();
+    expect(screen.getByText("synthetic-test-secret")).toBeTruthy();
+    await user.click(screen.getAllByRole("button", { name: "Close" })[0]!);
+    await openForm();
+    expect(screen.queryByText("synthetic-test-secret")).toBeNull();
+    expect(screen.getByRole("combobox").textContent).toContain(
+      "Organization-wide",
+    );
+  });
+
+  it("retains the admin gate", () => {
+    mocks.admin = false;
+    render(<OrgApiKeys />);
+    expect(screen.queryByRole("button", { name: "New API Key" })).toBeNull();
+  });
+});

--- a/client/dashboard/src/pages/org/OrgApiKeys.test.tsx
+++ b/client/dashboard/src/pages/org/OrgApiKeys.test.tsx
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
     ],
   },
   mutate: vi.fn(),
+  pending: false,
   onCreated: async (_key: object) => {},
   keys: [] as object[],
   admin: true,
@@ -53,7 +54,7 @@ vi.mock("@gram/client/react-query/createAPIKey", () => ({
     onSuccess: (key: object) => Promise<void>;
   }) => {
     mocks.onCreated = options.onSuccess;
-    return { mutate: mocks.mutate, isPending: false };
+    return { mutate: mocks.mutate, isPending: mocks.pending };
   },
 }));
 vi.mock("@gram/client/react-query/listAPIKeys", () => ({
@@ -69,6 +70,7 @@ vi.mock("@tanstack/react-query", () => ({
 
 beforeEach(() => {
   mocks.mutate.mockClear();
+  mocks.pending = false;
   mocks.keys = [];
   mocks.admin = true;
   mocks.organization = {
@@ -96,9 +98,7 @@ async function selectProject(
   user: ReturnType<typeof userEvent.setup>,
   name: string,
 ) {
-  await user.click(
-    screen.getByRole("combobox", { name: "Project binding (optional)" }),
-  );
+  await user.click(screen.getByRole("combobox", { name: "Project" }));
   await user.click(screen.getByRole("option", { name }));
 }
 
@@ -156,7 +156,7 @@ describe("API key project binding", () => {
     render(<OrgApiKeys />);
     const user = await openForm();
     await selectProject(user, "Test project");
-    await selectProject(user, "Organization-wide (no project)");
+    await selectProject(user, "Organization-wide");
     await user.click(screen.getByRole("button", { name: "Create" }));
     expect(
       mocks.mutate.mock.calls[0]?.[0].request.createKeyForm.projectId,
@@ -201,6 +201,51 @@ describe("API key project binding", () => {
     ).toBe(true);
     fireEvent.submit(screen.getByLabelText("Key name").closest("form")!);
     expect(mocks.mutate).not.toHaveBeenCalled();
+    expect(screen.getByRole("combobox", { name: "Project" }).textContent).toBe(
+      "Unavailable project",
+    );
+    expect(
+      screen.getByText(
+        "This project is no longer available. Select a project or Organization-wide.",
+      ),
+    ).toBeTruthy();
+    await selectProject(user, "Organization-wide");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+    expect(
+      mocks.mutate.mock.calls[0]?.[0].request.createKeyForm.projectId,
+    ).toBeUndefined();
+  });
+
+  it("blocks duplicate submissions while creation is pending", async () => {
+    const view = render(<OrgApiKeys />);
+    await openForm();
+    mocks.pending = true;
+    view.rerender(<OrgApiKeys />);
+    fireEvent.submit(screen.getByLabelText("Key name").closest("form")!);
+    expect(mocks.mutate).not.toHaveBeenCalled();
+  });
+
+  it("does not show an old organization's delayed creation result", async () => {
+    const view = render(<OrgApiKeys />);
+    const user = await openForm();
+    await selectProject(user, "Test project");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+    const oldOnCreated = mocks.onCreated;
+    mocks.organization = { id: "org_other", projects: [] };
+    view.rerender(<OrgApiKeys />);
+    await openForm();
+    await act(() =>
+      oldOnCreated({
+        id: "old_key",
+        name: "Old key",
+        key: "synthetic-old-secret",
+        projectId: "11111111-1111-4111-8111-111111111111",
+      }),
+    );
+    expect(screen.queryByText("synthetic-old-secret")).toBeNull();
+    expect(screen.getByRole("combobox").textContent).toContain(
+      "Organization-wide",
+    );
   });
 
   it("shows binding separately from permission scopes in the list", () => {

--- a/client/dashboard/src/pages/org/OrgApiKeys.tsx
+++ b/client/dashboard/src/pages/org/OrgApiKeys.tsx
@@ -20,20 +20,39 @@ import { Column, Table } from "@/components/ui/Table";
 import { useQueryClient } from "@tanstack/react-query";
 import { CheckCircle2, Copy } from "lucide-react";
 import { useMemo, useState } from "react";
+import { useOrganization } from "@/contexts/Auth";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/Select";
 import { RequireScope } from "@/components/require-scope";
 
 export default function OrgApiKeys(): JSX.Element {
+  const organization = useOrganization();
   // The key fetching request returns a forbidden error without the org:admin
   // scope; the outer RequireScope gates rendering (and the data hook) on that
   // scope.
   return (
     <RequireScope scope="org:admin" level="page">
-      <OrgApiKeysInner />
+      <OrgApiKeysInner key={organization.id} />
     </RequireScope>
   );
 }
 
 function OrgApiKeysInner() {
+  const organization = useOrganization();
+  const [projectId, setProjectId] = useState("organization-wide");
+  const projectSelectionValid =
+    projectId === "organization-wide" ||
+    organization.projects.some((project) => project.id === projectId);
+  const projectLabel = (id?: string) =>
+    id
+      ? (organization.projects.find((project) => project.id === id)?.name ??
+        "Unavailable project")
+      : "Organization-wide";
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [keyToRevoke, setKeyToRevoke] = useState<Key | null>(null);
   const [newlyCreatedKey, setNewlyCreatedKey] = useState<Key | null>(null);
@@ -72,6 +91,7 @@ function OrgApiKeysInner() {
 
   const handleCreateKey: React.FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
+    if (!projectSelectionValid || createKeyMutation.isPending) return;
     const formEl = e.currentTarget;
     const formData = new FormData(formEl);
     const newKeyName = formData.get("name");
@@ -85,6 +105,8 @@ function OrgApiKeysInner() {
         request: {
           createKeyForm: {
             name: newKeyName,
+            projectId:
+              projectId === "organization-wide" ? undefined : projectId,
             scopes: [scope],
           },
         },
@@ -120,6 +142,7 @@ function OrgApiKeysInner() {
     setIsCreateDialogOpen(false);
     setNewlyCreatedKey(null);
     setIsCopied(false);
+    setProjectId("organization-wide");
   };
 
   const apiKeyColumns: Column<Key>[] = [
@@ -137,9 +160,17 @@ function OrgApiKeysInner() {
     },
     {
       key: "scopes",
-      header: "Scopes",
+      header: "Permission scopes",
       width: "1fr",
       render: (key: Key) => <Text variant="body">{key.scopes.join(", ")}</Text>,
+    },
+    {
+      key: "projectId",
+      header: "Project binding",
+      width: "1fr",
+      render: (key: Key) => (
+        <Text variant="body">{projectLabel(key.projectId)}</Text>
+      ),
     },
     {
       key: "createdAt",
@@ -249,6 +280,9 @@ function OrgApiKeysInner() {
                 You will not be able to see this token value again once you
                 close this dialog. Copy it now and store it securely.
               </div>
+              <Text variant="body">
+                Project binding: {projectLabel(newlyCreatedKey.projectId)}
+              </Text>
               <div className="bg-muted flex items-center space-x-2 p-3">
                 <code className="flex-1 break-all">{newlyCreatedKey.key}</code>
                 <Button
@@ -283,8 +317,44 @@ function OrgApiKeysInner() {
                 autoCorrect="off"
               />
 
+              <div className="space-y-2">
+                <Label htmlFor="key-project">Project binding (optional)</Label>
+                <Select value={projectId} onValueChange={setProjectId}>
+                  <SelectTrigger
+                    id="key-project"
+                    aria-describedby="key-project-help"
+                    className="w-full"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="organization-wide">
+                      Organization-wide (no project)
+                    </SelectItem>
+                    {organization.projects.map((project) => (
+                      <SelectItem key={project.id} value={project.id}>
+                        {project.name}
+                      </SelectItem>
+                    ))}
+                    {!projectSelectionValid && (
+                      <SelectItem value={projectId} disabled>
+                        Unavailable project
+                      </SelectItem>
+                    )}
+                  </SelectContent>
+                </Select>
+                <Text
+                  id="key-project-help"
+                  variant="body"
+                  className="text-muted-foreground"
+                >
+                  Bind this key to one project, or leave it organization-wide.
+                  Permission scopes below determine what the key can do.
+                </Text>
+              </div>
+
               <AnyField
-                label="Scope"
+                label="Permission scope"
                 optionality="hidden"
                 render={() => {
                   return (
@@ -339,7 +409,12 @@ function OrgApiKeysInner() {
                 >
                   Cancel
                 </Button>
-                <Button type="submit" disabled={createKeyMutation.isPending}>
+                <Button
+                  type="submit"
+                  disabled={
+                    createKeyMutation.isPending || !projectSelectionValid
+                  }
+                >
                   Create
                 </Button>
               </div>

--- a/client/dashboard/src/pages/org/OrgApiKeys.tsx
+++ b/client/dashboard/src/pages/org/OrgApiKeys.tsx
@@ -268,7 +268,7 @@ function OrgApiKeysInner() {
       </ResourceListPage>
 
       <Dialog open={isCreateDialogOpen} onOpenChange={handleCloseCreateDialog}>
-        <Dialog.Content>
+        <Dialog.Content className="max-h-[90vh] overflow-y-auto">
           <Dialog.Header>
             <Dialog.Title>
               {newlyCreatedKey ? "API Key Created" : "Create New API Key"}

--- a/client/dashboard/src/pages/org/OrgApiKeys.tsx
+++ b/client/dashboard/src/pages/org/OrgApiKeys.tsx
@@ -48,11 +48,13 @@ function OrgApiKeysInner() {
   const projectSelectionValid =
     projectId === "organization-wide" ||
     organization.projects.some((project) => project.id === projectId);
-  const projectLabel = (id?: string) =>
-    id
-      ? (organization.projects.find((project) => project.id === id)?.name ??
-        "Unavailable project")
-      : "Organization-wide";
+  const projectLabel = (id?: string) => {
+    if (!id) return "Organization-wide";
+    return (
+      organization.projects.find((project) => project.id === id)?.name ??
+      "Unavailable project"
+    );
+  };
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [keyToRevoke, setKeyToRevoke] = useState<Key | null>(null);
   const [newlyCreatedKey, setNewlyCreatedKey] = useState<Key | null>(null);
@@ -160,7 +162,7 @@ function OrgApiKeysInner() {
     },
     {
       key: "scopes",
-      header: "Permission scopes",
+      header: "Scopes",
       width: "1fr",
       render: (key: Key) => <Text variant="body">{key.scopes.join(", ")}</Text>,
     },
@@ -317,44 +319,43 @@ function OrgApiKeysInner() {
                 autoCorrect="off"
               />
 
-              <div className="space-y-2">
-                <Label htmlFor="key-project">Project binding (optional)</Label>
-                <Select value={projectId} onValueChange={setProjectId}>
-                  <SelectTrigger
-                    id="key-project"
-                    aria-describedby="key-project-help"
-                    className="w-full"
-                  >
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="organization-wide">
-                      Organization-wide (no project)
-                    </SelectItem>
-                    {organization.projects.map((project) => (
-                      <SelectItem key={project.id} value={project.id}>
-                        {project.name}
+              <AnyField
+                label="Project"
+                hint="Restrict this key to a project without changing its scope."
+                error={
+                  !projectSelectionValid &&
+                  "This project is no longer available. Select a project or Organization-wide."
+                }
+                render={(props) => (
+                  <Select value={projectId} onValueChange={setProjectId}>
+                    <SelectTrigger
+                      {...props}
+                      aria-invalid={!projectSelectionValid}
+                      className="w-full"
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="organization-wide">
+                        Organization-wide
                       </SelectItem>
-                    ))}
-                    {!projectSelectionValid && (
-                      <SelectItem value={projectId} disabled>
-                        Unavailable project
-                      </SelectItem>
-                    )}
-                  </SelectContent>
-                </Select>
-                <Text
-                  id="key-project-help"
-                  variant="body"
-                  className="text-muted-foreground"
-                >
-                  Bind this key to one project, or leave it organization-wide.
-                  Permission scopes below determine what the key can do.
-                </Text>
-              </div>
+                      {organization.projects.map((project) => (
+                        <SelectItem key={project.id} value={project.id}>
+                          {project.name}
+                        </SelectItem>
+                      ))}
+                      {!projectSelectionValid && (
+                        <SelectItem value={projectId} disabled>
+                          Unavailable project
+                        </SelectItem>
+                      )}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
 
               <AnyField
-                label="Permission scope"
+                label="Scope"
                 optionality="hidden"
                 render={() => {
                   return (

--- a/client/dashboard/src/sdk/src/models/components/createkeyform.ts
+++ b/client/dashboard/src/sdk/src/models/components/createkeyform.ts
@@ -3,12 +3,17 @@
  */
 
 import * as z from "zod/v4-mini";
+import { remap as remap$ } from "../../lib/primitives.js";
 
 export type CreateKeyForm = {
   /**
    * The name of the key
    */
   name: string;
+  /**
+   * Optional project binding. Omit for an organization-wide key; independent of permission scopes and the Gram-Project header.
+   */
+  projectId?: string | undefined;
   /**
    * The scopes of the key that determines its permissions.
    */
@@ -18,6 +23,7 @@ export type CreateKeyForm = {
 /** @internal */
 export type CreateKeyForm$Outbound = {
   name: string;
+  project_id?: string | undefined;
   scopes: Array<string>;
 };
 
@@ -25,10 +31,18 @@ export type CreateKeyForm$Outbound = {
 export const CreateKeyForm$outboundSchema: z.ZodMiniType<
   CreateKeyForm$Outbound,
   CreateKeyForm
-> = z.object({
-  name: z.string(),
-  scopes: z.array(z.string()),
-});
+> = z.pipe(
+  z.object({
+    name: z.string(),
+    projectId: z.optional(z.string()),
+    scopes: z.array(z.string()),
+  }),
+  z.transform((v) => {
+    return remap$(v, {
+      projectId: "project_id",
+    });
+  }),
+);
 
 export function createKeyFormToJSON(createKeyForm: CreateKeyForm): string {
   return JSON.stringify(CreateKeyForm$outboundSchema.parse(createKeyForm));

--- a/seed/demo/PAGES.md
+++ b/seed/demo/PAGES.md
@@ -49,12 +49,12 @@ Status: `[x]` seeded + verified · `[~]` seeded, not yet verified · `[ ]` not s
 These come from `server/internal/demoseed/local.go` after the seed, so they are
 present in a developer's org and deliberately absent from the shared demo org.
 
-| Page               | Backing data                                                       |
-| ------------------ | ------------------------------------------------------------------ |
-| Environments       | One `Default` environment                                          |
-| Playground MCP App | Functions deployment + UI resource, zipped from `demoseed/mcpapp/` |
-| API keys           | The well-known `seed-key`                                          |
-| Catalog            | The global `Gram Recommended` registry row                         |
+| Page               | Backing data                                                                                |
+| ------------------ | ------------------------------------------------------------------------------------------- |
+| Environments       | One `Default` environment                                                                   |
+| Playground MCP App | Functions deployment + UI resource, zipped from `demoseed/mcpapp/`                          |
+| API keys           | The well-known `seed-key`, with its project binding shown separately from permission scopes |
+| Catalog            | The global `Gram Recommended` registry row                                                  |
 
 ## Not seeded (deliberate)
 

--- a/server/design/keys/design.go
+++ b/server/design/keys/design.go
@@ -101,6 +101,9 @@ var CreateKeyForm = Type("CreateKeyForm", func() {
 	Required("name", "scopes")
 
 	Attribute("name", String, "The name of the key")
+	Attribute("project_id", String, "Optional project binding. Omit for an organization-wide key; independent of permission scopes and the Gram-Project header.", func() {
+		Format(FormatUUID)
+	})
 	Attribute("scopes", ArrayOf(String), func() {
 		Description("The scopes of the key that determines its permissions.")
 

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -15381,7 +15381,7 @@ func keysCreateKeyUsage() {
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "keys create-key --body '{\n      \"name\": \"abc123\",\n      \"scopes\": [\n         \"abc123\",\n         \"abc123\"\n      ]\n   }' --session-token \"abc123\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "keys create-key --body '{\n      \"name\": \"abc123\",\n      \"project_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"scopes\": [\n         \"abc123\",\n         \"abc123\"\n      ]\n   }' --session-token \"abc123\"")
 }
 
 func keysListKeysUsage() {

--- a/server/gen/http/keys/client/cli.go
+++ b/server/gen/http/keys/client/cli.go
@@ -23,10 +23,13 @@ func BuildCreateKeyPayload(keysCreateKeyBody string, keysCreateKeySessionToken s
 	{
 		err = json.Unmarshal([]byte(keysCreateKeyBody), &body)
 		if err != nil {
-			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"name\": \"abc123\",\n      \"scopes\": [\n         \"abc123\",\n         \"abc123\"\n      ]\n   }'")
+			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"name\": \"abc123\",\n      \"project_id\": \"550e8400-e29b-41d4-a716-446655440000\",\n      \"scopes\": [\n         \"abc123\",\n         \"abc123\"\n      ]\n   }'")
 		}
 		if body.Scopes == nil {
 			err = goa.MergeErrors(err, goa.MissingFieldError("scopes", "body"))
+		}
+		if body.ProjectID != nil {
+			err = goa.MergeErrors(err, goa.ValidateFormat("body.project_id", *body.ProjectID, goa.FormatUUID))
 		}
 		if len(body.Scopes) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("body.scopes", body.Scopes, len(body.Scopes), 1, true))
@@ -42,7 +45,8 @@ func BuildCreateKeyPayload(keysCreateKeyBody string, keysCreateKeySessionToken s
 		}
 	}
 	v := &keys.CreateKeyPayload{
-		Name: body.Name,
+		Name:      body.Name,
+		ProjectID: body.ProjectID,
 	}
 	if body.Scopes != nil {
 		v.Scopes = make([]string, len(body.Scopes))

--- a/server/gen/http/keys/client/types.go
+++ b/server/gen/http/keys/client/types.go
@@ -17,6 +17,9 @@ import (
 type CreateKeyRequestBody struct {
 	// The name of the key
 	Name string `form:"name" json:"name" xml:"name"`
+	// Optional project binding. Omit for an organization-wide key; independent of
+	// permission scopes and the Gram-Project header.
+	ProjectID *string `form:"project_id,omitempty" json:"project_id,omitempty" xml:"project_id,omitempty"`
 	// The scopes of the key that determines its permissions.
 	Scopes []string `form:"scopes" json:"scopes" xml:"scopes"`
 }
@@ -837,7 +840,8 @@ type ValidateKeyProjectResponseBody struct {
 // "createKey" endpoint of the "keys" service.
 func NewCreateKeyRequestBody(p *keys.CreateKeyPayload) *CreateKeyRequestBody {
 	body := &CreateKeyRequestBody{
-		Name: p.Name,
+		Name:      p.Name,
+		ProjectID: p.ProjectID,
 	}
 	if p.Scopes != nil {
 		body.Scopes = make([]string, len(p.Scopes))

--- a/server/gen/http/keys/server/types.go
+++ b/server/gen/http/keys/server/types.go
@@ -17,6 +17,9 @@ import (
 type CreateKeyRequestBody struct {
 	// The name of the key
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
+	// Optional project binding. Omit for an organization-wide key; independent of
+	// permission scopes and the Gram-Project header.
+	ProjectID *string `form:"project_id,omitempty" json:"project_id,omitempty" xml:"project_id,omitempty"`
 	// The scopes of the key that determines its permissions.
 	Scopes []string `form:"scopes,omitempty" json:"scopes,omitempty" xml:"scopes,omitempty"`
 }
@@ -1471,7 +1474,8 @@ func NewVerifyKeyGatewayErrorResponseBody(res *goa.ServiceError) *VerifyKeyGatew
 // NewCreateKeyPayload builds a keys service createKey endpoint payload.
 func NewCreateKeyPayload(body *CreateKeyRequestBody, sessionToken *string) *keys.CreateKeyPayload {
 	v := &keys.CreateKeyPayload{
-		Name: *body.Name,
+		Name:      *body.Name,
+		ProjectID: body.ProjectID,
 	}
 	v.Scopes = make([]string, len(body.Scopes))
 	for i, val := range body.Scopes {
@@ -1515,6 +1519,9 @@ func ValidateCreateKeyRequestBody(body *CreateKeyRequestBody) (err error) {
 	}
 	if body.Scopes == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("scopes", "body"))
+	}
+	if body.ProjectID != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.project_id", *body.ProjectID, goa.FormatUUID))
 	}
 	if len(body.Scopes) < 1 {
 		err = goa.MergeErrors(err, goa.InvalidLengthError("body.scopes", body.Scopes, len(body.Scopes), 1, true))

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -69015,6 +69015,10 @@ components:
                 name:
                     type: string
                     description: The name of the key
+                project_id:
+                    type: string
+                    description: Optional project binding. Omit for an organization-wide key; independent of permission scopes and the Gram-Project header.
+                    format: uuid
                 scopes:
                     type: array
                     items:

--- a/server/gen/keys/service.go
+++ b/server/gen/keys/service.go
@@ -53,6 +53,9 @@ type CreateKeyPayload struct {
 	SessionToken *string
 	// The name of the key
 	Name string
+	// Optional project binding. Omit for an organization-wide key; independent of
+	// permission scopes and the Gram-Project header.
+	ProjectID *string
 	// The scopes of the key that determines its permissions.
 	Scopes []string
 }

--- a/server/internal/admin/converttrial_lock_test.go
+++ b/server/internal/admin/converttrial_lock_test.go
@@ -391,13 +391,17 @@ func TestMarkEnterpriseTrialConverted_SerializesRuntimeFeatureWritesThroughCache
 		return testrepo.New(conn).IsQueryBlockedOnLockFixture(check, "%AcquireOpenRouterBillingLock%")
 	}, "conversion did not reach the key lock after acquiring feature locks")
 
-	featureWriter, err := conn.Acquire(ctx)
-	require.NoError(t, err)
-	defer featureWriter.Release()
 	require.NotEmpty(t, productfeatures.TrialRuntimeFeatures)
 	feature := productfeatures.TrialRuntimeFeatures[0]
 	written := make(chan error, 1)
 	go func() {
+		featureWriter, acquireErr := conn.Acquire(ctx)
+		if acquireErr != nil {
+			written <- acquireErr
+			return
+		}
+		// The writer owns the connection until its deferred unlock completes.
+		defer featureWriter.Release()
 		q := featurerepo.New(featureWriter)
 		params := featurerepo.AcquireFeatureCacheLockParams{OrganizationID: orgID, FeatureName: string(feature)}
 		if lockErr := q.AcquireFeatureCacheLock(ctx, params); lockErr != nil {

--- a/server/internal/keys/impl.go
+++ b/server/internal/keys/impl.go
@@ -140,11 +140,27 @@ func (s *Service) CreateKey(ctx context.Context, payload *gen.CreateKeyPayload) 
 		return nil, oops.E(oops.CodeUnexpected, err, "error generating api key").LogError(ctx, s.logger)
 	}
 
+	// Binding is explicit: ambient request project context must not turn an
+	// organization-wide key into a project-bound key.
 	var projectID uuid.NullUUID
-	if authCtx.ProjectID != nil {
-		projectID = uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true}
-	} else {
-		projectID = uuid.NullUUID{UUID: uuid.UUID{}, Valid: false}
+	if payload.ProjectID != nil {
+		id, err := uuid.Parse(*payload.ProjectID)
+		if err != nil {
+			return nil, oops.E(oops.CodeBadRequest, err, "invalid project ID")
+		}
+		project, err := s.projectRepo.GetProjectByIDAndOrganizationID(ctx, project_repo.GetProjectByIDAndOrganizationIDParams{
+			ID: id, OrganizationID: authCtx.ActiveOrganizationID,
+		})
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, oops.E(oops.CodeNotFound, nil, "project not found")
+		}
+		if err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "load key project").LogError(ctx, s.logger)
+		}
+		if err := s.authz.Require(ctx, authz.Check{Scope: authz.ScopeProjectRead, ResourceKind: "", ResourceID: project.ID.String(), Dimensions: nil}); err != nil {
+			return nil, err
+		}
+		projectID = uuid.NullUUID{UUID: project.ID, Valid: true}
 	}
 
 	dbtx, err := s.db.Begin(ctx)

--- a/server/internal/keys/project_binding_test.go
+++ b/server/internal/keys/project_binding_test.go
@@ -3,18 +3,20 @@ package keys_test
 import (
 	"bytes"
 	"encoding/json"
-	httpkeys "github.com/speakeasy-api/gram/server/gen/http/keys/server"
-	goahttp "goa.design/goa/v3/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	goahttp "goa.design/goa/v3/http"
+
+	httpkeys "github.com/speakeasy-api/gram/server/gen/http/keys/server"
 	gen "github.com/speakeasy-api/gram/server/gen/keys"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
+	keysrepo "github.com/speakeasy-api/gram/server/internal/keys/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	projectrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
-	"github.com/stretchr/testify/require"
 )
 
 func TestKeysService_CreateKey_ProjectBinding(t *testing.T) {
@@ -34,12 +36,14 @@ func TestKeysService_CreateKey_ProjectBinding(t *testing.T) {
 				OrganizationID: authCtx.ActiveOrganizationID, Name: "Selected project", Slug: "selected-project",
 			})
 			require.NoError(t, err)
-			ctx = authztest.WithAdminGrants(ctx)
+			grants := []authz.Grant{authz.NewGrant(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID)}
 			var selected *string
 			if scoped {
 				id := project.ID.String()
 				selected = &id
+				grants = append(grants, authz.NewGrant(authz.ScopeProjectRead, id))
 			}
+			ctx = authztest.WithExactGrants(t, ctx, grants...)
 			body := map[string]any{"name": name, "scopes": []string{"producer"}}
 			if selected != nil {
 				body["project_id"] = *selected
@@ -66,7 +70,7 @@ func TestKeysService_CreateKey_ProjectBinding(t *testing.T) {
 
 func TestKeysService_CreateKey_RejectsInvalidProjectBinding(t *testing.T) {
 	t.Parallel()
-	for _, kind := range []string{"malformed", "unknown", "other-organization", "deleted", "no-project-grant", "no-admin-grant"} {
+	for _, kind := range []string{"malformed", "unknown", "other-organization", "deleted", "no-project-grant", "wrong-project-grant", "no-admin-grant", "wrong-organization-grant"} {
 		t.Run(kind, func(t *testing.T) {
 			t.Parallel()
 			ctx, ti := newTestKeysService(t)
@@ -83,10 +87,27 @@ func TestKeysService_CreateKey_RejectsInvalidProjectBinding(t *testing.T) {
 			case "other-organization":
 				authCtx.ActiveOrganizationID = "org_other_test"
 			case "deleted":
-				_, err := ti.conn.Exec(ctx, "UPDATE projects SET deleted_at = now() WHERE id = $1", authCtx.ProjectID)
+				_, err := projectrepo.New(ti.conn).DeleteProject(ctx, *authCtx.ProjectID)
 				require.NoError(t, err)
 			case "no-project-grant":
 				ctx = authztest.WithExactGrants(t, ctx, authz.Grant{Scope: authz.ScopeOrgAdmin, Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID)})
+				want = oops.CodeForbidden
+			case "wrong-project-grant":
+				project, err := projectrepo.New(ti.conn).CreateProject(ctx, projectrepo.CreateProjectParams{
+					OrganizationID: authCtx.ActiveOrganizationID, Name: "Selected project", Slug: "selected-project",
+				})
+				require.NoError(t, err)
+				ctx = authztest.WithExactGrants(t, ctx,
+					authz.NewGrant(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID),
+					authz.NewGrant(authz.ScopeProjectRead, projectID),
+				)
+				projectID = project.ID.String()
+				want = oops.CodeForbidden
+			case "wrong-organization-grant":
+				ctx = authztest.WithExactGrants(t, ctx,
+					authz.NewGrant(authz.ScopeOrgAdmin, "org_other_test"),
+					authz.NewGrant(authz.ScopeProjectRead, projectID),
+				)
 				want = oops.CodeForbidden
 			case "no-admin-grant":
 				ctx = authztest.WithExactGrants(t, ctx, authz.Grant{Scope: authz.ScopeProjectRead, Selector: authz.NewSelector(authz.ScopeProjectRead, projectID)})
@@ -97,9 +118,9 @@ func TestKeysService_CreateKey_RejectsInvalidProjectBinding(t *testing.T) {
 			var oe *oops.ShareableError
 			require.ErrorAs(t, err, &oe)
 			require.Equal(t, want, oe.Code)
-			var count int
-			require.NoError(t, ti.conn.QueryRow(ctx, "SELECT count(*) FROM api_keys").Scan(&count))
-			require.Zero(t, count)
+			stored, err := keysrepo.New(ti.conn).ListAPIKeysByOrganization(ctx, authCtx.ActiveOrganizationID)
+			require.NoError(t, err)
+			require.Empty(t, stored)
 		})
 	}
 }

--- a/server/internal/keys/project_binding_test.go
+++ b/server/internal/keys/project_binding_test.go
@@ -1,0 +1,105 @@
+package keys_test
+
+import (
+	"bytes"
+	"encoding/json"
+	httpkeys "github.com/speakeasy-api/gram/server/gen/http/keys/server"
+	goahttp "goa.design/goa/v3/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	gen "github.com/speakeasy-api/gram/server/gen/keys"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/authztest"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	projectrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeysService_CreateKey_ProjectBinding(t *testing.T) {
+	t.Parallel()
+	for _, scoped := range []bool{false, true} {
+		name := "organization-wide"
+		if scoped {
+			name = "project-bound"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx, ti := newTestKeysService(t)
+			authCtx := testAuthContext(t, ctx)
+			require.NotNil(t, authCtx.ProjectID)
+			// Choose a different project from the ambient context.
+			project, err := projectrepo.New(ti.conn).CreateProject(ctx, projectrepo.CreateProjectParams{
+				OrganizationID: authCtx.ActiveOrganizationID, Name: "Selected project", Slug: "selected-project",
+			})
+			require.NoError(t, err)
+			ctx = authztest.WithAdminGrants(ctx)
+			var selected *string
+			if scoped {
+				id := project.ID.String()
+				selected = &id
+			}
+			body := map[string]any{"name": name, "scopes": []string{"producer"}}
+			if selected != nil {
+				body["project_id"] = *selected
+			}
+			encoded, err := json.Marshal(body)
+			require.NoError(t, err)
+			request := httptest.NewRequest("POST", "/rpc/keys.create", bytes.NewReader(encoded))
+			request.Header.Set("Content-Type", "application/json")
+			request.Header.Set("Gram-Project", *authCtx.ProjectSlug)
+			payload, err := httpkeys.DecodeCreateKeyRequest(goahttp.NewMuxer(), goahttp.RequestDecoder)(request)
+			require.NoError(t, err)
+			key, err := ti.service.CreateKey(ctx, payload)
+			require.NoError(t, err)
+			require.Equal(t, selected, key.ProjectID)
+			require.Equal(t, []string{"producer"}, key.Scopes)
+			listed, err := ti.service.ListKeys(ctx, &gen.ListKeysPayload{})
+			require.NoError(t, err)
+			require.Len(t, listed.Keys, 1)
+			require.Equal(t, selected, listed.Keys[0].ProjectID)
+			require.Nil(t, listed.Keys[0].Key)
+		})
+	}
+}
+
+func TestKeysService_CreateKey_RejectsInvalidProjectBinding(t *testing.T) {
+	t.Parallel()
+	for _, kind := range []string{"malformed", "unknown", "other-organization", "deleted", "no-project-grant", "no-admin-grant"} {
+		t.Run(kind, func(t *testing.T) {
+			t.Parallel()
+			ctx, ti := newTestKeysService(t)
+			authCtx := testAuthContext(t, ctx)
+			projectID := authCtx.ProjectID.String()
+			ctx = authztest.WithAdminGrants(ctx)
+			want := oops.CodeNotFound
+			switch kind {
+			case "malformed":
+				projectID = "not-a-uuid"
+				want = oops.CodeBadRequest
+			case "unknown":
+				projectID = uuid.NewString()
+			case "other-organization":
+				authCtx.ActiveOrganizationID = "org_other_test"
+			case "deleted":
+				_, err := ti.conn.Exec(ctx, "UPDATE projects SET deleted_at = now() WHERE id = $1", authCtx.ProjectID)
+				require.NoError(t, err)
+			case "no-project-grant":
+				ctx = authztest.WithExactGrants(t, ctx, authz.Grant{Scope: authz.ScopeOrgAdmin, Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID)})
+				want = oops.CodeForbidden
+			case "no-admin-grant":
+				ctx = authztest.WithExactGrants(t, ctx, authz.Grant{Scope: authz.ScopeProjectRead, Selector: authz.NewSelector(authz.ScopeProjectRead, projectID)})
+				want = oops.CodeForbidden
+			}
+			key, err := ti.service.CreateKey(ctx, &gen.CreateKeyPayload{Name: "rejected-key", Scopes: []string{"consumer"}, ProjectID: &projectID})
+			require.Nil(t, key)
+			var oe *oops.ShareableError
+			require.ErrorAs(t, err, &oe)
+			require.Equal(t, want, oe.Code)
+			var count int
+			require.NoError(t, ti.conn.QueryRow(ctx, "SELECT count(*) FROM api_keys").Scan(&count))
+			require.Zero(t, count)
+		})
+	}
+}

--- a/server/internal/keys/setup_test.go
+++ b/server/internal/keys/setup_test.go
@@ -30,7 +30,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true, Redis: true, ClickHouse: true})
+	res, cleanup, err := testenv.Launch(context.Background(), testenv.LaunchOptions{Postgres: true, Redis: true, ClickHouse: false})
 	if err != nil {
 		log.Fatalf("Failed to launch test infrastructure: %v", err)
 		os.Exit(1)

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -399,9 +399,17 @@ func (ti *testInstance) createTestAPIKey(ctx context.Context, t *testing.T) stri
 	t.Helper()
 	keysService := keys.NewService(ti.logger, ti.tracerProvider, ti.conn, ti.sessionManager, "local", ti.authzEngine, ti.audit)
 
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	var projectID *string
+	if authCtx.ProjectID != nil {
+		id := authCtx.ProjectID.String()
+		projectID = &id
+	}
 	key, err := keysService.CreateKey(ctx, &keys_gen.CreateKeyPayload{
-		Name:   "test-key",
-		Scopes: []string{"consumer"},
+		Name:      "test-key",
+		Scopes:    []string{"consumer"},
+		ProjectID: projectID,
 	})
 	require.NoError(t, err)
 

--- a/server/internal/openrouterkeys/keys_test.go
+++ b/server/internal/openrouterkeys/keys_test.go
@@ -553,9 +553,20 @@ func TestAdminLocalHardTimeoutCannotCommitAfterCrashGuardBecomesEligible(t *test
 	unlocked, err := queries.ReleaseOpenRouterKeyBillingLock(ctx, activitiesrepo.ReleaseOpenRouterKeyBillingLockParams(params))
 	require.NoError(t, err)
 	require.True(t, unlocked)
-	require.Never(t, func() bool {
-		return len(readDisableCauses(t, ctx, ti, orgID, "chat")) > 0
-	}, 100*time.Millisecond, 10*time.Millisecond, "timed-out mutation must never commit later")
+	// Keep database checks on the test goroutine so none outlive its context.
+	observation := time.NewTimer(100 * time.Millisecond)
+	defer observation.Stop()
+	poll := time.NewTicker(10 * time.Millisecond)
+	defer poll.Stop()
+observe:
+	for {
+		require.Empty(t, readDisableCauses(t, ctx, ti, orgID, "chat"), "timed-out mutation must never commit later")
+		select {
+		case <-observation.C:
+			break observe
+		case <-poll.C:
+		}
+	}
 	require.EqualValues(t, 0, auditCount(t, ctx, ti, audit.ActionOpenRouterAPIKeyDisable))
 	after, err := executor.CaptureCursor(ctx, scope)
 	require.NoError(t, err)

--- a/server/internal/usage/create_stripe_checkout.go
+++ b/server/internal/usage/create_stripe_checkout.go
@@ -323,6 +323,10 @@ func (s *Service) prepareStripeCheckoutIntent(
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 
 	queries := repo.New(dbtx)
+	// Serialize first writes before either unique index sees a concurrent insert.
+	if err := queries.LockBillingMetadataOrganization(ctx, organizationID); err != nil {
+		return preparedStripeCheckoutIntent{}, oops.E(oops.CodeUnexpected, err, "lock billing metadata organization").LogError(ctx, s.logger)
+	}
 	stored, err := queries.StoreStripeCustomer(ctx, repo.StoreStripeCustomerParams{
 		OrganizationID:   organizationID,
 		StripeCustomerID: pgtype.Text{String: customerID, Valid: true},

--- a/server/internal/usage/create_stripe_checkout_test.go
+++ b/server/internal/usage/create_stripe_checkout_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	featurerepo "github.com/speakeasy-api/gram/server/internal/productfeatures/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	openrouterrepo "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
 	stripeclient "github.com/speakeasy-api/gram/server/internal/thirdparty/stripe"
@@ -1613,21 +1614,60 @@ func TestCreateStripeCheckoutWaitsForBillingMetadataOrganizationLock(t *testing.
 	holder := testenv.BeginTx(t, t.Context(), ti.service.db)
 	require.NoError(t, repo.New(holder).LockBillingMetadataOrganization(t.Context(), ti.orgID))
 
-	ctx, cancel := context.WithTimeout(ti.adminContext(t), time.Second)
-	defer cancel()
-	_, err := ti.service.CreateStripeCheckout(ctx, &gen.CreateStripeCheckoutPayload{})
-	require.ErrorIs(t, err, context.DeadlineExceeded)
-	require.ErrorContains(t, err, "lock billing metadata organization")
+	ctx, cancel := context.WithCancel(ti.adminContext(t))
+	done := make(chan struct{})
+	var checkoutErr error
+	go func() {
+		defer close(done)
+		_, checkoutErr = ti.service.CreateStripeCheckout(ctx, &gen.CreateStripeCheckoutPayload{})
+	}()
+	defer func() {
+		cancel()
+		<-done
+	}()
 
-	_, err = repo.New(ti.db).GetBillingMetadata(t.Context(), ti.orgID)
-	require.ErrorIs(t, err, pgx.ErrNoRows, "Checkout must not insert before acquiring the organization lock")
-	_, _, checkouts := ti.stripe.snapshot()
+	// The deadline guards the test; cancellation follows an observed lock wait.
+	probeCtx, cancelProbe := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancelProbe()
+	poll := time.NewTicker(10 * time.Millisecond)
+	defer poll.Stop()
+	for {
+		blocked, err := testrepo.New(ti.db).IsQueryBlockedOnLockFixture(probeCtx, "%LockBillingMetadataOrganization%")
+		require.NoError(t, err)
+		if blocked {
+			break
+		}
+		select {
+		case <-done:
+			require.FailNow(t, "Checkout returned before waiting for the billing metadata organization lock", "%v", checkoutErr)
+		case <-probeCtx.Done():
+			require.FailNow(t, "Checkout did not reach the billing metadata organization lock", "%v", probeCtx.Err())
+		case <-poll.C:
+		}
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-probeCtx.Done():
+		require.FailNow(t, "Checkout did not return after lock cancellation", "%v", probeCtx.Err())
+	}
+	require.ErrorIs(t, checkoutErr, context.Canceled)
+	require.ErrorContains(t, checkoutErr, "lock billing metadata organization")
+
+	_, err := repo.New(ti.db).GetBillingMetadata(t.Context(), ti.orgID)
+	require.ErrorIs(t, err, pgx.ErrNoRows, "Checkout must not insert billing metadata before acquiring the organization lock")
+	uniqueCustomers, customers, checkouts := ti.stripe.snapshot()
+	require.Equal(t, 1, uniqueCustomers, "idempotent Stripe customer creation intentionally precedes the billing metadata lock")
+	require.Len(t, customers, 1)
+	require.Equal(t, "customer:"+ti.orgID, customers[0].IdempotencyKey)
 	require.Empty(t, checkouts)
 
 	require.NoError(t, holder.Rollback(t.Context()))
 	checkoutURL, err := ti.service.CreateStripeCheckout(ti.adminContext(t), &gen.CreateStripeCheckoutPayload{})
 	require.NoError(t, err)
 	require.NotEmpty(t, checkoutURL)
+	uniqueCustomers, _, _ = ti.stripe.snapshot()
+	require.Equal(t, 1, uniqueCustomers, "retry must reuse the Stripe customer created before cancellation")
 }
 
 func TestCreateStripeCheckoutPersistsIntentWhenCheckoutFails(t *testing.T) {

--- a/server/internal/usage/create_stripe_checkout_test.go
+++ b/server/internal/usage/create_stripe_checkout_test.go
@@ -1623,7 +1623,13 @@ func TestCreateStripeCheckoutWaitsForBillingMetadataOrganizationLock(t *testing.
 	}()
 	defer func() {
 		cancel()
-		<-done
+		cleanupCtx, cancelCleanup := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+		defer cancelCleanup()
+		select {
+		case <-done:
+		case <-cleanupCtx.Done():
+			t.Error("Checkout did not return after cancellation during cleanup")
+		}
 	}()
 
 	// The deadline guards the test; cancellation follows an observed lock wait.

--- a/server/internal/usage/create_stripe_checkout_test.go
+++ b/server/internal/usage/create_stripe_checkout_test.go
@@ -1606,6 +1606,30 @@ func TestCreateStripeCheckoutConcurrentDoubleClickCreatesOneCustomer(t *testing.
 	require.Equal(t, "cus_1", stored.StripeCustomerID.String)
 }
 
+func TestCreateStripeCheckoutWaitsForBillingMetadataOrganizationLock(t *testing.T) {
+	t.Parallel()
+
+	ti := newStripeCheckoutTestInstance(t)
+	holder := testenv.BeginTx(t, t.Context(), ti.service.db)
+	require.NoError(t, repo.New(holder).LockBillingMetadataOrganization(t.Context(), ti.orgID))
+
+	ctx, cancel := context.WithTimeout(ti.adminContext(t), time.Second)
+	defer cancel()
+	_, err := ti.service.CreateStripeCheckout(ctx, &gen.CreateStripeCheckoutPayload{})
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.ErrorContains(t, err, "lock billing metadata organization")
+
+	_, err = repo.New(ti.db).GetBillingMetadata(t.Context(), ti.orgID)
+	require.ErrorIs(t, err, pgx.ErrNoRows, "Checkout must not insert before acquiring the organization lock")
+	_, _, checkouts := ti.stripe.snapshot()
+	require.Empty(t, checkouts)
+
+	require.NoError(t, holder.Rollback(t.Context()))
+	checkoutURL, err := ti.service.CreateStripeCheckout(ti.adminContext(t), &gen.CreateStripeCheckoutPayload{})
+	require.NoError(t, err)
+	require.NotEmpty(t, checkoutURL)
+}
+
 func TestCreateStripeCheckoutPersistsIntentWhenCheckoutFails(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Add an optional project selector to API key creation, defaulting to organization-wide access. Preserve the existing form and scope controls, display each key’s project binding in the result and list, and require an explicit valid selection when project access changes.

Fixes [AGE-3399](https://linear.app/speakeasy/issue/AGE-3399).

## Motivation

API keys need an explicit project restriction without confusing that restriction with permission scopes or the dashboard’s current project.

## Technical details

### Explicit project authorization

The create-key endpoint accepts optional `project_id` in the body, verifies that the project belongs to the active organization, and requires the caller’s `project:read` permission for that project. Omitting it always creates an organization-wide key, regardless of ambient `Gram-Project` headers. The Goa contract and dashboard SDK reflect the new field.

Organization changes reset creation state, and unavailable selections cannot silently broaden access. The local seed’s existing project-bound key exercises the binding display; the shared demo organization continues to contain no API keys.

### Concurrency repairs

Serialize Stripe billing-metadata initialization per organization so concurrent checkout requests do not collide on unique constraints. Keep pooled-connection cleanup and asynchronous assertions within their owning test lifetimes; project-scoped MCP fixtures now pass their intended binding explicitly.
