### PR TITLE
feat(platform-mcp): inspect shadow MCP inventory

### DIFF
--- a/.changeset/platform-mcp-shadow-inventory.md
+++ b/.changeset/platform-mcp-shadow-inventory.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+feat(platform-mcp): add privacy-safe Shadow MCP inventory and review reads

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -348,6 +348,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 		WithDataExportMutations(config.AuditLogger, config.DashboardURL).
 		WithRecentToolCalls(config.RecentToolCalls, config.DashboardURL).
 		WithOrganizationEvents(config.EventFeed, config.LogsEnabled, config.DashboardURL)
+	attachShadowInventory(platformReader, config, budgets.SensitiveDiagnostics)
 	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, config.SessionCapture, platformReader, readiness, budgets.Diagnostics).
 		WithDrilldown(config.TelemetryDrilldown, config.JWTSigningKey, budgets.SensitiveDiagnostics, budgets.DrilldownVolume, platformmcp.NewPostgresDrilldownAuditor(config.DB))
 	sessionRecall := platformmcp.NewSessionRecallService(config.Logger, config.DB, platformrepo.New(config.DB), audit.NewLogger(), config.SessionPortability, budgets.SensitiveSessionRecall)
@@ -396,6 +397,19 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 	platformmcp.AttachManagement(config.Mux, platformmcp.NewManagementService(config.Logger, config.TracerProvider, config.DB, config.Sessions, config.Authz, gate, authorizer, config.ServerURL.JoinPath("platform-mcp").String(), registrations, readiness, distributions, config.JWTSigningKey, catalog))
 	o11y.AttachHandler(config.Mux, http.MethodPost, platformmcp.Path, runtime.Handler().ServeHTTP)
 	return AssistantSurface{Tools: runtime.AssistantTools(), Authorizer: authorizer}, nil
+}
+
+// attachShadowInventory keeps the Shadow tools registered on both browser and
+// local-fixture surfaces. Missing dependencies degrade to stable unavailable
+// descriptors, but the capability loss is logged rather than silently hidden.
+func attachShadowInventory(reader *platformmcp.PostgresReader, config platformMCPConfig, budget platformmcp.OperationBudget) bool {
+	shadowInventory, err := platformmcp.NewShadowInventoryService(config.ShadowInventory, config.ShadowReview, config.FeatureFlags, platformmcp.NewPostgresOrganizationSlugResolver(config.DB), platformrepo.New(config.DB), budget, config.JWTSigningKey)
+	if err != nil {
+		config.Logger.WarnContext(context.Background(), "platform mcp shadow inventory unavailable", attr.SlogError(err))
+		return false
+	}
+	reader.WithShadowInventory(shadowInventory)
+	return true
 }
 
 // platformMCPSetupResources builds the reviewed setup corpus this deployment
@@ -699,10 +713,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 		WithDataExportMutations(config.AuditLogger, config.DashboardURL).
 		WithRecentToolCalls(config.RecentToolCalls, config.DashboardURL).
 		WithOrganizationEvents(config.EventFeed, config.LogsEnabled, config.DashboardURL)
-	shadowInventory, shadowErr := platformmcp.NewShadowInventoryService(config.ShadowInventory, config.ShadowReview, config.FeatureFlags, platformmcp.NewPostgresOrganizationSlugResolver(config.DB), platformrepo.New(config.DB), budgets.SensitiveDiagnostics, config.JWTSigningKey)
-	if shadowErr == nil {
-		platformReader.WithShadowInventory(shadowInventory)
-	}
+	attachShadowInventory(platformReader, config, budgets.SensitiveDiagnostics)
 	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, config.SessionCapture, platformReader, readiness, budgets.Diagnostics).
 		WithDrilldown(config.TelemetryDrilldown, config.JWTSigningKey, budgets.SensitiveDiagnostics, budgets.DrilldownVolume, platformmcp.NewPostgresDrilldownAuditor(config.DB))
 	sessionRecall := platformmcp.NewSessionRecallService(config.Logger, config.DB, platformrepo.New(config.DB), audit.NewLogger(), config.SessionPortability, budgets.SensitiveSessionRecall)

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -31,6 +31,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/externalmcp"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/mcpapproval"
 	"github.com/speakeasy-api/gram/server/internal/mcpservers"
 	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
@@ -104,9 +105,10 @@ type platformMCPConfig struct {
 	// LogsEnabled is the same product-feature gate the dashboard Event Feed
 	// uses. Nil, or a false result for the caller's organization, withholds
 	// live organization-event reads.
-	LogsEnabled platformmcp.FeatureChecker
-
-	LocalFixture *platformMCPLocalFixtureConfig
+	LogsEnabled     platformmcp.FeatureChecker
+	ShadowInventory *access.Service
+	ShadowReview    *mcpapproval.Service
+	LocalFixture    *platformMCPLocalFixtureConfig
 }
 
 var platformMCPLocalFixtureLoopbackCIDRBlocks = []string{"127.0.0.0/8", "::1/128"}
@@ -697,6 +699,10 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 		WithDataExportMutations(config.AuditLogger, config.DashboardURL).
 		WithRecentToolCalls(config.RecentToolCalls, config.DashboardURL).
 		WithOrganizationEvents(config.EventFeed, config.LogsEnabled, config.DashboardURL)
+	shadowInventory, shadowErr := platformmcp.NewShadowInventoryService(config.ShadowInventory, config.ShadowReview, config.FeatureFlags, platformmcp.NewPostgresOrganizationSlugResolver(config.DB), platformrepo.New(config.DB), budgets.SensitiveDiagnostics, config.JWTSigningKey)
+	if shadowErr == nil {
+		platformReader.WithShadowInventory(shadowInventory)
+	}
 	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, config.SessionCapture, platformReader, readiness, budgets.Diagnostics).
 		WithDrilldown(config.TelemetryDrilldown, config.JWTSigningKey, budgets.SensitiveDiagnostics, budgets.DrilldownVolume, platformmcp.NewPostgresDrilldownAuditor(config.DB))
 	sessionRecall := platformmcp.NewSessionRecallService(config.Logger, config.DB, platformrepo.New(config.DB), audit.NewLogger(), config.SessionPortability, budgets.SensitiveSessionRecall)

--- a/server/cmd/gram/platform_mcp_local_fixture_test.go
+++ b/server/cmd/gram/platform_mcp_local_fixture_test.go
@@ -8,7 +8,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/access"
+	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/marketplace"
+	"github.com/speakeasy-api/gram/server/internal/mcpapproval"
+	"github.com/speakeasy-api/gram/server/internal/platformmcp"
+	"github.com/speakeasy-api/gram/server/internal/ratelimit"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
 func TestPlatformMCPLocalFixtureConfigIsEnabledByDefaultLocally(t *testing.T) {
@@ -35,6 +41,27 @@ func TestPlatformMCPLocalFixtureConfigDoesNotLeakOutsideLocal(t *testing.T) {
 	fixture, err := platformMCPLocalFixtureConfigFromCLI("production", "https://localhost:8080")
 	require.NoError(t, err)
 	require.Nil(t, fixture)
+}
+
+type allowingPlatformMCPBudget struct{}
+
+func (allowingPlatformMCPBudget) Allow(context.Context, string) (ratelimit.Result, error) {
+	return ratelimit.Result{Allowed: true}, nil
+}
+func (allowingPlatformMCPBudget) AllowN(context.Context, string, int) (ratelimit.Result, error) {
+	return ratelimit.Result{Allowed: true}, nil
+}
+
+func TestAttachShadowInventoryConstructsWithLocalFixtureDependencies(t *testing.T) {
+	t.Parallel()
+
+	limiter := allowingPlatformMCPBudget{}
+	reader := platformmcp.NewPostgresReader(testenv.NewLogger(t), nil)
+	attached := attachShadowInventory(reader, platformMCPConfig{
+		DB: nil, JWTSigningKey: "test-signing-key", FeatureFlags: &feature.InMemory{},
+		ShadowInventory: &access.Service{}, ShadowReview: &mcpapproval.Service{},
+	}, platformmcp.OperationBudget{Connection: limiter, Organization: limiter})
+	require.True(t, attached)
 }
 
 func TestLocalPlatformMCPMarketplaceTokenResolvesDedicatedRepository(t *testing.T) {

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1407,7 +1407,8 @@ func newStartCommand() *cli.Command {
 			platformslack.NewFileProxy(logger, encryptionClient, guardianPolicy.PooledClient()).Attach(mux)
 			external.AttachWebhookHandler(mux, external.NewWebhookHandler(logger, tracerProvider, newWorkOSWebhooksClient(c), temporalEnv))
 			roleManager := access.NewRoleManager(logger, db, roleClient, auditLogger)
-			access.Attach(mux, access.NewService(logger, tracerProvider, db, chDB, sessionManager, roleManager, authzEngine, auditLogger, emailService, siteURL, telemSvc))
+			accessService := access.NewService(logger, tracerProvider, db, chDB, sessionManager, roleManager, authzEngine, auditLogger, emailService, siteURL, telemSvc)
+			access.Attach(mux, accessService)
 			agent.Attach(mux, agent.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, productFeatures, serverURL.String(), assetStorage, telemLogger, growthEmitter))
 			agentmanagement.Attach(mux, agentmanagement.NewService(logger, tracerProvider, db, sessionManager, authzEngine, auditLogger, featureFlags))
 			assistants.Attach(mux, assistantsSvc)
@@ -1700,6 +1701,8 @@ func newStartCommand() *cli.Command {
 				RecentToolCalls:         telemetryrepo.New(chDB),
 				EventFeed:               otelchrepo.New(chDB),
 				LogsEnabled:             platformmcp.FeatureChecker(logsEnabled),
+				ShadowInventory:         accessService,
+				ShadowReview:            mcpApprovalService,
 				SessionCapture:          platformmcp.FeatureChecker(sessionCaptureEnabled),
 				SessionPortability:      platformmcp.FeatureChecker(sessionPortabilityEnabled),
 				LocalFixture:            platformFixture,

--- a/server/internal/access/shadow_mcp_inventory.go
+++ b/server/internal/access/shadow_mcp_inventory.go
@@ -468,8 +468,7 @@ func (s *Service) ReadShadowMCPInventoryTarget(ctx context.Context, input Shadow
 }
 
 func (s *Service) shadowMCPApprovalRequestTarget(ctx context.Context, input ShadowMCPInventoryTargetInput) (mcpapprovalrepo.ListApprovalRequestTargetsRow, error) {
-	repo := mcpapprovalrepo.New(s.db)
-	request, err := repo.GetApprovalRequestByTarget(ctx, mcpapprovalrepo.GetApprovalRequestByTargetParams{
+	request, err := mcpapprovalrepo.New(s.db).GetApprovalRequestTarget(ctx, mcpapprovalrepo.GetApprovalRequestTargetParams{
 		ProjectID:  input.ProjectID,
 		TargetKind: input.TargetKind,
 		TargetKey:  input.TargetKey,
@@ -478,22 +477,24 @@ func (s *Service) shadowMCPApprovalRequestTarget(ctx context.Context, input Shad
 	case errors.Is(err, pgx.ErrNoRows):
 		return mcpapprovalrepo.ListApprovalRequestTargetsRow{}, oops.E(oops.CodeNotFound, nil, "shadow mcp inventory target not found").LogError(ctx, s.logger)
 	case err != nil:
-		return mcpapprovalrepo.ListApprovalRequestTargetsRow{}, oops.E(oops.CodeUnexpected, err, "get shadow mcp approval request by target").LogError(ctx, s.logger)
-	case request.OrganizationID != input.OrganizationID:
-		return mcpapprovalrepo.ListApprovalRequestTargetsRow{}, oops.E(oops.CodeUnexpected, nil, "approval request organization mismatch").LogError(ctx, s.logger)
+		return mcpapprovalrepo.ListApprovalRequestTargetsRow{}, oops.E(oops.CodeUnexpected, err, "get shadow mcp approval request target").LogError(ctx, s.logger)
+	default:
+		// Keep this explicit: the generated rows intentionally share a shape, but
+		// converting them positionally would let same-typed SQL columns be reordered
+		// without a compile error while silently changing the public projection.
+		result := mcpapprovalrepo.ListApprovalRequestTargetsRow{} //nolint:exhaustruct // Filled explicitly below to protect generated query field order.
+		result.ID = request.ID
+		result.TargetKind = request.TargetKind
+		result.TargetRaw = request.TargetRaw
+		result.TargetKey = request.TargetKey
+		result.Status = request.Status
+		result.EvidenceChangedAt = request.EvidenceChangedAt
+		result.CreatedAt = request.CreatedAt
+		result.UpdatedAt = request.UpdatedAt
+		result.LatestDecision = request.LatestDecision
+		result.RequesterCount = request.RequesterCount
+		return result, nil
 	}
-
-	targets, err := repo.ListApprovalRequestTargets(ctx, input.ProjectID)
-	if err != nil {
-		return mcpapprovalrepo.ListApprovalRequestTargetsRow{}, oops.E(oops.CodeUnexpected, err, "list shadow mcp approval request targets").LogError(ctx, s.logger)
-	}
-	for _, target := range targets {
-		if target.TargetKind == input.TargetKind && target.TargetKey == input.TargetKey {
-			return target, nil
-		}
-	}
-
-	return mcpapprovalrepo.ListApprovalRequestTargetsRow{}, oops.E(oops.CodeNotFound, nil, "shadow mcp inventory target not found").LogError(ctx, s.logger)
 }
 
 // shadowMCPServerFromApprovalRequest resolves a server page slug against the

--- a/server/internal/access/shadow_mcp_inventory.go
+++ b/server/internal/access/shadow_mcp_inventory.go
@@ -119,6 +119,22 @@ func formatTimeValue(ts time.Time) string {
 	return ts.UTC().Format(time.RFC3339)
 }
 
+// ShadowMCPInventoryReadInput identifies a project-scoped inventory page for a trusted internal caller.
+type ShadowMCPInventoryReadInput struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+	Limit          int
+	Cursor         *string
+}
+
+// ShadowMCPInventoryTargetInput identifies one exact project-scoped inventory target for a trusted internal caller.
+type ShadowMCPInventoryTargetInput struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+	TargetKind     string
+	TargetKey      string
+}
+
 func (s *Service) ListShadowMCPInventory(ctx context.Context, payload *gen.ListShadowMCPInventoryPayload) (*gen.ListShadowMCPInventoryResult, error) {
 	ac, err := s.requireOrgAdmin(ctx)
 	if err != nil {
@@ -129,20 +145,37 @@ func (s *Service) ListShadowMCPInventory(ctx context.Context, payload *gen.ListS
 	if err != nil {
 		return nil, oops.E(oops.CodeBadRequest, err, "invalid project id").LogError(ctx, s.logger)
 	}
-	if err := s.requireProjectInOrganization(ctx, ac.ActiveOrganizationID, projectID); err != nil {
+
+	return s.ReadShadowMCPInventory(ctx, ShadowMCPInventoryReadInput{
+		OrganizationID: ac.ActiveOrganizationID,
+		ProjectID:      projectID,
+		Limit:          payload.Limit,
+		Cursor:         payload.Cursor,
+	})
+}
+
+// ReadShadowMCPInventory composes an inventory page after validating its organization and project boundary.
+func (s *Service) ReadShadowMCPInventory(ctx context.Context, input ShadowMCPInventoryReadInput) (*gen.ListShadowMCPInventoryResult, error) {
+	if strings.TrimSpace(input.OrganizationID) == "" {
+		return nil, oops.E(oops.CodeBadRequest, nil, "organization id is required").LogError(ctx, s.logger)
+	}
+	if input.ProjectID == uuid.Nil {
+		return nil, oops.E(oops.CodeBadRequest, nil, "project id is required").LogError(ctx, s.logger)
+	}
+	if err := s.requireProjectInOrganization(ctx, input.OrganizationID, input.ProjectID); err != nil {
 		return nil, err
 	}
 
-	limit, err := shadowMCPInventoryLimit(payload.Limit)
+	limit, err := shadowMCPInventoryLimit(input.Limit)
 	if err != nil {
 		return nil, err
 	}
 
 	chRepo := telemetryrepo.New(s.chConn)
 	inventoryRows, err := chRepo.ListShadowMCPInventoryURLs(ctx, telemetryrepo.ListShadowMCPInventoryURLsParams{
-		GramProjectID: projectID.String(),
+		GramProjectID: input.ProjectID.String(),
 		Limit:         limit + shadowMCPInventoryPageLookaheadSize,
-		Cursor:        pointerStringValue(payload.Cursor),
+		Cursor:        pointerStringValue(input.Cursor),
 	})
 	if err != nil {
 		if errors.Is(err, telemetryrepo.ErrInvalidShadowMCPInventoryURLCursor) {
@@ -164,7 +197,7 @@ func (s *Service) ListShadowMCPInventory(ctx context.Context, payload *gen.ListS
 	usageByURL := map[string]telemetryrepo.ShadowMCPInventoryUsageRow{}
 	if len(inventoryRows) > 0 {
 		usageRows, err := chRepo.ListShadowMCPInventoryUsage(ctx, telemetryrepo.ListShadowMCPInventoryUsageParams{
-			GramProjectID:       projectID.String(),
+			GramProjectID:       input.ProjectID.String(),
 			CanonicalServerURLs: shadowMCPInventoryCanonicalURLs(inventoryRows),
 			Limit:               shadowMCPInventoryUsageTraceLimit,
 			OrganizationID:      "",
@@ -183,8 +216,8 @@ func (s *Service) ListShadowMCPInventory(ctx context.Context, payload *gen.ListS
 	// that traffic has never shown appear once, on the first page, ahead of
 	// the cursor-paginated observed set. Later pages are purely observed.
 	var requestOnly []mcpapprovalrepo.ListApprovalRequestTargetsRow
-	if payload.Cursor == nil {
-		requestOnly, err = s.shadowMCPRequestOnlyTargets(ctx, chRepo, projectID)
+	if input.Cursor == nil {
+		requestOnly, err = s.shadowMCPRequestOnlyTargets(ctx, chRepo, input.ProjectID)
 		if err != nil {
 			return nil, err
 		}
@@ -199,7 +232,7 @@ func (s *Service) ListShadowMCPInventory(ctx context.Context, payload *gen.ListS
 		policyURLs = append(policyURLs, request.TargetKey)
 	}
 
-	policyState, err := s.shadowMCPInventoryPolicyState(ctx, ac.ActiveOrganizationID, projectID, policyURLs)
+	policyState, err := s.shadowMCPInventoryPolicyState(ctx, input.OrganizationID, input.ProjectID, policyURLs)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "load shadow mcp inventory policy state").LogError(ctx, s.logger)
 	}
@@ -355,8 +388,7 @@ func (s *Service) GetShadowMCPInventoryServer(ctx context.Context, payload *gen.
 		return nil, err
 	}
 
-	chRepo := telemetryrepo.New(s.chConn)
-	inventoryRow, err := shadowMCPInventoryURLForSlug(ctx, chRepo, projectID.String(), payload.ServerSlug)
+	inventoryRow, err := shadowMCPInventoryURLForSlug(ctx, telemetryrepo.New(s.chConn), projectID.String(), payload.ServerSlug)
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "get shadow mcp inventory url by slug").LogError(ctx, s.logger)
 	}
@@ -366,26 +398,102 @@ func (s *Service) GetShadowMCPInventoryServer(ctx context.Context, payload *gen.
 		return s.shadowMCPServerFromApprovalRequest(ctx, ac.ActiveOrganizationID, projectID, payload.ServerSlug)
 	}
 
-	usageRows, err := chRepo.ListShadowMCPInventoryUsage(ctx, telemetryrepo.ListShadowMCPInventoryUsageParams{
-		GramProjectID:       projectID.String(),
-		CanonicalServerURLs: []string{inventoryRow.CanonicalServerURL},
-		Limit:               shadowMCPInventoryUsageTraceLimit,
-		OrganizationID:      "",
-		UserKeys:            nil,
-		From:                nil,
-		To:                  nil,
+	return s.ReadShadowMCPInventoryTarget(ctx, ShadowMCPInventoryTargetInput{
+		OrganizationID: ac.ActiveOrganizationID,
+		ProjectID:      projectID,
+		TargetKind:     shadowMCPTargetKindServerURL,
+		TargetKey:      inventoryRow.CanonicalServerURL,
 	})
-	if err != nil {
-		return nil, oops.E(oops.CodeUnexpected, err, "list shadow mcp inventory usage").LogError(ctx, s.logger)
-	}
-	usageByURL := shadowMCPInventoryUsageByURL(usageRows)
+}
 
-	policyState, err := s.shadowMCPInventoryPolicyState(ctx, ac.ActiveOrganizationID, projectID, []string{inventoryRow.CanonicalServerURL})
+// ReadShadowMCPInventoryTarget composes one exact observed or request-only inventory target.
+func (s *Service) ReadShadowMCPInventoryTarget(ctx context.Context, input ShadowMCPInventoryTargetInput) (*gen.ShadowMCPInventoryServer, error) {
+	if strings.TrimSpace(input.OrganizationID) == "" {
+		return nil, oops.E(oops.CodeBadRequest, nil, "organization id is required").LogError(ctx, s.logger)
+	}
+	if input.ProjectID == uuid.Nil {
+		return nil, oops.E(oops.CodeBadRequest, nil, "project id is required").LogError(ctx, s.logger)
+	}
+	if strings.TrimSpace(input.TargetKey) == "" {
+		return nil, oops.E(oops.CodeBadRequest, nil, "target key is required").LogError(ctx, s.logger)
+	}
+	if input.TargetKind != shadowMCPTargetKindServerURL && input.TargetKind != shadowMCPTargetKindStdioCommand {
+		return nil, oops.E(oops.CodeBadRequest, nil, "unsupported target kind").LogError(ctx, s.logger)
+	}
+	if err := s.requireProjectInOrganization(ctx, input.OrganizationID, input.ProjectID); err != nil {
+		return nil, err
+	}
+
+	if input.TargetKind == shadowMCPTargetKindServerURL {
+		chRepo := telemetryrepo.New(s.chConn)
+		inventoryRow, err := chRepo.GetShadowMCPInventoryURL(ctx, telemetryrepo.GetShadowMCPInventoryURLParams{
+			GramProjectID:      input.ProjectID.String(),
+			CanonicalServerURL: input.TargetKey,
+		})
+		if err != nil {
+			return nil, oops.E(oops.CodeUnexpected, err, "get shadow mcp inventory url").LogError(ctx, s.logger)
+		}
+		if inventoryRow != nil {
+			usageRows, err := chRepo.ListShadowMCPInventoryUsage(ctx, telemetryrepo.ListShadowMCPInventoryUsageParams{
+				GramProjectID:       input.ProjectID.String(),
+				CanonicalServerURLs: []string{input.TargetKey},
+				Limit:               shadowMCPInventoryUsageTraceLimit,
+				OrganizationID:      "",
+				UserKeys:            nil,
+				From:                nil,
+				To:                  nil,
+			})
+			if err != nil {
+				return nil, oops.E(oops.CodeUnexpected, err, "list shadow mcp inventory usage").LogError(ctx, s.logger)
+			}
+
+			policyState, err := s.shadowMCPInventoryPolicyState(ctx, input.OrganizationID, input.ProjectID, []string{input.TargetKey})
+			if err != nil {
+				return nil, oops.E(oops.CodeUnexpected, err, "load shadow mcp inventory policy state").LogError(ctx, s.logger)
+			}
+			usageByURL := shadowMCPInventoryUsageByURL(usageRows)
+			return buildShadowMCPInventoryServer(*inventoryRow, usageByURL[input.TargetKey], policyState.forURL(input.TargetKey), shadowMCPTargetKindServerURL), nil
+		}
+	}
+
+	request, err := s.shadowMCPApprovalRequestTarget(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	policyState, err := s.shadowMCPInventoryPolicyState(ctx, input.OrganizationID, input.ProjectID, []string{input.TargetKey})
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "load shadow mcp inventory policy state").LogError(ctx, s.logger)
 	}
+	return buildShadowMCPRequestOnlyServer(request, policyState), nil
+}
 
-	return buildShadowMCPInventoryServer(*inventoryRow, usageByURL[inventoryRow.CanonicalServerURL], policyState.forURL(inventoryRow.CanonicalServerURL), shadowMCPTargetKindServerURL), nil
+func (s *Service) shadowMCPApprovalRequestTarget(ctx context.Context, input ShadowMCPInventoryTargetInput) (mcpapprovalrepo.ListApprovalRequestTargetsRow, error) {
+	repo := mcpapprovalrepo.New(s.db)
+	request, err := repo.GetApprovalRequestByTarget(ctx, mcpapprovalrepo.GetApprovalRequestByTargetParams{
+		ProjectID:  input.ProjectID,
+		TargetKind: input.TargetKind,
+		TargetKey:  input.TargetKey,
+	})
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return mcpapprovalrepo.ListApprovalRequestTargetsRow{}, oops.E(oops.CodeNotFound, nil, "shadow mcp inventory target not found").LogError(ctx, s.logger)
+	case err != nil:
+		return mcpapprovalrepo.ListApprovalRequestTargetsRow{}, oops.E(oops.CodeUnexpected, err, "get shadow mcp approval request by target").LogError(ctx, s.logger)
+	case request.OrganizationID != input.OrganizationID:
+		return mcpapprovalrepo.ListApprovalRequestTargetsRow{}, oops.E(oops.CodeUnexpected, nil, "approval request organization mismatch").LogError(ctx, s.logger)
+	}
+
+	targets, err := repo.ListApprovalRequestTargets(ctx, input.ProjectID)
+	if err != nil {
+		return mcpapprovalrepo.ListApprovalRequestTargetsRow{}, oops.E(oops.CodeUnexpected, err, "list shadow mcp approval request targets").LogError(ctx, s.logger)
+	}
+	for _, target := range targets {
+		if target.TargetKind == input.TargetKind && target.TargetKey == input.TargetKey {
+			return target, nil
+		}
+	}
+
+	return mcpapprovalrepo.ListApprovalRequestTargetsRow{}, oops.E(oops.CodeNotFound, nil, "shadow mcp inventory target not found").LogError(ctx, s.logger)
 }
 
 // shadowMCPServerFromApprovalRequest resolves a server page slug against the
@@ -404,37 +512,12 @@ func (s *Service) shadowMCPServerFromApprovalRequest(ctx context.Context, organi
 			continue
 		}
 
-		policyState, err := s.shadowMCPInventoryPolicyState(ctx, organizationID, projectID, []string{request.TargetKey})
-		if err != nil {
-			return nil, oops.E(oops.CodeUnexpected, err, "load shadow mcp inventory policy state").LogError(ctx, s.logger)
-		}
-
-		inventoryURL, _ := shadowmcp.CanonicalizeInventoryURL(request.TargetKey)
-		row := telemetryrepo.ShadowMCPInventoryURLRow{
-			CanonicalServerURL: request.TargetKey,
-			URLHost:            inventoryURL.URLHost,
-			ServerName:         "",
-			ServerNameOverride: "",
-			// This branch is reached only when telemetry has never observed
-			// the server, so it has no first/last seen: the zero times render
-			// as the established never-observed sentinel rather than passing
-			// the request's own timeline off as observations. The request
-			// timeline lives on the approval request itself.
-			FirstSeen:          time.Time{},
-			LastSeen:           time.Time{},
-			LastCalledUnixNano: 0,
-			UpdatedAt:          request.UpdatedAt.Time,
-		}
-		usage := telemetryrepo.ShadowMCPInventoryUsageRow{
-			CanonicalServerURL: request.TargetKey,
-			ServerName:         "",
-			FirstCalled:        nil,
-			LastCalled:         nil,
-			CallCount:          0,
-			UserCount:          0,
-			TopUsers:           []string{},
-		}
-		return buildShadowMCPInventoryServer(row, usage, policyState.forURL(request.TargetKey), shadowMCPTargetKindServerURL), nil
+		return s.ReadShadowMCPInventoryTarget(ctx, ShadowMCPInventoryTargetInput{
+			OrganizationID: organizationID,
+			ProjectID:      projectID,
+			TargetKind:     shadowMCPTargetKindServerURL,
+			TargetKey:      request.TargetKey,
+		})
 	}
 
 	return nil, oops.E(oops.CodeNotFound, nil, "shadow mcp inventory url not found").LogError(ctx, s.logger)

--- a/server/internal/access/shadow_mcp_inventory_test.go
+++ b/server/internal/access/shadow_mcp_inventory_test.go
@@ -381,6 +381,22 @@ func TestService_ReadShadowMCPInventoryTarget_RequestOnlyStdio(t *testing.T) {
 	ctx, ti := newTestAccessService(t)
 	authCtx := testAccessAuthContext(t, ctx)
 	request := seedShadowMCPStdioApprovalRequest(t, ctx, ti, authCtx.ActiveOrganizationID, *authCtx.ProjectID, "npx -y exact-package", "requested")
+	queries := mcpapprovalrepo.New(ti.conn)
+	_, err := queries.CreateApprovalDecision(ctx, mcpapprovalrepo.CreateApprovalDecisionParams{
+		OrganizationID: authCtx.ActiveOrganizationID, ProjectID: *authCtx.ProjectID, McpApprovalRequestID: request.ID,
+		Decision: "approved", DecidedBy: authCtx.UserID, EvidenceSnapshot: []byte(`{}`), EvidenceVersion: 0, GrantedPrincipalUrns: []string{},
+	})
+	require.NoError(t, err)
+	_, err = queries.CreateApprovalDecision(ctx, mcpapprovalrepo.CreateApprovalDecisionParams{
+		OrganizationID: authCtx.ActiveOrganizationID, ProjectID: *authCtx.ProjectID, McpApprovalRequestID: request.ID,
+		Decision: "denied", DecidedBy: authCtx.UserID, EvidenceSnapshot: []byte(`{}`), EvidenceVersion: 0, GrantedPrincipalUrns: []string{},
+	})
+	require.NoError(t, err)
+	_, err = queries.UpsertApprovalRequestRequester(ctx, mcpapprovalrepo.UpsertApprovalRequestRequesterParams{
+		OrganizationID: authCtx.ActiveOrganizationID, ProjectID: *authCtx.ProjectID, McpApprovalRequestID: request.ID,
+		UserID: authCtx.UserID, UserEmail: conv.ToPGTextEmpty("reader@example.com"), Note: conv.ToPGTextEmpty("review request"),
+	})
+	require.NoError(t, err)
 
 	server, err := ti.service.ReadShadowMCPInventoryTarget(ctx, ShadowMCPInventoryTargetInput{
 		OrganizationID: authCtx.ActiveOrganizationID,
@@ -393,6 +409,24 @@ func TestService_ReadShadowMCPInventoryTarget_RequestOnlyStdio(t *testing.T) {
 	require.Equal(t, shadowMCPTargetKindStdioCommand, *server.TargetKind)
 	require.NotNil(t, server.ApprovalRequest)
 	require.Equal(t, request.ID.String(), server.ApprovalRequest.ID)
+	require.Equal(t, "denied", *server.ApprovalRequest.StandingDecision)
+	require.Equal(t, 1, server.ApprovalRequest.RequesterCount)
+}
+
+func TestService_ReadShadowMCPInventoryTarget_RejectsProjectFromAnotherOrganization(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAccessService(t)
+	authCtx := testAccessAuthContext(t, ctx)
+	seedShadowMCPStdioApprovalRequest(t, ctx, ti, authCtx.ActiveOrganizationID, *authCtx.ProjectID, "npx private-package", "requested")
+
+	_, err := ti.service.ReadShadowMCPInventoryTarget(ctx, ShadowMCPInventoryTargetInput{
+		OrganizationID: uuid.NewString(), ProjectID: *authCtx.ProjectID,
+		TargetKind: shadowMCPTargetKindStdioCommand, TargetKey: "npx private-package",
+	})
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeNotFound, oopsErr.Code)
 }
 
 func TestService_UpdateShadowMCPInventoryServerName_TrimsAndSavesOverride(t *testing.T) {

--- a/server/internal/access/shadow_mcp_inventory_test.go
+++ b/server/internal/access/shadow_mcp_inventory_test.go
@@ -186,6 +186,29 @@ func TestService_ListShadowMCPInventory_ComposesInventoryUsageAndPolicyState(t *
 	require.Empty(t, github.AllowedPolicyIds)
 }
 
+func TestService_ListShadowMCPInventory_DelegatesToReadSeam(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAccessService(t)
+	authCtx := testAccessAuthContext(t, ctx)
+	ctx = withRBACGrants(t, ctx, authz.Grant{Scope: authz.ScopeOrgAdmin, Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID)})
+	seedShadowMCPInventoryServer(t, ctx, ti, authCtx.ProjectID.String(), "Parity MCP")
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	handlerResult, err := ti.service.ListShadowMCPInventory(ctx, &gen.ListShadowMCPInventoryPayload{
+		ProjectID: authCtx.ProjectID.String(),
+		Limit:     10,
+	})
+	require.NoError(t, err)
+	readResult, err := ti.service.ReadShadowMCPInventory(ctx, ShadowMCPInventoryReadInput{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+		Limit:          10,
+	})
+	require.NoError(t, err)
+	require.Equal(t, handlerResult, readResult)
+}
+
 func TestService_ListShadowMCPInventory_CursorPagination(t *testing.T) {
 	t.Parallel()
 
@@ -324,6 +347,52 @@ func TestService_GetShadowMCPInventoryServer_ComposesOneURL(t *testing.T) {
 	require.Equal(t, 1, server.ObservedUseCount)
 	require.Equal(t, 1, server.UserCount)
 	require.Equal(t, []string{"alex@example.com"}, server.TopUsers)
+}
+
+func TestService_ReadShadowMCPInventoryTarget_ObservedURL(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAccessService(t)
+	authCtx := testAccessAuthContext(t, ctx)
+	seedShadowMCPInventoryServer(t, ctx, ti, authCtx.ProjectID.String(), "Exact Target MCP")
+	insertShadowMCPInventoryTelemetry(t, ctx, ti, shadowMCPInventoryTelemetryInput{
+		ProjectID:  authCtx.ProjectID.String(),
+		ServerURL:  "https://github.example.com/mcp?ignored=true",
+		ServerName: "Exact Target MCP",
+		UserEmail:  "reader@example.com",
+		ObservedAt: time.Now().UTC(),
+	})
+	testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+	server, err := ti.service.ReadShadowMCPInventoryTarget(ctx, ShadowMCPInventoryTargetInput{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+		TargetKind:     shadowMCPTargetKindServerURL,
+		TargetKey:      "https://github.example.com/mcp",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "https://github.example.com/mcp", server.CanonicalServerURL)
+	require.Equal(t, 1, server.ObservedUseCount)
+}
+
+func TestService_ReadShadowMCPInventoryTarget_RequestOnlyStdio(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAccessService(t)
+	authCtx := testAccessAuthContext(t, ctx)
+	request := seedShadowMCPStdioApprovalRequest(t, ctx, ti, authCtx.ActiveOrganizationID, *authCtx.ProjectID, "npx -y exact-package", "requested")
+
+	server, err := ti.service.ReadShadowMCPInventoryTarget(ctx, ShadowMCPInventoryTargetInput{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+		TargetKind:     shadowMCPTargetKindStdioCommand,
+		TargetKey:      "npx -y exact-package",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "npx -y exact-package", server.CanonicalServerURL)
+	require.Equal(t, shadowMCPTargetKindStdioCommand, *server.TargetKind)
+	require.NotNil(t, server.ApprovalRequest)
+	require.Equal(t, request.ID.String(), server.ApprovalRequest.ID)
 }
 
 func TestService_UpdateShadowMCPInventoryServerName_TrimsAndSavesOverride(t *testing.T) {

--- a/server/internal/mcpapproval/platform_read.go
+++ b/server/internal/mcpapproval/platform_read.go
@@ -1,0 +1,231 @@
+package mcpapproval
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/mcpapproval/evidence"
+	"github.com/speakeasy-api/gram/server/internal/mcpapproval/repo"
+	"github.com/speakeasy-api/gram/server/internal/mcpapproval/researchagent"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
+)
+
+const unreadableEvidenceGap = "unreadable_evidence"
+
+// PlatformReviewReadInput identifies one review for a trusted Platform runtime.
+type PlatformReviewReadInput struct {
+	OrganizationID string
+	ProjectID      uuid.UUID
+	TargetKind     string
+	TargetKey      string
+}
+
+// PlatformReviewSummary is a deliberately lossy projection containing only
+// closed classifications and aggregate counts.
+type PlatformReviewSummary struct {
+	Status                string   `json:"status"`
+	StandingDecision      string   `json:"standing_decision,omitempty"`
+	RequesterCount        int64    `json:"requester_count"`
+	CreatedAt             string   `json:"created_at"`
+	UpdatedAt             string   `json:"updated_at"`
+	EvidenceCollected     bool     `json:"evidence_collected"`
+	EvidenceChanged       bool     `json:"evidence_changed"`
+	EvidenceGaps          []string `json:"evidence_gaps"`
+	IdentityKind          string   `json:"identity_kind"`
+	VersionPinned         bool     `json:"version_pinned"`
+	PackagePublication    string   `json:"package_publication"`
+	RepositoryState       string   `json:"repository_state"`
+	AdvisoryLookup        string   `json:"advisory_lookup"`
+	KnownAdvisories       int      `json:"known_advisories"`
+	AuthorityState        string   `json:"authority_state"`
+	CapabilitySource      string   `json:"capability_source"`
+	DeclaredToolCount     int      `json:"declared_tool_count"`
+	RiskyDeclarationCount int      `json:"risky_declaration_count"`
+	ResearchStatus        string   `json:"research_status"`
+	ResearchCoverage      string   `json:"research_coverage"`
+	CitationCount         int      `json:"citation_count"`
+	TrustedCitationCount  int      `json:"trusted_citation_count"`
+}
+
+// ReadPlatformReview returns a privacy-safe review summary for a Platform
+// runtime that has already enforced live organization-admin authorization.
+func (s *Service) ReadPlatformReview(ctx context.Context, input PlatformReviewReadInput) (PlatformReviewSummary, error) {
+	if strings.TrimSpace(input.OrganizationID) == "" || input.ProjectID == uuid.Nil || strings.TrimSpace(input.TargetKey) == "" {
+		return PlatformReviewSummary{}, oops.E(oops.CodeBadRequest, nil, "organization, project, and target key are required")
+	}
+	if input.TargetKind != targetKindServerURL && input.TargetKind != targetKindStdioCommand {
+		return PlatformReviewSummary{}, oops.E(oops.CodeBadRequest, nil, "target_kind must be server_url or stdio_command")
+	}
+
+	if _, err := projectsrepo.New(s.db).GetProjectByIDAndOrganizationID(ctx, projectsrepo.GetProjectByIDAndOrganizationIDParams{ID: input.ProjectID, OrganizationID: input.OrganizationID}); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return PlatformReviewSummary{}, oops.E(oops.CodeNotFound, err, "approval request not found")
+		}
+		return PlatformReviewSummary{}, oops.E(oops.CodeUnexpected, err, "error reading approval project").LogError(ctx, s.logger)
+	}
+
+	queries := repo.New(s.db)
+	request, err := queries.GetApprovalRequestByTarget(ctx, repo.GetApprovalRequestByTargetParams{ProjectID: input.ProjectID, TargetKind: input.TargetKind, TargetKey: input.TargetKey})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return PlatformReviewSummary{}, oops.E(oops.CodeNotFound, err, "approval request not found")
+		}
+		return PlatformReviewSummary{}, oops.E(oops.CodeUnexpected, err, "error reading approval request").LogError(ctx, s.logger)
+	}
+	if request.OrganizationID != input.OrganizationID {
+		return PlatformReviewSummary{}, oops.E(oops.CodeNotFound, nil, "approval request not found")
+	}
+
+	decisions, err := queries.ListDecisionsForApprovalRequest(ctx, repo.ListDecisionsForApprovalRequestParams{McpApprovalRequestID: request.ID, ProjectID: input.ProjectID})
+	if err != nil {
+		return PlatformReviewSummary{}, oops.E(oops.CodeUnexpected, err, "error reading approval decisions").LogError(ctx, s.logger)
+	}
+	reports, err := queries.ListResearchReportsForApprovalRequest(ctx, repo.ListResearchReportsForApprovalRequestParams{McpApprovalRequestID: request.ID, ProjectID: input.ProjectID})
+	if err != nil {
+		return PlatformReviewSummary{}, oops.E(oops.CodeUnexpected, err, "error reading research reports").LogError(ctx, s.logger)
+	}
+
+	summary := newPlatformReviewSummary(request.Status)
+	summary.RequesterCount = request.RequesterCount
+	summary.CreatedAt = conv.FromPGTimestamptz(request.CreatedAt)
+	summary.UpdatedAt = conv.FromPGTimestamptz(request.UpdatedAt)
+	summary.EvidenceCollected = request.EvidenceCollectedAt.Valid
+	summary.EvidenceChanged = request.EvidenceChangedAt.Valid
+	if request.Status != statusSuperseded && len(decisions) > 0 {
+		switch decisions[0].Decision {
+		case decisionApproved, decisionDenied:
+			summary.StandingDecision = decisions[0].Decision
+		}
+	}
+
+	if summary.EvidenceCollected {
+		document, decodeErr := evidence.DecodeDocument(request.CurrentEvidence, int(request.EvidenceVersion))
+		if decodeErr != nil {
+			summary.EvidenceGaps = []string{unreadableEvidenceGap}
+		} else {
+			projectPlatformEvidence(&summary, document)
+		}
+	}
+	if len(reports) > 0 {
+		projectPlatformResearch(&summary, reports[0])
+	}
+
+	return summary, nil
+}
+
+func newPlatformReviewSummary(status string) PlatformReviewSummary {
+	switch status {
+	case statusUnreviewed, statusRequested, statusSuperseded, decisionApproved, decisionDenied:
+	default:
+		status = "unknown"
+	}
+	return PlatformReviewSummary{
+		Status: status, StandingDecision: "", RequesterCount: 0, CreatedAt: "", UpdatedAt: "",
+		EvidenceCollected: false, EvidenceChanged: false, EvidenceGaps: []string{}, IdentityKind: "unknown", VersionPinned: false,
+		PackagePublication: "unknown", RepositoryState: "unknown", AdvisoryLookup: "unknown", KnownAdvisories: 0,
+		AuthorityState: "unknown", CapabilitySource: "unknown", DeclaredToolCount: 0, RiskyDeclarationCount: 0,
+		ResearchStatus: "none", ResearchCoverage: "unknown", CitationCount: 0, TrustedCitationCount: 0,
+	}
+}
+
+func projectPlatformEvidence(summary *PlatformReviewSummary, document evidence.Document) {
+	summary.EvidenceGaps = closedPlatformEvidenceGaps(document.Gaps)
+	switch document.Identity.Kind {
+	case "unresolved", "remote", "package":
+		summary.IdentityKind = document.Identity.Kind
+	}
+	summary.VersionPinned = document.Identity.VersionPinned
+	if document.Package != nil {
+		summary.PackagePublication = "published"
+	} else if document.PackageNotPublished {
+		summary.PackagePublication = "not_published"
+	}
+	if document.Repository != nil {
+		summary.RepositoryState = "found"
+	} else if document.RepositoryNotFound {
+		summary.RepositoryState = "not_found"
+	}
+	if document.Advisories != nil {
+		summary.AdvisoryLookup = "complete"
+		summary.KnownAdvisories = max(document.Advisories.KnownCount, 0)
+	}
+	if document.Authority != nil {
+		switch document.Authority.Mode {
+		case "none":
+			summary.AuthorityState = "none"
+		case "api_key", "oauth":
+			summary.AuthorityState = "declared"
+		}
+	}
+	switch document.CapabilitiesSource {
+	case evidence.CapabilitiesFromServer, evidence.CapabilitiesFromRegistry:
+		summary.CapabilitySource = document.CapabilitiesSource
+	}
+	summary.DeclaredToolCount = len(document.Capabilities)
+	for _, declaration := range document.Capabilities {
+		if declaration.ActsOnBehalf || len(declaration.Declared) > 0 || len(declaration.SchemaImplied) > 0 {
+			summary.RiskyDeclarationCount++
+		}
+	}
+}
+
+func closedPlatformEvidenceGaps(gaps []string) []string {
+	closed := make([]string, 0, len(gaps))
+	seen := make(map[string]struct{}, len(gaps))
+	for _, gap := range gaps {
+		switch gap {
+		case evidence.GapPackageLookup, evidence.GapExposureLookup, evidence.GapAuthorityProbe,
+			evidence.GapToolDeclarations, evidence.GapCatalogLookup, evidence.GapRepositoryLookup,
+			evidence.GapAdvisoryLookup, evidence.GapDomainLookup:
+		default:
+			gap = unreadableEvidenceGap
+		}
+		if _, ok := seen[gap]; ok {
+			continue
+		}
+		seen[gap] = struct{}{}
+		closed = append(closed, gap)
+	}
+	return closed
+}
+
+func projectPlatformResearch(summary *PlatformReviewSummary, report repo.McpResearchReport) {
+	status := report.Status
+	if status == researchStatusRunning && report.StartedAt.Valid && time.Since(report.StartedAt.Time) > ResearchRunStaleAfter {
+		status = "failed"
+	}
+	switch status {
+	case researchStatusRunning, "failed", "completed":
+		summary.ResearchStatus = status
+	default:
+		summary.ResearchStatus = "failed"
+	}
+	if status != "completed" || report.ReportVersion != researchagent.ReportVersion {
+		return
+	}
+
+	var document researchagent.Document
+	if err := json.Unmarshal(report.Report, &document); err != nil {
+		return
+	}
+	switch document.Coverage.Level {
+	case researchagent.CoverageNone, researchagent.CoverageThin, researchagent.CoverageModerate, researchagent.CoverageSubstantial:
+		summary.ResearchCoverage = document.Coverage.Level
+	}
+	for _, claim := range document.Claims {
+		for _, citation := range claim.Citations {
+			summary.CitationCount++
+			if strings.TrimSpace(citation.TrustedSource) != "" {
+				summary.TrustedCitationCount++
+			}
+		}
+	}
+}

--- a/server/internal/mcpapproval/platform_read_test.go
+++ b/server/internal/mcpapproval/platform_read_test.go
@@ -1,0 +1,188 @@
+package mcpapproval_test
+
+import (
+	"encoding/json"
+
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/mcpapproval"
+	"github.com/speakeasy-api/gram/server/internal/mcpapproval/repo"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+func TestReadPlatformReview_ClosedSummaryDoesNotLeakStoredText(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	const (
+		target       = "https://sensitive-target.invalid/mcp?token=target-secret"
+		requester    = "sensitive-requester"
+		note         = "sensitive requester note"
+		secretName   = "SENSITIVE_API_TOKEN"
+		scope        = "sensitive:scope"
+		toolName     = "sensitive_tool_name"
+		claimText    = "sensitive research claim"
+		citationURL  = "https://citation.invalid/sensitive"
+		citationName = "Sensitive Citation Title"
+		traceQuery   = "sensitive trace query"
+	)
+	evidenceDocument := `{
+		"identity":{"kind":"package","artifact_ref":"npm:sensitive-package@1.2.3","version_pinned":true,"package_name":"sensitive-package","package_version":"1.2.3"},
+		"package":{"registry":"npm","name":"sensitive-package"},
+		"repository":{"url":"https://repository.invalid/sensitive","host":"repository.invalid","owner":"secret-owner","name":"secret-repository","stars":4,"forks":1,"open_issues":2},
+		"advisories":{"ecosystem":"npm","package":"sensitive-package","known_count":3},
+		"authority":{"mode":"oauth","scopes":["` + scope + `"],"demanded_secrets":[{"name":"` + secretName + `","required":true,"description":"secret description"}]},
+		"capabilities_source":"server",
+		"capabilities":[{"tool":"` + toolName + `","declared":["destructive"],"acts_on_behalf":true},{"tool":"safe_but_private"}],
+		"gaps":["domain_lookup_failed"]
+	}`
+	requestID := seedRequest(t, ctx, ti, ti.projectID, seededRequest{targetKey: target, status: "requested", evidence: evidenceDocument, version: 1})
+	seedRequester(t, ctx, ti, ti.projectID, requestID, requester, note)
+
+	_, err := ti.repo.CreateApprovalDecision(ctx, repo.CreateApprovalDecisionParams{
+		OrganizationID: ti.organizationID, ProjectID: ti.projectID, McpApprovalRequestID: requestID,
+		Decision: "approved", DecidedBy: "sensitive-decision-actor", Rationale: conv.ToPGText("sensitive rationale"),
+		EvidenceSnapshot: []byte(evidenceDocument), EvidenceVersion: 1, GrantedPrincipalUrns: []string{"urn:gram:user:sensitive-principal"},
+	})
+	require.NoError(t, err)
+
+	report := `{
+		"summary":"sensitive report summary",
+		"coverage":{"level":"moderate","note":"sensitive coverage note"},
+		"claims":[{"tier":"independently_reported","text":"` + claimText + `","citations":[
+			{"url":"` + citationURL + `","title":"` + citationName + `","trusted_source":"security research"},
+			{"url":"https://other.invalid/private","title":"Other Private Title"}
+		]}],
+		"injections":[{"url":"https://injection.invalid/private","rationale":"sensitive injection rationale"}],
+		"run":{"model":"sensitive-model","prompt_version":"sensitive-prompt"}
+	}`
+	reportRow, err := ti.repo.CreateResearchReport(ctx, repo.CreateResearchReportParams{
+		OrganizationID: ti.organizationID, ProjectID: ti.projectID, McpApprovalRequestID: requestID,
+		Status: "running", Report: []byte(`{}`), ReportVersion: 1, Model: conv.ToPGText("sensitive-model"),
+		PromptVersion: conv.ToPGText("sensitive-prompt"), RequestedBy: conv.ToPGText("sensitive-researcher"),
+		StartedAt: pgtype.Timestamptz{}, CompletedAt: pgtype.Timestamptz{}, Error: pgtype.Text{},
+	})
+	require.NoError(t, err)
+	_, err = ti.repo.CompleteResearchReport(ctx, repo.CompleteResearchReportParams{
+		Report: []byte(report), ReportVersion: 1,
+		ToolCalls: []byte(`[{"tool":"web_search","search":{"query":"` + traceQuery + `"}},{"tool":"fetch_page","fetch":{"url":"https://trace.invalid/private","content_preview":"sensitive preview"}}]`),
+		Model:     conv.ToPGText("sensitive-model"), ID: reportRow.ID, ProjectID: ti.projectID,
+	})
+	require.NoError(t, err)
+
+	summary, err := ti.service.ReadPlatformReview(ctx, mcpapproval.PlatformReviewReadInput{
+		OrganizationID: ti.organizationID, ProjectID: ti.projectID, TargetKind: "server_url", TargetKey: target,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "requested", summary.Status)
+	require.Equal(t, "approved", summary.StandingDecision)
+	require.Equal(t, int64(1), summary.RequesterCount)
+	require.NotEmpty(t, summary.CreatedAt)
+	require.NotEmpty(t, summary.UpdatedAt)
+	require.True(t, summary.EvidenceCollected)
+	require.False(t, summary.EvidenceChanged)
+	require.Equal(t, []string{"domain_lookup_failed"}, summary.EvidenceGaps)
+	require.Equal(t, "package", summary.IdentityKind)
+	require.True(t, summary.VersionPinned)
+	require.Equal(t, "published", summary.PackagePublication)
+	require.Equal(t, "found", summary.RepositoryState)
+	require.Equal(t, "complete", summary.AdvisoryLookup)
+	require.Equal(t, 3, summary.KnownAdvisories)
+	require.Equal(t, "declared", summary.AuthorityState)
+	require.Equal(t, "server", summary.CapabilitySource)
+	require.Equal(t, 2, summary.DeclaredToolCount)
+	require.Equal(t, 1, summary.RiskyDeclarationCount)
+	require.Equal(t, "completed", summary.ResearchStatus)
+	require.Equal(t, "moderate", summary.ResearchCoverage)
+	require.Equal(t, 2, summary.CitationCount)
+	require.Equal(t, 1, summary.TrustedCitationCount)
+	require.NotNil(t, summary.EvidenceGaps)
+
+	encoded, err := json.Marshal(summary)
+	require.NoError(t, err)
+	output := string(encoded)
+	for _, private := range []string{
+		target, requester, requester + "@example.test", note, secretName, scope, toolName,
+		"sensitive-package", "secret-owner", "secret-repository", "sensitive-decision-actor",
+		"sensitive rationale", "sensitive-principal", claimText, citationURL, citationName,
+		"Other Private Title", "injection.invalid", "sensitive injection rationale", "sensitive-model",
+		"sensitive-prompt", "sensitive-researcher", traceQuery, "trace.invalid", "sensitive preview",
+	} {
+		require.NotContains(t, output, private)
+	}
+}
+
+func TestReadPlatformReview_ProjectAndOrganizationBoundariesAreNotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	target := "npx sensitive-command --token command-secret"
+	requestID := seedUnresolvedRequest(t, ctx, ti, ti.projectID, target)
+	seedRequester(t, ctx, ti, ti.projectID, requestID, "private-user", "private note")
+
+	otherProject := createProject(t, ctx, ti.conn, ti.organizationID)
+	_, err := ti.service.ReadPlatformReview(ctx, mcpapproval.PlatformReviewReadInput{
+		OrganizationID: ti.organizationID, ProjectID: otherProject, TargetKind: "stdio_command", TargetKey: target,
+	})
+	requireOopsCode(t, err, oops.CodeNotFound)
+
+	_, err = ti.service.ReadPlatformReview(ctx, mcpapproval.PlatformReviewReadInput{
+		OrganizationID: "other-organization", ProjectID: ti.projectID, TargetKind: "stdio_command", TargetKey: target,
+	})
+	requireOopsCode(t, err, oops.CodeNotFound)
+}
+
+func TestReadPlatformReview_UnreadableEvidenceAndSupersededDecisionStayClosed(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	target := "https://malformed.invalid/private"
+	requestID := seedRequest(t, ctx, ti, ti.projectID, seededRequest{targetKey: target, status: "superseded", evidence: `{"private":"valid json, unsupported evidence version"}`, version: 99})
+	_, err := ti.repo.CreateApprovalDecision(ctx, repo.CreateApprovalDecisionParams{
+		OrganizationID: ti.organizationID, ProjectID: ti.projectID, McpApprovalRequestID: requestID,
+		Decision: "denied", DecidedBy: "private actor", Rationale: conv.ToPGText("private rationale"),
+		EvidenceSnapshot: []byte(`{"private":"snapshot"}`), EvidenceVersion: 1, GrantedPrincipalUrns: []string{},
+	})
+	require.NoError(t, err)
+
+	summary, err := ti.service.ReadPlatformReview(ctx, mcpapproval.PlatformReviewReadInput{
+		OrganizationID: ti.organizationID, ProjectID: ti.projectID, TargetKind: "server_url", TargetKey: target,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "superseded", summary.Status)
+	require.Empty(t, summary.StandingDecision)
+	require.Equal(t, []string{"unreadable_evidence"}, summary.EvidenceGaps)
+	require.Equal(t, "unknown", summary.IdentityKind)
+	require.Equal(t, "unknown", summary.PackagePublication)
+	require.Equal(t, "unknown", summary.RepositoryState)
+	require.Equal(t, "unknown", summary.AdvisoryLookup)
+	require.Equal(t, "unknown", summary.AuthorityState)
+	require.Equal(t, "unknown", summary.CapabilitySource)
+	require.Equal(t, "none", summary.ResearchStatus)
+	require.Equal(t, "unknown", summary.ResearchCoverage)
+
+	encoded, err := json.Marshal(summary)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), "malformed.invalid")
+	require.NotContains(t, string(encoded), "private")
+}
+
+func TestReadPlatformReview_RejectsInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	for _, input := range []mcpapproval.PlatformReviewReadInput{
+		{OrganizationID: "", ProjectID: ti.projectID, TargetKind: "server_url", TargetKey: "x"},
+		{OrganizationID: ti.organizationID, ProjectID: uuid.Nil, TargetKind: "server_url", TargetKey: "x"},
+		{OrganizationID: ti.organizationID, ProjectID: ti.projectID, TargetKind: "other", TargetKey: "x"},
+		{OrganizationID: ti.organizationID, ProjectID: ti.projectID, TargetKind: "server_url", TargetKey: "  "},
+	} {
+		_, err := ti.service.ReadPlatformReview(ctx, input)
+		requireOopsCode(t, err, oops.CodeBadRequest)
+	}
+}

--- a/server/internal/mcpapproval/queries.sql
+++ b/server/internal/mcpapproval/queries.sql
@@ -90,6 +90,42 @@ WHERE r.project_id = @project_id
   AND r.target_key = ANY (@target_keys::text[])
   AND r.deleted IS FALSE;
 
+-- name: GetApprovalRequestTarget :one
+-- Exact projection for one inventory target. This carries the same latest
+-- decision and requester count as ListApprovalRequestTargets without scanning
+-- every review in the project for a get-by-reference call. The partial unique
+-- index on (project_id, target_kind, target_key) guarantees one live row.
+SELECT
+  r.id
+  , r.target_kind
+  , r.target_raw
+  , r.target_key
+  , r.status
+  , r.evidence_changed_at
+  , r.created_at
+  , r.updated_at
+  , COALESCE((
+      SELECT d.decision
+      FROM mcp_approval_decisions d
+      WHERE d.mcp_approval_request_id = r.id
+        AND d.project_id = r.project_id
+        AND d.deleted IS FALSE
+      ORDER BY d.decided_at DESC, d.id DESC
+      LIMIT 1
+    ), '')::text AS latest_decision
+  , (
+      SELECT count(*)
+      FROM mcp_approval_request_requesters req
+      WHERE req.mcp_approval_request_id = r.id
+        AND req.project_id = r.project_id
+        AND req.deleted IS FALSE
+    ) AS requester_count
+FROM mcp_approval_requests r
+WHERE r.project_id = @project_id
+  AND r.target_kind = @target_kind
+  AND r.target_key = @target_key
+  AND r.deleted IS FALSE;
+
 -- name: ListApprovalRequestTargets :many
 -- Every review in a project, any kind and any status, with the requester
 -- count the unified servers table displays. Bounded by the one-review-per-

--- a/server/internal/mcpapproval/repo/queries.sql.go
+++ b/server/internal/mcpapproval/repo/queries.sql.go
@@ -576,6 +576,80 @@ func (q *Queries) GetApprovalRequestForRecheck(ctx context.Context, arg GetAppro
 	return i, err
 }
 
+const getApprovalRequestTarget = `-- name: GetApprovalRequestTarget :one
+SELECT
+  r.id
+  , r.target_kind
+  , r.target_raw
+  , r.target_key
+  , r.status
+  , r.evidence_changed_at
+  , r.created_at
+  , r.updated_at
+  , COALESCE((
+      SELECT d.decision
+      FROM mcp_approval_decisions d
+      WHERE d.mcp_approval_request_id = r.id
+        AND d.project_id = r.project_id
+        AND d.deleted IS FALSE
+      ORDER BY d.decided_at DESC, d.id DESC
+      LIMIT 1
+    ), '')::text AS latest_decision
+  , (
+      SELECT count(*)
+      FROM mcp_approval_request_requesters req
+      WHERE req.mcp_approval_request_id = r.id
+        AND req.project_id = r.project_id
+        AND req.deleted IS FALSE
+    ) AS requester_count
+FROM mcp_approval_requests r
+WHERE r.project_id = $1
+  AND r.target_kind = $2
+  AND r.target_key = $3
+  AND r.deleted IS FALSE
+`
+
+type GetApprovalRequestTargetParams struct {
+	ProjectID  uuid.UUID
+	TargetKind string
+	TargetKey  string
+}
+
+type GetApprovalRequestTargetRow struct {
+	ID                uuid.UUID
+	TargetKind        string
+	TargetRaw         string
+	TargetKey         string
+	Status            string
+	EvidenceChangedAt pgtype.Timestamptz
+	CreatedAt         pgtype.Timestamptz
+	UpdatedAt         pgtype.Timestamptz
+	LatestDecision    string
+	RequesterCount    int64
+}
+
+// Exact projection for one inventory target. This carries the same latest
+// decision and requester count as ListApprovalRequestTargets without scanning
+// every review in the project for a get-by-reference call. The partial unique
+// index on (project_id, target_kind, target_key) guarantees one live row.
+func (q *Queries) GetApprovalRequestTarget(ctx context.Context, arg GetApprovalRequestTargetParams) (GetApprovalRequestTargetRow, error) {
+	row := q.db.QueryRow(ctx, getApprovalRequestTarget, arg.ProjectID, arg.TargetKind, arg.TargetKey)
+	var i GetApprovalRequestTargetRow
+	err := row.Scan(
+		&i.ID,
+		&i.TargetKind,
+		&i.TargetRaw,
+		&i.TargetKey,
+		&i.Status,
+		&i.EvidenceChangedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.LatestDecision,
+		&i.RequesterCount,
+	)
+	return i, err
+}
+
 const getBypassRequestForPromotion = `-- name: GetBypassRequestForPromotion :one
 SELECT id, organization_id, project_id, target_kind, target_label, target_key,
        target_dimensions, requester_user_id, requester_email, note

--- a/server/internal/platformmcp/adapters.go
+++ b/server/internal/platformmcp/adapters.go
@@ -296,6 +296,7 @@ type PostgresReader struct {
 	dataExportMutations *dataExportMutationService
 	recentToolCalls     *RecentToolCallReadService
 	eventFeed           *EventFeedReadService
+	shadowInventory     *ShadowInventoryService
 }
 
 func NewPostgresReader(logger *slog.Logger, db *pgxpool.Pool) *PostgresReader {
@@ -311,7 +312,15 @@ func NewPostgresReader(logger *slog.Logger, db *pgxpool.Pool) *PostgresReader {
 		dataExportMutations: nil,
 		recentToolCalls:     nil,
 		eventFeed:           nil,
+		shadowInventory:     nil,
 	}
+}
+
+func (r *PostgresReader) WithShadowInventory(service *ShadowInventoryService) *PostgresReader {
+	if r != nil && service != nil && service.valid() {
+		r.shadowInventory = service
+	}
+	return r
 }
 
 func (r *PostgresReader) setInventoryCursorKey(keyMaterial string) {

--- a/server/internal/platformmcp/shadow_inventory.go
+++ b/server/internal/platformmcp/shadow_inventory.go
@@ -1,0 +1,446 @@
+package platformmcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	accessgen "github.com/speakeasy-api/gram/server/gen/access"
+	"github.com/speakeasy-api/gram/server/internal/access"
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/mcpapproval"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	platformrepo "github.com/speakeasy-api/gram/server/internal/platformmcp/repo"
+)
+
+const (
+	shadowTargetKindServerURL    = "server_url"
+	shadowTargetKindStdioCommand = "stdio_command"
+	shadowTargetReferenceKind    = "shadow_mcp_target"
+	shadowInventoryCursorKind    = "shadow_mcp_cursor"
+	shadowInventoryPageSize      = 50
+)
+
+var (
+	ErrShadowInventoryInvalid     = errors.New("invalid platform mcp shadow inventory request")
+	ErrShadowInventoryNotFound    = errors.New("platform mcp shadow inventory target not found")
+	ErrShadowInventoryUnavailable = errors.New("platform mcp shadow inventory unavailable")
+)
+
+type shadowInventoryReader interface {
+	ReadShadowMCPInventory(context.Context, access.ShadowMCPInventoryReadInput) (*accessgen.ListShadowMCPInventoryResult, error)
+	ReadShadowMCPInventoryTarget(context.Context, access.ShadowMCPInventoryTargetInput) (*accessgen.ShadowMCPInventoryServer, error)
+}
+
+type shadowReviewReader interface {
+	ReadPlatformReview(context.Context, mcpapproval.PlatformReviewReadInput) (mcpapproval.PlatformReviewSummary, error)
+}
+
+type ListShadowMCPInventoryInput struct {
+	ProjectID string `json:"project_id" jsonschema:"explicit project ID returned by list_projects"`
+	Cursor    string `json:"cursor,omitempty" jsonschema:"opaque cursor returned by the preceding list_shadow_mcp_inventory page"`
+	Limit     int    `json:"limit,omitempty" jsonschema:"maximum targets to return; server clamps this to 50"`
+}
+
+type GetShadowMCPReviewInput struct {
+	ProjectID       string `json:"project_id" jsonschema:"explicit project ID used to list this target"`
+	TargetReference string `json:"target_reference" jsonschema:"short-lived opaque target reference returned by list_shadow_mcp_inventory"`
+}
+
+type ShadowMCPAccessSummary struct {
+	State            string `json:"state"`
+	AllowedFor       string `json:"allowed_for"`
+	BlockedFor       string `json:"blocked_for"`
+	BlockingDefault  string `json:"blocking_default"`
+	Decision         string `json:"decision,omitempty"`
+	DecisionCoverage string `json:"decision_coverage"`
+}
+
+type ShadowMCPReviewSummary struct {
+	Status           string       `json:"status"`
+	StandingDecision string       `json:"standing_decision,omitempty"`
+	RequesterCount   SubjectCount `json:"requester_count"`
+	EvidenceChanged  bool         `json:"evidence_changed"`
+}
+
+type ShadowMCPTargetSummary struct {
+	Display            string                  `json:"display"`
+	TargetKind         string                  `json:"target_kind"`
+	ObservationState   string                  `json:"observation_state"`
+	FirstSeen          string                  `json:"first_seen,omitempty"`
+	LastSeen           string                  `json:"last_seen,omitempty"`
+	LastCalled         string                  `json:"last_called,omitempty"`
+	ObservedUseCount   int                     `json:"observed_use_count"`
+	UserCount          SubjectCount            `json:"user_count"`
+	Access             ShadowMCPAccessSummary  `json:"access"`
+	Review             *ShadowMCPReviewSummary `json:"review,omitempty"`
+	TargetReference    string                  `json:"target_reference"`
+	ReferenceExpiresAt string                  `json:"reference_expires_at"`
+}
+
+type ListShadowMCPInventoryOutput struct {
+	Project    RiskProject              `json:"project"`
+	Targets    []ShadowMCPTargetSummary `json:"targets"`
+	NextCursor string                   `json:"next_cursor,omitempty"`
+}
+
+type ShadowMCPEvidenceSummary struct {
+	Collected             bool     `json:"collected"`
+	Gaps                  []string `json:"gaps"`
+	IdentityKind          string   `json:"identity_kind"`
+	VersionPinned         bool     `json:"version_pinned"`
+	PackagePublication    string   `json:"package_publication"`
+	RepositoryState       string   `json:"repository_state"`
+	AdvisoryLookup        string   `json:"advisory_lookup"`
+	KnownAdvisories       int      `json:"known_advisories"`
+	AuthorityState        string   `json:"authority_state"`
+	CapabilitySource      string   `json:"capability_source"`
+	DeclaredToolCount     int      `json:"declared_tool_count"`
+	RiskyDeclarationCount int      `json:"risky_declaration_count"`
+	ResearchStatus        string   `json:"research_status"`
+	ResearchCoverage      string   `json:"research_coverage"`
+	CitationCount         int      `json:"citation_count"`
+	TrustedCitationCount  int      `json:"trusted_citation_count"`
+}
+
+type GetShadowMCPReviewOutput struct {
+	Project  RiskProject              `json:"project"`
+	Target   ShadowMCPTargetSummary   `json:"target"`
+	Evidence ShadowMCPEvidenceSummary `json:"evidence"`
+}
+
+type shadowTargetReference struct {
+	Kind string `json:"kind"`
+	Key  string `json:"key"`
+}
+
+type shadowInventoryCursor struct {
+	Offset       int    `json:"offset,omitempty"`
+	AccessCursor string `json:"access_cursor,omitempty"`
+}
+
+type ShadowInventoryService struct {
+	projects      riskProjectResolver
+	inventory     shadowInventoryReader
+	reviews       shadowReviewReader
+	flags         feature.Provider
+	organizations OrganizationSlugResolver
+	budget        OperationBudget
+	references    *subjectReferenceCodec
+	now           func() time.Time
+}
+
+func NewShadowInventoryService(dbReader shadowInventoryReader, reviews shadowReviewReader, flags feature.Provider, organizations OrganizationSlugResolver, dbQueries *platformrepo.Queries, budget OperationBudget, keyMaterial string) (*ShadowInventoryService, error) {
+	codec, err := newSubjectReferenceCodec(keyMaterial)
+	if err != nil {
+		return nil, ErrShadowInventoryUnavailable
+	}
+	if dbReader == nil || reviews == nil || flags == nil || organizations == nil || dbQueries == nil || !budget.valid() {
+		return nil, ErrShadowInventoryUnavailable
+	}
+	return &ShadowInventoryService{
+		projects: postgresRiskProjectResolver{queries: dbQueries}, inventory: dbReader, reviews: reviews,
+		flags: flags, organizations: organizations, budget: budget, references: codec, now: time.Now,
+	}, nil
+}
+
+func (s *ShadowInventoryService) valid() bool {
+	return s != nil && s.projects != nil && s.inventory != nil && s.reviews != nil && s.flags != nil && s.organizations != nil && s.budget.valid() && s.references != nil && s.now != nil
+}
+
+func (s *ShadowInventoryService) List(ctx context.Context, principal Principal, input ListShadowMCPInventoryInput) (ListShadowMCPInventoryOutput, error) {
+	if !s.valid() || principal.OrganizationID == "" {
+		return ListShadowMCPInventoryOutput{}, ErrShadowInventoryUnavailable
+	}
+	project, err := s.projects.Resolve(ctx, principal.OrganizationID, strings.TrimSpace(input.ProjectID), "")
+	if err != nil {
+		return ListShadowMCPInventoryOutput{}, mapShadowProjectError(err)
+	}
+	if err := s.admit(ctx, principal, project); err != nil {
+		return ListShadowMCPInventoryOutput{}, err
+	}
+	limit := input.Limit
+	if limit <= 0 || limit > shadowInventoryPageSize {
+		limit = shadowInventoryPageSize
+	}
+	scope := queryScope("shadow_inventory", project.ID.String())
+	page := shadowInventoryCursor{Offset: 0, AccessCursor: ""}
+	if input.Cursor != "" {
+		encoded, err := s.references.DecodeScoped(input.Cursor, principal, shadowInventoryCursorKind, scope, s.now())
+		if err != nil || json.Unmarshal([]byte(encoded), &page) != nil || page.Offset < 0 || (page.Offset > 0 && page.AccessCursor != "") {
+			return ListShadowMCPInventoryOutput{}, ErrShadowInventoryInvalid
+		}
+	}
+	accessCursor := page.AccessCursor
+	var cursor *string
+	if accessCursor != "" {
+		cursor = &accessCursor
+	}
+	rows, err := s.inventory.ReadShadowMCPInventory(ctx, access.ShadowMCPInventoryReadInput{
+		OrganizationID: principal.OrganizationID, ProjectID: project.ID, Limit: shadowInventoryPageSize, Cursor: cursor,
+	})
+	if err != nil {
+		return ListShadowMCPInventoryOutput{}, mapShadowReadError(err)
+	}
+	if page.Offset > len(rows.Servers) {
+		return ListShadowMCPInventoryOutput{}, ErrShadowInventoryInvalid
+	}
+	remaining := rows.Servers[page.Offset:]
+	selected := remaining
+	if len(selected) > limit {
+		selected = selected[:limit]
+	}
+	output := ListShadowMCPInventoryOutput{Project: riskProject(project), Targets: make([]ShadowMCPTargetSummary, 0, len(selected)), NextCursor: ""}
+	for _, row := range selected {
+		target, err := s.projectTarget(principal, project, row)
+		if err != nil {
+			return ListShadowMCPInventoryOutput{}, err
+		}
+		output.Targets = append(output.Targets, target)
+	}
+	consumed := page.Offset + len(selected)
+	next := shadowInventoryCursor{Offset: 0, AccessCursor: ""}
+	switch {
+	case consumed < len(rows.Servers):
+		next.Offset = consumed
+	case rows.NextCursor != nil && *rows.NextCursor != "":
+		next.AccessCursor = *rows.NextCursor
+	}
+	if next.Offset > 0 || next.AccessCursor != "" {
+		payload, err := json.Marshal(next)
+		if err != nil {
+			return ListShadowMCPInventoryOutput{}, fmt.Errorf("encode shadow inventory cursor: %w", err)
+		}
+		output.NextCursor, err = s.references.EncodeScoped(principal, shadowInventoryCursorKind, scope, string(payload), s.now())
+		if err != nil {
+			return ListShadowMCPInventoryOutput{}, ErrShadowInventoryUnavailable
+		}
+	}
+	return output, nil
+}
+
+func (s *ShadowInventoryService) GetReview(ctx context.Context, principal Principal, input GetShadowMCPReviewInput) (GetShadowMCPReviewOutput, error) {
+	if !s.valid() || principal.OrganizationID == "" {
+		return GetShadowMCPReviewOutput{}, ErrShadowInventoryUnavailable
+	}
+	project, err := s.projects.Resolve(ctx, principal.OrganizationID, strings.TrimSpace(input.ProjectID), "")
+	if err != nil {
+		return GetShadowMCPReviewOutput{}, mapShadowProjectError(err)
+	}
+	if err := s.admit(ctx, principal, project); err != nil {
+		return GetShadowMCPReviewOutput{}, err
+	}
+	scope := queryScope("shadow_target", project.ID.String())
+	encoded, err := s.references.DecodeScoped(strings.TrimSpace(input.TargetReference), principal, shadowTargetReferenceKind, scope, s.now())
+	if err != nil {
+		return GetShadowMCPReviewOutput{}, ErrShadowInventoryNotFound
+	}
+	var reference shadowTargetReference
+	if json.Unmarshal([]byte(encoded), &reference) != nil || !validShadowTargetKind(reference.Kind) || reference.Key == "" {
+		return GetShadowMCPReviewOutput{}, ErrShadowInventoryNotFound
+	}
+	row, err := s.inventory.ReadShadowMCPInventoryTarget(ctx, access.ShadowMCPInventoryTargetInput{
+		OrganizationID: principal.OrganizationID, ProjectID: project.ID, TargetKind: reference.Kind, TargetKey: reference.Key,
+	})
+	if err != nil {
+		return GetShadowMCPReviewOutput{}, mapShadowReadError(err)
+	}
+	target, err := s.projectTarget(principal, project, row)
+	if err != nil {
+		return GetShadowMCPReviewOutput{}, err
+	}
+	output := GetShadowMCPReviewOutput{Project: riskProject(project), Target: target, Evidence: emptyShadowEvidence()}
+	if row.ApprovalRequest == nil {
+		return output, nil
+	}
+	review, err := s.reviews.ReadPlatformReview(ctx, mcpapproval.PlatformReviewReadInput{
+		OrganizationID: principal.OrganizationID, ProjectID: project.ID, TargetKind: reference.Kind, TargetKey: reference.Key,
+	})
+	if err != nil {
+		return GetShadowMCPReviewOutput{}, mapShadowReadError(err)
+	}
+	output.Evidence = shadowEvidence(review)
+	return output, nil
+}
+
+func (s *ShadowInventoryService) admit(ctx context.Context, principal Principal, project ResolvedProject) error {
+	organizationSlug, err := s.organizations.OrganizationSlug(ctx, principal.OrganizationID)
+	if err != nil || organizationSlug == "" {
+		return ErrShadowInventoryUnavailable
+	}
+	evaluation, err := feature.EvaluateFlag(ctx, s.flags, feature.FlagMCPApproval, principal.OrganizationID, feature.OrgProjectGroups(organizationSlug, ""))
+	if err != nil {
+		return ErrShadowInventoryUnavailable
+	}
+	if evaluation != feature.EvaluationEnabled {
+		return ErrShadowInventoryUnavailable
+	}
+	if err := s.budget.Allow(ctx, principal); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *ShadowInventoryService) projectTarget(principal Principal, project ResolvedProject, row *accessgen.ShadowMCPInventoryServer) (ShadowMCPTargetSummary, error) {
+	if row == nil {
+		return ShadowMCPTargetSummary{}, ErrShadowInventoryUnavailable
+	}
+	kind := shadowTargetKindServerURL
+	if row.TargetKind != nil {
+		kind = *row.TargetKind
+	}
+	if !validShadowTargetKind(kind) || row.CanonicalServerURL == "" || row.AccessSummary == nil {
+		return ShadowMCPTargetSummary{}, ErrShadowInventoryUnavailable
+	}
+	referencePayload, err := json.Marshal(shadowTargetReference{Kind: kind, Key: row.CanonicalServerURL})
+	if err != nil {
+		return ShadowMCPTargetSummary{}, fmt.Errorf("encode shadow target reference: %w", err)
+	}
+	now := s.now().UTC()
+	reference, err := s.references.EncodeScoped(principal, shadowTargetReferenceKind, queryScope("shadow_target", project.ID.String()), string(referencePayload), now)
+	if err != nil {
+		return ShadowMCPTargetSummary{}, ErrShadowInventoryUnavailable
+	}
+	observed := row.FirstSeen != "" && row.FirstSeen != time.Time{}.UTC().Format(time.RFC3339)
+	observationState := "requested_only"
+	display := "Requested MCP target"
+	if observed {
+		observationState = "observed"
+		display = "Observed MCP server"
+	}
+	if kind == shadowTargetKindStdioCommand {
+		display = "Requested local MCP command"
+	}
+	result := ShadowMCPTargetSummary{
+		Display: display, TargetKind: kind, ObservationState: observationState,
+		FirstSeen: "", LastSeen: "", LastCalled: "", ObservedUseCount: max(row.ObservedUseCount, 0),
+		UserCount: NewSubjectCount(int64(row.UserCount)),
+		Access:    ShadowMCPAccessSummary{State: row.AccessSummary.State, AllowedFor: row.AccessSummary.AllowedFor, BlockedFor: row.AccessSummary.BlockedFor, BlockingDefault: row.AccessSummary.BlockingDefault, Decision: "", DecisionCoverage: row.AccessSummary.DecisionCoverage},
+		Review:    nil, TargetReference: reference, ReferenceExpiresAt: now.Add(SubjectReferenceTTL).Format(time.RFC3339),
+	}
+	if !validShadowAccessSummary(result.Access) {
+		return ShadowMCPTargetSummary{}, ErrShadowInventoryUnavailable
+	}
+	if row.AccessSummary.Decision != nil {
+		if !validShadowDecision(*row.AccessSummary.Decision) {
+			return ShadowMCPTargetSummary{}, ErrShadowInventoryUnavailable
+		}
+		result.Access.Decision = *row.AccessSummary.Decision
+	}
+	if observed {
+		result.FirstSeen, result.LastSeen = row.FirstSeen, row.LastSeen
+		if row.LastCalled != nil {
+			result.LastCalled = *row.LastCalled
+		}
+	}
+	if row.ApprovalRequest != nil {
+		if !validShadowReviewStatus(row.ApprovalRequest.Status) {
+			return ShadowMCPTargetSummary{}, ErrShadowInventoryUnavailable
+		}
+		result.Review = &ShadowMCPReviewSummary{
+			Status: row.ApprovalRequest.Status, StandingDecision: "", RequesterCount: NewSubjectCount(int64(row.ApprovalRequest.RequesterCount)), EvidenceChanged: row.ApprovalRequest.EvidenceChangedAt != nil,
+		}
+		if row.ApprovalRequest.StandingDecision != nil {
+			if !validShadowDecision(*row.ApprovalRequest.StandingDecision) {
+				return ShadowMCPTargetSummary{}, ErrShadowInventoryUnavailable
+			}
+			result.Review.StandingDecision = *row.ApprovalRequest.StandingDecision
+		}
+	}
+	return result, nil
+}
+
+func emptyShadowEvidence() ShadowMCPEvidenceSummary {
+	return ShadowMCPEvidenceSummary{
+		Collected: false, Gaps: []string{}, IdentityKind: "unknown", VersionPinned: false,
+		PackagePublication: "unknown", RepositoryState: "unknown", AdvisoryLookup: "unknown", KnownAdvisories: 0,
+		AuthorityState: "unknown", CapabilitySource: "unknown", DeclaredToolCount: 0, RiskyDeclarationCount: 0,
+		ResearchStatus: "none", ResearchCoverage: "unknown", CitationCount: 0, TrustedCitationCount: 0,
+	}
+}
+
+func shadowEvidence(review mcpapproval.PlatformReviewSummary) ShadowMCPEvidenceSummary {
+	if !validShadowEvidence(review) {
+		return emptyShadowEvidence()
+	}
+	return ShadowMCPEvidenceSummary{
+		Collected: review.EvidenceCollected, Gaps: append([]string{}, review.EvidenceGaps...), IdentityKind: review.IdentityKind,
+		VersionPinned: review.VersionPinned, PackagePublication: review.PackagePublication, RepositoryState: review.RepositoryState,
+		AdvisoryLookup: review.AdvisoryLookup, KnownAdvisories: review.KnownAdvisories, AuthorityState: review.AuthorityState,
+		CapabilitySource: review.CapabilitySource, DeclaredToolCount: review.DeclaredToolCount, RiskyDeclarationCount: review.RiskyDeclarationCount,
+		ResearchStatus: review.ResearchStatus, ResearchCoverage: review.ResearchCoverage, CitationCount: review.CitationCount,
+		TrustedCitationCount: review.TrustedCitationCount,
+	}
+}
+
+func validShadowEvidence(review mcpapproval.PlatformReviewSummary) bool {
+	if !oneOf(review.IdentityKind, "unknown", "unresolved", "remote", "package") ||
+		!oneOf(review.PackagePublication, "unknown", "published", "not_published") ||
+		!oneOf(review.RepositoryState, "unknown", "found", "not_found") ||
+		!oneOf(review.AdvisoryLookup, "unknown", "complete") ||
+		!oneOf(review.AuthorityState, "unknown", "declared", "none") ||
+		!oneOf(review.CapabilitySource, "unknown", "server", "registry") ||
+		!oneOf(review.ResearchStatus, "none", "running", "failed", "completed") ||
+		!oneOf(review.ResearchCoverage, "unknown", "none", "thin", "moderate", "substantial") {
+		return false
+	}
+	for _, gap := range review.EvidenceGaps {
+		if !oneOf(gap, "package_lookup_failed", "exposure_lookup_failed", "authority_probe_failed", "tool_declarations_probe_failed", "catalog_lookup_failed", "repository_lookup_failed", "advisory_lookup_failed", "domain_lookup_failed", "unreadable_evidence") {
+			return false
+		}
+	}
+	return true
+}
+
+func validShadowTargetKind(kind string) bool {
+	return kind == shadowTargetKindServerURL || kind == shadowTargetKindStdioCommand
+}
+
+func validShadowAccessSummary(summary ShadowMCPAccessSummary) bool {
+	return oneOf(summary.State, "allowed", "restricted", "blocked", "unenforced") &&
+		oneOf(summary.AllowedFor, "everyone", "selected", "none") &&
+		oneOf(summary.BlockedFor, "everyone", "some", "none") &&
+		oneOf(summary.BlockingDefault, "deny", "allow", "none") &&
+		oneOf(summary.DecisionCoverage, "full", "partial", "none")
+}
+
+func validShadowReviewStatus(status string) bool {
+	return oneOf(status, "unreviewed", "requested", "approved", "denied", "superseded")
+}
+
+func validShadowDecision(decision string) bool {
+	return oneOf(decision, "approved", "denied")
+}
+
+func oneOf(value string, allowed ...string) bool {
+	return slices.Contains(allowed, value)
+}
+
+func mapShadowProjectError(err error) error {
+	switch {
+	case errors.Is(err, ErrRiskReadInvalid):
+		return ErrShadowInventoryInvalid
+	case errors.Is(err, ErrRiskReadNotFound):
+		return ErrShadowInventoryNotFound
+	default:
+		return fmt.Errorf("resolve shadow mcp project: %w", ErrShadowInventoryUnavailable)
+	}
+}
+
+func mapShadowReadError(err error) error {
+	if shareable, ok := errors.AsType[*oops.ShareableError](err); ok {
+		switch shareable.Code {
+		case oops.CodeBadRequest, oops.CodeInvalid:
+			return ErrShadowInventoryInvalid
+		case oops.CodeNotFound:
+			return ErrShadowInventoryNotFound
+		default:
+			return fmt.Errorf("read shadow mcp inventory: %w", ErrShadowInventoryUnavailable)
+		}
+	}
+	return fmt.Errorf("read shadow mcp inventory: %w", ErrShadowInventoryUnavailable)
+}

--- a/server/internal/platformmcp/shadow_inventory_test.go
+++ b/server/internal/platformmcp/shadow_inventory_test.go
@@ -1,0 +1,151 @@
+package platformmcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	accessgen "github.com/speakeasy-api/gram/server/gen/access"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/access"
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/mcpapproval"
+)
+
+type stubShadowInventory struct {
+	list   *accessgen.ListShadowMCPInventoryResult
+	target *accessgen.ShadowMCPInventoryServer
+}
+
+func (s stubShadowInventory) ReadShadowMCPInventory(context.Context, access.ShadowMCPInventoryReadInput) (*accessgen.ListShadowMCPInventoryResult, error) {
+	return s.list, nil
+}
+
+func (s stubShadowInventory) ReadShadowMCPInventoryTarget(context.Context, access.ShadowMCPInventoryTargetInput) (*accessgen.ShadowMCPInventoryServer, error) {
+	return s.target, nil
+}
+
+type stubShadowReview struct {
+	summary mcpapproval.PlatformReviewSummary
+}
+
+func (s stubShadowReview) ReadPlatformReview(context.Context, mcpapproval.PlatformReviewReadInput) (mcpapproval.PlatformReviewSummary, error) {
+	return s.summary, nil
+}
+
+func TestShadowInventoryProjectionSuppressesIdentityAndReferencesRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	project := ResolvedProject{ID: uuid.New(), Name: "Default", Slug: "default"}
+	canonical := "https://private.example.test/mcp?token=secret"
+	decision := "approved"
+	status := "requested"
+	row := &accessgen.ShadowMCPInventoryServer{
+		CanonicalServerURL: canonical,
+		TargetKind:         new(shadowTargetKindServerURL),
+		ServerName:         new("Reviewed service"),
+		FirstSeen:          "2026-09-06T10:00:00Z",
+		LastSeen:           "2026-09-06T11:00:00Z",
+		ObservedUseCount:   7,
+		UserCount:          1,
+		AccessSummary: &accessgen.ShadowMCPAccessSummary{
+			State: "restricted", AllowedFor: "selected", BlockedFor: "some", BlockingDefault: "deny", Decision: &decision, DecisionCoverage: "partial",
+		},
+		ApprovalRequest: &accessgen.ShadowMCPInventoryApprovalRequest{Status: status, RequesterCount: 1},
+	}
+	flags := &riskMutationFlagProvider{evaluation: feature.EvaluationEnabled}
+	codec, err := newSubjectReferenceCodec("shadow-test-key")
+	require.NoError(t, err)
+	service := &ShadowInventoryService{
+		projects: &stubRiskProjects{project: project, expected: []riskProjectCall{{organizationID: "organization", projectID: project.ID.String()}, {organizationID: "organization", projectID: project.ID.String()}}}, inventory: stubShadowInventory{list: &accessgen.ListShadowMCPInventoryResult{Servers: []*accessgen.ShadowMCPInventoryServer{row}}, target: row},
+		reviews: stubShadowReview{summary: mcpapproval.PlatformReviewSummary{Status: status, EvidenceCollected: true, EvidenceGaps: []string{}, IdentityKind: "remote", PackagePublication: "unknown", RepositoryState: "found", AdvisoryLookup: "complete", KnownAdvisories: 2, AuthorityState: "declared", CapabilitySource: "server", DeclaredToolCount: 3, RiskyDeclarationCount: 1, ResearchStatus: "completed", ResearchCoverage: "moderate", CitationCount: 2, TrustedCitationCount: 1}},
+		flags:   flags, organizations: riskMutationOrganizationResolver{slug: "organization"}, budget: allowBudget(), references: codec,
+		now: func() time.Time { return time.Date(6, 9, 6, 12, 0, 0, 0, time.UTC) },
+	}
+	principal := Principal{UserID: "user", OrganizationID: "organization", ConnectionID: uuid.NewString(), Generation: uuid.NewString()}
+
+	listed, err := service.List(t.Context(), principal, ListShadowMCPInventoryInput{ProjectID: project.ID.String(), Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, listed.Targets, 1)
+	require.True(t, listed.Targets[0].UserCount.Suppressed())
+	require.True(t, listed.Targets[0].Review.RequesterCount.Suppressed())
+	require.Equal(t, "Observed MCP server", listed.Targets[0].Display)
+	require.NotContains(t, listed.Targets[0].TargetReference, "private")
+
+	detail, err := service.GetReview(t.Context(), principal, GetShadowMCPReviewInput{ProjectID: project.ID.String(), TargetReference: listed.Targets[0].TargetReference})
+	require.NoError(t, err)
+	require.Equal(t, 2, detail.Evidence.KnownAdvisories)
+
+	encoded, err := json.Marshal(struct {
+		List   ListShadowMCPInventoryOutput `json:"list"`
+		Detail GetShadowMCPReviewOutput     `json:"detail"`
+	}{List: listed, Detail: detail})
+	require.NoError(t, err)
+	for _, forbidden := range []string{canonical, "private.example.test", "token=secret", "Reviewed service", "user:", "policy_id", "citation.invalid", "requester@example"} {
+		require.NotContains(t, string(encoded), forbidden)
+	}
+}
+
+func TestShadowInventoryBoundsRequestOnlyPrefixAcrossPages(t *testing.T) {
+	t.Parallel()
+
+	project := ResolvedProject{ID: uuid.New(), Slug: "default"}
+	rows := make([]*accessgen.ShadowMCPInventoryServer, 0, 60)
+	for range 60 {
+		rows = append(rows, &accessgen.ShadowMCPInventoryServer{
+			CanonicalServerURL: uuid.NewString(), TargetKind: new(shadowTargetKindStdioCommand),
+			AccessSummary: &accessgen.ShadowMCPAccessSummary{State: "unenforced", AllowedFor: "none", BlockedFor: "none", BlockingDefault: "none", DecisionCoverage: "none"},
+		})
+	}
+	codec, err := newSubjectReferenceCodec("shadow-prefix-key")
+	require.NoError(t, err)
+	service := &ShadowInventoryService{
+		projects:  &stubRiskProjects{project: project, expected: []riskProjectCall{{organizationID: "organization", projectID: project.ID.String()}, {organizationID: "organization", projectID: project.ID.String()}}},
+		inventory: stubShadowInventory{list: &accessgen.ListShadowMCPInventoryResult{Servers: rows}}, reviews: stubShadowReview{},
+		flags: &riskMutationFlagProvider{evaluation: feature.EvaluationEnabled}, organizations: riskMutationOrganizationResolver{slug: "organization"},
+		budget: allowBudget(), references: codec, now: time.Now,
+	}
+	principal := Principal{UserID: "user", OrganizationID: "organization", ConnectionID: uuid.NewString(), Generation: uuid.NewString()}
+
+	first, err := service.List(t.Context(), principal, ListShadowMCPInventoryInput{ProjectID: project.ID.String()})
+	require.NoError(t, err)
+	require.Len(t, first.Targets, shadowInventoryPageSize)
+	require.NotEmpty(t, first.NextCursor)
+	second, err := service.List(t.Context(), principal, ListShadowMCPInventoryInput{ProjectID: project.ID.String(), Cursor: first.NextCursor})
+	require.NoError(t, err)
+	require.Len(t, second.Targets, 10)
+	require.Empty(t, second.NextCursor)
+}
+
+func TestShadowEvidenceRejectsUnknownCategories(t *testing.T) {
+	t.Parallel()
+
+	projected := shadowEvidence(mcpapproval.PlatformReviewSummary{
+		EvidenceGaps: []string{"future_gap"}, IdentityKind: "future_identity", PackagePublication: "unknown",
+		RepositoryState: "unknown", AdvisoryLookup: "unknown", AuthorityState: "unknown", CapabilitySource: "unknown",
+		ResearchStatus: "none", ResearchCoverage: "unknown",
+	})
+	require.Equal(t, emptyShadowEvidence(), projected)
+}
+
+func TestShadowInventoryCursorIsProjectAndSessionBound(t *testing.T) {
+	t.Parallel()
+
+	project := ResolvedProject{ID: uuid.New(), Slug: "default"}
+	row := &accessgen.ShadowMCPInventoryServer{CanonicalServerURL: "https://one.example.test", TargetKind: new(shadowTargetKindServerURL), FirstSeen: "2026-09-06T10:00:00Z", AccessSummary: &accessgen.ShadowMCPAccessSummary{State: "unenforced", AllowedFor: "none", BlockedFor: "none", BlockingDefault: "none", DecisionCoverage: "none"}}
+	codec, err := newSubjectReferenceCodec("shadow-cursor-key")
+	require.NoError(t, err)
+	service := &ShadowInventoryService{projects: &stubRiskProjects{project: project, expected: []riskProjectCall{{organizationID: "organization", projectID: project.ID.String()}, {organizationID: "organization", projectID: project.ID.String()}}}, inventory: stubShadowInventory{list: &accessgen.ListShadowMCPInventoryResult{Servers: []*accessgen.ShadowMCPInventoryServer{row, row}}}, reviews: stubShadowReview{}, flags: &riskMutationFlagProvider{evaluation: feature.EvaluationEnabled}, organizations: riskMutationOrganizationResolver{slug: "organization"}, budget: allowBudget(), references: codec, now: time.Now}
+	principal := Principal{UserID: "user", OrganizationID: "organization", ConnectionID: uuid.NewString(), Generation: uuid.NewString()}
+
+	first, err := service.List(t.Context(), principal, ListShadowMCPInventoryInput{ProjectID: project.ID.String(), Limit: 1})
+	require.NoError(t, err)
+	require.NotEmpty(t, first.NextCursor)
+	_, err = service.List(t.Context(), Principal{UserID: "user", OrganizationID: "organization", ConnectionID: uuid.NewString(), Generation: uuid.NewString()}, ListShadowMCPInventoryInput{ProjectID: project.ID.String(), Cursor: first.NextCursor})
+	require.ErrorIs(t, err, ErrShadowInventoryInvalid)
+	_, err = codec.DecodeScoped(first.NextCursor, principal, shadowInventoryCursorKind, queryScope("shadow_inventory", uuid.NewString()), time.Now())
+	require.ErrorIs(t, err, ErrSubjectReferenceNotFound)
+}

--- a/server/internal/platformmcp/tool_shadow_inventory.go
+++ b/server/internal/platformmcp/tool_shadow_inventory.go
@@ -1,0 +1,77 @@
+//nolint:exhaustruct // MCP manifests intentionally rely on documented optional zero values.
+package platformmcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func registerShadowInventoryTools(reg *Registrar, service *ShadowInventoryService) {
+	if !service.valid() {
+		registerUnavailableShadowInventoryTools(reg)
+		return
+	}
+	addTool(reg, &mcp.Tool{
+		Name:        "list_shadow_mcp_inventory",
+		Title:       "List Shadow MCP Inventory",
+		Description: "List privacy-safe observed or requested MCP targets in an explicit project. Pending reviews appear before observed targets on the first page. Raw URLs, local commands, people, principals, policies, evidence, and research traces are never returned; use the short-lived opaque target reference to inspect one review.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input ListShadowMCPInventoryInput) (*mcp.CallToolResult, ListShadowMCPInventoryOutput, error) {
+		return shadowInventoryToolCall(ctx, func(principal Principal) (ListShadowMCPInventoryOutput, error) {
+			return service.List(ctx, principal, input)
+		})
+	})
+	addTool(reg, &mcp.Tool{
+		Name:        "get_shadow_mcp_review",
+		Title:       "Get Shadow MCP Review",
+		Description: "Inspect the closed, privacy-safe evidence and review state for one opaque Shadow MCP target from list_shadow_mcp_inventory. Returns aggregate declarations, gaps, advisory counts, and research coverage only; never raw target values, requesters, evidence documents, findings text, citations, or research traces.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, func(ctx context.Context, _ *mcp.CallToolRequest, input GetShadowMCPReviewInput) (*mcp.CallToolResult, GetShadowMCPReviewOutput, error) {
+		return shadowInventoryToolCall(ctx, func(principal Principal) (GetShadowMCPReviewOutput, error) {
+			return service.GetReview(ctx, principal, input)
+		})
+	})
+}
+
+func registerUnavailableShadowInventoryTools(reg *Registrar) {
+	for _, tool := range []struct{ name, title, description string }{
+		{"list_shadow_mcp_inventory", "List Shadow MCP Inventory", "List privacy-safe Shadow MCP inventory. This is not switched on for your organization yet."},
+		{"get_shadow_mcp_review", "Get Shadow MCP Review", "Inspect one privacy-safe Shadow MCP review. This is not switched on for your organization yet."},
+	} {
+		addTool(reg, &mcp.Tool{Name: tool.name, Title: tool.title, Description: tool.description, Annotations: readOnlyAnnotations()}, ToolMeta{Audiences: externalOnly, ProjectScope: ProjectScopeExplicit}, unavailableTool("shadow_mcp_inventory"))
+	}
+}
+
+func shadowInventoryToolCall[Out any](ctx context.Context, call func(Principal) (Out, error)) (*mcp.CallToolResult, Out, error) {
+	var zero Out
+	principal, err := principalFromToolContext(ctx)
+	if err != nil {
+		return nil, zero, err
+	}
+	output, err := call(principal)
+	if err == nil {
+		return nil, output, nil
+	}
+	if budget, ok := operationBudgetToolResult(err); ok {
+		return budget, zero, nil
+	}
+	result := featureUnavailableResult{Feature: "shadow_mcp_inventory"}
+	switch {
+	case errors.Is(err, ErrShadowInventoryInvalid):
+		result.Code, result.Message = "invalid_request", "The Shadow MCP inventory request or cursor is invalid. Restart the list and use its latest opaque references."
+	case errors.Is(err, ErrShadowInventoryNotFound):
+		result.Code, result.Message = "not_found", "That project or Shadow MCP target is not available to this organization. List the project inventory again."
+	case errors.Is(err, ErrShadowInventoryUnavailable):
+		result.Code, result.Message = unavailableCode, "Shadow MCP inventory is not enabled or is temporarily unavailable."
+	default:
+		return nil, zero, err
+	}
+	content, marshalErr := json.Marshal(result)
+	if marshalErr != nil {
+		return nil, zero, errors.Join(errors.New("encode shadow inventory refusal"), marshalErr)
+	}
+	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(content)}}, IsError: true}, zero, nil
+}

--- a/server/internal/platformmcp/tool_shadow_inventory_test.go
+++ b/server/internal/platformmcp/tool_shadow_inventory_test.go
@@ -1,0 +1,20 @@
+package platformmcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShadowInventoryToolsAreExternalOnlyWithStableUnavailableDescriptors(t *testing.T) {
+	t.Parallel()
+
+	_, registrar := newServer(nil, nil, nil, "", nil, nil, nil, nil, nil, nil, nil, nil, CatalogDescriptor{})
+
+	external := registrar.For(AudienceExternal)
+	assistant := registrar.For(AudienceAssistant)
+	for _, name := range []string{"list_shadow_mcp_inventory", "get_shadow_mcp_review"} {
+		require.Contains(t, names(external), name)
+		require.NotContains(t, names(assistant), name)
+	}
+}

--- a/server/internal/platformmcp/tools.go
+++ b/server/internal/platformmcp/tools.go
@@ -215,12 +215,14 @@ func newServerWithRiskMutations(reader Reader, catalog Catalog, registrations *R
 		} else {
 			registerOrganizationEventTools(reg, postgresReader)
 		}
+		registerShadowInventoryTools(reg, postgresReader.shadowInventory)
 	} else {
 		registerUnavailableRiskToolsWithMutations(reg, riskMutations)
 		registerUnavailableDataExportTools(reg)
 		registerUnavailableDataExportMutationTool(reg)
 		registerUnavailableRecentToolCallTools(reg)
 		registerUnavailableOrganizationEventTools(reg)
+		registerUnavailableShadowInventoryTools(reg)
 	}
 	registerSetupResources(reg, setupResources, time.Now)
 	if registrations == nil || !registrations.budgets.Docs.valid() {


### PR DESCRIPTION
## Linear

- [AIM-223](https://linear.app/speakeasy/issue/AIM-223)

## Why

Platform MCP cannot currently help an administrator discover unsanctioned MCP usage or inspect its review and enforcement state. The dashboard already composes this state, but its response includes target and person-level details that are not safe to expose to a model.

## What changed

- Added external-only `list_shadow_mcp_inventory` and `get_shadow_mcp_review` tools for an explicit project.
- Extracted transport-neutral access and approval read seams so Platform MCP reuses the dashboard’s authoritative observation, request, policy, and review composition without invoking Goa handlers.
- Added encrypted, short-lived target references and page cursors bound to the organization, project, OAuth session, and connection generation.
- Added a deliberately lossy projection: generic target labels, closed enforcement/review/evidence/research categories, exact event counts, and privacy-suppressed person/requester counts.
- Gate reads on the existing MCP approval rollout and the sensitive diagnostics budget; dependencies that are absent keep stable unavailable tool descriptors.

## Review notes

- Privacy boundaries are concentrated in `server/internal/platformmcp/shadow_inventory.go` and `server/internal/mcpapproval/platform_read.go`. Raw URLs, commands, hosts, observed names, users, requesters, principals, policy IDs, evidence documents, findings, citations, and research traces never enter the public DTOs.
- The access compositor intentionally prepends every request-only target on its first internal page. The Platform layer applies its own 50-row bound and encrypted offset cursor; a regression covers a 60-row request-only prefix paginating as 50 + 10.
- No migration is required. D2 decision mutations and D3 approval-aware distribution remain out of scope.

## Testing

- `mise run test:server ./internal/platformmcp ./internal/mcpapproval ./internal/access ./cmd/gram` — passed (1,021 tests).
- `mise lint:server` — passed (existing `exhaustruct` deprecation warning only).
- `mise build:server` — passed.
- `git diff --check` — passed.
- Independent review identified the internal first-page prefix behavior; Platform-level bounding and regression coverage were verified. Three configured review-model attempts did not return a complete verdict and were not treated as approval.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two external-only Platform MCP tools so an admin can discover unsanctioned MCP usage and inspect its review and enforcement state. Every response is a deliberately lossy projection — raw URLs, commands, people, principals, policies, evidence documents, and research traces never enter the public DTOs.

**New Features**
- `list_shadow_mcp_inventory` pages observed and requested-only targets; pending reviews appear before observed targets on the first page.
- `get_shadow_mcp_review` returns closed evidence and review categories with aggregate counts for one opaque target reference; unknown categories are rejected rather than projected.
- Reads are gated on the existing MCP approval rollout and sensitive diagnostics budget; missing dependencies keep stable unavailable tool descriptors.

**Refactors**
- Extracts transport-neutral access and approval read seams so Platform MCP reuses the dashboard's observation, request, policy, and review composition without invoking Goa handlers.
- Adds encrypted, short-lived target references and page cursors bound to organization, project, OAuth session, and connection generation; pages are bounded at 50 rows with offset cursor continuation.
- No migration is required; D2 decision mutations and D3 approval-aware distribution remain out of scope.

<sup>Written for commit 0e9026d35205cbd8c0069a8bbdf7a5e071e47fce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

