### PR TITLE
chore: integrate detector workload and inference measurements

### DIFF
--- a/docs/pubsub-topology.md
+++ b/docs/pubsub-topology.md
@@ -80,34 +80,36 @@ flowchart LR
 
   p0[/"📤<br/>server/internal/authz/challenge_logger.go"/]:::go
   p0 --> t_gram_authz_v1_challenge
-  p1[/"📤<br/>server/internal/hooks/otel_tee.go"/]:::go
-  p1 --> t_gram_otel_v1_inbound_log_record
-  p2[/"📤<br/>server/internal/ping/publisher.go"/]:::go
-  p2 --> t_gram_ping_v2_message
-  p3[/"📤<br/>server/internal/background/activities/risk_analysis/scan_custom_rules.go"/]:::go
-  p3 --> t_gram_risk_v1_custom_rules_analysis
-  p4[/"📤<br/>pystreams/src/pystreams/risk/handler.py"/]:::python
-  p4 --> t_gram_risk_v1_finding
-  p5[/"📤<br/>server/internal/risk/false_positive.go"/]:::go
+  p1[/"📤<br/>pystreams/src/pystreams/risk/evaluation.py"/]:::python
+  p1 --> t_gram_metering_v1_risk_evaluation
+  p2[/"📤<br/>server/internal/hooks/otel_tee.go"/]:::go
+  p2 --> t_gram_otel_v1_inbound_log_record
+  p3[/"📤<br/>server/internal/ping/publisher.go"/]:::go
+  p3 --> t_gram_ping_v2_message
+  p4[/"📤<br/>server/internal/background/activities/risk_analysis/scan_custom_rules.go"/]:::go
+  p4 --> t_gram_risk_v1_custom_rules_analysis
+  p5[/"📤<br/>pystreams/src/pystreams/risk/handler.py"/]:::python
   p5 --> t_gram_risk_v1_finding
-  p6[/"📤<br/>server/internal/scanners/publish.go"/]:::go
+  p6[/"📤<br/>server/internal/risk/false_positive.go"/]:::go
   p6 --> t_gram_risk_v1_finding
-  p7[/"📤<br/>server/internal/background/activities/risk_analysis/scan_gitleaks.go"/]:::go
-  p7 --> t_gram_risk_v1_gitleaks_analysis
-  p8[/"📤<br/>server/internal/risk/enforcereply/dispatch.go"/]:::go
-  p8 --> t_gram_risk_v1_gitleaks_enforcement
-  p9[/"📤<br/>server/internal/background/activities/risk_analysis/scan_presidio.go"/]:::go
-  p9 --> t_gram_risk_v1_presidio_analysis
-  p10[/"📤<br/>server/internal/risk/enforcereply/dispatch.go"/]:::go
-  p10 --> t_gram_risk_v1_presidio_enforcement
-  p11[/"📤<br/>server/internal/background/activities/risk_analysis/scan_prompt_injection.go"/]:::go
-  p11 --> t_gram_risk_v1_prompt_injection_analysis
-  p12[/"📤<br/>server/internal/background/activities/risk_analysis/prompt_judge_batch.go"/]:::go
-  p12 --> t_gram_risk_v1_prompt_policy_analysis
-  p13[/"📤<br/>server/internal/telemetry/log_publisher.go"/]:::go
-  p13 --> t_gram_telemetry_v1_log_record
-  p14[/"📤<br/>server/internal/outbox/webhooks.go"/]:::go
-  p14 --> t_gram_webhooks_v1_event
+  p7[/"📤<br/>server/internal/scanners/publish.go"/]:::go
+  p7 --> t_gram_risk_v1_finding
+  p8[/"📤<br/>server/internal/background/activities/risk_analysis/scan_gitleaks.go"/]:::go
+  p8 --> t_gram_risk_v1_gitleaks_analysis
+  p9[/"📤<br/>server/internal/risk/enforcereply/dispatch.go"/]:::go
+  p9 --> t_gram_risk_v1_gitleaks_enforcement
+  p10[/"📤<br/>server/internal/background/activities/risk_analysis/scan_presidio.go"/]:::go
+  p10 --> t_gram_risk_v1_presidio_analysis
+  p11[/"📤<br/>server/internal/risk/enforcereply/dispatch.go"/]:::go
+  p11 --> t_gram_risk_v1_presidio_enforcement
+  p12[/"📤<br/>server/internal/background/activities/risk_analysis/scan_prompt_injection.go"/]:::go
+  p12 --> t_gram_risk_v1_prompt_injection_analysis
+  p13[/"📤<br/>server/internal/background/activities/risk_analysis/prompt_judge_batch.go"/]:::go
+  p13 --> t_gram_risk_v1_prompt_policy_analysis
+  p14[/"📤<br/>server/internal/telemetry/log_publisher.go"/]:::go
+  p14 --> t_gram_telemetry_v1_log_record
+  p15[/"📤<br/>server/internal/outbox/webhooks.go"/]:::go
+  p15 --> t_gram_webhooks_v1_event
   t_gram_authz_v1_challenge --> s_gram_authz_v1_challenge_ch_writer
   s_gram_authz_v1_challenge_ch_writer -. dead-letter .-> t_gram_authz_v1_challenge_ch_writer_dlq
   t_gram_metering_v1_meter_reading --> s_gram_metering_v1_meter_reading_ch_writer
@@ -150,54 +152,56 @@ flowchart LR
   t_gram_telemetry_v1_log_record --> s_gram_telemetry_v1_noop
   t_gram_webhooks_v1_event --> s_gram_webhooks_v1_svix_relay
   s_gram_webhooks_v1_svix_relay -. dead-letter .-> t_gram_webhooks_v1_svix_relay_dlq
-  c15[\"📥<br/>server/cmd/gram/streams.go<br/>authz.NewChallengeCHWriter<br/>(batch)"\]:::go
-  s_gram_authz_v1_challenge_ch_writer --> c15
-  c16[\"📥<br/>server/cmd/gram/streams.go<br/>metering.NewMeterReadingCHWriter<br/>(batch)"\]:::go
-  s_gram_metering_v1_meter_reading_ch_writer --> c16
-  c17[\"📥<br/>server/cmd/gram/streams.go<br/>metering.NewMeterReadingStripeExporter"\]:::go
-  s_gram_metering_v1_meter_reading_stripe_exporter --> c17
-  c18[\"📥<br/>server/cmd/gram/streams.go<br/>otelsvc.NewLogTransformHandler"\]:::go
-  s_gram_otel_v1_inbound_log_record_transformer --> c18
-  c19[\"📥<br/>server/cmd/gram/streams.go<br/>otelsvc.NewMetricTransformHandler"\]:::go
-  s_gram_otel_v1_inbound_metric_transformer --> c19
-  c20[\"📥<br/>server/cmd/gram/streams.go<br/>otelsvc.NewSpanTransformHandler"\]:::go
-  s_gram_otel_v1_inbound_span_transformer --> c20
-  c21[\"📥<br/>server/cmd/gram/streams.go<br/>otelsvc.NewLogEventCHWriter<br/>(batch)"\]:::go
-  s_gram_otel_v1_log_event_ch_writer --> c21
-  c22[\"📥<br/>server/cmd/gram/streams.go<br/>logRelayHandler<br/>(batch)"\]:::go
-  s_gram_otel_v1_log_relay --> c22
-  c23[\"📥<br/>server/cmd/gram/streams.go<br/>metricRelayHandler<br/>(batch)"\]:::go
-  s_gram_otel_v1_metric_relay --> c23
-  c24[\"📥<br/>server/cmd/gram/streams.go<br/>otelsvc.NewSpanEventCHWriter<br/>(batch)"\]:::go
-  s_gram_otel_v1_span_event_ch_writer --> c24
-  c25[\"📥<br/>server/cmd/gram/streams.go<br/>spanRelayHandler<br/>(batch)"\]:::go
-  s_gram_otel_v1_span_relay --> c25
-  c26[\"📥<br/>server/cmd/gram/streams.go<br/>ping.NewHandler"\]:::go
-  s_gram_ping_v2_processor --> c26
-  c27[\"📥<br/>pystreams/src/pystreams/cmd/multi.py<br/>PingHandler.handle"\]:::python
-  s_gram_ping_v2_py_processor --> c27
-  c28[\"📥<br/>server/cmd/gram/streams.go<br/>customRulesHandler"\]:::go
-  s_gram_risk_v1_custom_rules_analyzer --> c28
-  c29[\"📥<br/>server/cmd/gram/streams.go<br/>risk.NewFindingCHWriter<br/>(batch)"\]:::go
-  s_gram_risk_v1_finding_ch_writer --> c29
-  c30[\"📥<br/>server/cmd/gram/streams.go<br/>riskFindingRelayHandler<br/>(batch)"\]:::go
-  s_gram_risk_v1_finding_otel_relay --> c30
-  c31[\"📥<br/>server/cmd/gram/streams.go<br/>gitleaksHandler"\]:::go
-  s_gram_risk_v1_gitleaks_analyzer --> c31
-  c32[\"📥<br/>server/cmd/gram/streams.go<br/>gitleaksEnforceHandler"\]:::go
-  s_gram_risk_v1_gitleaks_enforcer --> c32
-  c33[\"📥<br/>pystreams/src/pystreams/cmd/multi.py<br/>presidio_handler.handle"\]:::python
-  s_gram_risk_v1_presidio_analyzer --> c33
-  c34[\"📥<br/>pystreams/src/pystreams/cmd/multi.py<br/>enforce_handler.handle"\]:::python
-  s_gram_risk_v1_presidio_enforcer --> c34
-  c35[\"📥<br/>server/cmd/gram/streams.go<br/>promptInjectionHandler"\]:::go
-  s_gram_risk_v1_prompt_injection_analyzer --> c35
-  c36[\"📥<br/>server/cmd/gram/streams.go<br/>promptPolicyHandler"\]:::go
-  s_gram_risk_v1_prompt_policy_analyzer --> c36
-  c37[\"📥<br/>server/cmd/gram/streams.go<br/>new"\]:::go
-  s_gram_telemetry_v1_noop --> c37
-  c38[\"📥<br/>server/cmd/gram/streams.go<br/>webhookEventHandler"\]:::go
-  s_gram_webhooks_v1_svix_relay --> c38
+  c16[\"📥<br/>server/cmd/gram/streams.go<br/>authz.NewChallengeCHWriter<br/>(batch)"\]:::go
+  s_gram_authz_v1_challenge_ch_writer --> c16
+  c17[\"📥<br/>server/cmd/gram/streams.go<br/>metering.NewMeterReadingCHWriter<br/>(batch)"\]:::go
+  s_gram_metering_v1_meter_reading_ch_writer --> c17
+  c18[\"📥<br/>server/cmd/gram/streams.go<br/>metering.NewMeterReadingStripeExporter"\]:::go
+  s_gram_metering_v1_meter_reading_stripe_exporter --> c18
+  c19[\"📥<br/>server/cmd/gram/streams.go<br/>riskmeterconsumer.NewRiskEvaluationCHWriter<br/>(batch)"\]:::go
+  s_gram_metering_v1_risk_evaluation_ch_writer --> c19
+  c20[\"📥<br/>server/cmd/gram/streams.go<br/>otelsvc.NewLogTransformHandler"\]:::go
+  s_gram_otel_v1_inbound_log_record_transformer --> c20
+  c21[\"📥<br/>server/cmd/gram/streams.go<br/>otelsvc.NewMetricTransformHandler"\]:::go
+  s_gram_otel_v1_inbound_metric_transformer --> c21
+  c22[\"📥<br/>server/cmd/gram/streams.go<br/>otelsvc.NewSpanTransformHandler"\]:::go
+  s_gram_otel_v1_inbound_span_transformer --> c22
+  c23[\"📥<br/>server/cmd/gram/streams.go<br/>otelsvc.NewLogEventCHWriter<br/>(batch)"\]:::go
+  s_gram_otel_v1_log_event_ch_writer --> c23
+  c24[\"📥<br/>server/cmd/gram/streams.go<br/>logRelayHandler<br/>(batch)"\]:::go
+  s_gram_otel_v1_log_relay --> c24
+  c25[\"📥<br/>server/cmd/gram/streams.go<br/>metricRelayHandler<br/>(batch)"\]:::go
+  s_gram_otel_v1_metric_relay --> c25
+  c26[\"📥<br/>server/cmd/gram/streams.go<br/>otelsvc.NewSpanEventCHWriter<br/>(batch)"\]:::go
+  s_gram_otel_v1_span_event_ch_writer --> c26
+  c27[\"📥<br/>server/cmd/gram/streams.go<br/>spanRelayHandler<br/>(batch)"\]:::go
+  s_gram_otel_v1_span_relay --> c27
+  c28[\"📥<br/>server/cmd/gram/streams.go<br/>ping.NewHandler"\]:::go
+  s_gram_ping_v2_processor --> c28
+  c29[\"📥<br/>pystreams/src/pystreams/cmd/multi.py<br/>PingHandler.handle"\]:::python
+  s_gram_ping_v2_py_processor --> c29
+  c30[\"📥<br/>server/cmd/gram/streams.go<br/>customRulesHandler"\]:::go
+  s_gram_risk_v1_custom_rules_analyzer --> c30
+  c31[\"📥<br/>server/cmd/gram/streams.go<br/>risk.NewFindingCHWriter<br/>(batch)"\]:::go
+  s_gram_risk_v1_finding_ch_writer --> c31
+  c32[\"📥<br/>server/cmd/gram/streams.go<br/>riskFindingRelayHandler<br/>(batch)"\]:::go
+  s_gram_risk_v1_finding_otel_relay --> c32
+  c33[\"📥<br/>server/cmd/gram/streams.go<br/>gitleaksHandler"\]:::go
+  s_gram_risk_v1_gitleaks_analyzer --> c33
+  c34[\"📥<br/>server/cmd/gram/streams.go<br/>gitleaksEnforceHandler"\]:::go
+  s_gram_risk_v1_gitleaks_enforcer --> c34
+  c35[\"📥<br/>pystreams/src/pystreams/cmd/multi.py<br/>presidio_handler.handle"\]:::python
+  s_gram_risk_v1_presidio_analyzer --> c35
+  c36[\"📥<br/>pystreams/src/pystreams/cmd/multi.py<br/>enforce_handler.handle"\]:::python
+  s_gram_risk_v1_presidio_enforcer --> c36
+  c37[\"📥<br/>server/cmd/gram/streams.go<br/>promptInjectionHandler"\]:::go
+  s_gram_risk_v1_prompt_injection_analyzer --> c37
+  c38[\"📥<br/>server/cmd/gram/streams.go<br/>promptPolicyHandler"\]:::go
+  s_gram_risk_v1_prompt_policy_analyzer --> c38
+  c39[\"📥<br/>server/cmd/gram/streams.go<br/>new"\]:::go
+  s_gram_telemetry_v1_noop --> c39
+  c40[\"📥<br/>server/cmd/gram/streams.go<br/>webhookEventHandler"\]:::go
+  s_gram_webhooks_v1_svix_relay --> c40
 ```
 
 ## Topics
@@ -208,7 +212,7 @@ flowchart LR
 | [`gram-authz-v1-challenge-ch-writer-dlq`](../infra/proto/gram/authz/v1/challenge_ch_writer.proto) | DLQ | 7d | — |
 | [`gram-metering-v1-meter-reading`](../infra/proto/gram/metering/v1/meter_reading.proto) | topic | 31d | — |
 | [`gram-metering-v1-meter-reading-ch-writer-dlq`](../infra/proto/gram/metering/v1/meter_reading_ch_writer.proto) | DLQ | 31d | — |
-| [`gram-metering-v1-risk-evaluation`](../infra/proto/gram/metering/v1/risk_evaluation.proto) | topic | 31d | — |
+| [`gram-metering-v1-risk-evaluation`](../infra/proto/gram/metering/v1/risk_evaluation.proto) | topic | 31d | [`pystreams/src/pystreams/risk/evaluation.py`](../pystreams/src/pystreams/risk/evaluation.py) |
 | [`gram-metering-v1-risk-evaluation-ch-writer-dlq`](../infra/proto/gram/metering/v1/risk_evaluation_ch_writer.proto) | DLQ | 31d | — |
 | [`gram-otel-v1-inbound-log-record`](../infra/proto/gram/otel/v1/inbound_log_record.proto) | topic | — | [`server/internal/hooks/otel_tee.go`](../server/internal/hooks/otel_tee.go) |
 | [`gram-otel-v1-inbound-log-record-transformer-dlq`](../infra/proto/gram/otel/v1/inbound_log_record_transformer.proto) | DLQ | 7d | — |
@@ -249,7 +253,7 @@ flowchart LR
 | [`gram-authz-v1-challenge-ch-writer`](../infra/proto/gram/authz/v1/challenge_ch_writer.proto) | `gram-authz-v1-challenge` | 1m | `gram-authz-v1-challenge-ch-writer-dlq` | [`server/cmd/gram/streams.go`](../server/cmd/gram/streams.go) |
 | [`gram-metering-v1-meter-reading-ch-writer`](../infra/proto/gram/metering/v1/meter_reading_ch_writer.proto) | `gram-metering-v1-meter-reading` | 1m | `gram-metering-v1-meter-reading-ch-writer-dlq` | [`server/cmd/gram/streams.go`](../server/cmd/gram/streams.go) |
 | [`gram-metering-v1-meter-reading-stripe-exporter`](../infra/proto/gram/metering/v1/meter_reading_stripe_exporter.proto) | `gram-metering-v1-meter-reading` | 1m | — | [`server/cmd/gram/streams.go`](../server/cmd/gram/streams.go) |
-| [`gram-metering-v1-risk-evaluation-ch-writer`](../infra/proto/gram/metering/v1/risk_evaluation_ch_writer.proto) | `gram-metering-v1-risk-evaluation` | 1m | `gram-metering-v1-risk-evaluation-ch-writer-dlq` | — |
+| [`gram-metering-v1-risk-evaluation-ch-writer`](../infra/proto/gram/metering/v1/risk_evaluation_ch_writer.proto) | `gram-metering-v1-risk-evaluation` | 1m | `gram-metering-v1-risk-evaluation-ch-writer-dlq` | [`server/cmd/gram/streams.go`](../server/cmd/gram/streams.go) |
 | [`gram-otel-v1-inbound-log-record-transformer`](../infra/proto/gram/otel/v1/inbound_log_record_transformer.proto) | `gram-otel-v1-inbound-log-record` | 1m | `gram-otel-v1-inbound-log-record-transformer-dlq` | [`server/cmd/gram/streams.go`](../server/cmd/gram/streams.go) |
 | [`gram-otel-v1-inbound-metric-transformer`](../infra/proto/gram/otel/v1/inbound_metric_transformer.proto) | `gram-otel-v1-inbound-metric` | 1m | `gram-otel-v1-inbound-metric-transformer-dlq` | [`server/cmd/gram/streams.go`](../server/cmd/gram/streams.go) |
 | [`gram-otel-v1-inbound-span-transformer`](../infra/proto/gram/otel/v1/inbound_span_transformer.proto) | `gram-otel-v1-inbound-span` | 1m | `gram-otel-v1-inbound-span-transformer-dlq` | [`server/cmd/gram/streams.go`](../server/cmd/gram/streams.go) |
@@ -275,11 +279,9 @@ flowchart LR
 ## Notes
 
 - Topic `gram-metering-v1-meter-reading` has no publisher in `server/` or `pystreams/`.
-- Topic `gram-metering-v1-risk-evaluation` has no publisher in `server/` or `pystreams/`.
 - Topic `gram-otel-v1-inbound-metric` has no publisher in `server/` or `pystreams/`.
 - Topic `gram-otel-v1-inbound-span` has no publisher in `server/` or `pystreams/`.
 - Topic `gram-otel-v1-log-record` has no publisher in `server/` or `pystreams/`.
 - Topic `gram-otel-v1-metric` has no publisher in `server/` or `pystreams/`.
 - Topic `gram-otel-v1-span` has no publisher in `server/` or `pystreams/`.
-- Subscription `gram-metering-v1-risk-evaluation-ch-writer` has no consumer in `server/` or `pystreams/`.
 

--- a/pystreams/Dockerfile.pystreams
+++ b/pystreams/Dockerfile.pystreams
@@ -53,6 +53,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=pystreams/pyproject.toml,target=pystreams/pyproject.toml \
     uv sync --frozen --no-install-workspace --no-dev --package pystreams
 
+# Canonical tokenization must work without runtime network access.
+ENV TIKTOKEN_CACHE_DIR=/app/tiktoken-cache
+RUN /app/.venv/bin/python -c "import tiktoken; tiktoken.get_encoding('o200k_base')"
+
 # Layer 2: bring in the workspace sources and install pystreams + gram-infra.
 # With all member sources present, `--locked` asserts the lockfile is current.
 # `--no-editable` installs both members as real wheels so the final image needs
@@ -76,6 +80,8 @@ FROM gcr.io/distroless/cc-debian12:nonroot@sha256:fccdbb0a547c14e23fcf4ce8ad62ca
 # no source tree (the venv is --no-editable) and no build tooling.
 COPY --from=builder /python /python
 COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder /app/tiktoken-cache /app/tiktoken-cache
+ENV TIKTOKEN_CACHE_DIR=/app/tiktoken-cache
 
 # numpy (pulled in transitively via presidio-analyzer -> spacy -> thinc) ships
 # manylinux wheels whose C extensions dynamically link libz.so.1. The manylinux

--- a/pystreams/pyproject.toml
+++ b/pystreams/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "redis>=6.4.0",
   "starlette>=0.40.0",
   "structlog>=26.1.0",
+  "tiktoken>=0.14.0",
   "uvicorn>=0.51.0",
 ]
 

--- a/pystreams/src/pystreams/cmd/multi.py
+++ b/pystreams/src/pystreams/cmd/multi.py
@@ -8,6 +8,7 @@ import anyio
 import click
 import structlog
 from google.cloud.pubsub_v1 import PublisherClient, SubscriberClient
+from gram.metering.v1 import risk_evaluation_pb2
 from gram.ping.v2 import ping_pb2, processor_pb2
 from gram.risk.v1 import (
     finding_pb2,
@@ -31,6 +32,7 @@ from pystreams.deps.scanner import build_presidio_scanner
 from pystreams.health import HealthState, serve_control
 from pystreams.ping.handler import PingHandler
 from pystreams.risk.enforce_handler import PresidioEnforceHandler
+from pystreams.risk.evaluation import build_risk_evaluation_recorder
 from pystreams.risk.fingerprint import parse_pepper_keyring
 from pystreams.risk.handler import PresidioHandler
 from pystreams.risk.replywriter import ReplyWriter
@@ -131,6 +133,12 @@ async def multi(
             findings_publisher = await pubsub_publisher_for_message_async(
                 broker, finding_pb2.Finding
             )
+            risk_evaluation_publisher = await pubsub_publisher_for_message_async(
+                broker, risk_evaluation_pb2.RiskEvaluation
+            )
+            evaluation_recorder = await build_risk_evaluation_recorder(
+                logger, risk_evaluation_publisher
+            )
 
             # The enforcement lane registers only when both Redis and the
             # pepper keyring are configured; validated before the scan pool
@@ -190,7 +198,10 @@ async def multi(
                 activate_blocking_detection(logger=logger)
 
             presidio_handler = PresidioHandler(
-                logger, findings_publisher, presidio_scanner
+                logger,
+                findings_publisher,
+                presidio_scanner,
+                evaluation_recorder,
             )
 
             enforce_handler = None
@@ -200,6 +211,7 @@ async def multi(
                     ReplyWriter(enforce_redis),
                     presidio_scanner,
                     enforce_fingerprinter,
+                    evaluation_recorder,
                 )
 
             # The scanner is an async context manager: leaving the block

--- a/pystreams/src/pystreams/risk/enforce_handler.py
+++ b/pystreams/src/pystreams/risk/enforce_handler.py
@@ -22,12 +22,19 @@ import uuid
 from datetime import UTC, datetime
 from typing import Final
 
+import anyio
 import structlog
+from gram.metering.v1.risk_evaluation_pb2 import RiskEvaluation
 from gram.risk.v1 import enforcement_reply_pb2, presidio_enforcement_pb2
 from gram_infra.pubsub.subscriber import MessageMetadata
 from opentelemetry import metrics
 
 from pystreams.risk import maskdisplay
+from pystreams.risk.evaluation import (
+    Evaluation,
+    RiskEvaluationRecorder,
+    realtime_operation_id,
+)
 from pystreams.risk.fingerprint import Fingerprinter, encode_fingerprint
 from pystreams.risk.replywriter import ReplyWriter, parse_reply_urn
 from pystreams.risk.scanner import (
@@ -126,12 +133,14 @@ class PresidioEnforceHandler:
         writer: ReplyWriter,
         scanner: Scanner,
         fingerprinter: Fingerprinter,
+        evaluation_recorder: RiskEvaluationRecorder,
         max_request_age_seconds: float = DEFAULT_MAX_REQUEST_AGE_SECONDS,
     ) -> None:
         self._logger = logger
         self._writer = writer
         self._scanner = scanner
         self._fingerprinter = fingerprinter
+        self._evaluation_recorder = evaluation_recorder
         # abs(age) > NaN/inf is always false, defeating the freshness window.
         if not math.isfinite(max_request_age_seconds) or max_request_age_seconds <= 0:
             max_request_age_seconds = DEFAULT_MAX_REQUEST_AGE_SECONDS
@@ -193,20 +202,44 @@ class PresidioEnforceHandler:
                 score_threshold = message.score_threshold
             else:
                 score_threshold = DEFAULT_SCORE_THRESHOLD
+            evaluation = Evaluation(
+                organization_id=message.organization_id,
+                project_id=message.project_id,
+                operation_id=realtime_operation_id(message.request_id),
+                detector=RiskEvaluation.DETECTOR_PRESIDIO,
+                execution_mode=RiskEvaluation.EXECUTION_MODE_REALTIME,
+                policy_id=message.risk_policy_id,
+                policy_version=message.risk_policy_version,
+            )
+            attempt = self._evaluation_recorder.start(evaluation)
             try:
                 detections = await self._scanner.scan(
                     message.content, requested, score_threshold
                 )
             except ScanSlotTimeout:
-                # Requeueing cannot rescue an inline scan: reply ERROR now so
-                # the waiter applies its failure mode without burning the deadline.
+                # Inline requests are ACKed after an error reply, unlike the
+                # shadow lane's nack. Both represent an admission skip with no
+                # scanner volume.
+                await attempt.finish(
+                    RiskEvaluation.OUTCOME_SKIPPED, include_volume=False
+                )
                 status = enforcement_reply_pb2.ENFORCEMENT_STATUS_ERROR
                 reason = "presidio scan slot timeout"
             except Exception as exc:
+                with anyio.CancelScope(shield=True):
+                    await attempt.measure([message.content])
+                    await attempt.finish(RiskEvaluation.OUTCOME_FAILED)
                 # Only the exception type: an error string can echo the
                 # scanned content, which never leaves this handler.
                 status = enforcement_reply_pb2.ENFORCEMENT_STATUS_ERROR
                 reason = "presidio scan failed: " + type(exc).__name__
+            except BaseException:
+                await attempt.finish(RiskEvaluation.OUTCOME_CANCELLED)
+                raise
+            else:
+                with anyio.CancelScope(shield=True):
+                    await attempt.measure([message.content])
+                    await attempt.finish(RiskEvaluation.OUTCOME_COMPLETED)
 
         findings: list[enforcement_reply_pb2.EnforcementFinding] = []
         if status == enforcement_reply_pb2.ENFORCEMENT_STATUS_OK:

--- a/pystreams/src/pystreams/risk/evaluation.py
+++ b/pystreams/src/pystreams/risk/evaluation.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import hashlib
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Final, Protocol
+
+import anyio
+import structlog
+import tiktoken
+from anyio import to_thread
+from gram.metering.v1.risk_evaluation_pb2 import RiskEvaluation
+from gram_infra.pubsub import PublishResult
+
+MEASUREMENT_METHOD: Final = "tiktoken_o200k_base"
+
+_PUBLISH_TIMEOUT_SECONDS: Final = 10.0
+_EVALUATION_ID_PREFIX: Final = "gram:risk:evaluation:v1"
+_OPERATION_ID_PREFIX: Final = b"gram:risk:operation:v1\x00"
+_NO_SPECIAL_TOKENS: Final = frozenset[str]()
+
+# These labels are part of the logical identity, independent of enum names.
+_DETECTOR_IDENTITY_LABELS: Final = {
+    RiskEvaluation.DETECTOR_GITLEAKS: "gitleaks",
+    RiskEvaluation.DETECTOR_PRESIDIO: "presidio",
+    RiskEvaluation.DETECTOR_PROMPT_INJECTION: "prompt_injection",
+    RiskEvaluation.DETECTOR_PROMPT_POLICY: "prompt_policy",
+    RiskEvaluation.DETECTOR_CUSTOM_RULES: "custom_rules",
+}
+_MODE_IDENTITY_LABELS: Final = {
+    RiskEvaluation.EXECUTION_MODE_REALTIME: "realtime",
+    RiskEvaluation.EXECUTION_MODE_BATCH: "batch",
+    RiskEvaluation.EXECUTION_MODE_SHADOW: "shadow",
+}
+
+
+class RiskEvaluationPublisher(Protocol):
+    def publish(self, message: RiskEvaluation) -> PublishResult: ...
+
+
+@dataclass(frozen=True)
+class Evaluation:
+    organization_id: str
+    project_id: str
+    operation_id: str
+    detector: RiskEvaluation.Detector
+    execution_mode: RiskEvaluation.ExecutionMode
+    policy_id: str = ""
+    policy_version: int = 0
+
+
+async def build_risk_evaluation_recorder(
+    logger: structlog.stdlib.BoundLogger,
+    publisher: RiskEvaluationPublisher,
+) -> RiskEvaluationRecorder:
+    """Initialize the canonical tokenizer off-loop before steady-state detection."""
+
+    encoding = await to_thread.run_sync(tiktoken.get_encoding, "o200k_base")
+    return RiskEvaluationRecorder(logger, publisher, encoding=encoding)
+
+
+class RiskEvaluationRecorder:
+    """Records safe terminal detector attempts without retaining scanned text."""
+
+    def __init__(
+        self,
+        logger: structlog.stdlib.BoundLogger,
+        publisher: RiskEvaluationPublisher,
+        *,
+        encoding: tiktoken.Encoding,
+    ) -> None:
+        self._logger = logger
+        self._publisher = publisher
+        self._encoding = encoding
+
+    def start(self, evaluation: Evaluation) -> EvaluationAttempt:
+        return EvaluationAttempt(
+            logger=self._logger,
+            publisher=self._publisher,
+            encoding=self._encoding,
+            evaluation=evaluation,
+            occurred_at=datetime.now(UTC),
+        )
+
+
+class EvaluationAttempt:
+    def __init__(
+        self,
+        *,
+        logger: structlog.stdlib.BoundLogger,
+        publisher: RiskEvaluationPublisher,
+        encoding: tiktoken.Encoding,
+        evaluation: Evaluation,
+        occurred_at: datetime,
+    ) -> None:
+        self._logger = logger
+        self._publisher = publisher
+        self._encoding = encoding
+        self._evaluation = evaluation
+        self._occurred_at = occurred_at
+        self._stokens: int | None = None
+        self._measurement_error = False
+        self._finished = False
+
+    async def measure(self, fragments: list[str]) -> None:
+        """Count fragments separately off-loop; tokenization failure stays unknown."""
+
+        try:
+            self._stokens = await to_thread.run_sync(self._count_fragments, fragments)
+        except Exception as exc:
+            self._stokens = None
+            self._measurement_error = True
+            self._logger.warning(
+                "risk evaluation tokenization failed",
+                evaluation_id=evaluation_id(self._evaluation),
+                detector=self._evaluation.detector,
+                execution_mode=self._evaluation.execution_mode,
+                error_type=type(exc).__name__,
+            )
+
+    def _count_fragments(self, fragments: list[str]) -> int:
+        # Treat every fragment as ordinary text. In particular, strings that
+        # resemble tiktoken special tokens must be encoded rather than rejected
+        # or interpreted as control tokens.
+        return sum(
+            len(
+                self._encoding.encode(
+                    fragment,
+                    allowed_special=_NO_SPECIAL_TOKENS,
+                    disallowed_special=(),
+                )
+            )
+            for fragment in fragments
+        )
+
+    async def finish(
+        self, outcome: RiskEvaluation.Outcome, *, include_volume: bool = True
+    ) -> None:
+        if self._finished:
+            raise RuntimeError("risk evaluation attempt already finished")
+        self._finished = True
+
+        event = RiskEvaluation(
+            id=str(uuid.uuid7()),
+            evaluation_id=evaluation_id(self._evaluation),
+            organization_id=self._evaluation.organization_id,
+            project_id=self._evaluation.project_id,
+            operation_id=self._evaluation.operation_id,
+            detector=self._evaluation.detector,
+            execution_mode=self._evaluation.execution_mode,
+            outcome=outcome,
+            occurred_at=_rfc3339(self._occurred_at),
+            produced_at=_rfc3339(datetime.now(UTC)),
+            measurement_method=MEASUREMENT_METHOD,
+            policy_id=self._evaluation.policy_id,
+            policy_version=self._evaluation.policy_version,
+            record_kind="scan",
+        )
+        if include_volume and self._stokens is not None:
+            event.stokens = self._stokens
+        if include_volume and self._measurement_error:
+            event.measurement_error = True
+        try:
+            # Completion publication must not change the scan's existing
+            # ack/nack or enforcement behavior, including during shutdown.
+            with anyio.move_on_after(
+                _PUBLISH_TIMEOUT_SECONDS, shield=True
+            ) as publish_scope:
+                await self._publisher.publish(event).get()
+            if publish_scope.cancel_called:
+                self._log_publish_failure(event, "TimeoutError")
+        except Exception as exc:
+            self._log_publish_failure(event, type(exc).__name__)
+
+    def _log_publish_failure(self, event: RiskEvaluation, error_type: str) -> None:
+        self._logger.error(
+            "publish risk evaluation failed",
+            evaluation_id=event.evaluation_id,
+            detector=event.detector,
+            execution_mode=event.execution_mode,
+            outcome=event.outcome,
+            error_type=error_type,
+        )
+
+
+def evaluation_id(evaluation: Evaluation) -> str:
+    name = "\x00".join(
+        (
+            _EVALUATION_ID_PREFIX,
+            evaluation.organization_id,
+            evaluation.project_id,
+            _MODE_IDENTITY_LABELS[evaluation.execution_mode],
+            _DETECTOR_IDENTITY_LABELS[evaluation.detector],
+            evaluation.operation_id,
+        )
+    )
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, name))
+
+
+def operation_id(*parts: str) -> str:
+    """Return a safe deterministic id from unambiguous length-framed parts."""
+
+    digest = hashlib.sha256()
+    digest.update(_OPERATION_ID_PREFIX)
+    for part in parts:
+        encoded = part.encode()
+        digest.update(len(encoded).to_bytes(8, "big"))
+        digest.update(encoded)
+    return "riskop:v1:" + digest.hexdigest()
+
+
+def shadow_operation_id(
+    *,
+    request_id: str,
+    chat_message_id: str,
+    content_part_id: str,
+    policy_id: str,
+    policy_version: int,
+) -> str:
+    if chat_message_id or content_part_id:
+        return operation_id(
+            "content",
+            chat_message_id,
+            content_part_id,
+            policy_id,
+            str(policy_version),
+        )
+    return operation_id("request", request_id, policy_id, str(policy_version))
+
+
+def realtime_operation_id(request_id: str) -> str:
+    # Realtime Presidio is shared detector work. Policy attribution remains on
+    # the event but must not multiply the logical identity.
+    return operation_id("request", request_id)
+
+
+def _rfc3339(value: datetime) -> str:
+    return (
+        value.astimezone(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
+    )

--- a/pystreams/src/pystreams/risk/handler.py
+++ b/pystreams/src/pystreams/risk/handler.py
@@ -5,8 +5,10 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Protocol
 
+import anyio
 import structlog
 from asyncer import asyncify
+from gram.metering.v1.risk_evaluation_pb2 import RiskEvaluation
 from gram.risk.v1 import finding_pb2, presidio_analysis_pb2
 from gram_infra.pubsub import PublishResult
 from gram_infra.pubsub.subscriber import MessageMetadata
@@ -14,6 +16,11 @@ from opentelemetry import trace
 
 from pystreams import attr
 from pystreams.risk import metrics
+from pystreams.risk.evaluation import (
+    Evaluation,
+    RiskEvaluationRecorder,
+    shadow_operation_id,
+)
 from pystreams.risk.scanner import (
     DEFAULT_SCORE_THRESHOLD,
     Detection,
@@ -54,10 +61,12 @@ class PresidioHandler:
         logger: structlog.stdlib.BoundLogger,
         publisher: FindingPublisher,
         scanner: Scanner,
+        evaluation_recorder: RiskEvaluationRecorder,
     ):
         self.logger = logger
         self.publisher = publisher
         self._scanner = scanner
+        self._evaluation_recorder = evaluation_recorder
 
     async def handle(
         self,
@@ -93,6 +102,22 @@ class PresidioHandler:
             # clock, so it includes any wait for a free scan slot / pool worker,
             # which under load (not the scan itself) can dominate per-message ACK
             # latency.
+            evaluation = Evaluation(
+                organization_id=message.organization_id,
+                project_id=message.project_id,
+                operation_id=shadow_operation_id(
+                    request_id=message.request_id,
+                    chat_message_id=message.chat_message_id,
+                    content_part_id=message.content_part_id,
+                    policy_id=message.risk_policy_id,
+                    policy_version=message.risk_policy_version,
+                ),
+                detector=RiskEvaluation.DETECTOR_PRESIDIO,
+                execution_mode=RiskEvaluation.EXECUTION_MODE_SHADOW,
+                policy_id=message.risk_policy_id,
+                policy_version=message.risk_policy_version,
+            )
+            attempt = self._evaluation_recorder.start(evaluation)
             try:
                 scan_started = time.perf_counter()
                 detections = await self._scanner.scan(
@@ -100,30 +125,20 @@ class PresidioHandler:
                 )
                 scan_ms = (time.perf_counter() - scan_started) * 1000
             except ScanSlotTimeout:
-                # The scan never started: the pool was backlogged for the whole
-                # slot budget and the content was never touched. Unlike the
-                # swallowed failures below this is not a property of the
-                # message, so re-raising to nack is safe (nothing scanned,
-                # nothing published — redelivery duplicates no work) and
-                # correct: the subscription's retry policy backs the message
-                # off (10s..600s) and it lands back here once capacity clears,
-                # instead of being silently dropped unscanned. No log line:
-                # backlog requeues fire in bursts, and the ``requeued`` outcome
-                # recorded in the ``finally`` already carries the signal.
+                # Queue admission expired before Presidio touched the content.
+                # Preserve the nack/redelivery behavior and record no volume.
                 outcome = metrics.OUTCOME_REQUEUED
+                await attempt.finish(
+                    RiskEvaluation.OUTCOME_SKIPPED, include_volume=False
+                )
                 raise
             except Exception as exc:
                 # This is best-effort shadow processing, and the PresidioAnalyzer
                 # subscription declares no dead-letter policy. Letting a scan
-                # failure escape would nack the message, and any input that
-                # deterministically trips the analyzer would then redeliver and
-                # fail again for the full retention window (30 days) — one bad
-                # message poisoning the subscription. Swallow it (so the message is
-                # acked) and log instead. Cancellation derives from BaseException,
-                # not Exception, so graceful shutdown still propagates. Only the
-                # exception *type* is logged: an error string or traceback could
-                # echo the scanned content, which this handler never emits (see the
-                # detection log below).
+                # failure escape would poison the subscription via redelivery.
+                with anyio.CancelScope(shield=True):
+                    await attempt.measure([message.content])
+                    await attempt.finish(RiskEvaluation.OUTCOME_FAILED)
                 self.logger.warning(
                     "presidio scan failed",
                     request_id=message.request_id,
@@ -133,6 +148,15 @@ class PresidioHandler:
                     delivery_attempt=meta.delivery_attempt,
                 )
                 return
+            except BaseException:
+                await attempt.finish(RiskEvaluation.OUTCOME_CANCELLED)
+                raise
+            else:
+                # Detector completion is independent of downstream finding
+                # publication, and includes clean scans.
+                with anyio.CancelScope(shield=True):
+                    await attempt.measure([message.content])
+                    await attempt.finish(RiskEvaluation.OUTCOME_COMPLETED)
 
             if not detections:
                 outcome = metrics.OUTCOME_CLEAN

--- a/pystreams/tests/test_multi.py
+++ b/pystreams/tests/test_multi.py
@@ -29,6 +29,10 @@ async def test_blocking_detection_starts_after_scanner_initialization(
     async def fake_publisher(*_args, **_kwargs):
         return object()
 
+    async def fake_build_evaluation_recorder(*_args, **_kwargs):
+        startup_events.append("risk tokenizer initialized")
+        return object()
+
     async def fake_build_scanner(**_kwargs):
         startup_events.append("scanner initialized")
         return object()
@@ -42,6 +46,11 @@ async def test_blocking_detection_starts_after_scanner_initialization(
     monkeypatch.setattr(multi_mod.otel, "otel_sdk", fake_otel_sdk)
     monkeypatch.setattr(multi_mod, "_build_broker", lambda **_kwargs: _Broker())
     monkeypatch.setattr(multi_mod, "pubsub_publisher_for_message_async", fake_publisher)
+    monkeypatch.setattr(
+        multi_mod,
+        "build_risk_evaluation_recorder",
+        fake_build_evaluation_recorder,
+    )
     monkeypatch.setattr(multi_mod, "build_presidio_scanner", fake_build_scanner)
     monkeypatch.setattr(multi_mod, "activate_blocking_detection", fake_activate)
 
@@ -70,6 +79,7 @@ async def test_blocking_detection_starts_after_scanner_initialization(
         )
 
     assert startup_events == [
+        "risk tokenizer initialized",
         "scanner initialized",
         "blocking detection activated",
     ]

--- a/pystreams/tests/test_risk_enforce.py
+++ b/pystreams/tests/test_risk_enforce.py
@@ -7,6 +7,8 @@ from typing import cast
 import fakeredis.aioredis
 import pytest
 import structlog
+import tiktoken
+from gram.metering.v1 import risk_evaluation_pb2
 from gram.risk.v1 import enforcement_reply_pb2, presidio_enforcement_pb2
 from gram_infra.pubsub.subscriber import MessageMetadata
 
@@ -17,6 +19,7 @@ from pystreams.risk.enforce_handler import (
     MalformedEnforcementRequest,
     PresidioEnforceHandler,
 )
+from pystreams.risk.evaluation import RiskEvaluationRecorder
 from pystreams.risk.fingerprint import (
     Fingerprinter,
     FingerprintKeyringError,
@@ -28,6 +31,8 @@ from pystreams.risk.replywriter import (
     inbox_key,
 )
 from pystreams.risk.scanner import Detection, ScanSlotTimeout
+
+_ENCODING = tiktoken.get_encoding("o200k_base")
 
 # Keyring shared with the Go golden-vector run (see the fingerprint parity test).
 _KEYRING = json.dumps(
@@ -74,6 +79,28 @@ class FakeScanner:
         return None
 
 
+class _Published:
+    async def get(self) -> str:
+        return "risk-event"
+
+
+class FakeRiskPublisher:
+    def __init__(self) -> None:
+        self.published: list[risk_evaluation_pb2.RiskEvaluation] = []
+
+    def publish(self, message: risk_evaluation_pb2.RiskEvaluation) -> _Published:
+        self.published.append(message)
+        return _Published()
+
+
+def _recorder(
+    publisher: FakeRiskPublisher | None = None,
+) -> RiskEvaluationRecorder:
+    return RiskEvaluationRecorder(
+        structlog.get_logger(), publisher or FakeRiskPublisher(), encoding=_ENCODING
+    )
+
+
 def _message(
     *,
     content: str = "email jane.doe@example.com",
@@ -100,13 +127,16 @@ def _meta(reply_urn: str = _REPLY_URN) -> MessageMetadata:
 
 
 def _handler(
-    scanner: FakeScanner, client: fakeredis.aioredis.FakeRedis
+    scanner: FakeScanner,
+    client: fakeredis.aioredis.FakeRedis,
+    evaluation_publisher: FakeRiskPublisher | None = None,
 ) -> PresidioEnforceHandler:
     return PresidioEnforceHandler(
         structlog.get_logger(),
         ReplyWriter(client),
         scanner,
         parse_pepper_keyring(_KEYRING),
+        _recorder(evaluation_publisher),
     )
 
 
@@ -154,6 +184,7 @@ def test_maskdisplay_tiers():
 
 async def test_handler_writes_ok_reply_with_safe_findings():
     client = fakeredis.aioredis.FakeRedis()
+    evaluation_publisher = FakeRiskPublisher()
     scanner = FakeScanner(
         detections=[
             Detection(
@@ -165,7 +196,7 @@ async def test_handler_writes_ok_reply_with_safe_findings():
             )
         ]
     )
-    await _handler(scanner, client).handle(_message(), _meta())
+    await _handler(scanner, client, evaluation_publisher).handle(_message(), _meta())
 
     # TTL is set alongside the push; -1 (no expiry) must fail. Checked before
     # reading, since popping the only element deletes the key.
@@ -181,6 +212,16 @@ async def test_handler_writes_ok_reply_with_safe_findings():
     assert finding.masked_preview == "***@example.com"
     assert "jane.doe" not in finding.masked_preview
     assert finding.fingerprint == "OtttmK1tiaZmS8oK2PAT-n3vNa4iic0SQh6RpOY5_yo"
+
+    (event,) = evaluation_publisher.published
+    assert (
+        event.execution_mode
+        == risk_evaluation_pb2.RiskEvaluation.EXECUTION_MODE_REALTIME
+    )
+    assert event.outcome == risk_evaluation_pb2.RiskEvaluation.OUTCOME_COMPLETED
+    assert event.HasField("stokens")
+    assert event.stokens > 0
+    assert _message().content not in repr(event)
 
 
 class FailingWriter:
@@ -201,6 +242,7 @@ async def test_handler_acks_request_when_reply_write_fails():
         cast(ReplyWriter, writer),
         FakeScanner(),
         parse_pepper_keyring(_KEYRING),
+        _recorder(),
     )
     await handler.handle(_message(), _meta())
     assert writer.called
@@ -236,6 +278,7 @@ async def test_handler_replies_error_when_fingerprinting_fails():
         ReplyWriter(client),
         scanner,
         cast(Fingerprinter, FailingFingerprinter()),
+        _recorder(),
     )
     await handler.handle(_message(), _meta())
     reply = await _read_reply(client)
@@ -264,6 +307,7 @@ def test_handler_rejects_non_finite_max_request_age():
             ReplyWriter(fakeredis.aioredis.FakeRedis()),
             FakeScanner(),
             parse_pepper_keyring(_KEYRING),
+            _recorder(),
             max_request_age_seconds=bad,
         )
         assert (
@@ -334,10 +378,14 @@ async def test_handler_replies_error_on_scan_failure_without_content():
 
 async def test_handler_replies_error_on_scan_slot_timeout():
     client = fakeredis.aioredis.FakeRedis()
+    evaluation_publisher = FakeRiskPublisher()
     scanner = FakeScanner(error=ScanSlotTimeout("pool saturated"))
-    await _handler(scanner, client).handle(_message(), _meta())
+    await _handler(scanner, client, evaluation_publisher).handle(_message(), _meta())
     reply = await _read_reply(client)
     assert reply.status == enforcement_reply_pb2.ENFORCEMENT_STATUS_ERROR
+    (event,) = evaluation_publisher.published
+    assert event.outcome == risk_evaluation_pb2.RiskEvaluation.OUTCOME_SKIPPED
+    assert not event.HasField("stokens")
 
 
 async def test_handler_drops_far_future_request_without_reply():

--- a/pystreams/tests/test_risk_handler.py
+++ b/pystreams/tests/test_risk_handler.py
@@ -3,12 +3,20 @@ import uuid
 
 import pytest
 import structlog
+import tiktoken
+from gram.metering.v1 import risk_evaluation_pb2
 from gram.risk.v1 import finding_pb2, presidio_analysis_pb2
 from gram_infra.pubsub.subscriber import MessageMetadata
 from structlog.testing import capture_logs
 
 from pystreams.risk import handler as handler_mod
 from pystreams.risk import metrics
+from pystreams.risk.evaluation import (
+    Evaluation,
+    RiskEvaluationRecorder,
+    evaluation_id,
+    operation_id,
+)
 from pystreams.risk.handler import PresidioHandler
 from pystreams.risk.scanner import (
     DEFAULT_SCORE_THRESHOLD,
@@ -16,6 +24,8 @@ from pystreams.risk.scanner import (
     ScanSlotTimeout,
     _AsyncCloseable,
 )
+
+_ENCODING = tiktoken.get_encoding("o200k_base")
 
 # Matches the RFC3339 UTC form the handler stamps on a finding's created_at.
 _RFC3339_UTC = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z")
@@ -91,22 +101,63 @@ class FakePublisher:
         return _FakeResult(f"id-{len(self.published)}")
 
 
+class FakeRiskPublisher:
+    def __init__(self):
+        self.published: list[risk_evaluation_pb2.RiskEvaluation] = []
+
+    def publish(self, message: risk_evaluation_pb2.RiskEvaluation) -> _FakeResult:
+        self.published.append(message)
+        return _FakeResult(f"risk-{len(self.published)}")
+
+
+def _recorder(
+    publisher: FakeRiskPublisher | None = None,
+) -> RiskEvaluationRecorder:
+    return RiskEvaluationRecorder(
+        structlog.get_logger(), publisher or FakeRiskPublisher(), encoding=_ENCODING
+    )
+
+
 def _meta(delivery_attempt: int = 1) -> MessageMetadata:
     return MessageMetadata(id="m-1", attributes={}, delivery_attempt=delivery_attempt)
 
 
 def _handler(
-    scanner: FakeScanner, publisher: FakePublisher | None = None
+    scanner: FakeScanner,
+    publisher: FakePublisher | None = None,
+    evaluation_publisher: FakeRiskPublisher | None = None,
 ) -> PresidioHandler:
     return PresidioHandler(
         structlog.get_logger(),
         publisher or FakePublisher(),
         scanner,
+        _recorder(evaluation_publisher),
     )
 
 
 def _message(content: str, **kwargs) -> presidio_analysis_pb2.PresidioAnalysis:
     return presidio_analysis_pb2.PresidioAnalysis(content=content, **kwargs)
+
+
+def test_risk_identity_matches_go_golden_vectors():
+    operation = operation_id("content", "chat-1", "part-1", "policy-1", "7")
+    assert operation == (
+        "riskop:v1:4020859cf0c39659aaa2344133079078b04f664477bbf5fb59110c02848a1485"
+    )
+    assert (
+        evaluation_id(
+            Evaluation(
+                organization_id="org-1",
+                project_id="proj-1",
+                operation_id=operation,
+                detector=risk_evaluation_pb2.RiskEvaluation.DETECTOR_PRESIDIO,
+                execution_mode=risk_evaluation_pb2.RiskEvaluation.EXECUTION_MODE_SHADOW,
+                policy_id="policy-1",
+                policy_version=7,
+            )
+        )
+        == "13532e25-5911-5594-bd18-8e0c7dfc0919"
+    )
 
 
 async def test_publishes_a_finding_per_detection():
@@ -370,6 +421,97 @@ async def test_unset_score_threshold_defaults():
     assert scanner.score_thresholds == [DEFAULT_SCORE_THRESHOLD]
 
 
+async def test_clean_scan_publishes_known_volume_without_content():
+    content = "ordinary <|endoftext|> content"
+    evaluation_publisher = FakeRiskPublisher()
+    handler = _handler(FakeScanner(), evaluation_publisher=evaluation_publisher)
+    message = _message(
+        content,
+        request_id="req-1",
+        chat_message_id="chat-1",
+        content_part_id="part-1",
+        organization_id="org-1",
+        project_id="proj-1",
+        risk_policy_id="policy-1",
+        risk_policy_version=7,
+    )
+
+    await handler.handle(message, _meta())
+
+    (event,) = evaluation_publisher.published
+    expected = len(
+        tiktoken.get_encoding("o200k_base").encode(
+            content, allowed_special=set(), disallowed_special=()
+        )
+    )
+    assert event.outcome == risk_evaluation_pb2.RiskEvaluation.OUTCOME_COMPLETED
+    assert event.record_kind == "scan"
+    assert event.stokens == expected
+    assert event.HasField("stokens")
+    assert event.measurement_method == "tiktoken_o200k_base"
+    assert content not in repr(event)
+
+
+async def test_tokenization_failure_keeps_volume_unknown_and_scans(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    secret = "ordinary <|endoftext|> content"
+    scanner = FakeScanner()
+    evaluation_publisher = FakeRiskPublisher()
+    recorder = _recorder(evaluation_publisher)
+
+    class BrokenEncoding:
+        def encode(self, content: str, **_kwargs) -> list[int]:
+            raise RuntimeError(content)
+
+    monkeypatch.setattr(recorder, "_encoding", BrokenEncoding())
+    handler = PresidioHandler(
+        structlog.get_logger(), FakePublisher(), scanner, recorder
+    )
+
+    with capture_logs() as logs:
+        await handler.handle(
+            _message(
+                secret,
+                request_id="req-1",
+                organization_id="org-1",
+                project_id="proj-1",
+            ),
+            _meta(),
+        )
+
+    assert scanner.calls == [(secret, None)]
+    (event,) = evaluation_publisher.published
+    assert event.outcome == risk_evaluation_pb2.RiskEvaluation.OUTCOME_COMPLETED
+    assert event.measurement_error
+    assert not event.HasField("stokens")
+    assert secret not in repr(event)
+    assert secret not in repr(logs)
+
+
+async def test_redelivery_reuses_logical_identity_with_new_attempt_id():
+    evaluation_publisher = FakeRiskPublisher()
+    handler = _handler(FakeScanner(), evaluation_publisher=evaluation_publisher)
+    message = _message(
+        "clean",
+        request_id="first-transport-request",
+        chat_message_id="chat-1",
+        content_part_id="part-1",
+        organization_id="org-1",
+        project_id="proj-1",
+        risk_policy_id="policy-1",
+        risk_policy_version=7,
+    )
+
+    await handler.handle(message, _meta(delivery_attempt=1))
+    await handler.handle(message, _meta(delivery_attempt=2))
+
+    first, retry = evaluation_publisher.published
+    assert first.evaluation_id == retry.evaluation_id
+    assert first.operation_id == retry.operation_id
+    assert first.id != retry.id
+
+
 async def test_scan_failure_is_swallowed_and_logged():
     secret = "my ssn is 123-45-6789"
     # The error carries the content to prove it isn't logged.
@@ -399,23 +541,20 @@ async def test_scan_failure_is_swallowed_and_logged():
 async def test_slot_timeout_is_reraised_for_redelivery():
     scanner = FakeScanner(error=ScanSlotTimeout("scan queued for 60s"))
     publisher = FakePublisher()
-    handler = _handler(scanner, publisher)
+    evaluation_publisher = FakeRiskPublisher()
+    handler = _handler(scanner, publisher, evaluation_publisher)
     msg = _message("my ssn is 123-45-6789", request_id="req-1")
 
     # A slot timeout means the content was never scanned: unlike other scan
-    # failures it must propagate, so the message nacks and Pub/Sub redelivers
-    # it (with the subscription's retry backoff) once capacity clears, instead
-    # of being acked away unscanned.
+    # failures it must propagate so Pub/Sub can redeliver it.
     with capture_logs() as logs, pytest.raises(ScanSlotTimeout):
         await handler.handle(msg, _meta(delivery_attempt=4))
 
-    # Nothing was scanned, so nothing is published — redelivery duplicates no
-    # findings.
     assert publisher.published == []
-    # Deliberately silent: requeues fire in bursts under backlog, and the
-    # ``requeued`` outcome on process_duration already carries the signal, so
-    # the handler emits no per-message log line (it must not be mislabeled as
-    # a "presidio scan failed" swallow either).
+    (event,) = evaluation_publisher.published
+    assert event.outcome == risk_evaluation_pb2.RiskEvaluation.OUTCOME_SKIPPED
+    assert not event.HasField("stokens")
+    assert not event.measurement_error
     assert logs == []
 
 
@@ -451,7 +590,9 @@ class _BoomPublisher:
 async def test_publish_failure_is_swallowed_and_logged():
     secret = "a@b.com"
     scanner = FakeScanner([_detection("EMAIL_ADDRESS", secret)])
-    handler = PresidioHandler(structlog.get_logger(), _BoomPublisher(), scanner)
+    handler = PresidioHandler(
+        structlog.get_logger(), _BoomPublisher(), scanner, _recorder()
+    )
 
     # A publish failure must not propagate either: nacking would redeliver and
     # re-publish any findings that already landed, duplicating them.
@@ -481,7 +622,9 @@ class _SyncBoomPublisher:
 async def test_sync_publish_failure_is_swallowed_and_logged():
     secret = "a@b.com"
     scanner = FakeScanner([_detection("EMAIL_ADDRESS", secret)])
-    handler = PresidioHandler(structlog.get_logger(), _SyncBoomPublisher(), scanner)
+    handler = PresidioHandler(
+        structlog.get_logger(), _SyncBoomPublisher(), scanner, _recorder()
+    )
 
     # A synchronous publish failure must be treated like an async one: logged as a
     # publish failure and skipped, never escaping to nack/redeliver the message
@@ -555,7 +698,9 @@ async def test_records_error_outcome_when_all_publishes_fail(recorded_durations)
     # Detections found, but every publish fails: nothing landed, so this must not
     # inflate the "detected" bucket — it is recorded as an error outcome.
     scanner = FakeScanner([_detection("EMAIL_ADDRESS", "a@b.com")])
-    handler = PresidioHandler(structlog.get_logger(), _BoomPublisher(), scanner)
+    handler = PresidioHandler(
+        structlog.get_logger(), _BoomPublisher(), scanner, _recorder()
+    )
 
     await handler.handle(_message("a@b.com", request_id="req-1"), _meta())
 

--- a/pystreams/tests/test_tracing.py
+++ b/pystreams/tests/test_tracing.py
@@ -1,5 +1,6 @@
 import pytest
 import structlog
+from gram.metering.v1 import risk_evaluation_pb2
 from gram.ping.v2 import ping_pb2, processor_pb2
 from gram.risk.v1 import finding_pb2, presidio_analysis_pb2
 from gram_infra.pubsub import PublishResult
@@ -14,6 +15,7 @@ from opentelemetry.trace import StatusCode
 
 from pystreams import attr
 from pystreams.deps import tracing
+from pystreams.risk.evaluation import build_risk_evaluation_recorder
 from pystreams.risk.handler import PresidioHandler
 from pystreams.risk.scanner import Detection, _AsyncCloseable
 
@@ -131,6 +133,16 @@ class _UnusedPublisher:
         raise AssertionError("no findings expected on the clean path")
 
 
+class _Published:
+    async def get(self) -> str:
+        return "risk-event"
+
+
+class _RiskPublisher:
+    def publish(self, message: risk_evaluation_pb2.RiskEvaluation) -> _Published:
+        return _Published()
+
+
 async def test_presidio_handler_stamps_content_size_on_delivery_span(
     exporter: InMemorySpanExporter,
 ):
@@ -138,7 +150,10 @@ async def test_presidio_handler_stamps_content_size_on_delivery_span(
     # so its content-size attribute must land on that delivery span — the exact
     # per-message value trace analytics correlates against duration.
     handler = PresidioHandler(
-        structlog.get_logger(), _UnusedPublisher(), _CleanScanner()
+        structlog.get_logger(),
+        _UnusedPublisher(),
+        _CleanScanner(),
+        await build_risk_evaluation_recorder(structlog.get_logger(), _RiskPublisher()),
     )
     wrapped = tracing.traced(
         handler.handle,

--- a/server/cmd/gram/deps.go
+++ b/server/cmd/gram/deps.go
@@ -1256,6 +1256,14 @@ func newPublishers(ctx context.Context, psbroker pubSubBroker) (*background.Publ
 	}
 	pubs = append(pubs, labelledStop{label: "telemetryLogs", pub: telemetryLogs})
 
+	riskEvaluations, err := gcp.PubSubPublisherForMessage(ctx, psbroker, &meteringv1.RiskEvaluation{},
+		gcp.WithPubSubPublishSettings(&telemetryPublishSettings),
+	)
+	if err != nil {
+		return nil, noopShutdown, fmt.Errorf("create pubsub publisher for risk evaluations: %w", err)
+	}
+	pubs = append(pubs, labelledStop{label: "riskEvaluations", pub: riskEvaluations})
+
 	meterReadings, err := gcp.PubSubPublisherForMessage(ctx, psbroker, &meteringv1.MeterReading{},
 		gcp.WithPubSubPublishSettings(&telemetryPublishSettings),
 	)
@@ -1338,6 +1346,7 @@ func newPublishers(ctx context.Context, psbroker pubSubBroker) (*background.Publ
 		CustomRulesAnalysis:     customRulesAnalysis,
 		RiskFindings:            riskFindings,
 		MeterReadings:           meterReadings,
+		RiskEvaluations:         riskEvaluations,
 		TelemetryLogs:           telemetryLogs,
 		OTELLogs:                otelLogs,
 		OTELMetrics:             otelMetrics,

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -129,6 +129,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/risk/enforcereply"
 	"github.com/speakeasy-api/gram/server/internal/risk/policybypass"
 	"github.com/speakeasy-api/gram/server/internal/risk/presetlib"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
+	riskmeterinference "github.com/speakeasy-api/gram/server/internal/riskmeter/inference"
 	"github.com/speakeasy-api/gram/server/internal/scanners"
 	"github.com/speakeasy-api/gram/server/internal/scanners/customruleanalyzer"
 	"github.com/speakeasy-api/gram/server/internal/scanners/promptinjection"
@@ -974,16 +976,8 @@ func newStartCommand() *cli.Command {
 			)
 			chatWriter.AddObserver(analysis.NewObserver(logger, chatAnalysisSignaler))
 
-			completionsClient := openrouter.NewUnifiedClient(
-				logger,
-				guardianPolicy,
-				openRouter,
-				modelkeys.NewResolver(db, encryptionClient, openRouter),
-				captureStrategy,
-				chat.NewDefaultUsageTrackingStrategy(db, logger, billingTracker),
-				&background.TemporalChatTitleGenerator{TemporalEnv: temporalEnv},
-				telemLogger,
-			)
+			riskRecorder := riskmeter.NewRecorder(logger, publishers.RiskEvaluations)
+			completionsClient := openrouter.NewUnifiedClient(logger, guardianPolicy, openRouter, modelkeys.NewResolver(db, encryptionClient, openRouter), captureStrategy, chat.NewDefaultUsageTrackingStrategy(db, logger, billingTracker), &background.TemporalChatTitleGenerator{TemporalEnv: temporalEnv}, telemLogger, riskmeterinference.NewObserver(riskRecorder))
 
 			memorySvc := memory.NewMemoryService(
 				logger,
@@ -1328,15 +1322,15 @@ func newStartCommand() *cli.Command {
 			// so the runtime hook scanner can flag/redact PII inputs too.
 			var hookPIIScanner risk_analysis.PIIScanner
 			if presidioURL := c.String("presidio-analyzer-url"); presidioURL != "" {
-				hookPIIScanner = risk_analysis.NewPresidioClient(presidioURL, tracerProvider, meterProvider, logger)
+				hookPIIScanner = risk_analysis.NewPresidioClient(presidioURL, tracerProvider, meterProvider, logger, riskRecorder)
 			}
 
 			// L1 prompt-injection engine is the LLM judge (POC-193). A completions
 			// client is always constructed, so the judge is always available.
 			hookJudgeLimiter := openrouter.NewJudgeRateLimiter(ratelimit.NewRedisStore(redisClient))
-			hookPIScanner := promptinjection.NewScanner(logger, piopenrouter.New(logger, tracerProvider, meterProvider, completionsClient, hookJudgeLimiter).Classify)
+			hookPIScanner := promptinjection.NewScanner(logger, piopenrouter.New(logger, tracerProvider, meterProvider, completionsClient, hookJudgeLimiter, riskRecorder).Classify)
 
-			hookPromptJudge := ppopenrouter.New(logger, tracerProvider, meterProvider, completionsClient, hookJudgeLimiter).Evaluate
+			hookPromptJudge := ppopenrouter.New(logger, tracerProvider, meterProvider, completionsClient, hookJudgeLimiter, riskRecorder).Evaluate
 			hookPromptPolicyScanner := promptpolicy.NewScanner(logger, hookPromptJudge)
 			celEngine, err := celenv.New()
 			if err != nil {
@@ -1346,11 +1340,11 @@ func newStartCommand() *cli.Command {
 			if err != nil {
 				return fmt.Errorf("load built-in exclusion library: %w", err)
 			}
-			customRulesScanner, err := customruleanalyzer.NewScanner(db)
+			customRulesScanner, err := customruleanalyzer.NewScanner(db, riskRecorder)
 			if err != nil {
 				return fmt.Errorf("create custom rules scanner: %w", err)
 			}
-			riskScanner, err := risk.NewScannerWithEnforcementDispatcher(logger, tracerProvider, meterProvider, db, customRulesScanner, hookPIIScanner, hookPIScanner, hookPromptPolicyScanner, featureFlags, celEngine, enforcementDispatcher)
+			riskScanner, err := risk.NewScannerWithEnforcementDispatcher(logger, tracerProvider, meterProvider, db, customRulesScanner, hookPIIScanner, hookPIScanner, hookPromptPolicyScanner, featureFlags, riskRecorder, celEngine, enforcementDispatcher)
 			if err != nil {
 				return fmt.Errorf("create risk scanner: %w", err)
 			}
@@ -1807,10 +1801,10 @@ func newStartCommand() *cli.Command {
 				group.Go(func() {
 					var piiScanner risk_analysis.PIIScanner = &risk_analysis.StubPIIScanner{}
 					if presidioURL := c.String("presidio-analyzer-url"); presidioURL != "" {
-						piiScanner = risk_analysis.NewPresidioClient(presidioURL, tracerProvider, meterProvider, logger)
+						piiScanner = risk_analysis.NewPresidioClient(presidioURL, tracerProvider, meterProvider, logger, riskRecorder)
 					}
 
-					piScanner := promptinjection.NewScanner(logger, piopenrouter.New(logger, tracerProvider, meterProvider, completionsClient, openrouter.NewJudgeRateLimiter(ratelimit.NewRedisStore(redisClient))).Classify)
+					piScanner := promptinjection.NewScanner(logger, piopenrouter.New(logger, tracerProvider, meterProvider, completionsClient, openrouter.NewJudgeRateLimiter(ratelimit.NewRedisStore(redisClient)), riskRecorder).Classify)
 
 					temporalWorker := background.NewTemporalWorker(temporalEnv, logger, tracerProvider, meterProvider, &background.WorkerOptions{
 						GuardianPolicy:            guardianPolicy,

--- a/server/cmd/gram/streams.go
+++ b/server/cmd/gram/streams.go
@@ -57,6 +57,10 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/risk"
 	"github.com/speakeasy-api/gram/server/internal/risk/chrepo"
 	"github.com/speakeasy-api/gram/server/internal/risk/enforcereply"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
+	riskmeterchrepo "github.com/speakeasy-api/gram/server/internal/riskmeter/chrepo"
+	riskmeterconsumer "github.com/speakeasy-api/gram/server/internal/riskmeter/consumer"
+	riskmeterinference "github.com/speakeasy-api/gram/server/internal/riskmeter/inference"
 	"github.com/speakeasy-api/gram/server/internal/scanners"
 	"github.com/speakeasy-api/gram/server/internal/scanners/customruleanalyzer"
 	"github.com/speakeasy-api/gram/server/internal/scanners/gitleaks"
@@ -367,16 +371,6 @@ func newStreamsCommand() *cli.Command {
 				openRouter = openrouter.New(logger, tracerProvider, guardianPolicy, db, c.String("environment"), c.String("openrouter-provisioning-key"), nil, productFeatures, billingTracker, encryptionClient)
 			}
 
-			completionsClient := openrouter.NewUnifiedClient(
-				logger,
-				guardianPolicy,
-				openRouter,
-				modelkeys.NewResolver(db, encryptionClient, openRouter),
-				nil,
-				chat.NewDefaultUsageTrackingStrategy(db, logger, billingTracker),
-				nil,
-				nil,
-			)
 			judgeRateLimiter := openrouter.NewJudgeRateLimiter(ratelimit.NewRedisStore(redisClient))
 
 			_, psbroker, pubsubShutdown, err := newPubSubClient(ctx, c, logger)
@@ -384,13 +378,14 @@ func newStreamsCommand() *cli.Command {
 				return fmt.Errorf("failed to create pubsub client: %w", err)
 			}
 			var (
-				findingsPub gcp.Publisher[*riskv1.Finding]
-				logPub      gcp.Publisher[*otelv1.LogRecord]
-				metricPub   gcp.Publisher[*otelv1.Metric]
-				spanPub     gcp.Publisher[*otelv1.Span]
+				findingsPub        gcp.Publisher[*riskv1.Finding]
+				riskEvaluationsPub gcp.Publisher[*meteringv1.RiskEvaluation]
+				logPub             gcp.Publisher[*otelv1.LogRecord]
+				metricPub          gcp.Publisher[*otelv1.Metric]
+				spanPub            gcp.Publisher[*otelv1.Span]
 			)
 			shutdownFuncs = append(shutdownFuncs, func(ctx context.Context) error {
-				return shutdownPubSubPublishers(ctx, pubsubShutdown, findingsPub, logPub, metricPub, spanPub)
+				return shutdownPubSubPublishers(ctx, pubsubShutdown, findingsPub, riskEvaluationsPub, logPub, metricPub, spanPub)
 			})
 
 			riskFingerprinter, err := risk.ParsePepperKeyRing([]byte(c.String("risk-fingerprint-pepper-keyring")))
@@ -413,7 +408,14 @@ func newStreamsCommand() *cli.Command {
 				return fmt.Errorf("failed to create pubsub publisher for risk findings: %w", err)
 			}
 
-			gitleaksHandler := gitleaks.NewHandler(logger, findingsPub)
+			riskEvaluationsPub, err = gcp.PubSubPublisherForMessage(ctx, psbroker, &meteringv1.RiskEvaluation{})
+			if err != nil {
+				return fmt.Errorf("create pubsub publisher for risk evaluations: %w", err)
+			}
+			riskRecorder := riskmeter.NewRecorder(logger, riskEvaluationsPub)
+			completionsClient := openrouter.NewUnifiedClient(logger, guardianPolicy, openRouter, modelkeys.NewResolver(db, encryptionClient, openRouter), nil, chat.NewDefaultUsageTrackingStrategy(db, logger, billingTracker), nil, nil, riskmeterinference.NewObserver(riskRecorder))
+
+			gitleaksHandler := gitleaks.NewHandler(logger, findingsPub, riskRecorder)
 			gitleaksEnforceHandler, err := gitleaks.NewEnforceHandler(
 				logger,
 				meterProvider,
@@ -422,22 +424,23 @@ func newStreamsCommand() *cli.Command {
 					sum, _, fingerprintErr := riskFingerprinter.TenantedHS256(tenantID, message)
 					return risk.EncodeFingerprint(sum), fingerprintErr
 				},
+				riskRecorder,
 				gitleaks.EnforceHandlerConfig{MaxRequestAge: gitleaks.DefaultMaxRequestAge},
 			)
 			if err != nil {
 				return fmt.Errorf("create gitleaks enforcement handler: %w", err)
 			}
-			promptInjectionScanner := promptinjection.NewScanner(logger, piopenrouter.New(logger, tracerProvider, meterProvider, completionsClient, judgeRateLimiter).Classify)
+			promptInjectionScanner := promptinjection.NewScanner(logger, piopenrouter.New(logger, tracerProvider, meterProvider, completionsClient, judgeRateLimiter, riskRecorder).Classify)
 			promptInjectionStubScanner := promptinjection.NewScanner(logger, promptinjection.NoopClassifier)
 			promptInjectionHandler := promptinjection.NewHandler(logger, meterProvider, promptInjectionScanner, promptInjectionStubScanner, findingsPub, scanners.NewAsyncShadowGate(logger, featureFlags, replicaDB))
-			promptPolicyScanner := promptpolicy.NewScanner(logger, ppopenrouter.New(logger, tracerProvider, meterProvider, completionsClient, judgeRateLimiter).Evaluate)
+			promptPolicyScanner := promptpolicy.NewScanner(logger, ppopenrouter.New(logger, tracerProvider, meterProvider, completionsClient, judgeRateLimiter, riskRecorder).Evaluate)
 			promptPolicyStubScanner := promptpolicy.NewScanner(logger, promptpolicy.NoopEvaluator)
 			promptPolicyHandler := promptpolicy.NewHandler(logger, meterProvider, promptPolicyScanner, promptPolicyStubScanner, findingsPub, scanners.NewAsyncShadowGate(logger, featureFlags, replicaDB))
 
 			// Custom-rules shadow-mode subscriber: loads a project's selected CEL
 			// detection rules from the read replica (caching their compilation) and
 			// publishes any matches into the shared Finding topic.
-			scanner, err := customruleanalyzer.NewScanner(replicaDB)
+			scanner, err := customruleanalyzer.NewScanner(replicaDB, riskRecorder)
 			if err != nil {
 				return fmt.Errorf("failed to create custom rules scanner: %w", err)
 			}
@@ -572,6 +575,7 @@ func newStreamsCommand() *cli.Command {
 
 				mustReceiveBatchWithResult(rg, &authzv1.Challenge{}, &authzv1.ChallengeCHWriter{}, authz.NewChallengeCHWriter(logger, meterProvider, chConn), gcp.BatchReceiveSettings{MaxMessages: 1000, MaxBytes: 10 * constants.MiB, MaxLatency: 1 * time.Second})
 				mustReceiveBatch(rg, &meteringv1.MeterReading{}, &meteringv1.MeterReadingCHWriter{}, metering.NewMeterReadingCHWriter(logger, db, meteringchrepo.New(chConn)), gcp.BatchReceiveSettings{MaxMessages: 1000, MaxBytes: 10 * constants.MiB, MaxLatency: time.Second})
+				mustReceiveBatchWithResult(rg, &meteringv1.RiskEvaluation{}, &meteringv1.RiskEvaluationCHWriter{}, riskmeterconsumer.NewRiskEvaluationCHWriter(logger, meterProvider, riskmeterchrepo.New(chConn), meteringchrepo.New(chConn)), gcp.BatchReceiveSettings{MaxMessages: 1000, MaxBytes: 10 * constants.MiB, MaxLatency: time.Second})
 				mustReceive(rg, &meteringv1.MeterReading{}, &meteringv1.MeterReadingStripeExporter{}, metering.NewMeterReadingStripeExporter(logger, meterProvider, replicaDB, stripeMeterEvents, stripeCatalog, c.Bool(stripeMeterEventExportFlagName)))
 
 				mustReceive(rg, &otelv1.InboundLogRecord{}, &otelv1.InboundLogRecordTransformer{}, otelsvc.NewLogTransformHandler(

--- a/server/cmd/gram/worker.go
+++ b/server/cmd/gram/worker.go
@@ -47,6 +47,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/ratelimit"
 	"github.com/speakeasy-api/gram/server/internal/risk"
 	"github.com/speakeasy-api/gram/server/internal/risk/presetlib"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
+	riskmeterinference "github.com/speakeasy-api/gram/server/internal/riskmeter/inference"
 	"github.com/speakeasy-api/gram/server/internal/scanners"
 	"github.com/speakeasy-api/gram/server/internal/scanners/customruleanalyzer"
 	"github.com/speakeasy-api/gram/server/internal/scanners/promptinjection"
@@ -627,16 +629,8 @@ func newWorkerCommand() *cli.Command {
 			)
 			telemetryLogger.AddObserver(spendUsageTrigger)
 
-			completionsClient := openrouter.NewUnifiedClient(
-				logger,
-				guardianPolicy,
-				openRouter,
-				modelkeys.NewResolver(db, encryptionClient, openRouter),
-				captureStrategy,
-				chat.NewDefaultUsageTrackingStrategy(db, logger, billingTracker),
-				&background.TemporalChatTitleGenerator{TemporalEnv: temporalEnv},
-				telemetryLogger,
-			)
+			riskRecorder := riskmeter.NewRecorder(logger, publishers.RiskEvaluations)
+			completionsClient := openrouter.NewUnifiedClient(logger, guardianPolicy, openRouter, modelkeys.NewResolver(db, encryptionClient, openRouter), captureStrategy, chat.NewDefaultUsageTrackingStrategy(db, logger, billingTracker), &background.TemporalChatTitleGenerator{TemporalEnv: temporalEnv}, telemetryLogger, riskmeterinference.NewObserver(riskRecorder))
 
 			ragService := rag.NewToolsetVectorStore(logger, tracerProvider, db, completionsClient)
 			mcpRegistryClient, err := newMCPRegistryClient(logger, tracerProvider, guardianPolicy, mcpRegistryClientOptions{
@@ -717,13 +711,13 @@ func newWorkerCommand() *cli.Command {
 
 			var piiScanner risk_analysis.PIIScanner = &risk_analysis.StubPIIScanner{}
 			if presidioURL := c.String("presidio-analyzer-url"); presidioURL != "" {
-				piiScanner = risk_analysis.NewPresidioClient(presidioURL, tracerProvider, meterProvider, logger)
+				piiScanner = risk_analysis.NewPresidioClient(presidioURL, tracerProvider, meterProvider, logger, riskRecorder)
 				logger.InfoContext(ctx, "presidio PII scanner enabled", attr.SlogURL(presidioURL))
 			}
 
-			piScanner := promptinjection.NewScanner(logger, piopenrouter.New(logger, tracerProvider, meterProvider, completionsClient, openrouter.NewJudgeRateLimiter(ratelimit.NewRedisStore(redisClient))).Classify)
+			piScanner := promptinjection.NewScanner(logger, piopenrouter.New(logger, tracerProvider, meterProvider, completionsClient, openrouter.NewJudgeRateLimiter(ratelimit.NewRedisStore(redisClient)), riskRecorder).Classify)
 
-			customRuleScanner, err := customruleanalyzer.NewScanner(db)
+			customRuleScanner, err := customruleanalyzer.NewScanner(db, riskRecorder)
 			if err != nil {
 				return fmt.Errorf("create custom rules scanner: %w", err)
 			}

--- a/server/cmd/risk-pi-report/main.go
+++ b/server/cmd/risk-pi-report/main.go
@@ -718,6 +718,7 @@ func newOpenRouterClient(apiKey string) openrouter.CompletionClient {
 		nil, // usage tracking   (nil-guarded)
 		nil, // chat title gen   (nil-guarded)
 		nil, // telemetry logger (nil-guarded)
+		nil,
 	)
 }
 

--- a/server/cmd/riskjudgebench/main.go
+++ b/server/cmd/riskjudgebench/main.go
@@ -153,6 +153,7 @@ func main() {
 		nil, // usage tracking   (nil-guarded)
 		nil, // chat title gen   (nil-guarded)
 		nil, // telemetry logger (nil-guarded)
+		nil,
 	)
 	_ = metricnoop.NewMeterProvider() // (ppopenrouter.New would need this; we call the client directly)
 

--- a/server/cmd/skillefficacybench/main.go
+++ b/server/cmd/skillefficacybench/main.go
@@ -230,16 +230,7 @@ func main() {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	provisioner := openrouter.NewDevelopment(apiKey)
-	client := openrouter.NewUnifiedClient(
-		logger,
-		guardian.NewDefaultPolicy(tracenoop.NewTracerProvider()),
-		provisioner,
-		&openrouter.PlatformKeyResolver{Provisioner: provisioner},
-		nil,
-		nil,
-		nil,
-		nil,
-	)
+	client := openrouter.NewUnifiedClient(logger, guardian.NewDefaultPolicy(tracenoop.NewTracerProvider()), provisioner, &openrouter.PlatformKeyResolver{Provisioner: provisioner}, nil, nil, nil, nil, nil)
 
 	results := runBench(client, set, models, *runs, *concurrency, *timeout, reasoning)
 	passed := true

--- a/server/cmd/skillsuggestbench/main.go
+++ b/server/cmd/skillsuggestbench/main.go
@@ -164,16 +164,7 @@ func main() {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	provisioner := openrouter.NewDevelopment(apiKey)
-	client := openrouter.NewUnifiedClient(
-		logger,
-		guardian.NewDefaultPolicy(tracenoop.NewTracerProvider()),
-		provisioner,
-		&openrouter.PlatformKeyResolver{Provisioner: provisioner},
-		nil,
-		nil,
-		nil,
-		nil,
-	)
+	client := openrouter.NewUnifiedClient(logger, guardian.NewDefaultPolicy(tracenoop.NewTracerProvider()), provisioner, &openrouter.PlatformKeyResolver{Provisioner: provisioner}, nil, nil, nil, nil, nil)
 
 	results := runBench(client, set, models, *runs, *concurrency, *timeout, reasoning)
 

--- a/server/cmd/tools/enforceload/main.go
+++ b/server/cmd/tools/enforceload/main.go
@@ -561,6 +561,7 @@ func newFullLoop(ctx context.Context, logger *slog.Logger, redisClient *redis.Cl
 			sum, _, fingerprintErr := fingerprinter.TenantedHS256(tenantID, message)
 			return risk.EncodeFingerprint(sum), fingerprintErr
 		},
+		nil,
 		gitleaks.EnforceHandlerConfig{MaxRequestAge: gitleaks.DefaultMaxRequestAge},
 	)
 	if err != nil {

--- a/server/cmd/tools/enforceproto/main.go
+++ b/server/cmd/tools/enforceproto/main.go
@@ -92,6 +92,7 @@ func run() error {
 			sum, _, fingerprintErr := fingerprinter.TenantedHS256(tenantID, message)
 			return risk.EncodeFingerprint(sum), fingerprintErr
 		},
+		nil,
 		gitleaks.EnforceHandlerConfig{MaxRequestAge: gitleaks.DefaultMaxRequestAge},
 	)
 	if err != nil {

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -68,6 +68,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/risk/celenv"
 	riskchrepo "github.com/speakeasy-api/gram/server/internal/risk/chrepo"
 	"github.com/speakeasy-api/gram/server/internal/risk/presetlib"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
 	"github.com/speakeasy-api/gram/server/internal/scanners/customruleanalyzer"
 	"github.com/speakeasy-api/gram/server/internal/scanners/promptinjection"
 	ppopenrouter "github.com/speakeasy-api/gram/server/internal/scanners/promptpolicy/openrouter"
@@ -93,11 +94,13 @@ type Publishers struct {
 	CustomRulesAnalysis     gcp.Publisher[*riskv1.CustomRulesAnalysis]
 	RiskFindings            gcp.Publisher[*riskv1.Finding]
 	MeterReadings           gcp.Publisher[*meteringv1.MeterReading]
-	TelemetryLogs           gcp.Publisher[*telemetryv1.LogRecord]
-	OTELLogs                gcp.Publisher[*otelv1.InboundLogRecord]
-	OTELMetrics             gcp.Publisher[*otelv1.InboundMetric]
-	OTELSpans               gcp.Publisher[*otelv1.InboundSpan]
-	Outbox                  topics.Publisher
+	// RiskEvaluations publishes raw detector completion and inference attempts.
+	RiskEvaluations gcp.Publisher[*meteringv1.RiskEvaluation]
+	TelemetryLogs   gcp.Publisher[*telemetryv1.LogRecord]
+	OTELLogs        gcp.Publisher[*otelv1.InboundLogRecord]
+	OTELMetrics     gcp.Publisher[*otelv1.InboundMetric]
+	OTELSpans       gcp.Publisher[*otelv1.InboundSpan]
+	Outbox          topics.Publisher
 }
 
 type expiredTrialDemoter interface {
@@ -255,18 +258,20 @@ func NewActivities(
 	if chConn != nil && !disableRiskRetroReconcile {
 		riskFindingsCH = riskchrepo.New(chConn)
 	}
+	riskRecorder := riskmeter.NewRecorder(logger, publishers.RiskEvaluations)
 
 	analyzeBatch, err := risk_analysis.NewAnalyzeBatch(
 		logger,
 		tracerProvider,
 		meterProvider,
+		riskRecorder,
 		db,
 		assetStorage,
 		piiScanner,
 		piScanner,
 		shadowMCPClient,
 		telemetryRepo,
-		ppopenrouter.New(logger, tracerProvider, meterProvider, chatClient, judgeRateLimiter).Evaluate,
+		ppopenrouter.New(logger, tracerProvider, meterProvider, chatClient, judgeRateLimiter, riskRecorder).Evaluate,
 		features,
 		publishers.PresidioAnalysis,
 		publishers.GitleaksAnalysis,

--- a/server/internal/background/activities/risk_analysis/analyze_batch.go
+++ b/server/internal/background/activities/risk_analysis/analyze_batch.go
@@ -26,6 +26,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/risk/presetlib"
 	"github.com/speakeasy-api/gram/server/internal/risk/recommendedscopes"
 	"github.com/speakeasy-api/gram/server/internal/risk/repo"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
 	"github.com/speakeasy-api/gram/server/internal/scanners"
 	"github.com/speakeasy-api/gram/server/internal/scanners/clidestructive"
 	"github.com/speakeasy-api/gram/server/internal/scanners/customruleanalyzer"
@@ -71,6 +72,7 @@ func NewAnalyzeBatch(
 	logger *slog.Logger,
 	tracerProvider trace.TracerProvider,
 	meterProvider metric.MeterProvider,
+	recorder *riskmeter.Recorder,
 	db *pgxpool.Pool,
 	assetStorage contentPartAssetReader,
 	piiScanner PIIScanner,
@@ -114,7 +116,7 @@ func NewAnalyzeBatch(
 		metrics:                metrics,
 		db:                     db,
 		assetStorage:           assetStorage,
-		gitleaksScanner:        gitleaks.NewScanner(),
+		gitleaksScanner:        gitleaks.NewScanner(recorder),
 		piiScanner:             piiScanner,
 		promptInjectionScanner: promptInjectionScanner,
 		shadowMCPScanner: shadowmcpscan.NewScanner(

--- a/server/internal/background/activities/risk_analysis/analyze_batch_test.go
+++ b/server/internal/background/activities/risk_analysis/analyze_batch_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/outbox/events"
 	"github.com/speakeasy-api/gram/server/internal/risk/celenv"
 	riskrepo "github.com/speakeasy-api/gram/server/internal/risk/repo"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
 	"github.com/speakeasy-api/gram/server/internal/scanners"
 	"github.com/speakeasy-api/gram/server/internal/scanners/customruleanalyzer"
 	"github.com/speakeasy-api/gram/server/internal/scanners/promptpolicy"
@@ -97,7 +98,7 @@ func mustCELEngine(t *testing.T) *celenv.Engine {
 
 func mustCustomRuleScanner(t *testing.T, db riskrepo.DBTX) *customruleanalyzer.Scanner {
 	t.Helper()
-	s, err := customruleanalyzer.NewScanner(db)
+	s, err := customruleanalyzer.NewScanner(db, nil)
 	require.NoError(t, err)
 	return s
 }
@@ -178,7 +179,7 @@ func capturingFindingsPub(t *testing.T) (*gcp.MockPublisher[*riskv1.Finding], *[
 
 func TestAnalyzeBatch_EmptyMessageIDs(t *testing.T) {
 	t.Parallel()
-	ab, err := risk_analysis.NewAnalyzeBatch(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), nil, nil, &risk_analysis.StubPIIScanner{}, nil, nil, nil, nil, nil, newPresidioPub(), newGitleaksPub(), newPromptInjectionPub(), newPromptPolicyPub(), newCustomRulesPub(), newFindingsPub(), mustCustomRuleScanner(t, nil), mustCELEngine(t), nil, nil)
+	ab, err := risk_analysis.NewAnalyzeBatch(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), nil, nil, nil, &risk_analysis.StubPIIScanner{}, nil, nil, nil, nil, nil, newPresidioPub(), newGitleaksPub(), newPromptInjectionPub(), newPromptPolicyPub(), newCustomRulesPub(), newFindingsPub(), mustCustomRuleScanner(t, nil), mustCELEngine(t), nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, ab)
 
@@ -220,12 +221,14 @@ func TestAnalyzeBatch_GracefulDegradationWhenPresidioDown(t *testing.T) {
 		testenv.NewTracerProvider(t),
 		testenv.NewMeterProvider(t),
 		testenv.NewLogger(t),
+		nil,
 	)
 
 	ab, err := risk_analysis.NewAnalyzeBatch(
 		testenv.NewLogger(t),
 		testenv.NewTracerProvider(t),
 		testenv.NewMeterProvider(t),
+		nil,
 		conn,
 		nil,
 		piiScanner,
@@ -310,6 +313,7 @@ func TestAnalyzeBatch_ContentSourcesNotRepublishedToFindingsTopic(t *testing.T) 
 		testenv.NewLogger(t),
 		testenv.NewTracerProvider(t),
 		testenv.NewMeterProvider(t),
+		nil,
 		conn,
 		nil,
 		&risk_analysis.StubPIIScanner{},
@@ -380,6 +384,7 @@ func TestAnalyzeBatch_PromptInjectionPublishesAsyncRequestsForEveryMessage(t *te
 		testenv.NewLogger(t),
 		testenv.NewTracerProvider(t),
 		testenv.NewMeterProvider(t),
+		nil,
 		conn,
 		assetStorage,
 		&risk_analysis.StubPIIScanner{},
@@ -463,6 +468,7 @@ func TestAnalyzeBatch_PromptPolicyPublishesAsyncRequestsForEveryEligibleMessage(
 		testenv.NewLogger(t),
 		testenv.NewTracerProvider(t),
 		testenv.NewMeterProvider(t),
+		nil,
 		conn,
 		nil,
 		&risk_analysis.StubPIIScanner{},
@@ -541,6 +547,7 @@ func TestAnalyzeBatch_FilteredMessagesStillClearExistingResults(t *testing.T) {
 		testenv.NewLogger(t),
 		testenv.NewTracerProvider(t),
 		testenv.NewMeterProvider(t),
+		nil,
 		conn,
 		nil,
 		&risk_analysis.StubPIIScanner{},
@@ -653,6 +660,7 @@ func TestAnalyzeBatch_PromptJudgeUsesToolCallPayload(t *testing.T) {
 		testenv.NewLogger(t),
 		testenv.NewTracerProvider(t),
 		testenv.NewMeterProvider(t),
+		nil,
 		conn,
 		nil,
 		&risk_analysis.StubPIIScanner{},
@@ -760,6 +768,7 @@ func TestAnalyzeBatch_PromptJudgeMultiToolCallAttribution(t *testing.T) {
 		testenv.NewLogger(t),
 		testenv.NewTracerProvider(t),
 		testenv.NewMeterProvider(t),
+		nil,
 		conn,
 		nil,
 		&risk_analysis.StubPIIScanner{},
@@ -929,7 +938,7 @@ type deletingPIIScanner struct {
 	policyID  uuid.UUID
 }
 
-func (s *deletingPIIScanner) AnalyzeBatch(ctx context.Context, texts []string, _ []string, _ float64, _ func()) ([][]scanners.Finding, error) {
+func (s *deletingPIIScanner) AnalyzeBatch(ctx context.Context, texts []string, _ []string, _ float64, _ func(), _ ...riskmeter.Evaluation) ([][]scanners.Finding, error) {
 	if err := riskrepo.New(s.conn).DeleteRiskPolicy(ctx, riskrepo.DeleteRiskPolicyParams{
 		ID:        s.policyID,
 		ProjectID: s.projectID,
@@ -955,6 +964,7 @@ func TestAnalyzeBatch_PolicyDeletedMidAnalysisPublishesNothing(t *testing.T) {
 		testenv.NewLogger(t),
 		testenv.NewTracerProvider(t),
 		testenv.NewMeterProvider(t),
+		nil,
 		conn,
 		nil,
 		&deletingPIIScanner{conn: conn, projectID: td.projectID, policyID: td.policyID},
@@ -1060,6 +1070,7 @@ func TestAnalyzeBatch_Presidio_PIIInToolCallArgsOnly(t *testing.T) {
 		testenv.NewLogger(t),
 		testenv.NewTracerProvider(t),
 		testenv.NewMeterProvider(t),
+		nil,
 		conn,
 		nil,
 		infra.NewPresidioClient(t),
@@ -1588,6 +1599,7 @@ func executeAnalyzeBatchForIDs(t *testing.T, conn *pgxpool.Pool, assetStorage as
 		testenv.NewLogger(t),
 		testenv.NewTracerProvider(t),
 		testenv.NewMeterProvider(t),
+		nil,
 		conn,
 		assetStorage,
 		&risk_analysis.StubPIIScanner{},

--- a/server/internal/background/activities/risk_analysis/eval_guardrail.go
+++ b/server/internal/background/activities/risk_analysis/eval_guardrail.go
@@ -96,7 +96,7 @@ func EvalPromptGuardrail(
 	}
 
 	judgeFanout(
-		ctx, judge, orgID, projectID, prompt, cfg, built, inScope,
+		ctx, judge, orgID, projectID, prompt, cfg, built, inScope, nil,
 		func(pos, idx int, verdict *promptpolicy.Verdict, err error, latency time.Duration) {
 			out := messageVerdictSkeleton(idx, built[idx])
 			out.LatencyMs = latency.Milliseconds()

--- a/server/internal/background/activities/risk_analysis/presidio.go
+++ b/server/internal/background/activities/risk_analysis/presidio.go
@@ -27,6 +27,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/risk/presidiofp"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
 	"github.com/speakeasy-api/gram/server/internal/scanners"
 )
 
@@ -116,7 +117,7 @@ type PIIScanner interface {
 	// Permanent per-message failures surface as a single Finding with
 	// DeadLetterReason populated rather than as an error; the returned
 	// error is non-nil only on outer-ctx cancellation.
-	AnalyzeBatch(ctx context.Context, texts []string, entities []string, scoreThreshold float64, onProgress func()) ([][]scanners.Finding, error)
+	AnalyzeBatch(ctx context.Context, texts []string, entities []string, scoreThreshold float64, onProgress func(), evaluations ...riskmeter.Evaluation) ([][]scanners.Finding, error)
 }
 
 // DefaultPresidioScoreThreshold is the minimum recognizer confidence applied
@@ -302,10 +303,15 @@ type PresidioClient struct {
 	attemptFailures      metric.Int64Counter
 	deadLetters          metric.Int64Counter
 	truncations          metric.Int64Counter
+	recorder             *riskmeter.Recorder
 }
 
 // NewPresidioClient creates a client pointing at the given base URL.
-func NewPresidioClient(baseURL string, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, logger *slog.Logger) *PresidioClient {
+func NewPresidioClient(baseURL string, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, logger *slog.Logger, recorders ...*riskmeter.Recorder) *PresidioClient {
+	var recorder *riskmeter.Recorder
+	if len(recorders) > 0 {
+		recorder = recorders[0]
+	}
 	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis/presidio")
 
 	requestDuration, _ := meter.Float64Histogram(
@@ -377,6 +383,7 @@ func NewPresidioClient(baseURL string, tracerProvider trace.TracerProvider, mete
 		throttleWaitDuration: throttleWaitDuration,
 		attemptFailures:      attemptFailures,
 		deadLetters:          deadLetters,
+		recorder:             recorder,
 		truncations:          truncations,
 	}
 }
@@ -390,7 +397,7 @@ func NewPresidioClient(baseURL string, tracerProvider trace.TracerProvider, mete
 // Returns a non-nil error only on outer-ctx cancellation. Per-message
 // failures surface as DeadLetterReason sentinels so the rest of the batch
 // can still write.
-func (p *PresidioClient) AnalyzeBatch(ctx context.Context, texts []string, entities []string, scoreThreshold float64, onProgress func()) (_ [][]scanners.Finding, err error) {
+func (p *PresidioClient) AnalyzeBatch(ctx context.Context, texts []string, entities []string, scoreThreshold float64, onProgress func(), evaluations ...riskmeter.Evaluation) (_ [][]scanners.Finding, err error) {
 	n := len(texts)
 	if n == 0 {
 		return nil, nil
@@ -438,7 +445,11 @@ func (p *PresidioClient) AnalyzeBatch(ctx context.Context, texts []string, entit
 	var wg sync.WaitGroup
 	for i, text := range texts {
 		wg.Go(func() {
-			finding, dl := p.analyzeOne(ctx, i, text, entities, scoreThreshold, onProgress)
+			scanCtx := ctx
+			if i < len(evaluations) && evaluations[i].OperationID != "" {
+				scanCtx = riskmeter.WithEvaluation(ctx, evaluations[i])
+			}
+			finding, dl := p.analyzeOne(scanCtx, i, text, entities, scoreThreshold, onProgress)
 			results[i] = finding
 			if dl {
 				deadLetters.Add(1)
@@ -458,7 +469,7 @@ func (p *PresidioClient) AnalyzeBatch(ctx context.Context, texts []string, entit
 // analyzeOne runs the retry loop for a single text. Returns the per-text
 // findings slice (real findings, or a single dead-letter sentinel) and a
 // boolean indicating whether the result was a dead letter.
-func (p *PresidioClient) analyzeOne(ctx context.Context, idx int, text string, entities []string, scoreThreshold float64, onProgress func()) ([]scanners.Finding, bool) {
+func (p *PresidioClient) analyzeOne(ctx context.Context, idx int, text string, entities []string, scoreThreshold float64, onProgress func()) (findings []scanners.Finding, deadLetter bool) {
 	if onProgress != nil {
 		onProgress()
 	}
@@ -482,6 +493,18 @@ func (p *PresidioClient) analyzeOne(ctx context.Context, idx int, text string, e
 		if p.truncations != nil {
 			p.truncations.Add(ctx, 1)
 		}
+	}
+	if evaluation, ok := riskmeter.EvaluationFromContext(ctx); ok {
+		defer func() {
+			outcome := riskmeter.OutcomeCompleted
+			switch {
+			case ctx.Err() != nil:
+				outcome = riskmeter.OutcomeCancelled
+			case deadLetter:
+				outcome = riskmeter.OutcomeFailed
+			}
+			_ = p.recorder.Record(ctx, evaluation, []string{text}, outcome, nil)
+		}()
 	}
 
 	var lastErr error
@@ -859,6 +882,6 @@ func isCancelErr(err error) bool {
 // StubPIIScanner is a no-op implementation for environments without Presidio.
 type StubPIIScanner struct{}
 
-func (s *StubPIIScanner) AnalyzeBatch(_ context.Context, texts []string, _ []string, _ float64, _ func()) ([][]scanners.Finding, error) {
+func (s *StubPIIScanner) AnalyzeBatch(_ context.Context, texts []string, _ []string, _ float64, _ func(), _ ...riskmeter.Evaluation) ([][]scanners.Finding, error) {
 	return make([][]scanners.Finding, len(texts)), nil
 }

--- a/server/internal/background/activities/risk_analysis/presidio_test.go
+++ b/server/internal/background/activities/risk_analysis/presidio_test.go
@@ -212,7 +212,7 @@ func TestCombinedScanners_BothSourcesAppear(t *testing.T) {
 	// Message with both a secret (AWS key) and PII (email)
 	content := "Here is my AccessKeyId ASIAZ2XY3WNBQR5TUVWX SecretAccessKey wJalrXUtnFEMIbKp7MDoRZfiCYqTvHgNsQ8xLcWd and my email is alice@globex.com"
 
-	gitleaksFindings, err := gitleaks.NewScanner().Scan(t.Context(), content)
+	gitleaksFindings, err := gitleaks.NewScanner(nil).Scan(t.Context(), content)
 	require.NoError(t, err)
 
 	presidioResults, err := client.AnalyzeBatch(t.Context(), []string{content}, nil, 0, nil)

--- a/server/internal/background/activities/risk_analysis/prompt_judge_batch.go
+++ b/server/internal/background/activities/risk_analysis/prompt_judge_batch.go
@@ -16,6 +16,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/risk/categories"
 	"github.com/speakeasy-api/gram/server/internal/risk/policyflags"
 	"github.com/speakeasy-api/gram/server/internal/risk/repo"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
 	"github.com/speakeasy-api/gram/server/internal/scanners"
 	"github.com/speakeasy-api/gram/server/internal/scanners/promptpolicy"
 )
@@ -53,6 +54,7 @@ func judgeFanout(
 	cfg promptpolicy.Config,
 	msgs []batchMessage,
 	indices []int,
+	evaluations []riskmeter.Evaluation,
 	apply func(pos, idx int, verdict *promptpolicy.Verdict, err error, latency time.Duration),
 	onChunk func(end int),
 ) {
@@ -64,8 +66,12 @@ func judgeFanout(
 			go func(pos int) {
 				defer wg.Done()
 				idx := indices[pos]
+				callCtx := ctx
+				if idx < len(evaluations) && evaluations[idx].OperationID != "" {
+					callCtx = riskmeter.WithEvaluation(ctx, evaluations[idx])
+				}
 				started := time.Now()
-				verdict, err := judge(ctx, promptpolicy.Input{
+				verdict, err := judge(callCtx, promptpolicy.Input{
 					OrgID:     orgID,
 					ProjectID: projectID,
 					UserID:    msgs[idx].UserID,
@@ -116,10 +122,28 @@ func (a *AnalyzeBatch) scanPromptPolicy(ctx context.Context, args AnalyzeBatchAr
 		return nil, err
 	}
 
+	evaluations := make([]riskmeter.Evaluation, len(messages))
+	occurredAt := time.Now().UTC().Format(time.RFC3339Nano)
+	requestID := batchScanRequestID(args, "prompt_policy")
+	for i, msg := range messages {
+		chatMessageID, contentPartID := msg.anchorIDStrings()
+		chatID, partID := "", ""
+		if chatMessageID != nil {
+			chatID = *chatMessageID
+		}
+		if contentPartID != nil {
+			partID = *contentPartID
+		}
+		evaluations[i] = scanners.EvaluationForAnalysis(
+			args.OrganizationID, args.ProjectID.String(), requestID.String(),
+			chatID, partID, args.RiskPolicyID.String(), args.PolicyVersion,
+			riskmeter.DetectorPromptPolicy, riskmeter.ModeBatch, occurredAt,
+		)
+	}
 	judgeFanout(
 		ctx, a.judge,
 		args.OrganizationID, args.ProjectID.String(), policy.Prompt.String, cfg,
-		messages, indices,
+		messages, indices, evaluations,
 		func(_, idx int, verdict *promptpolicy.Verdict, err error, _ time.Duration) {
 			findings := promptpolicy.FindingsFromEvaluation(cfg, verdict, err, false)
 			setEventMatch(findings, messages[idx])

--- a/server/internal/background/activities/risk_analysis/scan_account_identity_test.go
+++ b/server/internal/background/activities/risk_analysis/scan_account_identity_test.go
@@ -134,6 +134,7 @@ func newAccountIdentityAnalyzeBatch(t *testing.T, conn *pgxpool.Pool, findingsPu
 		testenv.NewLogger(t),
 		testenv.NewTracerProvider(t),
 		testenv.NewMeterProvider(t),
+		nil,
 		conn,
 		nil,
 		&risk_analysis.StubPIIScanner{},

--- a/server/internal/background/activities/risk_analysis/scan_custom_rules.go
+++ b/server/internal/background/activities/risk_analysis/scan_custom_rules.go
@@ -10,6 +10,7 @@ import (
 
 	riskv1 "github.com/speakeasy-api/gram/infra/gen/gram/risk/v1"
 	"github.com/speakeasy-api/gram/infra/pkg/gcp"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
 	"github.com/speakeasy-api/gram/server/internal/scanners"
 	"github.com/speakeasy-api/gram/server/internal/scanners/customruleanalyzer"
 )
@@ -24,17 +25,32 @@ func (a *AnalyzeBatch) scanCustomRules(ctx context.Context, args AnalyzeBatchArg
 	// keeping DB work constant in the number of messages. It re-loads and
 	// compiles the rules internally, so we hand it the resolved ids directly.
 	scanMessages := make([]customruleanalyzer.ScanMessage, 0, len(messages))
+	occurredAt := time.Now().UTC().Format(time.RFC3339Nano)
 	for _, msg := range messages {
 		view := batchMessageView(msg)
 		toolCalls := make([]customruleanalyzer.ScanToolCall, 0, len(view.Tools))
 		for _, t := range view.Tools {
 			toolCalls = append(toolCalls, customruleanalyzer.ScanToolCall{Name: t.Name, Arguments: t.Arguments})
 		}
+		chatMessageID, contentPartID := msg.anchorIDStrings()
+		chatID, partID := "", ""
+		if chatMessageID != nil {
+			chatID = *chatMessageID
+		}
+		if contentPartID != nil {
+			partID = *contentPartID
+		}
 
+		evaluation := scanners.EvaluationForAnalysis(
+			args.OrganizationID, args.ProjectID.String(), requestID.String(),
+			chatID, partID, args.RiskPolicyID.String(), args.PolicyVersion,
+			riskmeter.DetectorCustomRules, riskmeter.ModeBatch, occurredAt,
+		)
 		scanMessages = append(scanMessages, customruleanalyzer.ScanMessage{
-			Content:   view.Content,
-			Kind:      view.Type,
-			ToolCalls: toolCalls,
+			Content:    view.Content,
+			Kind:       view.Type,
+			ToolCalls:  toolCalls,
+			Evaluation: &evaluation,
 		})
 	}
 

--- a/server/internal/background/activities/risk_analysis/scan_gitleaks.go
+++ b/server/internal/background/activities/risk_analysis/scan_gitleaks.go
@@ -9,6 +9,7 @@ import (
 
 	riskv1 "github.com/speakeasy-api/gram/infra/gen/gram/risk/v1"
 	"github.com/speakeasy-api/gram/infra/pkg/gcp"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
 	"github.com/speakeasy-api/gram/server/internal/scanners"
 )
 
@@ -17,7 +18,25 @@ func (a *AnalyzeBatch) scanGitleaks(ctx context.Context, args AnalyzeBatchArgs, 
 		return nil, err
 	}
 
-	findings, err := a.gitleaksScanner.ScanBatch(ctx, contents)
+	evaluations := make([]riskmeter.Evaluation, len(messages))
+	occurredAt := time.Now().UTC().Format(time.RFC3339Nano)
+	for i, msg := range messages {
+		chatMessageID, contentPartID := msg.anchorIDStrings()
+		chatID, partID := "", ""
+		if chatMessageID != nil {
+			chatID = *chatMessageID
+		}
+		if contentPartID != nil {
+			partID = *contentPartID
+		}
+		evaluations[i] = scanners.EvaluationForAnalysis(
+			args.OrganizationID, args.ProjectID.String(), requestID.String(),
+			chatID, partID,
+			args.RiskPolicyID.String(), args.PolicyVersion,
+			riskmeter.DetectorGitleaks, riskmeter.ModeBatch, occurredAt,
+		)
+	}
+	findings, err := a.gitleaksScanner.ScanBatch(ctx, contents, evaluations)
 	if err != nil {
 		return [][]scanners.Finding{}, fmt.Errorf("scan gitleaks batch: %w", err)
 	}

--- a/server/internal/background/activities/risk_analysis/scan_presidio.go
+++ b/server/internal/background/activities/risk_analysis/scan_presidio.go
@@ -11,6 +11,7 @@ import (
 	riskv1 "github.com/speakeasy-api/gram/infra/gen/gram/risk/v1"
 	"github.com/speakeasy-api/gram/infra/pkg/gcp"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
 	"github.com/speakeasy-api/gram/server/internal/scanners"
 )
 
@@ -18,9 +19,26 @@ import (
 // lives with the caller (scanStandardPolicy), which fails the activity on a
 // publish error while tolerating this scan's partial results.
 func (a *AnalyzeBatch) scanPresidio(ctx context.Context, args AnalyzeBatchArgs, scoreThreshold float64, messages []batchMessage, contents []string) ([][]scanners.Finding, error) {
+	evaluations := make([]riskmeter.Evaluation, len(messages))
+	occurredAt := time.Now().UTC().Format(time.RFC3339Nano)
+	for i, msg := range messages {
+		chatMessageID, contentPartID := msg.anchorIDStrings()
+		chatID, partID := "", ""
+		if chatMessageID != nil {
+			chatID = *chatMessageID
+		}
+		if contentPartID != nil {
+			partID = *contentPartID
+		}
+		evaluations[i] = scanners.EvaluationForAnalysis(
+			args.OrganizationID, args.ProjectID.String(), "",
+			chatID, partID, args.RiskPolicyID.String(), args.PolicyVersion,
+			riskmeter.DetectorPresidio, riskmeter.ModeBatch, occurredAt,
+		)
+	}
 	results, err := a.piiScanner.AnalyzeBatch(ctx, contents, args.PresidioEntities, scoreThreshold, func() {
 		activity.RecordHeartbeat(ctx, SourcePresidio)
-	})
+	}, evaluations...)
 	if results == nil {
 		results = make([][]scanners.Finding, len(messages))
 	}

--- a/server/internal/background/activities/risk_analysis/scan_prompt_injection.go
+++ b/server/internal/background/activities/risk_analysis/scan_prompt_injection.go
@@ -11,6 +11,7 @@ import (
 	"github.com/speakeasy-api/gram/infra/pkg/gcp"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/judgemessage"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
 	"github.com/speakeasy-api/gram/server/internal/scanners"
 )
 
@@ -18,15 +19,30 @@ func (a *AnalyzeBatch) scanPromptInjection(ctx context.Context, args AnalyzeBatc
 	out := make([][]scanners.Finding, len(messages))
 	judgeMessages := make([]judgemessage.Message, len(messages))
 	judgeUserIDs := make([]string, len(messages))
+	evaluations := make([]riskmeter.Evaluation, len(messages))
+	occurredAt := time.Now().UTC().Format(time.RFC3339Nano)
 	for i := range messages {
 		judgeMessages[i] = batchJudgeMessage(messages[i])
 		judgeUserIDs[i] = messages[i].UserID
+		chatMessageID, contentPartID := messages[i].anchorIDStrings()
+		chatID, partID := "", ""
+		if chatMessageID != nil {
+			chatID = *chatMessageID
+		}
+		if contentPartID != nil {
+			partID = *contentPartID
+		}
+		evaluations[i] = scanners.EvaluationForAnalysis(
+			args.OrganizationID, args.ProjectID.String(), requestID.String(),
+			chatID, partID, args.RiskPolicyID.String(), args.PolicyVersion,
+			riskmeter.DetectorPromptInjection, riskmeter.ModeBatch, occurredAt,
+		)
 	}
 	if err := a.publishPromptInjectionScanRequests(ctx, args, requestID, messages); err != nil {
 		return nil, err
 	}
 
-	results, err := a.promptInjectionScanner.ScanBatch(ctx, contents, args.OrganizationID, args.ProjectID.String(), judgeUserIDs, judgeMessages)
+	results, err := a.promptInjectionScanner.ScanBatch(ctx, contents, args.OrganizationID, args.ProjectID.String(), judgeUserIDs, judgeMessages, evaluations)
 	if err != nil {
 		a.logger.WarnContext(ctx, "prompt injection scan failed", attr.SlogError(err))
 		return out, nil

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -202,6 +202,7 @@ func ForDeploymentProcessing(
 			CustomRulesAnalysis:     gcp.NewNoopPublisher[*riskv1.CustomRulesAnalysis](),
 			RiskFindings:            gcp.NewNoopPublisher[*riskv1.Finding](),
 			MeterReadings:           gcp.NewNoopPublisher[*meteringv1.MeterReading](),
+			RiskEvaluations:         gcp.NewNoopPublisher[*meteringv1.RiskEvaluation](),
 			TelemetryLogs:           gcp.NewNoopPublisher[*telemetryv1.LogRecord](),
 			OTELLogs:                gcp.NewNoopPublisher[*otelv1.InboundLogRecord](),
 			OTELMetrics:             gcp.NewNoopPublisher[*otelv1.InboundMetric](),

--- a/server/internal/litellm/integration_test.go
+++ b/server/internal/litellm/integration_test.go
@@ -907,7 +907,7 @@ func TestRealHooksPureTextResponseProducesAssistantPolicyFinding(t *testing.T) {
 	require.Len(t, fetched.Policies, 1)
 	require.Equal(t, []string{message.Assistant}, fetched.Policies[0].MessageTypes)
 
-	customRules, err := customruleanalyzer.NewScanner(ti.conn)
+	customRules, err := customruleanalyzer.NewScanner(ti.conn, nil)
 	require.NoError(t, err)
 	celEngine, err := riskcelenv.New()
 	require.NoError(t, err)
@@ -918,6 +918,7 @@ func TestRealHooksPureTextResponseProducesAssistantPolicyFinding(t *testing.T) {
 		testenv.NewLogger(t),
 		testenv.NewTracerProvider(t),
 		testenv.NewMeterProvider(t),
+		nil,
 		ti.conn,
 		nil,
 		&riskanalysis.StubPIIScanner{},

--- a/server/internal/litellm/litellm_proxy_e2e_test.go
+++ b/server/internal/litellm/litellm_proxy_e2e_test.go
@@ -290,13 +290,13 @@ func TestLiteLLMProxyE2E(t *testing.T) { //nolint:paralleltest // Scenarios inte
 func newProxyHarness(t *testing.T) *proxyHarness {
 	t.Helper()
 	ctx, instance := newRealTestServiceWithScannerFactory(t, func(conn *pgxpool.Pool) risk.RiskScanner {
-		customRules, err := customruleanalyzer.NewScanner(conn)
+		customRules, err := customruleanalyzer.NewScanner(conn, nil)
 		require.NoError(t, err)
 		celEngine, err := riskcelenv.New()
 		require.NoError(t, err)
 		scanner, err := risk.NewScanner(
 			testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), conn,
-			customRules, nil, nil, nil, &feature.InMemory{}, celEngine,
+			customRules, nil, nil, nil, &feature.InMemory{}, nil, celEngine,
 		)
 		require.NoError(t, err)
 		return scanner
@@ -787,14 +787,14 @@ func (h *proxyHarness) timeoutAndResend() {
 
 func (h *proxyHarness) materializeFinding(messageID uuid.UUID) {
 	h.t.Helper()
-	customRules, err := customruleanalyzer.NewScanner(h.conn)
+	customRules, err := customruleanalyzer.NewScanner(h.conn, nil)
 	require.NoError(h.t, err)
 	celEngine, err := riskcelenv.New()
 	require.NoError(h.t, err)
 	flags := &feature.InMemory{}
 	shadowMCPClient := shadowmcp.NewClient(testenv.NewLogger(h.t), h.conn, cache.NoopCache, nil)
 	analyze, err := riskanalysis.NewAnalyzeBatch(
-		testenv.NewLogger(h.t), testenv.NewTracerProvider(h.t), testenv.NewMeterProvider(h.t), h.conn,
+		testenv.NewLogger(h.t), testenv.NewTracerProvider(h.t), testenv.NewMeterProvider(h.t), nil, h.conn,
 		nil, &riskanalysis.StubPIIScanner{}, nil, shadowMCPClient, noMCPProvenance{}, nil, flags,
 		gcp.NewNoopPublisher[*riskv1.PresidioAnalysis](),
 		gcp.NewNoopPublisher[*riskv1.GitleaksAnalysis](),

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -302,7 +302,7 @@ func newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(
 	}
 	billingStub := billing.NewStubClient(logger, tracerProvider)
 	devProvisioner := openrouter.NewDevelopment("test-openrouter-key")
-	chatClient := openrouter.NewUnifiedClient(logger, guardianPolicy, devProvisioner, &openrouter.PlatformKeyResolver{Provisioner: devProvisioner}, nil, nil, nil, nil)
+	chatClient := openrouter.NewUnifiedClient(logger, guardianPolicy, devProvisioner, &openrouter.PlatformKeyResolver{Provisioner: devProvisioner}, nil, nil, nil, nil, nil)
 	vectorToolStore := rag.NewToolsetVectorStore(logger, tracerProvider, conn, chatClient)
 	chatSessions := chatsessions.NewManager(logger, redisClient, "test-jwt-secret")
 	featClient := productfeatures.NewClient(logger, tracerProvider, conn, redisClient)

--- a/server/internal/risk/impl.go
+++ b/server/internal/risk/impl.go
@@ -258,7 +258,7 @@ func NewService(
 		approvalIntake:               approvalIntake,
 		piiScanner:                   piiScanner,
 		piScanner:                    piScanner,
-		gitleaksScanner:              gitleaks.NewScanner(),
+		gitleaksScanner:              gitleaks.NewScanner(nil),
 		flags:                        flags,
 		celEng:                       celEng,
 		builtinPresets:               builtinPresets,

--- a/server/internal/risk/policy_audience_test.go
+++ b/server/internal/risk/policy_audience_test.go
@@ -187,6 +187,7 @@ func TestScanner_ScanForEnforcement_RespectsTargetedAudience(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 		testCELEngine(t),
 	)
 	require.NoError(t, err)
@@ -229,6 +230,7 @@ func TestScanner_ScanForEnforcement_EveryoneAudienceAppliesWithoutResolvedUser(t
 		ti.conn,
 		newTestCustomRuleAnalyzer(t, ti.conn),
 		pii,
+		nil,
 		nil,
 		nil,
 		nil,
@@ -277,6 +279,7 @@ func TestScanner_LookupShadowMCPBlockingPolicy_EveryoneAudienceAppliesWithoutRes
 		testenv.NewMeterProvider(t),
 		ti.conn,
 		newTestCustomRuleAnalyzer(t, ti.conn),
+		nil,
 		nil,
 		nil,
 		nil,

--- a/server/internal/risk/prompt_policy_scanner_test.go
+++ b/server/internal/risk/prompt_policy_scanner_test.go
@@ -112,7 +112,7 @@ func TestScanner_PromptBasedPolicyBlocksToolRequest(t *testing.T) {
 	insertPromptBasedBlockPolicy(t, ti, ctx, "no-deletes", "Block destructive deletes", []string{message.ToolRequest})
 	judge := &fakePromptJudge{verdict: matchedJudgeVerdict(0.9, "destructive delete")}
 
-	scanner, err := risk.NewScanner(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), ti.conn, newTestCustomRuleAnalyzer(t, ti.conn), nil, nil, promptpolicy.NewScanner(testenv.NewLogger(t), judge.Evaluate), promptPoliciesFlag(ctx), testCELEngine(t))
+	scanner, err := risk.NewScanner(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), ti.conn, newTestCustomRuleAnalyzer(t, ti.conn), nil, nil, promptpolicy.NewScanner(testenv.NewLogger(t), judge.Evaluate), promptPoliciesFlag(ctx), nil, testCELEngine(t))
 	require.NoError(t, err)
 
 	authCtx, _ := contextvalues.GetAuthContext(ctx)
@@ -135,7 +135,7 @@ func TestScanner_PromptBasedPolicyAttributesMCPTool(t *testing.T) {
 	insertPromptBasedBlockPolicy(t, ti, ctx, "no-github-writes", "Block writes to the github MCP server", []string{message.ToolRequest})
 	judge := &fakePromptJudge{verdict: matchedJudgeVerdict(1, "x")}
 
-	scanner, err := risk.NewScanner(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), ti.conn, newTestCustomRuleAnalyzer(t, ti.conn), nil, nil, promptpolicy.NewScanner(testenv.NewLogger(t), judge.Evaluate), promptPoliciesFlag(ctx), testCELEngine(t))
+	scanner, err := risk.NewScanner(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), ti.conn, newTestCustomRuleAnalyzer(t, ti.conn), nil, nil, promptpolicy.NewScanner(testenv.NewLogger(t), judge.Evaluate), promptPoliciesFlag(ctx), nil, testCELEngine(t))
 	require.NoError(t, err)
 
 	authCtx, _ := contextvalues.GetAuthContext(ctx)
@@ -160,7 +160,7 @@ func TestScanner_PromptBasedPolicyJudgesNonToolMessages(t *testing.T) {
 	insertPromptBasedBlockPolicy(t, ti, ctx, "no-deletes", "Block destructive deletes", nil)
 	judge := &fakePromptJudge{verdict: matchedJudgeVerdict(1, "x")}
 
-	scanner, err := risk.NewScanner(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), ti.conn, newTestCustomRuleAnalyzer(t, ti.conn), nil, nil, promptpolicy.NewScanner(testenv.NewLogger(t), judge.Evaluate), promptPoliciesFlag(ctx), testCELEngine(t))
+	scanner, err := risk.NewScanner(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), ti.conn, newTestCustomRuleAnalyzer(t, ti.conn), nil, nil, promptpolicy.NewScanner(testenv.NewLogger(t), judge.Evaluate), promptPoliciesFlag(ctx), nil, testCELEngine(t))
 	require.NoError(t, err)
 
 	authCtx, _ := contextvalues.GetAuthContext(ctx)
@@ -179,7 +179,7 @@ func TestScanner_PromptBasedPolicyRespectsMessageTypes(t *testing.T) {
 	insertPromptBasedBlockPolicy(t, ti, ctx, "no-deletes", "Block destructive deletes", []string{message.ToolRequest})
 	judge := &fakePromptJudge{verdict: matchedJudgeVerdict(1, "x")}
 
-	scanner, err := risk.NewScanner(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), ti.conn, newTestCustomRuleAnalyzer(t, ti.conn), nil, nil, promptpolicy.NewScanner(testenv.NewLogger(t), judge.Evaluate), promptPoliciesFlag(ctx), testCELEngine(t))
+	scanner, err := risk.NewScanner(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), ti.conn, newTestCustomRuleAnalyzer(t, ti.conn), nil, nil, promptpolicy.NewScanner(testenv.NewLogger(t), judge.Evaluate), promptPoliciesFlag(ctx), nil, testCELEngine(t))
 	require.NoError(t, err)
 
 	authCtx, _ := contextvalues.GetAuthContext(ctx)
@@ -198,7 +198,7 @@ func TestScanner_PromptBasedPolicyNoMatch(t *testing.T) {
 	insertPromptBasedBlockPolicy(t, ti, ctx, "no-deletes", "Block destructive deletes", []string{message.ToolRequest})
 	judge := &fakePromptJudge{verdict: nil}
 
-	scanner, err := risk.NewScanner(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), ti.conn, newTestCustomRuleAnalyzer(t, ti.conn), nil, nil, promptpolicy.NewScanner(testenv.NewLogger(t), judge.Evaluate), promptPoliciesFlag(ctx), testCELEngine(t))
+	scanner, err := risk.NewScanner(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), ti.conn, newTestCustomRuleAnalyzer(t, ti.conn), nil, nil, promptpolicy.NewScanner(testenv.NewLogger(t), judge.Evaluate), promptPoliciesFlag(ctx), nil, testCELEngine(t))
 	require.NoError(t, err)
 
 	authCtx, _ := contextvalues.GetAuthContext(ctx)
@@ -215,7 +215,7 @@ func TestScanner_PromptBasedPolicyDisabledWhenFlagOff(t *testing.T) {
 	insertPromptBasedBlockPolicy(t, ti, ctx, "no-deletes", "Block destructive deletes", []string{message.ToolRequest})
 	judge := &fakePromptJudge{verdict: matchedJudgeVerdict(1, "x")}
 
-	scanner, err := risk.NewScanner(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), ti.conn, newTestCustomRuleAnalyzer(t, ti.conn), nil, nil, promptpolicy.NewScanner(testenv.NewLogger(t), judge.Evaluate), &feature.InMemory{}, testCELEngine(t))
+	scanner, err := risk.NewScanner(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), ti.conn, newTestCustomRuleAnalyzer(t, ti.conn), nil, nil, promptpolicy.NewScanner(testenv.NewLogger(t), judge.Evaluate), &feature.InMemory{}, nil, testCELEngine(t))
 	require.NoError(t, err)
 
 	authCtx, _ := contextvalues.GetAuthContext(ctx)
@@ -234,7 +234,7 @@ func TestScanner_PromptBasedPolicyFailClosedWhenJudgeUnavailable(t *testing.T) {
 	require.NoError(t, err)
 	insertPromptBasedBlockPolicyWithConfig(t, ti, ctx, "no-deletes", "Block destructive deletes", []string{message.ToolRequest}, modelConfig)
 
-	scanner, err := risk.NewScanner(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), ti.conn, newTestCustomRuleAnalyzer(t, ti.conn), nil, nil, nil, promptPoliciesFlag(ctx), testCELEngine(t))
+	scanner, err := risk.NewScanner(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), ti.conn, newTestCustomRuleAnalyzer(t, ti.conn), nil, nil, nil, promptPoliciesFlag(ctx), nil, testCELEngine(t))
 	require.NoError(t, err)
 
 	authCtx, _ := contextvalues.GetAuthContext(ctx)

--- a/server/internal/risk/scanner.go
+++ b/server/internal/risk/scanner.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -20,6 +21,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 
+	meteringv1 "github.com/speakeasy-api/gram/infra/gen/gram/metering/v1"
 	riskv1 "github.com/speakeasy-api/gram/infra/gen/gram/risk/v1"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/authz"
@@ -34,6 +36,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/risk/policyflags"
 	"github.com/speakeasy-api/gram/server/internal/risk/recommendedscopes"
 	"github.com/speakeasy-api/gram/server/internal/risk/repo"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
 	"github.com/speakeasy-api/gram/server/internal/scanners"
 	"github.com/speakeasy-api/gram/server/internal/scanners/customruleanalyzer"
 	"math"
@@ -243,9 +246,10 @@ func NewScanner(
 	piScanner *promptinjection.Scanner,
 	promptPolicy *promptpolicy.Scanner,
 	flags feature.Provider,
+	recorder *riskmeter.Recorder,
 	celEng *celenv.Engine,
 ) (*Scanner, error) {
-	return newScanner(logger, tracerProvider, meterProvider, db, customRuleScanner, piiScanner, piScanner, promptPolicy, flags, celEng, nil)
+	return newScanner(logger, tracerProvider, meterProvider, db, customRuleScanner, piiScanner, piScanner, promptPolicy, flags, celEng, recorder, nil)
 }
 
 // NewScannerWithEnforcementDispatcher creates a scanner with Pub/Sub enforcement enabled when flagged.
@@ -259,10 +263,11 @@ func NewScannerWithEnforcementDispatcher(
 	piScanner *promptinjection.Scanner,
 	promptPolicy *promptpolicy.Scanner,
 	flags feature.Provider,
+	recorder *riskmeter.Recorder,
 	celEng *celenv.Engine,
 	dispatcher EnforcementDispatcher,
 ) (*Scanner, error) {
-	return newScanner(logger, tracerProvider, meterProvider, db, customRuleScanner, piiScanner, piScanner, promptPolicy, flags, celEng, dispatcher)
+	return newScanner(logger, tracerProvider, meterProvider, db, customRuleScanner, piiScanner, piScanner, promptPolicy, flags, celEng, recorder, dispatcher)
 }
 
 func newScanner(
@@ -276,13 +281,14 @@ func newScanner(
 	promptPolicy *promptpolicy.Scanner,
 	flags feature.Provider,
 	celEng *celenv.Engine,
+	recorder *riskmeter.Recorder,
 	dispatcher EnforcementDispatcher,
 ) (*Scanner, error) {
 	if piScanner == nil {
 		piScanner = promptinjection.NewScanner(logger, promptinjection.NoopClassifier)
 	}
 
-	gitleaksScanner := gitleaks.NewScanner()
+	gitleaksScanner := gitleaks.NewScanner(recorder)
 	if err := gitleaksScanner.Prime(); err != nil {
 		return nil, fmt.Errorf("prime gitleaks scanner: %w", err)
 	}
@@ -428,10 +434,11 @@ func (s *Scanner) ScanForEnforcement(
 		warnWinner       atomic.Pointer[ScanResult] // challenge; kept only if no hard deny matches
 		matchErr         = errors.New("risk policy enforcing match")
 	)
+	invocationID := uuid.NewString()
 	g, gctx := errgroup.WithContext(ctx)
 	for _, p := range applicablePolicies {
 		g.Go(func() error {
-			result, scanErr := s.scanPolicy(gctx, p, userID, text, messageType, toolName, promptPoliciesOn, recommendedScopesOn, pubsubFindings)
+			result, scanErr := s.scanPolicy(gctx, p, invocationID, userID, text, messageType, toolName, promptPoliciesOn, recommendedScopesOn, pubsubFindings)
 			if scanErr != nil {
 				if errors.Is(scanErr, context.Canceled) {
 					return nil
@@ -588,7 +595,7 @@ func (s *Scanner) recordScan(ctx context.Context, projectID string, outcome o11y
 // text per call - its internal worker pool only fans out when n > 1, so
 // per-policy parallelism over sources buys roughly nothing. The
 // across-policies fan-out in ScanForEnforcement is the real win.
-func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, userID string, text string, messageType message.Type, toolName string, promptPoliciesOn bool, recommendedScopesOn bool, pubsubFindings map[string][]scanners.Finding) (result *ScanResult, retErr error) {
+func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, invocationID, userID, text string, messageType message.Type, toolName string, promptPoliciesOn bool, recommendedScopesOn bool, pubsubFindings map[string][]scanners.Finding) (result *ScanResult, retErr error) {
 	// Per-policy child span so an individual gitleaks/presidio/judge span
 	// attributes to the policy that spawned it (the g.Go fan-out threads gctx
 	// here, so this span parents under risk.scanForEnforcement).
@@ -628,7 +635,7 @@ func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, userID
 		if !categoryScope.SourceInScope(view, promptpolicy.Source) {
 			return nil, nil
 		}
-		return s.scanPromptPolicy(ctx, policy, userID, text, messageType, toolName, promptPoliciesOn), nil
+		return s.scanPromptPolicy(ctx, policy, invocationID, userID, text, messageType, toolName, promptPoliciesOn), nil
 	}
 
 	disabled := ra.NewDisabledRuleSet(policy.DisabledRules)
@@ -652,7 +659,8 @@ func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, userID
 	// applied above via the policy's scope_exempt.
 	var customFindings []scanners.Finding
 	if len(policy.CustomRuleIds) > 0 {
-		customFindings, err = s.scanCustomRules(ctx, policy, view)
+		evaluation := realtimeEvaluation(policy, invocationID, riskmeter.DetectorCustomRules)
+		customFindings, err = s.scanCustomRules(riskmeter.WithEvaluation(ctx, evaluation), policy, view)
 		if err != nil {
 			// A broken custom rule must not disable the built-in detectors (a
 			// fail-open bypass); drop its findings and keep scanning.
@@ -689,7 +697,8 @@ func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, userID
 		case ra.SourceGitleaks:
 			gitleaksFindings := pubsubFindings[ra.SourceGitleaks]
 			if pubsubFindings == nil {
-				gitleaksFindings, err = s.scanGitleaks(ctx, text)
+				evaluation := realtimeEvaluation(policy, invocationID, riskmeter.DetectorGitleaks)
+				gitleaksFindings, err = s.scanGitleaks(riskmeter.WithEvaluation(ctx, evaluation), text)
 				if err != nil {
 					return failWithHeldSentinel(fmt.Errorf("gitleaks scan: %w", err))
 				}
@@ -719,12 +728,14 @@ func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, userID
 				if s.piiScanner == nil {
 					continue
 				}
+				evaluation := realtimeEvaluation(policy, invocationID, riskmeter.DetectorPresidio)
 				batchResults, analyzeErr := s.piiScanner.AnalyzeBatch(
 					ctx,
 					[]string{text},
 					policy.PresidioEntities,
 					ra.PresidioScoreThresholdFromConfig(policy.AnalyzerConfig),
 					func() {},
+					evaluation,
 				)
 				if analyzeErr != nil {
 					return failWithHeldSentinel(fmt.Errorf("presidio scan: %w", analyzeErr))
@@ -775,7 +786,8 @@ func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, userID
 				}
 			}
 		case ra.SourcePromptInjection:
-			findings, err := s.piScanner.Scan(ctx, text, policy.OrganizationID, policy.ProjectID.String(), userID, judgemessage.New(messageType, toolName, text))
+			evaluation := realtimeEvaluation(policy, invocationID, riskmeter.DetectorPromptInjection)
+			findings, err := s.piScanner.Scan(riskmeter.WithEvaluation(ctx, evaluation), text, policy.OrganizationID, policy.ProjectID.String(), userID, judgemessage.New(messageType, toolName, text))
 			if err != nil {
 				return failWithHeldSentinel(fmt.Errorf("prompt injection scan: %w", err))
 			}
@@ -839,7 +851,7 @@ func realtimeMessageView(text string, messageType message.Type, toolName string)
 // filtered policies to those whose message_types apply to this message, so the
 // judge runs for whatever message types the policy declares. Returns nil when
 // the judge does not match (including fail-open on judge error).
-func (s *Scanner) scanPromptPolicy(ctx context.Context, policy repo.RiskPolicy, userID string, text string, messageType message.Type, toolName string, promptPoliciesOn bool) *ScanResult {
+func (s *Scanner) scanPromptPolicy(ctx context.Context, policy repo.RiskPolicy, invocationID, userID, text string, messageType message.Type, toolName string, promptPoliciesOn bool) *ScanResult {
 	cfg := promptpolicy.ParseConfig(policy.ModelConfig)
 	if !promptPoliciesOn {
 		return nil
@@ -853,7 +865,8 @@ func (s *Scanner) scanPromptPolicy(ctx context.Context, policy repo.RiskPolicy, 
 		// text is the type-appropriate body the hook layer already flattened:
 		// the prompt for user messages, tool-input JSON for tool_request,
 		// tool-output JSON for tool_response.
-		findings = s.promptPolicy.Scan(ctx, policy.OrganizationID, policy.ProjectID.String(), userID, prompt, cfg, judgemessage.New(messageType, toolName, text))
+		evaluation := realtimeEvaluation(policy, invocationID, riskmeter.DetectorPromptPolicy)
+		findings = s.promptPolicy.Scan(riskmeter.WithEvaluation(ctx, evaluation), policy.OrganizationID, policy.ProjectID.String(), userID, prompt, cfg, judgemessage.New(messageType, toolName, text))
 	} else {
 		findings = promptpolicy.FindingsFromEvaluation(cfg, nil, nil, true)
 	}
@@ -1054,6 +1067,22 @@ func (s *Scanner) projectFlagEnabled(ctx context.Context, orgID string, projectI
 	return policyflags.ProjectFlagEnabled(ctx, s.logger, s.repo, s.flags, orgID, projectID, flag)
 }
 
+func realtimeEvaluation(policy repo.RiskPolicy, invocationID string, detector meteringv1.RiskEvaluation_Detector) riskmeter.Evaluation {
+	return riskmeter.Evaluation{
+		OrganizationID: policy.OrganizationID,
+		ProjectID:      policy.ProjectID.String(),
+		OperationID: riskmeter.OperationID(
+			"realtime_invocation", invocationID, policy.ID.String(),
+			strconv.FormatInt(policy.Version, 10),
+		),
+		Detector:      detector,
+		ExecutionMode: riskmeter.ModeRealtime,
+		PolicyID:      policy.ID.String(),
+		PolicyVersion: policy.Version,
+		OccurredAt:    time.Now().UTC(),
+	}
+}
+
 func (s *Scanner) scanCustomRules(ctx context.Context, policy repo.RiskPolicy, view ra.MessageView) ([]scanners.Finding, error) {
 	if len(policy.CustomRuleIds) == 0 {
 		return []scanners.Finding{}, nil
@@ -1070,6 +1099,7 @@ func (s *Scanner) scanCustomRules(ctx context.Context, policy repo.RiskPolicy, v
 		Content:       view.Content,
 		Kind:          view.Type,
 		ToolCalls:     toolCalls,
+		Evaluation:    nil,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("scan custom detection rules: %w", err)

--- a/server/internal/risk/scanner_test.go
+++ b/server/internal/risk/scanner_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/risk"
 	"github.com/speakeasy-api/gram/server/internal/risk/enforcereply"
 	riskrepo "github.com/speakeasy-api/gram/server/internal/risk/repo"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
 	"github.com/speakeasy-api/gram/server/internal/scanners"
 	"github.com/speakeasy-api/gram/server/internal/scanners/promptinjection"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
@@ -78,7 +79,7 @@ func (e *recordingPIEngine) Classify(_ context.Context, req promptinjection.Requ
 	return results, nil
 }
 
-func (l *instrumentedPIIScanner) AnalyzeBatch(ctx context.Context, texts []string, entities []string, _ float64, _ func()) ([][]scanners.Finding, error) {
+func (l *instrumentedPIIScanner) AnalyzeBatch(ctx context.Context, texts []string, entities []string, _ float64, _ func(), _ ...riskmeter.Evaluation) ([][]scanners.Finding, error) {
 	l.callCount.Add(1)
 	cur := l.inflight.Add(1)
 	defer l.inflight.Add(-1)
@@ -220,6 +221,7 @@ func newScannerWithPIEngine(t *testing.T, ti *testInstance, flags *feature.InMem
 		promptinjection.NewScanner(testenv.NewLogger(t), engine.Classify),
 		nil,
 		flags,
+		nil,
 		testCELEngine(t),
 	)
 	require.NoError(t, err)
@@ -245,6 +247,7 @@ func newScannerWithDispatcher(t *testing.T, ti *testInstance, pii risk_analysis.
 		nil,
 		nil,
 		flags,
+		nil,
 		testCELEngine(t),
 		dispatcher,
 	)
@@ -347,6 +350,7 @@ func TestScanner_PubsubKeepsPromptInjectionLocal(t *testing.T) {
 		promptinjection.NewScanner(testenv.NewLogger(t), engine.Classify),
 		nil,
 		pubsubEnforcementFlags(ctx),
+		nil,
 		testCELEngine(t),
 		dispatcher,
 	)
@@ -433,6 +437,7 @@ func TestScanner_FanOutAcrossPoliciesIsConcurrent(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 		testCELEngine(t),
 	)
 	require.NoError(t, err)
@@ -466,6 +471,7 @@ func TestScanner_ScanForEnforcement_SkipsGrantResolutionWhenNoPolicies(t *testin
 		testenv.NewMeterProvider(t),
 		ti.conn,
 		newTestCustomRuleAnalyzer(t, ti.conn),
+		nil,
 		nil,
 		nil,
 		nil,
@@ -505,6 +511,7 @@ func TestScanner_FirstMatchCancelsSiblings(t *testing.T) {
 		ti.conn,
 		newTestCustomRuleAnalyzer(t, ti.conn),
 		pii,
+		nil,
 		nil,
 		nil,
 		nil,
@@ -576,6 +583,7 @@ func TestScanner_CustomDetectionRuleEnforcement(t *testing.T) {
 		testenv.NewMeterProvider(t),
 		ti.conn,
 		newTestCustomRuleAnalyzer(t, ti.conn),
+		nil,
 		nil,
 		nil,
 		nil,
@@ -655,6 +663,7 @@ func TestScanner_ScanForEnforcement_BlockWinsOverWarn(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 		testCELEngine(t),
 	)
 	require.NoError(t, err)
@@ -713,6 +722,7 @@ func TestScanner_OutOfScopeQuarantineDoesNotDelayBlock(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 		testCELEngine(t),
 	)
 	require.NoError(t, err)
@@ -739,6 +749,7 @@ func TestScanner_RespectsMessageTypes(t *testing.T) {
 		ti.conn,
 		newTestCustomRuleAnalyzer(t, ti.conn),
 		pii,
+		nil,
 		nil,
 		nil,
 		nil,
@@ -874,7 +885,7 @@ type deadLetterPIIScanner struct {
 	alsoRealFinding bool
 }
 
-func (d *deadLetterPIIScanner) AnalyzeBatch(_ context.Context, texts []string, _ []string, _ float64, _ func()) ([][]scanners.Finding, error) {
+func (d *deadLetterPIIScanner) AnalyzeBatch(_ context.Context, texts []string, _ []string, _ float64, _ func(), _ ...riskmeter.Evaluation) ([][]scanners.Finding, error) {
 	out := make([][]scanners.Finding, len(texts))
 	for i := range texts {
 		out[i] = []scanners.Finding{{
@@ -928,6 +939,7 @@ func newDeadLetterScanner(t *testing.T, ti *testInstance, pii *deadLetterPIIScan
 		ti.conn,
 		newTestCustomRuleAnalyzer(t, ti.conn),
 		pii,
+		nil,
 		nil,
 		nil,
 		nil,
@@ -1016,7 +1028,7 @@ type deadLetterThenErrorPIIScanner struct {
 	err   error
 }
 
-func (d *deadLetterThenErrorPIIScanner) AnalyzeBatch(_ context.Context, texts []string, _ []string, _ float64, _ func()) ([][]scanners.Finding, error) {
+func (d *deadLetterThenErrorPIIScanner) AnalyzeBatch(_ context.Context, texts []string, _ []string, _ float64, _ func(), _ ...riskmeter.Evaluation) ([][]scanners.Finding, error) {
 	if d.calls.Add(1) > 1 {
 		if d.err != nil {
 			return nil, d.err
@@ -1070,6 +1082,7 @@ func TestScanner_PresidioDeadLetterSurvivesLaterSourceError(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 		testCELEngine(t),
 	)
 	require.NoError(t, err)
@@ -1114,6 +1127,7 @@ func TestScanner_PresidioDeadLetterDiscardedOnDeadline(t *testing.T) {
 		ti.conn,
 		newTestCustomRuleAnalyzer(t, ti.conn),
 		pii,
+		nil,
 		nil,
 		nil,
 		nil,

--- a/server/internal/risk/setup_test.go
+++ b/server/internal/risk/setup_test.go
@@ -61,7 +61,7 @@ func testPresetLibrary(t *testing.T) *presetlib.Library {
 
 func newTestCustomRuleAnalyzer(t *testing.T, conn riskrepo.DBTX) *customruleanalyzer.Scanner {
 	t.Helper()
-	scanner, err := customruleanalyzer.NewScanner(conn)
+	scanner, err := customruleanalyzer.NewScanner(conn, nil)
 	require.NoError(t, err)
 
 	return scanner

--- a/server/internal/risk/shadow_mcp_policy_limit_test.go
+++ b/server/internal/risk/shadow_mcp_policy_limit_test.go
@@ -158,6 +158,7 @@ func TestScanner_LookupShadowMCPBlockingPolicy_CarriesDispositionAndBlocklist(t 
 		nil,
 		nil,
 		nil,
+		nil,
 		testCELEngine(t),
 	)
 	require.NoError(t, err)
@@ -189,6 +190,7 @@ func TestScanner_LookupShadowMCPBlockingPolicy_BlockAllDisposition(t *testing.T)
 		testenv.NewMeterProvider(t),
 		ti.conn,
 		newTestCustomRuleAnalyzer(t, ti.conn),
+		nil,
 		nil,
 		nil,
 		nil,

--- a/server/internal/riskmeter/inference/observer.go
+++ b/server/internal/riskmeter/inference/observer.go
@@ -1,0 +1,66 @@
+// Package inference adapts provider completion attempts to risk measurements.
+package inference
+
+import (
+	"context"
+	"fmt"
+
+	meteringv1 "github.com/speakeasy-api/gram/infra/gen/gram/metering/v1"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+)
+
+// Observer records physical provider attempts associated with a logical risk evaluation.
+type Observer struct {
+	recorder *riskmeter.Recorder
+}
+
+var _ openrouter.CompletionAttemptObserver = (*Observer)(nil)
+
+// NewObserver creates an inference observer backed by recorder.
+func NewObserver(recorder *riskmeter.Recorder) *Observer {
+	return &Observer{recorder: recorder}
+}
+
+// ObserveCompletionAttempt records attempt when ctx carries a risk evaluation.
+func (o *Observer) ObserveCompletionAttempt(ctx context.Context, attempt openrouter.CompletionAttempt) error {
+	if o == nil || o.recorder == nil {
+		return nil
+	}
+
+	evaluation, ok := riskmeter.EvaluationFromContext(ctx)
+	if !ok {
+		return nil
+	}
+	evaluation.OccurredAt = attempt.StartedAt
+
+	outcome, err := mapOutcome(attempt.Status)
+	if err != nil {
+		return err
+	}
+
+	if err := o.recorder.RecordInference(ctx, evaluation, outcome, &riskmeter.Inference{
+		Model:             conv.Default(attempt.ReturnedModel, attempt.RequestedModel),
+		ProviderRequestID: attempt.ProviderRequestID,
+		PromptTokens:      attempt.PromptTokens,
+		CompletionTokens:  attempt.CompletionTokens,
+		CostUSD:           attempt.CostUSD,
+	}); err != nil {
+		return fmt.Errorf("record inference attempt: %w", err)
+	}
+	return nil
+}
+
+func mapOutcome(status openrouter.CompletionAttemptStatus) (meteringv1.RiskEvaluation_Outcome, error) {
+	switch status {
+	case openrouter.CompletionAttemptSucceeded:
+		return riskmeter.OutcomeCompleted, nil
+	case openrouter.CompletionAttemptFailed:
+		return riskmeter.OutcomeFailed, nil
+	case openrouter.CompletionAttemptCancelled:
+		return riskmeter.OutcomeCancelled, nil
+	default:
+		return meteringv1.RiskEvaluation_OUTCOME_UNSPECIFIED, fmt.Errorf("unsupported completion attempt status %q", status)
+	}
+}

--- a/server/internal/riskmeter/inference/observer_test.go
+++ b/server/internal/riskmeter/inference/observer_test.go
@@ -1,0 +1,126 @@
+package inference_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	meteringv1 "github.com/speakeasy-api/gram/infra/gen/gram/metering/v1"
+	"github.com/speakeasy-api/gram/infra/pkg/gcp"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter/inference"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
+)
+
+func TestObserverMapsPhysicalAttemptsFromRiskContext(t *testing.T) {
+	t.Parallel()
+
+	publisher := &capturePublisher{messages: nil}
+	observer := inference.NewObserver(riskmeter.NewRecorder(testenv.NewLogger(t), publisher))
+	startedAt := time.Date(2026, time.September, 6, 12, 0, 0, 0, time.UTC)
+	evaluation := riskmeter.Evaluation{
+		OrganizationID: "test-org",
+		ProjectID:      "b5f82eb4-982d-4db3-8f3a-78784255c4d4",
+		OperationID:    "logical-evaluation",
+		Detector:       riskmeter.DetectorPromptPolicy,
+		ExecutionMode:  riskmeter.ModeRealtime,
+		PolicyID:       "policy-test",
+		PolicyVersion:  3,
+		OccurredAt:     startedAt.Add(-time.Hour),
+	}
+	ctx := riskmeter.WithEvaluation(t.Context(), evaluation)
+	promptTokens := int64(17)
+	completionTokens := int64(3)
+	costUSD := 0.01
+
+	require.NoError(t, observer.ObserveCompletionAttempt(ctx, openrouter.CompletionAttempt{
+		StartedAt:         startedAt,
+		CompletedAt:       startedAt.Add(time.Second),
+		RequestedModel:    "requested-model",
+		ReturnedModel:     "returned-model",
+		ProviderRequestID: "provider-success",
+		PromptTokens:      &promptTokens,
+		CompletionTokens:  &completionTokens,
+		CostUSD:           &costUSD,
+		Status:            openrouter.CompletionAttemptSucceeded,
+		Err:               nil,
+	}))
+	require.NoError(t, observer.ObserveCompletionAttempt(ctx, openrouter.CompletionAttempt{
+		StartedAt:         startedAt.Add(2 * time.Second),
+		CompletedAt:       startedAt.Add(3 * time.Second),
+		RequestedModel:    "fallback-model",
+		ReturnedModel:     "",
+		ProviderRequestID: "provider-failed",
+		PromptTokens:      nil,
+		CompletionTokens:  nil,
+		CostUSD:           nil,
+		Status:            openrouter.CompletionAttemptFailed,
+		Err:               nil,
+	}))
+	require.NoError(t, observer.ObserveCompletionAttempt(ctx, openrouter.CompletionAttempt{
+		StartedAt:         startedAt.Add(4 * time.Second),
+		CompletedAt:       startedAt.Add(5 * time.Second),
+		RequestedModel:    "cancelled-model",
+		ReturnedModel:     "",
+		ProviderRequestID: "",
+		PromptTokens:      nil,
+		CompletionTokens:  nil,
+		CostUSD:           nil,
+		Status:            openrouter.CompletionAttemptCancelled,
+		Err:               context.Canceled,
+	}))
+
+	require.Len(t, publisher.messages, 3)
+	require.Equal(t, meteringv1.RiskEvaluation_OUTCOME_COMPLETED, publisher.messages[0].GetOutcome())
+	require.Equal(t, meteringv1.RiskEvaluation_OUTCOME_FAILED, publisher.messages[1].GetOutcome())
+	require.Equal(t, meteringv1.RiskEvaluation_OUTCOME_CANCELLED, publisher.messages[2].GetOutcome())
+	require.Equal(t, "returned-model", publisher.messages[0].GetModel())
+	require.Equal(t, "fallback-model", publisher.messages[1].GetModel())
+	require.Equal(t, startedAt.Format(time.RFC3339Nano), publisher.messages[0].GetOccurredAt())
+	require.Equal(t, startedAt.Add(2*time.Second).Format(time.RFC3339Nano), publisher.messages[1].GetOccurredAt())
+	require.Equal(t, int64(17), publisher.messages[0].GetPromptTokens())
+	require.Equal(t, int64(3), publisher.messages[0].GetCompletionTokens())
+	require.InEpsilon(t, 0.01, publisher.messages[0].GetCostUsd(), 1e-12)
+	require.False(t, publisher.messages[1].HasPromptTokens())
+	require.False(t, publisher.messages[1].HasCompletionTokens())
+	require.False(t, publisher.messages[1].HasCostUsd())
+	for _, message := range publisher.messages {
+		require.Equal(t, riskmeter.RecordKindInference, message.GetRecordKind())
+		require.False(t, message.HasStokens())
+		require.Equal(t, evaluation.OperationID, message.GetOperationId())
+	}
+}
+
+func TestObserverIgnoresAttemptsOutsideRiskEvaluation(t *testing.T) {
+	t.Parallel()
+
+	publisher := &capturePublisher{messages: nil}
+	observer := inference.NewObserver(riskmeter.NewRecorder(testenv.NewLogger(t), publisher))
+	require.NoError(t, observer.ObserveCompletionAttempt(t.Context(), openrouter.CompletionAttempt{
+		StartedAt:         time.Now().UTC(),
+		CompletedAt:       time.Now().UTC(),
+		RequestedModel:    "model",
+		ReturnedModel:     "model",
+		ProviderRequestID: "provider-request",
+		PromptTokens:      nil,
+		CompletionTokens:  nil,
+		CostUSD:           nil,
+		Status:            openrouter.CompletionAttemptSucceeded,
+		Err:               nil,
+	}))
+	require.Empty(t, publisher.messages)
+}
+
+type capturePublisher struct {
+	messages []*meteringv1.RiskEvaluation
+}
+
+func (p *capturePublisher) Publish(_ context.Context, message *meteringv1.RiskEvaluation, _ ...gcp.PublishOption) gcp.PublishResult {
+	p.messages = append(p.messages, message)
+	return gcp.NewSuccessPublishResult()
+}
+
+func (*capturePublisher) Stop(context.Context) error { return nil }

--- a/server/internal/scanners/customruleanalyzer/handler.go
+++ b/server/internal/scanners/customruleanalyzer/handler.go
@@ -11,6 +11,7 @@ import (
 	riskv1 "github.com/speakeasy-api/gram/infra/gen/gram/risk/v1"
 	"github.com/speakeasy-api/gram/infra/pkg/gcp"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
 	"github.com/speakeasy-api/gram/server/internal/scanners"
 )
 
@@ -60,12 +61,19 @@ func (h *Handler) Handle(ctx context.Context, m *riskv1.CustomRulesAnalysis, _ g
 		toolCalls = append(toolCalls, ScanToolCall{Name: tc.GetName(), Arguments: tc.GetArguments()})
 	}
 
+	evaluation := scanners.EvaluationForAnalysis(
+		m.GetOrganizationId(), m.GetProjectId(), m.GetRequestId(),
+		m.GetChatMessageId(), m.GetContentPartId(),
+		m.GetRiskPolicyId(), m.GetRiskPolicyVersion(),
+		riskmeter.DetectorCustomRules, riskmeter.ModeShadow, m.GetCreatedAt(),
+	)
 	findings, err := h.scanner.Scan(ctx, ScanRequest{
 		ProjectID:     projectID,
 		CustomRuleIDs: m.GetCustomRuleIds(),
 		Content:       m.GetContent(),
 		Kind:          m.GetKind(),
 		ToolCalls:     toolCalls,
+		Evaluation:    &evaluation,
 	})
 	var loadErr *loadError
 	switch {

--- a/server/internal/scanners/customruleanalyzer/handler_test.go
+++ b/server/internal/scanners/customruleanalyzer/handler_test.go
@@ -14,7 +14,7 @@ import (
 
 func newTestScanner(t *testing.T, conn repo.DBTX) *customruleanalyzer.Scanner {
 	t.Helper()
-	s, err := customruleanalyzer.NewScanner(conn)
+	s, err := customruleanalyzer.NewScanner(conn, nil)
 	require.NoError(t, err)
 
 	return s

--- a/server/internal/scanners/customruleanalyzer/scanner.go
+++ b/server/internal/scanners/customruleanalyzer/scanner.go
@@ -2,6 +2,7 @@ package customruleanalyzer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -9,6 +10,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/risk/celenv"
 	"github.com/speakeasy-api/gram/server/internal/risk/customrules"
 	"github.com/speakeasy-api/gram/server/internal/risk/repo"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
 	"github.com/speakeasy-api/gram/server/internal/scanners"
 	"github.com/speakeasy-api/gram/server/internal/toolref"
 )
@@ -23,6 +25,7 @@ type ScanRequest struct {
 	Content       string
 	Kind          string
 	ToolCalls     []ScanToolCall
+	Evaluation    *riskmeter.Evaluation
 }
 
 // ScanToolCall is one tool invocation carried in the message.
@@ -42,23 +45,25 @@ type ScanBatchRequest struct {
 
 // ScanMessage is a single message within a batch: the CEL input to evaluate.
 type ScanMessage struct {
-	Content   string
-	Kind      string
-	ToolCalls []ScanToolCall
+	Content    string
+	Kind       string
+	ToolCalls  []ScanToolCall
+	Evaluation *riskmeter.Evaluation
 }
 
 type Scanner struct {
-	db   repo.DBTX
-	eval *evaluator
+	db       repo.DBTX
+	eval     *evaluator
+	recorder *riskmeter.Recorder
 }
 
-func NewScanner(db repo.DBTX) (*Scanner, error) {
+func NewScanner(db repo.DBTX, recorder *riskmeter.Recorder) (*Scanner, error) {
 	eval, err := newEvaluator(evaluatorCacheSize)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Scanner{db: db, eval: eval}, nil
+	return &Scanner{db: db, eval: eval, recorder: recorder}, nil
 }
 
 func (s *Scanner) Scan(ctx context.Context, req ScanRequest) ([]scanners.Finding, error) {
@@ -71,10 +76,15 @@ func (s *Scanner) Scan(ctx context.Context, req ScanRequest) ([]scanners.Finding
 		return []scanners.Finding{}, nil
 	}
 
-	return s.evaluate(rules, celMessageFromMessage(ScanMessage{
-		Content:   req.Content,
-		Kind:      req.Kind,
-		ToolCalls: req.ToolCalls,
+	scanCtx := ctx
+	if req.Evaluation != nil {
+		scanCtx = riskmeter.WithEvaluation(ctx, *req.Evaluation)
+	}
+	return s.evaluate(scanCtx, rules, celMessageFromMessage(ScanMessage{
+		Content:    req.Content,
+		Kind:       req.Kind,
+		ToolCalls:  req.ToolCalls,
+		Evaluation: req.Evaluation,
 	}))
 }
 
@@ -103,7 +113,11 @@ func (s *Scanner) ScanBatch(ctx context.Context, req ScanBatchRequest) ([][]scan
 	}
 
 	for i, m := range req.Messages {
-		findings, err := s.evaluate(rules, celMessageFromMessage(m))
+		scanCtx := ctx
+		if m.Evaluation != nil {
+			scanCtx = riskmeter.WithEvaluation(ctx, *m.Evaluation)
+		}
+		findings, err := s.evaluate(scanCtx, rules, celMessageFromMessage(m))
 		if err != nil {
 			return nil, err
 		}
@@ -116,13 +130,39 @@ func (s *Scanner) ScanBatch(ctx context.Context, req ScanBatchRequest) ([][]scan
 // evaluate runs each rule's detection expression against a single CEL message
 // and collects the matched spans as findings. It is shared by Scan and
 // ScanBatch so both produce identical findings; only rule loading differs.
-func (s *Scanner) evaluate(rules []customrules.Rule, msg celenv.Message) ([]scanners.Finding, error) {
-	findings := []scanners.Finding{}
+func (s *Scanner) evaluate(ctx context.Context, rules []customrules.Rule, msg celenv.Message) (findings []scanners.Finding, retErr error) {
+	fragments := make([]string, 0, 1+2*len(msg.Tools))
+	fragments = append(fragments, msg.Content)
+	for _, tool := range msg.Tools {
+		fragments = append(fragments, tool.Name, tool.Args)
+	}
+
+	attempted := false
+	defer func() {
+		if !attempted {
+			return
+		}
+		evaluation, ok := riskmeter.EvaluationFromContext(ctx)
+		if !ok || evaluation.OperationID == "" {
+			return
+		}
+		outcome := riskmeter.OutcomeCompleted
+		switch {
+		case errors.Is(retErr, context.Canceled), errors.Is(retErr, context.DeadlineExceeded):
+			outcome = riskmeter.OutcomeCancelled
+		case retErr != nil:
+			outcome = riskmeter.OutcomeFailed
+		}
+		_ = s.recorder.Record(ctx, evaluation, fragments, outcome, nil)
+	}()
+
+	findings = []scanners.Finding{}
 	for _, rule := range rules {
 		expr := rule.EffectiveDetectionExpr()
 		if expr == "" {
 			continue
 		}
+		attempted = true
 
 		spans, matched, err := s.eval.execute(expr, msg)
 		if err != nil {
@@ -133,19 +173,19 @@ func (s *Scanner) evaluate(rules []customrules.Rule, msg celenv.Message) ([]scan
 			continue
 		}
 
-		for _, s := range spans {
+		for _, span := range spans {
 			findings = append(findings, scanners.Finding{
 				RuleID:       scanners.GuardRuleID(rule.RuleID),
 				Description:  rule.DisplayDescription(),
-				Match:        s.Value,
-				StartPos:     s.Start,
-				EndPos:       s.End,
+				Match:        span.Value,
+				StartPos:     span.Start,
+				EndPos:       span.End,
 				Tags:         []string{},
 				Source:       Source,
 				Confidence:   1.0,
-				SpanGroupKey: s.ToolCallID,
-				Field:        s.Target,
-				Path:         s.Path,
+				SpanGroupKey: span.ToolCallID,
+				Field:        span.Target,
+				Path:         span.Path,
 
 				// The span's ToolCallID is the tool NAME (per-name grouping
 				// key), not a recorded call id, so it must never be published

--- a/server/internal/scanners/customruleanalyzer/scanner_test.go
+++ b/server/internal/scanners/customruleanalyzer/scanner_test.go
@@ -17,6 +17,7 @@ func scanReq(p seededProject, content string, ruleIDs ...string) customruleanaly
 		Content:       content,
 		Kind:          "user_message",
 		ToolCalls:     nil,
+		Evaluation:    nil,
 	}
 }
 
@@ -108,6 +109,7 @@ func TestScan_ToolCallRuleMatches(t *testing.T) {
 		Content:       "",
 		Kind:          "tool_request",
 		ToolCalls:     []customruleanalyzer.ScanToolCall{{Name: "mcp__fs__delete_file", Arguments: "{}"}},
+		Evaluation:    nil,
 	}
 
 	findings, err := scanner.Scan(t.Context(), req)
@@ -141,6 +143,7 @@ func TestScan_ToolArgsGetPopulatesPath(t *testing.T) {
 		Content:       "",
 		Kind:          "tool_request",
 		ToolCalls:     []customruleanalyzer.ScanToolCall{{Name: "shell:run_bash_command", Arguments: `{"command":"DROP TABLE users"}`}},
+		Evaluation:    nil,
 	}
 
 	findings, err := scanner.Scan(t.Context(), req)
@@ -237,9 +240,9 @@ func TestScanBatch_IndexAlignedFindings(t *testing.T) {
 		ProjectID:     p.projectID,
 		CustomRuleIDs: []string{"custom.secret"},
 		Messages: []customruleanalyzer.ScanMessage{
-			{Content: "here is a secret value", Kind: "user_message"},
-			{Content: "totally benign message", Kind: "user_message"},
-			{Content: "secret then another secret", Kind: "user_message"},
+			{Content: "here is a secret value", Kind: "user_message", ToolCalls: nil, Evaluation: nil},
+			{Content: "totally benign message", Kind: "user_message", ToolCalls: nil, Evaluation: nil},
+			{Content: "secret then another secret", Kind: "user_message", ToolCalls: nil, Evaluation: nil},
 		},
 	})
 	require.NoError(t, err)
@@ -287,8 +290,8 @@ func TestScanBatch_NoRulesSelectedReturnsPerMessageEmpty(t *testing.T) {
 		ProjectID:     p.projectID,
 		CustomRuleIDs: nil,
 		Messages: []customruleanalyzer.ScanMessage{
-			{Content: "here is a secret value", Kind: "user_message"},
-			{Content: "another secret", Kind: "user_message"},
+			{Content: "here is a secret value", Kind: "user_message", ToolCalls: nil, Evaluation: nil},
+			{Content: "another secret", Kind: "user_message", ToolCalls: nil, Evaluation: nil},
 		},
 	})
 	require.NoError(t, err)

--- a/server/internal/scanners/evaluation.go
+++ b/server/internal/scanners/evaluation.go
@@ -1,0 +1,39 @@
+package scanners
+
+import (
+	"strconv"
+	"time"
+
+	meteringv1 "github.com/speakeasy-api/gram/infra/gen/gram/metering/v1"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
+)
+
+// EvaluationForAnalysis builds retry-stable metadata for an anchored scanner request.
+func EvaluationForAnalysis(organizationID, projectID, requestID, chatMessageID, contentPartID, policyID string, policyVersion int64, detector meteringv1.RiskEvaluation_Detector, mode meteringv1.RiskEvaluation_ExecutionMode, createdAt string) riskmeter.Evaluation {
+	anchorKind := "request"
+	anchorID := requestID
+	if chatMessageID != "" {
+		anchorKind = "chat_message"
+		anchorID = chatMessageID
+	} else if contentPartID != "" {
+		anchorKind = "content_part"
+		anchorID = contentPartID
+	}
+
+	occurredAt, err := time.Parse(time.RFC3339Nano, createdAt)
+	if err != nil {
+		occurredAt = time.Now().UTC()
+	} else {
+		occurredAt = occurredAt.UTC()
+	}
+	return riskmeter.Evaluation{
+		OrganizationID: organizationID,
+		ProjectID:      projectID,
+		OperationID:    riskmeter.OperationID(anchorKind, anchorID, policyID, strconv.FormatInt(policyVersion, 10)),
+		Detector:       detector,
+		ExecutionMode:  mode,
+		PolicyID:       policyID,
+		PolicyVersion:  policyVersion,
+		OccurredAt:     occurredAt,
+	}
+}

--- a/server/internal/scanners/evaluation_test.go
+++ b/server/internal/scanners/evaluation_test.go
@@ -1,0 +1,30 @@
+package scanners_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
+	"github.com/speakeasy-api/gram/server/internal/scanners"
+)
+
+func TestEvaluationForAnalysisIgnoresBatchRequestForAnchoredWork(t *testing.T) {
+	t.Parallel()
+
+	first := scanners.EvaluationForAnalysis("org", "00000000-0000-0000-0000-000000000001", "batch-a", "message-1", "", "policy-1", 3, riskmeter.DetectorGitleaks, riskmeter.ModeShadow, "2026-09-06T12:00:00Z")
+	regrouped := scanners.EvaluationForAnalysis("org", "00000000-0000-0000-0000-000000000001", "batch-b", "message-1", "", "policy-1", 3, riskmeter.DetectorGitleaks, riskmeter.ModeShadow, "2026-09-06T12:01:00Z")
+
+	require.Equal(t, first.OperationID, regrouped.OperationID)
+	require.Equal(t, riskmeter.EvaluationID(first), riskmeter.EvaluationID(regrouped))
+}
+
+func TestEvaluationForAnalysisUsesRequestForUnanchoredWork(t *testing.T) {
+	t.Parallel()
+
+	first := scanners.EvaluationForAnalysis("org", "00000000-0000-0000-0000-000000000001", "request-a", "", "", "", 0, riskmeter.DetectorGitleaks, riskmeter.ModeRealtime, "2026-09-06T12:00:00Z")
+	second := scanners.EvaluationForAnalysis("org", "00000000-0000-0000-0000-000000000001", "request-b", "", "", "", 0, riskmeter.DetectorGitleaks, riskmeter.ModeRealtime, "2026-09-06T12:00:00Z")
+
+	require.NotEqual(t, first.OperationID, second.OperationID)
+	require.NotEqual(t, riskmeter.EvaluationID(first), riskmeter.EvaluationID(second))
+}

--- a/server/internal/scanners/gitleaks/aws_rules_test.go
+++ b/server/internal/scanners/gitleaks/aws_rules_test.go
@@ -25,7 +25,7 @@ const (
 
 func ruleSet(t *testing.T, content string) map[string]bool {
 	t.Helper()
-	findings, err := gitleaks.NewScanner().Scan(context.Background(), content)
+	findings, err := gitleaks.NewScanner(nil).Scan(context.Background(), content)
 	require.NoError(t, err)
 	out := map[string]bool{}
 	for _, f := range findings {
@@ -41,7 +41,7 @@ func TestExtendedConfig_MatchIsValueNotLabel(t *testing.T) {
 	t.Parallel()
 
 	content := `{ "SessionToken": "` + fakeToken + `" }`
-	findings, err := gitleaks.NewScanner().Scan(context.Background(), content)
+	findings, err := gitleaks.NewScanner(nil).Scan(context.Background(), content)
 	require.NoError(t, err)
 
 	var tok *scanners.Finding
@@ -127,7 +127,7 @@ func TestExtendedConfig_HashNextToIDNotDetected(t *testing.T) {
 func TestExtendedConfig_ConstructsCleanly(t *testing.T) {
 	t.Parallel()
 	require.NotPanics(t, func() {
-		require.NoError(t, gitleaks.NewScanner().Prime())
+		require.NoError(t, gitleaks.NewScanner(nil).Prime())
 	})
 }
 

--- a/server/internal/scanners/gitleaks/enforce_handler.go
+++ b/server/internal/scanners/gitleaks/enforce_handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/risk/categories"
 	"github.com/speakeasy-api/gram/server/internal/risk/enforcereply"
 	"github.com/speakeasy-api/gram/server/internal/risk/maskdisplay"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
 	"github.com/speakeasy-api/gram/server/internal/scanners"
 )
 
@@ -55,6 +56,7 @@ func NewEnforceHandler(
 	meterProvider metric.MeterProvider,
 	writer requestreply.ReplyBroker[*riskv1.EnforcementReply],
 	fingerprint FingerprintFinding,
+	recorder *riskmeter.Recorder,
 	cfg EnforceHandlerConfig,
 ) (*EnforceHandler, error) {
 	if writer == nil {
@@ -73,7 +75,7 @@ func NewEnforceHandler(
 	return &EnforceHandler{
 		logger:        logger.With(attr.SlogComponent("gitleaks-enforcer")),
 		writer:        writer,
-		scanner:       NewScanner(),
+		scanner:       NewScanner(recorder),
 		fingerprint:   fingerprint,
 		metrics:       metrics,
 		consumerID:    uuid.NewString(),
@@ -120,6 +122,12 @@ func (h *EnforceHandler) Handle(ctx context.Context, m *riskv1.GitleaksEnforceme
 		status = riskv1.EnforcementStatus_ENFORCEMENT_STATUS_ERROR
 		reason = fmt.Sprintf("enforcement content is %d bytes; maximum is %d bytes", len(m.GetContent()), enforcereply.MaxContentBytes)
 	} else {
+		evaluation := scanners.EvaluationForAnalysis(
+			m.GetOrganizationId(), m.GetProjectId(), m.GetRequestId(),
+			"", "", "", 0,
+			riskmeter.DetectorGitleaks, riskmeter.ModeRealtime, m.GetCreatedAt(),
+		)
+		ctx = riskmeter.WithEvaluation(ctx, evaluation)
 		var scanErr error
 		findings, scanErr = h.scanner.Scan(ctx, m.GetContent())
 		if scanErr != nil {

--- a/server/internal/scanners/gitleaks/enforce_handler_test.go
+++ b/server/internal/scanners/gitleaks/enforce_handler_test.go
@@ -46,7 +46,7 @@ func TestEnforceHandlerWritesSafePepperedReply(t *testing.T) {
 	require.NotEmpty(t, reply.GetDiagnostics().GetConsumerId())
 	require.NotEmpty(t, reply.GetFindings())
 
-	rawFindings, err := gitleaks.NewScanner().Scan(t.Context(), content)
+	rawFindings, err := gitleaks.NewScanner(nil).Scan(t.Context(), content)
 	require.NoError(t, err)
 	expectedFingerprints := make(map[string]string, len(rawFindings))
 	for _, finding := range rawFindings {

--- a/server/internal/scanners/gitleaks/handler.go
+++ b/server/internal/scanners/gitleaks/handler.go
@@ -9,6 +9,7 @@ import (
 	riskv1 "github.com/speakeasy-api/gram/infra/gen/gram/risk/v1"
 	"github.com/speakeasy-api/gram/infra/pkg/gcp"
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
 	"github.com/speakeasy-api/gram/server/internal/scanners"
 )
 
@@ -26,11 +27,11 @@ type Handler struct {
 // NewHandler builds a gitleaks subscription handler. Its Scanner reuses a warm
 // detector across messages (the subscriber processes one message per Handle,
 // so it materializes a single detector), avoiding per-message rule compilation.
-func NewHandler(logger *slog.Logger, findingsPub gcp.Publisher[*riskv1.Finding]) *Handler {
+func NewHandler(logger *slog.Logger, findingsPub gcp.Publisher[*riskv1.Finding], recorder *riskmeter.Recorder) *Handler {
 	return &Handler{
 		logger:      logger.With(attr.SlogComponent("gitleaks-analyzer")),
 		findingsPub: findingsPub,
-		scanner:     NewScanner(),
+		scanner:     NewScanner(recorder),
 	}
 }
 
@@ -44,6 +45,13 @@ func NewHandler(logger *slog.Logger, findingsPub gcp.Publisher[*riskv1.Finding])
 // instead of duplicating ClickHouse rows — and the reveal metadata (surface
 // et al.) is stamped uniformly.
 func (h *Handler) Handle(ctx context.Context, m *riskv1.GitleaksAnalysis, _ gcp.MessageMetadata) error {
+	evaluation := scanners.EvaluationForAnalysis(
+		m.GetOrganizationId(), m.GetProjectId(), m.GetRequestId(),
+		m.GetChatMessageId(), m.GetContentPartId(),
+		m.GetRiskPolicyId(), m.GetRiskPolicyVersion(),
+		riskmeter.DetectorGitleaks, riskmeter.ModeShadow, m.GetCreatedAt(),
+	)
+	ctx = riskmeter.WithEvaluation(ctx, evaluation)
 	findings, err := h.scanner.Scan(ctx, m.GetContent())
 	if err != nil {
 		return fmt.Errorf("gitleaks scan failed: %w", err)

--- a/server/internal/scanners/gitleaks/handler_test.go
+++ b/server/internal/scanners/gitleaks/handler_test.go
@@ -45,7 +45,7 @@ func TestHandle_PublishesGitleaksFinding(t *testing.T) {
 	t.Parallel()
 
 	pub, published := capturingPub(t)
-	h := gitleaks.NewHandler(testenv.NewLogger(t), pub)
+	h := gitleaks.NewHandler(testenv.NewLogger(t), pub, nil)
 
 	// The access key id anchors detection but is not itself reported (it is an
 	// identifier, not a secret); the secret access key is the reported finding.
@@ -83,7 +83,7 @@ func TestHandle_PublishesGitleaksFindingForContentPart(t *testing.T) {
 	t.Parallel()
 
 	pub, published := capturingPub(t)
-	h := gitleaks.NewHandler(testenv.NewLogger(t), pub)
+	h := gitleaks.NewHandler(testenv.NewLogger(t), pub, nil)
 
 	content := `AccessKeyId: ` + fakeAccessKeyID + `, SecretAccessKey: ` + fakeSecret
 	req := newRequest(content)
@@ -102,7 +102,7 @@ func TestHandle_CleanContentPublishesNothing(t *testing.T) {
 	t.Parallel()
 
 	pub, published := capturingPub(t)
-	h := gitleaks.NewHandler(testenv.NewLogger(t), pub)
+	h := gitleaks.NewHandler(testenv.NewLogger(t), pub, nil)
 
 	require.NoError(t, h.Handle(t.Context(), newRequest("hello world, this is a normal message"), gcp.MessageMetadata{}))
 	require.Empty(t, *published)
@@ -114,7 +114,7 @@ func TestHandle_StampsContentSurface(t *testing.T) {
 	t.Parallel()
 
 	pub, published := capturingPub(t)
-	h := gitleaks.NewHandler(testenv.NewLogger(t), pub)
+	h := gitleaks.NewHandler(testenv.NewLogger(t), pub, nil)
 
 	content := `SecretAccessKey: ` + fakeSecret
 	require.NoError(t, h.Handle(t.Context(), newRequest(content), gcp.MessageMetadata{}))
@@ -139,8 +139,8 @@ func TestHandle_RedeliveryKeepsDeterministicIDs(t *testing.T) {
 	secondPub, secondPublished := capturingPub(t)
 
 	content := `AccessKeyId: ` + fakeAccessKeyID + `, SecretAccessKey: ` + fakeSecret
-	require.NoError(t, gitleaks.NewHandler(testenv.NewLogger(t), firstPub).Handle(t.Context(), newRequest(content), gcp.MessageMetadata{}))
-	require.NoError(t, gitleaks.NewHandler(testenv.NewLogger(t), secondPub).Handle(t.Context(), newRequest(content), gcp.MessageMetadata{}))
+	require.NoError(t, gitleaks.NewHandler(testenv.NewLogger(t), firstPub, nil).Handle(t.Context(), newRequest(content), gcp.MessageMetadata{}))
+	require.NoError(t, gitleaks.NewHandler(testenv.NewLogger(t), secondPub, nil).Handle(t.Context(), newRequest(content), gcp.MessageMetadata{}))
 
 	require.NotEmpty(t, *firstPublished)
 	require.Len(t, *secondPublished, len(*firstPublished))

--- a/server/internal/scanners/gitleaks/scanner.go
+++ b/server/internal/scanners/gitleaks/scanner.go
@@ -23,6 +23,7 @@ import (
 	"github.com/zricethezav/gitleaks/v8/report"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
 	"github.com/speakeasy-api/gram/server/internal/scanners"
 )
 
@@ -155,12 +156,13 @@ type Scanner struct {
 	// has not been created yet; a non-nil slot is a warm, reusable detector.
 	// Its capacity caps both the live detector count and Scan concurrency.
 	detectors chan *detect.Detector
+	recorder  *riskmeter.Recorder
 }
 
 // NewScanner creates a new Scanner with a warm detector set sized to NumCPU.
-func NewScanner() *Scanner {
+func NewScanner(recorder *riskmeter.Recorder) *Scanner {
 	n := runtime.NumCPU()
-	s := &Scanner{detectors: make(chan *detect.Detector, n)}
+	s := &Scanner{detectors: make(chan *detect.Detector, n), recorder: recorder}
 	for range n {
 		s.detectors <- nil
 	}
@@ -229,17 +231,24 @@ func (s *Scanner) Scan(ctx context.Context, content string) ([]scanners.Finding,
 	}
 	defer func() { s.detectors <- d }()
 
-	return convertFindings(content, d.DetectString(content)), nil
+	findings := convertFindings(content, d.DetectString(content))
+	if evaluation, ok := riskmeter.EvaluationFromContext(ctx); ok {
+		_ = s.recorder.Record(ctx, evaluation, []string{content}, riskmeter.OutcomeCompleted, nil)
+	}
+	return findings, nil
 }
-
-func (s *Scanner) ScanBatch(ctx context.Context, contents []string) ([][]scanners.Finding, error) {
+func (s *Scanner) ScanBatch(ctx context.Context, contents []string, evaluations []riskmeter.Evaluation) ([][]scanners.Finding, error) {
 	g, ctx := errgroup.WithContext(ctx)
 	g.SetLimit(runtime.NumCPU())
 
 	findings := make([][]scanners.Finding, len(contents))
 	for i, content := range contents {
 		g.Go(func() error {
-			f, err := s.Scan(ctx, content)
+			scanCtx := ctx
+			if i < len(evaluations) && evaluations[i].OperationID != "" {
+				scanCtx = riskmeter.WithEvaluation(ctx, evaluations[i])
+			}
+			f, err := s.Scan(scanCtx, content)
 			if err != nil {
 				return fmt.Errorf("scan content: %w", err)
 			}

--- a/server/internal/scanners/gitleaks/scanner_cancel_test.go
+++ b/server/internal/scanners/gitleaks/scanner_cancel_test.go
@@ -68,7 +68,7 @@ func (c *blockingCheckoutCtx) cancel() {
 func TestScanCancelWhileWaiting(t *testing.T) {
 	t.Parallel()
 
-	s := NewScanner()
+	s := NewScanner(nil)
 
 	// Drain every slot so the warm set is empty; the next checkout must block.
 	held := make([]*detect.Detector, 0, cap(s.detectors))

--- a/server/internal/scanners/gitleaks/scanner_race_test.go
+++ b/server/internal/scanners/gitleaks/scanner_race_test.go
@@ -36,7 +36,7 @@ func TestConcurrentScan(t *testing.T) {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			_, err := gitleaks.NewScanner().Scan(t.Context(), messages[idx%len(messages)])
+			_, err := gitleaks.NewScanner(nil).Scan(t.Context(), messages[idx%len(messages)])
 			errs[idx] = err
 		}(i)
 	}

--- a/server/internal/scanners/gitleaks/scanner_test.go
+++ b/server/internal/scanners/gitleaks/scanner_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestPrime(t *testing.T) {
 	t.Parallel()
-	s := gitleaks.NewScanner()
+	s := gitleaks.NewScanner(nil)
 	// Prime materializes a detector up front; a successful call means the
 	// first scan is warm and any init failure surfaces here at startup.
 	require.NoError(t, s.Prime())
@@ -26,7 +26,7 @@ func TestPrime(t *testing.T) {
 
 func TestScan_NoSecrets(t *testing.T) {
 	t.Parallel()
-	findings, err := gitleaks.NewScanner().Scan(t.Context(), "hello world, this is a normal message")
+	findings, err := gitleaks.NewScanner(nil).Scan(t.Context(), "hello world, this is a normal message")
 	require.NoError(t, err)
 	assert.Empty(t, findings)
 }
@@ -37,7 +37,7 @@ func TestScan_DetectsAWSKey(t *testing.T) {
 	// secret access key is the flagged finding. ("EXAMPLE" values are globally
 	// allowlisted by gitleaks, so the fixtures avoid them.)
 	content := `AccessKeyId: ` + fakeAccessKeyID + `, SecretAccessKey: ` + fakeSecret
-	findings, err := gitleaks.NewScanner().Scan(t.Context(), content)
+	findings, err := gitleaks.NewScanner(nil).Scan(t.Context(), content)
 	require.NoError(t, err)
 	assert.NotEmpty(t, findings, "expected at least one finding for AWS credentials")
 	for _, f := range findings {
@@ -51,14 +51,14 @@ func TestScan_DetectsAWSKey(t *testing.T) {
 func TestScan_DetectsGitHubToken(t *testing.T) {
 	t.Parallel()
 	content := `export GITHUB_TOKEN=ghp_R2D2C3POLuk3Skywalker1234567890ab`
-	findings, err := gitleaks.NewScanner().Scan(t.Context(), content)
+	findings, err := gitleaks.NewScanner(nil).Scan(t.Context(), content)
 	require.NoError(t, err)
 	assert.NotEmpty(t, findings, "expected at least one finding for GitHub token")
 }
 
 func TestScan_EmptyContent(t *testing.T) {
 	t.Parallel()
-	findings, err := gitleaks.NewScanner().Scan(t.Context(), "")
+	findings, err := gitleaks.NewScanner(nil).Scan(t.Context(), "")
 	require.NoError(t, err)
 	assert.Empty(t, findings)
 }
@@ -104,7 +104,7 @@ GITHUB_TOKEN=ghp_1234567890abcdefghijklmnopqrstuvwxyz`,
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			findings, err := gitleaks.NewScanner().Scan(t.Context(), tc.content)
+			findings, err := gitleaks.NewScanner(nil).Scan(t.Context(), tc.content)
 			require.NoError(t, err)
 
 			// For each finding, verify we can extract the correct match using byte positions

--- a/server/internal/scanners/gitleaks/setup_test.go
+++ b/server/internal/scanners/gitleaks/setup_test.go
@@ -45,6 +45,7 @@ func newTestEnforceHandler(t *testing.T, meterProvider metric.MeterProvider, wri
 			sum, _, fingerprintErr := fingerprinter.TenantedHS256(tenantID, message)
 			return risk.EncodeFingerprint(sum), fingerprintErr
 		},
+		nil,
 		gitleaks.EnforceHandlerConfig{MaxRequestAge: maxRequestAge},
 	)
 	require.NoError(t, err)

--- a/server/internal/scanners/promptinjection/handler.go
+++ b/server/internal/scanners/promptinjection/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/speakeasy-api/gram/infra/pkg/gcp"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/judgemessage"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
 	"github.com/speakeasy-api/gram/server/internal/scanners"
 )
 
@@ -65,6 +66,13 @@ func (h *Handler) Handle(ctx context.Context, m *riskv1.PromptInjectionAnalysis,
 	scanner := h.stubScanner
 	if engine == scanners.AsyncScanEngineReal {
 		scanner = h.realScanner
+		evaluation := scanners.EvaluationForAnalysis(
+			m.GetOrganizationId(), m.GetProjectId(), m.GetRequestId(),
+			m.GetChatMessageId(), m.GetContentPartId(),
+			m.GetRiskPolicyId(), m.GetRiskPolicyVersion(),
+			riskmeter.DetectorPromptInjection, riskmeter.ModeShadow, m.GetCreatedAt(),
+		)
+		ctx = riskmeter.WithEvaluation(ctx, evaluation)
 	}
 
 	findings, err := scanner.Scan(ctx, m.GetContent(), m.GetOrganizationId(), m.GetProjectId(), m.GetUserId(), promptInjectionJudgeMessage(m))

--- a/server/internal/scanners/promptinjection/openrouter/judge.go
+++ b/server/internal/scanners/promptinjection/openrouter/judge.go
@@ -4,6 +4,7 @@ package openrouter
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -18,11 +19,13 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 
+	meteringv1 "github.com/speakeasy-api/gram/infra/gen/gram/metering/v1"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/judgemessage"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/ratelimit"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
 	"github.com/speakeasy-api/gram/server/internal/scanners/promptinjection"
 	gramopenrouter "github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 )
@@ -103,6 +106,7 @@ type Engine struct {
 	metrics     *metrics
 	client      gramopenrouter.CompletionClient
 	limiter     *ratelimit.Limiter
+	recorder    *riskmeter.Recorder
 	model       string
 	temperature float64
 	schema      or.ChatJSONSchemaConfig // built once; the verdict shape is constant
@@ -119,7 +123,7 @@ var unavailableResult = promptinjection.Result{Label: promptinjection.LabelUnava
 
 // New constructs an Engine. The composition root constructs the completions
 // client unconditionally, so it is always non-nil here.
-func New(logger *slog.Logger, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, client gramopenrouter.CompletionClient, limiter *ratelimit.Limiter) *Engine {
+func New(logger *slog.Logger, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, client gramopenrouter.CompletionClient, limiter *ratelimit.Limiter, recorder *riskmeter.Recorder) *Engine {
 	logger = logger.With(attr.SlogComponent("pi-llm-judge"))
 	strict := true
 	return &Engine{
@@ -128,6 +132,7 @@ func New(logger *slog.Logger, tracerProvider trace.TracerProvider, meterProvider
 		metrics:     newMetrics(meterProvider, logger),
 		client:      client,
 		limiter:     limiter,
+		recorder:    recorder,
 		model:       defaultModel,
 		temperature: defaultTemperature,
 		schema: or.ChatJSONSchemaConfig{
@@ -172,12 +177,31 @@ func (c *Engine) Classify(ctx context.Context, req promptinjection.Request) (_ [
 			attr.SlogProjectID(req.ProjectID),
 		)
 	}
+	if len(req.Evaluations) != 0 && len(req.Evaluations) != n {
+		c.logger.WarnContext(ctx, "pi judge evaluations not parallel to messages; unmatched messages use context metadata",
+			attr.SlogOrganizationID(req.OrgID),
+			attr.SlogProjectID(req.ProjectID),
+		)
+	}
+
+	results := make([]promptinjection.Result, n)
+	if c.client == nil {
+		for i, msg := range req.Messages {
+			if !msg.HasContent() {
+				results[i] = safeResult
+				continue
+			}
+			messageCtx := messageEvaluationContext(ctx, req.Evaluations, i)
+			c.record(messageCtx, nil, riskmeter.OutcomeSkipped)
+			results[i] = unavailableResult
+		}
+		return results, nil
+	}
 
 	// The rate-limit bucket is identical for every message in the batch, so
 	// resolve the spending key once rather than per message.
 	bucket := gramopenrouter.ResolveJudgeRateLimitKey(ctx, c.logger, c.client, req.OrgID, req.ProjectID, billing.ModelUsageSourcePromptInjection, c.model)
 
-	results := make([]promptinjection.Result, n)
 	sem := make(chan struct{}, concurrency)
 	var wg sync.WaitGroup
 	for i := range req.Messages {
@@ -196,11 +220,12 @@ func (c *Engine) Classify(ctx context.Context, req promptinjection.Request) (_ [
 		if i < len(req.UserIDs) {
 			userID = req.UserIDs[i]
 		}
-		go func(i int, msg judgemessage.Message, userID string) {
+		messageCtx := messageEvaluationContext(ctx, req.Evaluations, i)
+		go func(i int, msg judgemessage.Message, userID string, messageCtx context.Context) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			results[i] = c.classifyOne(ctx, req, msg, userID, bucket)
-		}(i, msg, userID)
+			results[i] = c.classifyOne(messageCtx, req, msg, userID, bucket)
+		}(i, msg, userID, messageCtx)
 	}
 	wg.Wait()
 	return results, nil
@@ -225,14 +250,17 @@ func (c *Engine) classifyOne(ctx context.Context, req promptinjection.Request, m
 		)
 	case !res.Allowed:
 		c.metrics.RecordRateLimited(ctx, req.OrgID)
+		c.record(ctx, nil, riskmeter.OutcomeSkipped)
 		c.logger.WarnContext(ctx, "pi judge rate limited; failing open",
 			attr.SlogOrganizationID(req.OrgID),
 		)
 		return unavailableResult
 	}
 
+	messagePayload := judgemessage.RenderPayload(msg)
 	start := time.Now()
-	verdict, err := c.call(ctx, req, msg, userID)
+	verdict, err := c.call(ctx, req, messagePayload, userID)
+	c.record(ctx, messageFragments(messagePayload), riskOutcome(err))
 	outcome := o11y.OutcomeFromErrorWithTimeout(err)
 	c.metrics.RecordClassification(ctx, req.OrgID, labelFor(verdict.IsAttack, err), outcome, time.Since(start))
 	if err != nil {
@@ -254,6 +282,13 @@ func (c *Engine) classifyOne(ctx context.Context, req promptinjection.Request, m
 		attr.SlogOrganizationID(req.OrgID),
 	)
 	return promptinjection.Result{Label: promptinjection.LabelInjection, Score: verdict.Confidence, Rationale: verdict.Rationale}
+}
+
+func messageEvaluationContext(ctx context.Context, evaluations []riskmeter.Evaluation, index int) context.Context {
+	if index >= len(evaluations) {
+		return ctx
+	}
+	return riskmeter.WithEvaluation(ctx, evaluations[index])
 }
 
 // judgePayload is the user turn: the captured event rendered as a structured
@@ -288,12 +323,12 @@ func cachedSystemMessage() or.ChatMessages {
 	})
 }
 
-func (c *Engine) call(ctx context.Context, req promptinjection.Request, msg judgemessage.Message, userID string) (judgeVerdict, error) {
-	payload, err := json.Marshal(judgePayload{Message: judgemessage.RenderPayload(msg)})
+func (c *Engine) call(ctx context.Context, req promptinjection.Request, messagePayload judgemessage.Payload, userID string) (judgeVerdict, error) {
+	payload, err := json.Marshal(judgePayload{Message: messagePayload})
 	if err != nil {
 		// Unreachable: the payload is strings, bools, and slices. Fall back to the
 		// raw body so a marshaling regression can't silently drop the event.
-		payload = []byte(msg.Body)
+		payload = []byte(messagePayload.Body)
 	}
 
 	callCtx, cancel := context.WithTimeout(ctx, judgeTimeout)
@@ -386,4 +421,45 @@ func labelFor(isAttack bool, err error) string {
 		return promptinjection.LabelInjection
 	}
 	return promptinjection.LabelSafe
+}
+
+func messageFragments(payload judgemessage.Payload) []string {
+	fragments := make([]string, 0, 1+len(payload.ToolCalls)*4)
+	appendTool := func(tool *judgemessage.ToolPayload) {
+		if tool == nil {
+			return
+		}
+		for _, value := range []string{tool.MCPServer, tool.MCPFunction, tool.Name} {
+			if value != "" {
+				fragments = append(fragments, value)
+			}
+		}
+	}
+	if len(payload.ToolCalls) > 0 {
+		for _, call := range payload.ToolCalls {
+			appendTool(call.Tool)
+			fragments = append(fragments, call.Arguments)
+		}
+		return fragments
+	}
+	appendTool(payload.Tool)
+	return append(fragments, payload.Body)
+}
+
+func riskOutcome(err error) meteringv1.RiskEvaluation_Outcome {
+	if err == nil {
+		return riskmeter.OutcomeCompleted
+	}
+	if errors.Is(err, context.Canceled) {
+		return riskmeter.OutcomeCancelled
+	}
+	return riskmeter.OutcomeFailed
+}
+
+func (c *Engine) record(ctx context.Context, fragments []string, outcome meteringv1.RiskEvaluation_Outcome) {
+	evaluation, ok := riskmeter.EvaluationFromContext(ctx)
+	if !ok {
+		return
+	}
+	_ = c.recorder.Record(ctx, evaluation, fragments, outcome, nil)
 }

--- a/server/internal/scanners/promptinjection/openrouter/judge_test.go
+++ b/server/internal/scanners/promptinjection/openrouter/judge_test.go
@@ -8,21 +8,26 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	or "github.com/OpenRouterTeam/go-sdk/models/components"
 	"github.com/OpenRouterTeam/go-sdk/optionalnullable"
+	meteringv1 "github.com/speakeasy-api/gram/infra/gen/gram/metering/v1"
+	"github.com/speakeasy-api/gram/infra/pkg/gcp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/judgemessage"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
 	"github.com/speakeasy-api/gram/server/internal/scanners/promptinjection"
+	"github.com/speakeasy-api/gram/server/internal/stokens"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 )
 
 func newEngine(t *testing.T, client openrouter.CompletionClient) *Engine {
 	t.Helper()
-	return New(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), client, testJudgeLimiter(t))
+	return New(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), client, testJudgeLimiter(t), nil)
 }
 
 func req(texts ...string) promptinjection.Request {
@@ -37,7 +42,7 @@ func req(texts ...string) promptinjection.Request {
 			ToolCalls:   nil,
 		}
 	}
-	return promptinjection.Request{Messages: msgs, OrgID: "org-a", ProjectID: "proj", UserIDs: nil}
+	return promptinjection.Request{Messages: msgs, OrgID: "org-a", ProjectID: "proj", UserIDs: nil, Evaluations: nil}
 }
 
 // TestClassifyBillsInternalKeyAndAttributesScannedUser pins the PI judge's
@@ -95,6 +100,90 @@ func TestClassifySafeVerdict(t *testing.T) {
 	require.Len(t, out, 1)
 	require.Equal(t, "SAFE", out[0].Label)
 	require.Zero(t, out[0].Score, "a SAFE verdict carries no confidence score")
+}
+
+func TestClassifyRecordsCompletedTruncatedContent(t *testing.T) {
+	t.Parallel()
+
+	publisher := &captureRiskPublisher{}
+	recorder := riskmeter.NewRecorder(testenv.NewLogger(t), publisher)
+	client := &fakeCompletionClient{responder: func(string) string {
+		return `{"is_attack":false,"confidence":0.8,"rationale":"benign"}`
+	}}
+	c := New(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), client, testJudgeLimiter(t), recorder)
+	body := strings.Repeat("detector visible ", 2000)
+	ctx := riskmeter.WithEvaluation(t.Context(), riskmeter.Evaluation{
+		OrganizationID: "org-a",
+		ProjectID:      "11111111-1111-1111-1111-111111111111",
+		OperationID:    "pi-truncated-content",
+		Detector:       riskmeter.DetectorPromptInjection,
+		ExecutionMode:  riskmeter.ModeRealtime,
+		PolicyID:       "",
+		PolicyVersion:  0,
+		OccurredAt:     time.Now().UTC(),
+	})
+
+	out, err := c.Classify(ctx, req(body))
+
+	require.NoError(t, err)
+	require.Equal(t, promptinjection.LabelSafe, out[0].Label)
+	events := publisher.Events()
+	require.Len(t, events, 1)
+	require.Equal(t, riskmeter.RecordKindScan, events[0].GetRecordKind())
+	require.Equal(t, riskmeter.OutcomeCompleted, events[0].GetOutcome())
+	rendered := judgemessage.RenderPayload(req(body).Messages[0])
+	expected, err := stokens.NewCodec().Count(t.Context(), rendered.Body)
+	require.NoError(t, err)
+	require.Equal(t, int64(expected), events[0].GetStokens())
+	require.False(t, events[0].HasPromptTokens(), "provider accounting belongs to the inference record")
+	require.False(t, events[0].HasCostUsd(), "unknown cost must remain absent")
+
+	_, err = c.Classify(t.Context(), req("benchmark without risk metadata"))
+	require.NoError(t, err)
+	require.Len(t, publisher.Events(), 1, "contexts without evaluation metadata must not emit risk records")
+}
+
+func TestClassifyUsesPerMessageEvaluationIdentity(t *testing.T) {
+	t.Parallel()
+
+	publisher := &captureRiskPublisher{}
+	recorder := riskmeter.NewRecorder(testenv.NewLogger(t), publisher)
+	client := &fakeCompletionClient{responder: func(string) string {
+		return `{"is_attack":false,"confidence":0.8,"rationale":"benign"}`
+	}}
+	c := New(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), client, testJudgeLimiter(t), recorder)
+	in := req("first", "second")
+	started := time.Now().UTC()
+	in.Evaluations = []riskmeter.Evaluation{
+		{
+			OrganizationID: "org-a",
+			ProjectID:      "11111111-1111-1111-1111-111111111111",
+			OperationID:    "pi-first",
+			Detector:       riskmeter.DetectorPromptInjection,
+			ExecutionMode:  riskmeter.ModeBatch,
+			PolicyID:       "",
+			PolicyVersion:  0,
+			OccurredAt:     started,
+		},
+		{
+			OrganizationID: "org-a",
+			ProjectID:      "11111111-1111-1111-1111-111111111111",
+			OperationID:    "pi-second",
+			Detector:       riskmeter.DetectorPromptInjection,
+			ExecutionMode:  riskmeter.ModeBatch,
+			PolicyID:       "",
+			PolicyVersion:  0,
+			OccurredAt:     started,
+		},
+	}
+
+	out, err := c.Classify(t.Context(), in)
+
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+	events := publisher.Events()
+	require.Len(t, events, 2)
+	require.ElementsMatch(t, []string{"pi-first", "pi-second"}, []string{events[0].GetOperationId(), events[1].GetOperationId()})
 }
 
 func TestClassifyFailsOpenOnClientError(t *testing.T) {
@@ -266,6 +355,28 @@ func (c *fakeCompletionClient) GetCompletionStream(_ context.Context, _ openrout
 
 func (c *fakeCompletionClient) CreateEmbeddings(_ context.Context, _ string, _ string, _ []string, _ ...openrouter.EmbeddingOption) ([][]float32, error) {
 	return nil, errors.New("not implemented")
+}
+
+type captureRiskPublisher struct {
+	mu     sync.Mutex
+	events []*meteringv1.RiskEvaluation
+}
+
+func (p *captureRiskPublisher) Publish(_ context.Context, event *meteringv1.RiskEvaluation, _ ...gcp.PublishOption) gcp.PublishResult {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.events = append(p.events, event)
+	return gcp.NewSuccessPublishResult()
+}
+
+func (p *captureRiskPublisher) Stop(context.Context) error {
+	return nil
+}
+
+func (p *captureRiskPublisher) Events() []*meteringv1.RiskEvaluation {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]*meteringv1.RiskEvaluation(nil), p.events...)
 }
 
 func (c *fakeCompletionClient) ResolveKey(_ context.Context, _ string, _ string, _ billing.ModelUsageSource, _ openrouter.KeyType) (openrouter.ResolvedKey, error) {

--- a/server/internal/scanners/promptinjection/scanner.go
+++ b/server/internal/scanners/promptinjection/scanner.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/judgemessage"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
 	"github.com/speakeasy-api/gram/server/internal/scanners"
 )
 
@@ -40,6 +41,9 @@ type Request struct {
 	// (empty string = unattributed). Rides on the judge's completion
 	// telemetry so scanning volume attributes to whose traffic was analyzed.
 	UserIDs []string
+	// Evaluations is parallel to Messages and carries one logical identity per
+	// actual judge evaluation.
+	Evaluations []riskmeter.Evaluation
 }
 
 type Result struct {
@@ -102,7 +106,17 @@ func (s *Scanner) ScanStrict(ctx context.Context, text, orgID, projectID, userID
 		return nil, nil
 	}
 
-	results, err := s.classifier(ctx, Request{Messages: []judgemessage.Message{msg}, OrgID: orgID, ProjectID: projectID, UserIDs: []string{userID}})
+	evaluations := []riskmeter.Evaluation(nil)
+	if evaluation, ok := riskmeter.EvaluationFromContext(ctx); ok {
+		evaluations = []riskmeter.Evaluation{evaluation}
+	}
+	results, err := s.classifier(ctx, Request{
+		Messages:    []judgemessage.Message{msg},
+		OrgID:       orgID,
+		ProjectID:   projectID,
+		UserIDs:     []string{userID},
+		Evaluations: evaluations,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("pi judge classify: %w", err)
 	}
@@ -119,7 +133,7 @@ func (s *Scanner) ScanStrict(ctx context.Context, text, orgID, projectID, userID
 	return nil, nil
 }
 
-func (s *Scanner) ScanBatch(ctx context.Context, texts []string, orgID, projectID string, userIDs []string, msgs []judgemessage.Message) ([][]scanners.Finding, error) {
+func (s *Scanner) ScanBatch(ctx context.Context, texts []string, orgID, projectID string, userIDs []string, msgs []judgemessage.Message, evaluations []riskmeter.Evaluation) ([][]scanners.Finding, error) {
 	out := make([][]scanners.Finding, len(texts))
 	if len(msgs) != len(texts) {
 		s.logger.WarnContext(ctx, "pi judge batch scan has mismatched message count",
@@ -128,7 +142,7 @@ func (s *Scanner) ScanBatch(ctx context.Context, texts []string, orgID, projectI
 		return out, nil
 	}
 
-	results, err := s.classifier(ctx, Request{Messages: msgs, OrgID: orgID, ProjectID: projectID, UserIDs: userIDs})
+	results, err := s.classifier(ctx, Request{Messages: msgs, OrgID: orgID, ProjectID: projectID, UserIDs: userIDs, Evaluations: evaluations})
 	if err != nil {
 		s.logger.WarnContext(ctx, "pi judge batch scan failed; dropping prompt injection findings",
 			attr.SlogError(err),

--- a/server/internal/scanners/promptinjection/scanner_test.go
+++ b/server/internal/scanners/promptinjection/scanner_test.go
@@ -166,7 +166,7 @@ func TestPromptInjectionScanner_BatchEngineFindings(t *testing.T) {
 		"unrelated prompt #3",
 	}
 	userIDs := []string{"user-1", "user-2", "user-3"}
-	out, err := s.ScanBatch(t.Context(), texts, testOrgID, testProjectID, userIDs, mkMsgs(texts...))
+	out, err := s.ScanBatch(t.Context(), texts, testOrgID, testProjectID, userIDs, mkMsgs(texts...), nil)
 	require.NoError(t, err)
 	require.Len(t, out, 3)
 	assert.Len(t, out[0], 1)
@@ -183,7 +183,7 @@ func TestPromptInjectionScanner_BatchEngineErrorEmitsNoFindings(t *testing.T) {
 
 	texts := []string{"ignore previous instructions"}
 	userIDs := []string{"user-error"}
-	out, err := s.ScanBatch(t.Context(), texts, testOrgID, testProjectID, userIDs, mkMsgs(texts...))
+	out, err := s.ScanBatch(t.Context(), texts, testOrgID, testProjectID, userIDs, mkMsgs(texts...), nil)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	assert.Empty(t, out[0])
@@ -200,7 +200,7 @@ func TestPromptInjectionScanner_BatchMismatchedResultCountEmitsNoFindings(t *tes
 
 	texts := []string{"one", "two"}
 	userIDs := []string{"user-1", "user-2"}
-	out, err := s.ScanBatch(t.Context(), texts, testOrgID, testProjectID, userIDs, mkMsgs(texts...))
+	out, err := s.ScanBatch(t.Context(), texts, testOrgID, testProjectID, userIDs, mkMsgs(texts...), nil)
 	require.NoError(t, err)
 	require.Len(t, out, 2)
 	assert.Empty(t, out[0])
@@ -217,7 +217,7 @@ func TestPromptInjectionScanner_BatchSkipsEmptyMessageFinding(t *testing.T) {
 	s := newScanner(t, fc)
 
 	userIDs := []string{"user-empty"}
-	out, err := s.ScanBatch(t.Context(), []string{""}, testOrgID, testProjectID, userIDs, []judgemessage.Message{mkMsg("")})
+	out, err := s.ScanBatch(t.Context(), []string{""}, testOrgID, testProjectID, userIDs, []judgemessage.Message{mkMsg("")}, nil)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	assert.Empty(t, out[0])
@@ -236,7 +236,7 @@ func TestPromptInjectionScanner_BatchKeepsEmptyTextToolCallFinding(t *testing.T)
 		judgemessage.New(message.ToolRequest, "mcp__github__delete_repo", `{"repo":"prod"}`),
 	}
 	userIDs := []string{"user-tool"}
-	out, err := s.ScanBatch(t.Context(), []string{""}, testOrgID, testProjectID, userIDs, msgs)
+	out, err := s.ScanBatch(t.Context(), []string{""}, testOrgID, testProjectID, userIDs, msgs, nil)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	require.Len(t, out[0], 1)

--- a/server/internal/scanners/promptpolicy/handler.go
+++ b/server/internal/scanners/promptpolicy/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/speakeasy-api/gram/infra/pkg/gcp"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/judgemessage"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
 	"github.com/speakeasy-api/gram/server/internal/scanners"
 )
 
@@ -66,6 +67,13 @@ func (h *Handler) Handle(ctx context.Context, m *riskv1.PromptPolicyAnalysis, _ 
 	scanner := h.stubScanner
 	if engine == scanners.AsyncScanEngineReal {
 		scanner = h.realScanner
+		evaluation := scanners.EvaluationForAnalysis(
+			m.GetOrganizationId(), m.GetProjectId(), m.GetRequestId(),
+			m.GetChatMessageId(), m.GetContentPartId(),
+			m.GetRiskPolicyId(), m.GetRiskPolicyVersion(),
+			riskmeter.DetectorPromptPolicy, riskmeter.ModeShadow, m.GetCreatedAt(),
+		)
+		ctx = riskmeter.WithEvaluation(ctx, evaluation)
 	}
 
 	findings := scanner.Scan(ctx, m.GetOrganizationId(), m.GetProjectId(), m.GetUserId(), m.GetPrompt(), cfg, promptPolicyJudgeMessage(m))

--- a/server/internal/scanners/promptpolicy/openrouter/judge.go
+++ b/server/internal/scanners/promptpolicy/openrouter/judge.go
@@ -4,6 +4,7 @@ package openrouter
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -16,11 +17,13 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 
+	meteringv1 "github.com/speakeasy-api/gram/infra/gen/gram/metering/v1"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/judgemessage"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/ratelimit"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
 	"github.com/speakeasy-api/gram/server/internal/scanners/promptpolicy"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 )
@@ -77,23 +80,25 @@ Output ONLY the JSON object, no prose or markdown fences.`
 // custom-rule suggestion path: strict JSON schema, low temperature, hard
 // timeout, OpenRouter object completion.
 type Judge struct {
-	logger  *slog.Logger
-	tracer  trace.Tracer
-	metrics *judgeMetrics
-	client  openrouter.CompletionClient
-	limiter *ratelimit.Limiter
+	logger   *slog.Logger
+	tracer   trace.Tracer
+	metrics  *judgeMetrics
+	client   openrouter.CompletionClient
+	limiter  *ratelimit.Limiter
+	recorder *riskmeter.Recorder
 }
 
 // New constructs a Judge. A nil client yields a judge whose Evaluate always
 // returns (nil, nil), so callers can wire it unconditionally.
-func New(logger *slog.Logger, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, client openrouter.CompletionClient, limiter *ratelimit.Limiter) *Judge {
+func New(logger *slog.Logger, tracerProvider trace.TracerProvider, meterProvider metric.MeterProvider, client openrouter.CompletionClient, limiter *ratelimit.Limiter, recorder *riskmeter.Recorder) *Judge {
 	logger = logger.With(attr.SlogComponent("risk-llm-judge"))
 	return &Judge{
-		logger:  logger,
-		tracer:  tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/scanners/promptpolicy/openrouter"),
-		metrics: newJudgeMetrics(meterProvider, logger),
-		client:  client,
-		limiter: limiter,
+		logger:   logger,
+		tracer:   tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/scanners/promptpolicy/openrouter"),
+		metrics:  newJudgeMetrics(meterProvider, logger),
+		client:   client,
+		limiter:  limiter,
+		recorder: recorder,
 	}
 }
 
@@ -102,7 +107,7 @@ func New(logger *slog.Logger, tracerProvider trace.TracerProvider, meterProvider
 // client or an empty prompt/text yields (nil, nil). On judge error or timeout it
 // returns a non-nil error so callers can apply policy fail-mode.
 func (j *Judge) Evaluate(ctx context.Context, in promptpolicy.Input) (*promptpolicy.Verdict, error) {
-	if j == nil || j.client == nil {
+	if j == nil {
 		return nil, nil
 	}
 	// Skip only when there is nothing to judge. An empty body is NOT enough:
@@ -110,6 +115,10 @@ func (j *Judge) Evaluate(ctx context.Context, in promptpolicy.Input) (*promptpol
 	// tool-scoped policy ("flag any call to MCP server X") can match, so
 	// HasContent keeps those events in scope.
 	if strings.TrimSpace(in.Prompt) == "" || !in.Message.HasContent() {
+		return nil, nil
+	}
+	if j.client == nil {
+		j.record(ctx, nil, riskmeter.OutcomeSkipped)
 		return nil, nil
 	}
 
@@ -135,6 +144,7 @@ func (j *Judge) Evaluate(ctx context.Context, in promptpolicy.Input) (*promptpol
 		)
 	case !res.Allowed:
 		j.metrics.RecordRateLimited(ctx, in.OrgID)
+		j.record(ctx, nil, riskmeter.OutcomeSkipped)
 		span.SetAttributes(attribute.Bool("risk.judge.rate_limited", true))
 		j.logger.WarnContext(ctx, "llm judge rate limited",
 			attr.SlogOrganizationID(in.OrgID),
@@ -144,6 +154,7 @@ func (j *Judge) Evaluate(ctx context.Context, in promptpolicy.Input) (*promptpol
 
 	start := time.Now()
 	callResult, err := j.call(ctx, in)
+	j.record(ctx, callResult.fragments, riskOutcome(err))
 	outcome := o11y.OutcomeFromErrorWithTimeout(err)
 	j.metrics.RecordEvaluation(ctx, in.OrgID, outcome, time.Since(start))
 	if err != nil {
@@ -182,6 +193,7 @@ type judgeCallResult struct {
 	promptTokens     int
 	completionTokens int
 	totalTokens      int
+	fragments        []string
 }
 
 func (j *Judge) call(ctx context.Context, in promptpolicy.Input) (judgeCallResult, error) {
@@ -203,7 +215,8 @@ func (j *Judge) call(ctx context.Context, in promptpolicy.Input) (judgeCallResul
 		model = defaultJudgeModel
 	}
 
-	judgePrompt := BuildJudgePrompt(in)
+	messagePayload := judgemessage.RenderPayload(in.Message)
+	judgePrompt := buildJudgePrompt(in.Prompt, messagePayload)
 
 	callCtx, cancel := context.WithTimeout(ctx, judgeTimeout)
 	defer cancel()
@@ -226,15 +239,26 @@ func (j *Judge) call(ctx context.Context, in promptpolicy.Input) (judgeCallResul
 		Reasoning:              nil,
 		DisableResponseHealing: false,
 	})
+	var result judgeCallResult
+	result.fragments = messageFragments(messagePayload)
 	if err != nil {
-		return judgeCallResult{}, fmt.Errorf("openrouter object completion: %w", err)
+		return result, fmt.Errorf("openrouter object completion: %w", err)
 	}
-	if response == nil || response.Message == nil {
-		return judgeCallResult{}, fmt.Errorf("empty completion response")
+	if response == nil {
+		return result, fmt.Errorf("empty completion response")
+	}
+	result.promptTokens = response.Usage.PromptTokens
+	result.completionTokens = response.Usage.CompletionTokens
+	result.totalTokens = response.Usage.TotalTokens
+	if response.Usage.Cost != nil {
+		result.costUSD = *response.Usage.Cost
+	}
+	if response.Message == nil {
+		return result, fmt.Errorf("empty completion response")
 	}
 	raw := strings.TrimSpace(openrouter.GetText(*response.Message))
 	if raw == "" {
-		return judgeCallResult{}, fmt.Errorf("empty completion content")
+		return result, fmt.Errorf("empty completion content")
 	}
 
 	var verdict struct {
@@ -243,7 +267,7 @@ func (j *Judge) call(ctx context.Context, in promptpolicy.Input) (judgeCallResul
 		Rationale  string  `json:"rationale"`
 	}
 	if err := json.Unmarshal([]byte(raw), &verdict); err != nil {
-		return judgeCallResult{}, fmt.Errorf("parse judge response: %w", err)
+		return result, fmt.Errorf("parse judge response: %w", err)
 	}
 	// Clamp confidence and cap rationale length in code - the schema no longer
 	// enforces these (see the schema note above re: Anthropic route 400s).
@@ -253,19 +277,10 @@ func (j *Judge) call(ctx context.Context, in promptpolicy.Input) (judgeCallResul
 	if utf8.RuneCountInString(rationale) > maxRationaleLen {
 		rationale = string([]rune(rationale)[:maxRationaleLen])
 	}
-	costUSD := 0.0
-	if response.Usage.Cost != nil {
-		costUSD = *response.Usage.Cost
-	}
-	return judgeCallResult{
-		matched:          verdict.Matched,
-		confidence:       max(0, min(1, verdict.Confidence)),
-		rationale:        rationale,
-		costUSD:          costUSD,
-		promptTokens:     response.Usage.PromptTokens,
-		completionTokens: response.Usage.CompletionTokens,
-		totalTokens:      response.Usage.TotalTokens,
-	}, nil
+	result.matched = verdict.Matched
+	result.confidence = max(0, min(1, verdict.Confidence))
+	result.rationale = rationale
+	return result, nil
 }
 
 // VerdictSchema is the judge's structured-output JSON schema. Deliberately no
@@ -299,22 +314,63 @@ type judgePromptPayload struct {
 	Message judgemessage.Payload `json:"message"`
 }
 
+func buildJudgePrompt(policy string, messagePayload judgemessage.Payload) string {
+	payload := judgePromptPayload{
+		Policy:  policy,
+		Message: messagePayload,
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return messagePayload.Body
+	}
+	return string(b)
+}
+
 // BuildJudgePrompt renders the policy plus the message under evaluation as the
 // JSON user turn the judge reads. Bodies are truncated by judgemessage so an
 // oversized payload cannot blow the model's context window. Exported so
 // server/cmd/riskjudgebench drives the exact production user prompt.
 func BuildJudgePrompt(in promptpolicy.Input) string {
-	payload := judgePromptPayload{
-		Policy:  in.Prompt,
-		Message: judgemessage.RenderPayload(in.Message),
+	return buildJudgePrompt(in.Prompt, judgemessage.RenderPayload(in.Message))
+}
+
+func messageFragments(payload judgemessage.Payload) []string {
+	fragments := make([]string, 0, 1+len(payload.ToolCalls)*4)
+	appendTool := func(tool *judgemessage.ToolPayload) {
+		if tool == nil {
+			return
+		}
+		for _, value := range []string{tool.MCPServer, tool.MCPFunction, tool.Name} {
+			if value != "" {
+				fragments = append(fragments, value)
+			}
+		}
 	}
-	b, err := json.Marshal(payload)
-	if err != nil {
-		// Unreachable: payload is composed solely of strings, bools, slices, and
-		// pointers to string structs, none of which json.Marshal can fail on. Fall
-		// back to the raw body so a future change that breaks marshaling can't
-		// silently drop the message under evaluation entirely.
-		return in.Message.Body
+	if len(payload.ToolCalls) > 0 {
+		for _, call := range payload.ToolCalls {
+			appendTool(call.Tool)
+			fragments = append(fragments, call.Arguments)
+		}
+		return fragments
 	}
-	return string(b)
+	appendTool(payload.Tool)
+	return append(fragments, payload.Body)
+}
+
+func riskOutcome(err error) meteringv1.RiskEvaluation_Outcome {
+	if err == nil {
+		return riskmeter.OutcomeCompleted
+	}
+	if errors.Is(err, context.Canceled) {
+		return riskmeter.OutcomeCancelled
+	}
+	return riskmeter.OutcomeFailed
+}
+
+func (j *Judge) record(ctx context.Context, fragments []string, outcome meteringv1.RiskEvaluation_Outcome) {
+	evaluation, ok := riskmeter.EvaluationFromContext(ctx)
+	if !ok {
+		return
+	}
+	_ = j.recorder.Record(ctx, evaluation, fragments, outcome, nil)
 }

--- a/server/internal/scanners/promptpolicy/openrouter/judge_test.go
+++ b/server/internal/scanners/promptpolicy/openrouter/judge_test.go
@@ -15,9 +15,12 @@ import (
 	"github.com/OpenRouterTeam/go-sdk/optionalnullable"
 	"github.com/stretchr/testify/require"
 
+	meteringv1 "github.com/speakeasy-api/gram/infra/gen/gram/metering/v1"
+	"github.com/speakeasy-api/gram/infra/pkg/gcp"
 	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/judgemessage"
 	"github.com/speakeasy-api/gram/server/internal/message"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
 	"github.com/speakeasy-api/gram/server/internal/scanners/promptpolicy"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
@@ -192,11 +195,116 @@ func TestJudgeReturnsUsageForCleanVerdict(t *testing.T) {
 	require.Equal(t, 168, verdict.TotalTokens)
 }
 
+func TestJudgeRecordsFailedScanForInvalidVerdict(t *testing.T) {
+	t.Parallel()
+
+	publisher := &captureRiskPublisher{}
+	recorder := riskmeter.NewRecorder(testenv.NewLogger(t), publisher)
+	client := &successfulCompletionClient{body: "not json", usage: openrouter.Usage{}}
+	j := New(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), client, testJudgeLimiter(t), recorder)
+	ctx := riskmeter.WithEvaluation(t.Context(), riskmeter.Evaluation{
+		OrganizationID: "org-a",
+		ProjectID:      "11111111-1111-1111-1111-111111111111",
+		OperationID:    "policy-invalid-verdict",
+		Detector:       riskmeter.DetectorPromptPolicy,
+		ExecutionMode:  riskmeter.ModeRealtime,
+		PolicyID:       "policy-a",
+		PolicyVersion:  1,
+		OccurredAt:     time.Now().UTC(),
+	})
+
+	verdict, err := j.Evaluate(ctx, promptpolicy.Input{
+		OrgID:     "org-a",
+		ProjectID: "11111111-1111-1111-1111-111111111111",
+		Prompt:    "flag secrets",
+		Message:   judgemessage.New(message.User, "", "detector-visible content"),
+		Config:    promptpolicy.Config{Model: "", Temperature: nil, FailOpen: true},
+	})
+
+	require.Error(t, err)
+	require.Nil(t, verdict)
+	events := publisher.Events()
+	require.Len(t, events, 1)
+	require.Equal(t, riskmeter.RecordKindScan, events[0].GetRecordKind())
+	require.Equal(t, riskmeter.OutcomeFailed, events[0].GetOutcome())
+	require.True(t, events[0].HasStokens())
+	require.Positive(t, events[0].GetStokens())
+	require.False(t, events[0].HasPromptTokens(), "provider accounting belongs to the inference record")
+	require.False(t, events[0].HasCostUsd(), "unknown cost must remain absent")
+}
+
+func TestJudgeRecordsSkipWhenClientMissing(t *testing.T) {
+	t.Parallel()
+
+	publisher := &captureRiskPublisher{}
+	recorder := riskmeter.NewRecorder(testenv.NewLogger(t), publisher)
+	j := New(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), nil, testJudgeLimiter(t), recorder)
+	ctx := riskmeter.WithEvaluation(t.Context(), riskmeter.Evaluation{
+		OrganizationID: "org-a",
+		ProjectID:      "11111111-1111-1111-1111-111111111111",
+		OperationID:    "policy-missing-client",
+		Detector:       riskmeter.DetectorPromptPolicy,
+		ExecutionMode:  riskmeter.ModeBatch,
+		PolicyID:       "policy-a",
+		PolicyVersion:  1,
+		OccurredAt:     time.Now().UTC(),
+	})
+
+	verdict, err := j.Evaluate(ctx, promptpolicy.Input{
+		OrgID:     "org-a",
+		ProjectID: "11111111-1111-1111-1111-111111111111",
+		Prompt:    "flag secrets",
+		Message:   judgemessage.New(message.User, "", "content"),
+		Config:    promptpolicy.Config{Model: "", Temperature: nil, FailOpen: true},
+	})
+
+	require.NoError(t, err)
+	require.Nil(t, verdict)
+	events := publisher.Events()
+	require.Len(t, events, 1)
+	require.Equal(t, riskmeter.OutcomeSkipped, events[0].GetOutcome())
+	require.False(t, events[0].HasStokens(), "a missing client did not scan content")
+}
+
+func TestJudgeRecordsCancelledScan(t *testing.T) {
+	t.Parallel()
+
+	publisher := &captureRiskPublisher{}
+	recorder := riskmeter.NewRecorder(testenv.NewLogger(t), publisher)
+	client := &countingCompletionClient{err: context.Canceled}
+	j := New(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), client, testJudgeLimiter(t), recorder)
+	ctx := riskmeter.WithEvaluation(t.Context(), riskmeter.Evaluation{
+		OrganizationID: "org-a",
+		ProjectID:      "11111111-1111-1111-1111-111111111111",
+		OperationID:    "policy-cancelled",
+		Detector:       riskmeter.DetectorPromptPolicy,
+		ExecutionMode:  riskmeter.ModeRealtime,
+		PolicyID:       "policy-a",
+		PolicyVersion:  1,
+		OccurredAt:     time.Now().UTC(),
+	})
+
+	verdict, err := j.Evaluate(ctx, promptpolicy.Input{
+		OrgID:     "org-a",
+		ProjectID: "11111111-1111-1111-1111-111111111111",
+		Prompt:    "flag secrets",
+		Message:   judgemessage.New(message.User, "", "content"),
+		Config:    promptpolicy.Config{Model: "", Temperature: nil, FailOpen: true},
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, verdict)
+	events := publisher.Events()
+	require.Len(t, events, 1)
+	require.Equal(t, riskmeter.OutcomeCancelled, events[0].GetOutcome())
+	require.True(t, events[0].HasStokens())
+}
+
 // newTestJudge builds a Judge with a Redis-backed judge limiter on its own
 // logical DB, isolated per test.
 func newTestJudge(t *testing.T, client openrouter.CompletionClient) *Judge {
 	t.Helper()
-	return New(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), client, testJudgeLimiter(t))
+	return New(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), client, testJudgeLimiter(t), nil)
 }
 
 // drainLimiter exhausts the model token bucket so the next Evaluate is
@@ -248,10 +356,14 @@ func TestJudgeBillsInternalKeyAsRiskAnalysis(t *testing.T) {
 // so tests can assert a throttled Evaluate never reaches the LLM.
 type countingCompletionClient struct {
 	calls atomic.Int64
+	err   error
 }
 
 func (c *countingCompletionClient) GetObjectCompletion(_ context.Context, _ openrouter.ObjectCompletionRequest) (*openrouter.CompletionResponse, error) {
 	c.calls.Add(1)
+	if c.err != nil {
+		return nil, c.err
+	}
 	return nil, errors.New("not implemented")
 }
 
@@ -306,6 +418,28 @@ func (c *successfulCompletionClient) GetCompletionStream(_ context.Context, _ op
 
 func (c *successfulCompletionClient) CreateEmbeddings(_ context.Context, _ string, _ string, _ []string, _ ...openrouter.EmbeddingOption) ([][]float32, error) {
 	return nil, errors.New("not implemented")
+}
+
+type captureRiskPublisher struct {
+	mu     sync.Mutex
+	events []*meteringv1.RiskEvaluation
+}
+
+func (p *captureRiskPublisher) Publish(_ context.Context, event *meteringv1.RiskEvaluation, _ ...gcp.PublishOption) gcp.PublishResult {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.events = append(p.events, event)
+	return gcp.NewSuccessPublishResult()
+}
+
+func (p *captureRiskPublisher) Stop(context.Context) error {
+	return nil
+}
+
+func (p *captureRiskPublisher) Events() []*meteringv1.RiskEvaluation {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]*meteringv1.RiskEvaluation(nil), p.events...)
 }
 
 func TestBuildJudgePromptMCPToolCall(t *testing.T) {

--- a/server/internal/skills/efficacy/publish.go
+++ b/server/internal/skills/efficacy/publish.go
@@ -143,7 +143,7 @@ func NewPublisher(logger *slog.Logger, tracerProvider trace.TracerProvider, db *
 		scores:                scores,
 		judge:                 judge,
 		signaler:              signaler,
-		recommendationScanner: gitleaks.NewScanner(),
+		recommendationScanner: gitleaks.NewScanner(nil),
 		evaluationTimeout:     publishEvaluationTimeout,
 	}
 }

--- a/server/internal/thirdparty/openrouter/errors_test.go
+++ b/server/internal/thirdparty/openrouter/errors_test.go
@@ -321,16 +321,7 @@ func newTestClientForServer(t *testing.T, server *httptest.Server) *ChatClient {
 	guardianPolicy, err := guardian.NewUnsafePolicy(tracerProvider, []string{})
 	require.NoError(t, err)
 
-	client := NewUnifiedClient(
-		testenv.NewLogger(t),
-		guardianPolicy,
-		&mockProvisioner{apiKey: "test-api-key"},
-		&PlatformKeyResolver{Provisioner: &mockProvisioner{apiKey: "test-api-key"}},
-		&mockMessageCaptureStrategy{},
-		&mockUsageTrackingStrategy{},
-		&mockChatTitleGenerator{},
-		&mockTelemetryLogger{},
-	)
+	client := NewUnifiedClient(testenv.NewLogger(t), guardianPolicy, &mockProvisioner{apiKey: "test-api-key"}, &PlatformKeyResolver{Provisioner: &mockProvisioner{apiKey: "test-api-key"}}, &mockMessageCaptureStrategy{}, &mockUsageTrackingStrategy{}, &mockChatTitleGenerator{}, &mockTelemetryLogger{}, nil)
 	client.httpClient = &http.Client{Transport: &testTransport{server: server}}
 	return client
 }

--- a/server/internal/thirdparty/openrouter/risk_measurement_test.go
+++ b/server/internal/thirdparty/openrouter/risk_measurement_test.go
@@ -1,0 +1,81 @@
+package openrouter
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/billing"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func TestCompletionObserverPreservesPhysicalAttemptsAndUnknownUsage(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		if calls == 1 {
+			_, _ = fmt.Fprint(w, `{"id":"attempt-empty","model":"openai/gpt-5.4","choices":[],"usage":{"prompt_tokens":17,"completion_tokens":3,"cost":0.01}}`)
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"id":"attempt-final","model":"openai/gpt-5.4","choices":[{"message":{"role":"assistant","content":"not valid judge JSON"},"finish_reason":"stop"}]}`)
+	}))
+	t.Cleanup(server.Close)
+	logger := testenv.NewLogger(t)
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), nil)
+	require.NoError(t, err)
+	observer := &captureCompletionAttemptObserver{attempts: nil}
+	provisioner := &mockProvisioner{apiKey: "test-api-key"}
+	client := NewUnifiedClient(logger, policy, provisioner, &PlatformKeyResolver{Provisioner: provisioner}, nil, nil, nil, nil, observer)
+	client.httpClient = &http.Client{Transport: &testTransport{server: server}}
+	projectID := uuid.NewString()
+	var req ObjectCompletionRequest
+	req.OrgID = "test-org"
+	req.ProjectID = projectID
+	req.Prompt = "Classify this content"
+	req.Model = "openai/gpt-5.4"
+	req.UsageSource = billing.ModelUsageSourceRiskAnalysis
+	req.KeyType = KeyTypeInternal
+	response, err := client.GetObjectCompletion(t.Context(), req)
+	require.NoError(t, err)
+	require.Equal(t, "not valid judge JSON", response.Content)
+	require.Len(t, observer.attempts, 2)
+	first, second := observer.attempts[0], observer.attempts[1]
+	require.Equal(t, "attempt-empty", first.ProviderRequestID)
+	require.Equal(t, CompletionAttemptFailed, first.Status)
+	require.NoError(t, first.Err)
+	require.Equal(t, "openai/gpt-5.4", first.RequestedModel)
+	require.Equal(t, "openai/gpt-5.4", first.ReturnedModel)
+	require.NotNil(t, first.CostUSD)
+	require.InEpsilon(t, 0.01, *first.CostUSD, 1e-12)
+	require.Equal(t, int64(17), *first.PromptTokens)
+	require.Equal(t, int64(3), *first.CompletionTokens)
+	require.False(t, first.StartedAt.IsZero())
+	require.False(t, first.CompletedAt.Before(first.StartedAt))
+	require.Equal(t, "attempt-final", second.ProviderRequestID)
+	require.Equal(t, CompletionAttemptSucceeded, second.Status)
+	require.NoError(t, second.Err)
+	require.Equal(t, "openai/gpt-5.4", second.RequestedModel)
+	require.Equal(t, "openai/gpt-5.4", second.ReturnedModel)
+	require.Nil(t, second.CostUSD)
+	require.Nil(t, second.PromptTokens)
+	require.Nil(t, second.CompletionTokens)
+	require.False(t, second.StartedAt.Before(first.CompletedAt))
+	require.False(t, second.CompletedAt.Before(second.StartedAt))
+}
+
+type captureCompletionAttemptObserver struct {
+	attempts []CompletionAttempt
+}
+
+func (o *captureCompletionAttemptObserver) ObserveCompletionAttempt(_ context.Context, attempt CompletionAttempt) error {
+	o.attempts = append(o.attempts, attempt)
+	return nil
+}

--- a/server/internal/thirdparty/openrouter/unified_client.go
+++ b/server/internal/thirdparty/openrouter/unified_client.go
@@ -36,6 +36,58 @@ type TelemetryLogger interface {
 	Log(ctx context.Context, params telemetry.LogParams)
 }
 
+// CompletionAttemptObserver observes one physical non-streaming provider request.
+type CompletionAttemptObserver interface {
+	ObserveCompletionAttempt(ctx context.Context, attempt CompletionAttempt) error
+}
+
+// CompletionAttemptStatus describes the provider-neutral result of one request.
+type CompletionAttemptStatus string
+
+const (
+	// CompletionAttemptSucceeded indicates that the provider returned a usable completion.
+	CompletionAttemptSucceeded CompletionAttemptStatus = "succeeded"
+
+	// CompletionAttemptFailed indicates that the request failed or returned no completion.
+	CompletionAttemptFailed CompletionAttemptStatus = "failed"
+
+	// CompletionAttemptCancelled indicates that the request context was cancelled.
+	CompletionAttemptCancelled CompletionAttemptStatus = "cancelled"
+)
+
+// CompletionAttempt captures provider-reported accounting for one physical request.
+type CompletionAttempt struct {
+	// StartedAt is when the physical request began.
+	StartedAt time.Time
+
+	// CompletedAt is when the physical request returned.
+	CompletedAt time.Time
+
+	// RequestedModel is the effective model sent to the provider.
+	RequestedModel string
+
+	// ReturnedModel is the model reported by the provider, when present.
+	ReturnedModel string
+
+	// ProviderRequestID is the provider's physical request identity.
+	ProviderRequestID string
+
+	// PromptTokens is nil when the provider did not report prompt usage.
+	PromptTokens *int64
+
+	// CompletionTokens is nil when the provider did not report completion usage.
+	CompletionTokens *int64
+
+	// CostUSD is nil when the provider did not report request cost.
+	CostUSD *float64
+
+	// Status is the terminal result of the physical request.
+	Status CompletionAttemptStatus
+
+	// Err is the request error, when one occurred.
+	Err error
+}
+
 const (
 	DefaultChatModel = "anthropic/claude-opus-5"
 
@@ -47,14 +99,15 @@ const (
 // ChatClient is the single HTTP client for all OpenRouter communication.
 // It applies pluggable strategies for message capture and usage tracking.
 type ChatClient struct {
-	logger                 *slog.Logger
-	httpClient             *guardian.HTTPClient
-	provisioner            Provisioner
-	keyResolver            KeyResolver
-	messageCaptureStrategy MessageCaptureStrategy
-	usageTrackingStrategy  UsageTrackingStrategy
-	chatTitleGenerator     ChatTitleGenerator
-	telemetryLogger        TelemetryLogger
+	logger                    *slog.Logger
+	httpClient                *guardian.HTTPClient
+	provisioner               Provisioner
+	keyResolver               KeyResolver
+	messageCaptureStrategy    MessageCaptureStrategy
+	usageTrackingStrategy     UsageTrackingStrategy
+	chatTitleGenerator        ChatTitleGenerator
+	telemetryLogger           TelemetryLogger
+	completionAttemptObserver CompletionAttemptObserver
 }
 
 // NewUnifiedClient creates a new UnifiedClient with the given strategies.
@@ -67,16 +120,18 @@ func NewUnifiedClient(
 	trackingStrategy UsageTrackingStrategy,
 	chatTitleGenerator ChatTitleGenerator,
 	telemetryLogger TelemetryLogger,
+	completionAttemptObserver CompletionAttemptObserver,
 ) *ChatClient {
 	return &ChatClient{
-		logger:                 logger.With(attr.SlogComponent("openrouter_completions")),
-		httpClient:             guardianPolicy.PooledClient(),
-		provisioner:            provisioner,
-		keyResolver:            keyResolver,
-		messageCaptureStrategy: captureStrategy,
-		usageTrackingStrategy:  trackingStrategy,
-		chatTitleGenerator:     chatTitleGenerator,
-		telemetryLogger:        telemetryLogger,
+		logger:                    logger.With(attr.SlogComponent("openrouter_completions")),
+		httpClient:                guardianPolicy.PooledClient(),
+		provisioner:               provisioner,
+		keyResolver:               keyResolver,
+		messageCaptureStrategy:    captureStrategy,
+		usageTrackingStrategy:     trackingStrategy,
+		chatTitleGenerator:        chatTitleGenerator,
+		telemetryLogger:           telemetryLogger,
+		completionAttemptObserver: completionAttemptObserver,
 	}
 }
 
@@ -389,8 +444,39 @@ func (c *ChatClient) GetCompletion(ctx context.Context, req CompletionRequest) (
 		body     []byte
 	)
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		attemptStarted := time.Now().UTC()
 		var err error
 		chatResp, body, err = c.requestCompletion(ctx, initResult.apiKey, reqBody)
+		attemptCompleted := time.Now().UTC()
+		if c.completionAttemptObserver != nil {
+			status := CompletionAttemptSucceeded
+			if err != nil || len(chatResp.Choices) == 0 {
+				status = CompletionAttemptFailed
+				if ctx.Err() != nil {
+					status = CompletionAttemptCancelled
+				}
+			}
+			observation := CompletionAttempt{
+				StartedAt:         attemptStarted,
+				CompletedAt:       attemptCompleted,
+				RequestedModel:    reqBody.Model,
+				ReturnedModel:     chatResp.Model,
+				ProviderRequestID: chatResp.ID,
+				PromptTokens:      nil,
+				CompletionTokens:  nil,
+				CostUSD:           nil,
+				Status:            status,
+				Err:               err,
+			}
+			if chatResp.Usage != nil {
+				observation.PromptTokens = new(int64(chatResp.Usage.PromptTokens))
+				observation.CompletionTokens = new(int64(chatResp.Usage.CompletionTokens))
+				observation.CostUSD = chatResp.Usage.Cost
+			}
+			if observeErr := c.completionAttemptObserver.ObserveCompletionAttempt(ctx, observation); observeErr != nil {
+				c.logger.ErrorContext(ctx, "observe openrouter completion attempt", attr.SlogError(observeErr))
+			}
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/server/internal/thirdparty/openrouter/unified_client_test.go
+++ b/server/internal/thirdparty/openrouter/unified_client_test.go
@@ -252,6 +252,7 @@ func TestChatClient_GetCompletion(t *testing.T) {
 		trackingStrategy,
 		titleGenerator,
 		telemetryLogger,
+		nil,
 	)
 
 	// Override the HTTP client to use the test server
@@ -401,6 +402,7 @@ func TestChatClient_GetCompletionStream(t *testing.T) {
 		trackingStrategy,
 		titleGenerator,
 		telemetryLogger,
+		nil,
 	)
 
 	// Override the HTTP client to use the test server
@@ -528,6 +530,7 @@ func TestChatClient_GetCompletionStream_FetchesFallbackUsageWhenFinalUsageChunkM
 		trackingStrategy,
 		&mockChatTitleGenerator{},
 		&mockTelemetryLogger{},
+		nil,
 	)
 	client.httpClient = &http.Client{Transport: &testTransport{server: server}}
 
@@ -623,6 +626,7 @@ func TestChatClient_GetCompletion_FetchesFallbackUsageWhenInlineCostMissing(t *t
 		trackingStrategy,
 		&mockChatTitleGenerator{},
 		&mockTelemetryLogger{},
+		nil,
 	)
 	client.httpClient = &http.Client{Transport: &testTransport{server: server}}
 
@@ -732,6 +736,7 @@ func TestChatClient_GetCompletion_WithToolCalls(t *testing.T) {
 		trackingStrategy,
 		titleGenerator,
 		telemetryService,
+		nil,
 	)
 
 	// Override the HTTP client to use the test server
@@ -831,6 +836,7 @@ func TestChatClient_NormalizesMixedAssistantOnlyForOpenRouterRequest(t *testing.
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 	client.httpClient = &http.Client{
 		Transport: &testTransport{server: server},
@@ -909,6 +915,7 @@ func TestChatClient_PassesMixedAssistantThroughWhenNormalizeFlagUnset(t *testing
 		&mockProvisioner{apiKey: "test-api-key"},
 		&PlatformKeyResolver{Provisioner: &mockProvisioner{apiKey: "test-api-key"}},
 		&mockMessageCaptureStrategy{},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -993,6 +1000,7 @@ func TestChatClient_ErrorHandling(t *testing.T) {
 				trackingStrategy,
 				titleGenerator,
 				telemetryService,
+				nil,
 			)
 
 			// Create test request
@@ -1064,6 +1072,7 @@ func TestChatClient_MultipleCompletions_TitleAndResolutionScheduling(t *testing.
 		trackingStrategy,
 		titleGenerator,
 		telemetryService,
+		nil,
 	)
 
 	// Override the HTTP client to use the test server
@@ -1229,6 +1238,7 @@ func TestChatClient_NilChatID_ShouldNotScheduleTitleGeneration(t *testing.T) {
 		&mockUsageTrackingStrategy{},
 		titleGenerator,
 		&mockTelemetryLogger{},
+		nil,
 	)
 	client.httpClient = &http.Client{Transport: &testTransport{server: server}}
 
@@ -1276,6 +1286,7 @@ func TestChatClient_TitleGeneration_ScheduledPerCompletionWithValidChatID(t *tes
 		&mockUsageTrackingStrategy{},
 		titleGenerator,
 		&mockTelemetryLogger{},
+		nil,
 	)
 	client.httpClient = &http.Client{Transport: &testTransport{server: server}}
 
@@ -1341,6 +1352,7 @@ func TestChatClient_ReloadChat_NoDuplicateMessages(t *testing.T) {
 		&mockUsageTrackingStrategy{},
 		&mockChatTitleGenerator{},
 		&mockTelemetryLogger{},
+		nil,
 	)
 	client.httpClient = &http.Client{Transport: &testTransport{server: server}}
 
@@ -1470,6 +1482,7 @@ func TestChatClient_GetCompletion_WithJSONSchema(t *testing.T) {
 		trackingStrategy,
 		titleGenerator,
 		telemetryService,
+		nil,
 	)
 
 	// Override the HTTP client to use the test server
@@ -1586,6 +1599,7 @@ func TestChatClient_GetCompletion_WithoutJSONSchema(t *testing.T) {
 		trackingStrategy,
 		titleGenerator,
 		telemetryService,
+		nil,
 	)
 
 	// Override the HTTP client to use the test server
@@ -1708,6 +1722,7 @@ func TestChatClient_GetCompletion_UnsupportedModelFallback(t *testing.T) {
 		&mockUsageTrackingStrategy{},
 		&mockChatTitleGenerator{},
 		&mockTelemetryLogger{},
+		nil,
 	)
 	client.httpClient = &http.Client{Transport: &testTransport{server: server}}
 
@@ -1766,6 +1781,7 @@ func TestChatClient_GetCompletion_AttributionFields(t *testing.T) {
 		&mockUsageTrackingStrategy{},
 		&mockChatTitleGenerator{},
 		&mockTelemetryLogger{},
+		nil,
 	)
 	client.httpClient = &http.Client{Transport: &testTransport{server: server}}
 

--- a/server/internal/xmcp/setup_test.go
+++ b/server/internal/xmcp/setup_test.go
@@ -139,7 +139,7 @@ func newTestService(t *testing.T) (context.Context, *testInstance) {
 	posthogClient := posthog.New(ctx, logger, "test-posthog-key", "test-posthog-host", "")
 	cacheAdapter := cache.NewRedisCacheAdapter(redisClient)
 	devProvisioner := openrouter.NewDevelopment("test-openrouter-key")
-	chatClient := openrouter.NewUnifiedClient(logger, guardianPolicy, devProvisioner, &openrouter.PlatformKeyResolver{Provisioner: devProvisioner}, nil, nil, nil, nil)
+	chatClient := openrouter.NewUnifiedClient(logger, guardianPolicy, devProvisioner, &openrouter.PlatformKeyResolver{Provisioner: devProvisioner}, nil, nil, nil, nil, nil)
 	vectorToolStore := rag.NewToolsetVectorStore(logger, tracerProvider, conn, chatClient)
 	chatSessionsManager := chatsessions.NewManager(logger, redisClient, "test-jwt-secret")
 	logsEnabled := func(_ context.Context, _ string) (bool, error) { return true, nil }

--- a/uv.lock
+++ b/uv.lock
@@ -1084,6 +1084,7 @@ dependencies = [
     { name = "redis" },
     { name = "starlette" },
     { name = "structlog" },
+    { name = "tiktoken" },
     { name = "uvicorn" },
 ]
 
@@ -1115,6 +1116,7 @@ requires-dist = [
     { name = "redis", specifier = ">=6.4.0" },
     { name = "starlette", specifier = ">=0.40.0" },
     { name = "structlog", specifier = ">=26.1.0" },
+    { name = "tiktoken", specifier = ">=0.14.0" },
     { name = "uvicorn", specifier = ">=0.51.0" },
 ]
 
@@ -1450,6 +1452,46 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/a8/f57819347fc4d8bef2204d15fcbb9d7dff2d6cdd5f83d5ed91456ddacc55/thinc-8.3.13-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba8119daf84a12259ae4d251d36426417bafa0b34108890b4b7e2b50966bd990", size = 4986051, upload-time = "2026-03-23T07:22:30.933Z" },
     { url = "https://files.pythonhosted.org/packages/05/ef/a82214bb7c7c1e2d92b69e1a7654be90cfab180082c6108e45a98af2422c/thinc-8.3.13-cp314-cp314-win_amd64.whl", hash = "sha256:433e3826e018da489f1a8068e6de677f6eff3cc93991a599d90f12cd1bc26cdc", size = 1740382, upload-time = "2026-03-23T07:22:32.869Z" },
     { url = "https://files.pythonhosted.org/packages/9f/ef/1648fda54e9689058335ff54f650a7a314db2a42e21af1b83949b2dc748e/thinc-8.3.13-cp314-cp314-win_arm64.whl", hash = "sha256:11754fada9ad5ba2e02d5f3f234f940e24015b82333db58372f4a6aedad9b43f", size = 1667687, upload-time = "2026-03-23T07:22:34.967Z" },
+]
+
+[[package]]
+name = "tiktoken"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/62/167a842aa0429d45f5e797354fd4343a96f6043d67d0513c675c7b8d36e6/tiktoken-0.14.0.tar.gz", hash = "sha256:231dec90efcdccf1b565a1416107736f1e09b1a08fe736ef9d6363e626d03874", size = 38898, upload-time = "2026-08-17T19:49:49.514Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/b0/1cf129f4af8fc513931f931023def596b7c4bfc77026513cd9d851da9e88/tiktoken-0.14.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e067f4cbcc5d036e8aff7fe7a6b530a8f4de2e4616ad9005a24a1879e24e6450", size = 1096273, upload-time = "2026-08-17T19:49:05.807Z" },
+    { url = "https://files.pythonhosted.org/packages/62/85/2ae74575e321148484147e10b53c3b1717c59ebaa9edb4fe18b1f5c055f8/tiktoken-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f2af4a336ea56d6c14f27741a0e1d8294a35dd0b038bcf990d232ebb54eb994b", size = 1040269, upload-time = "2026-08-17T19:49:06.943Z" },
+    { url = "https://files.pythonhosted.org/packages/89/29/92a1120a12e4bcf2d5464350d1a91b68a433d63ce656bb7f806c27aec09c/tiktoken-0.14.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:f702e0aeeb6506e57687e881c59e844ebe8f0a6a097ddafe20e3ab25f387be4e", size = 1186101, upload-time = "2026-08-17T19:49:08.102Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7d/144af98dc5ad68108451a82e2f5a17f80e2663f5115058b8dfd215c1ad02/tiktoken-0.14.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:e3442bbb2f0c588cec876061e37ae67b455b9df9978b003c8fe30e45f2ef5b42", size = 1204457, upload-time = "2026-08-17T19:49:09.28Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/1f/be7cb06ab2108f612f3e92e7b76cf391e192db0db37a984616f0cc32aafc/tiktoken-0.14.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:979c1524f753b662b0f3cd261b135afe6659cce33caaa7a5ea00dd1756b3055c", size = 1251716, upload-time = "2026-08-17T19:49:10.509Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/6b/81f158d0f90adb826cd704069c2129a046cb784a2a09861009519fc41cf4/tiktoken-0.14.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2cc19ac87b41c9493c9778ff5847f0c8bbcf5bd0ec6b87ce06c1c802adc8a771", size = 1315432, upload-time = "2026-08-17T19:49:11.844Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/ec/f5fa35ec13f07279fdcaf3cc9c04bbb154ea591d23978651f2b672593e8a/tiktoken-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:eceeff0c62419bc78d4b6e70a4762a4d25df3ae8f2d5946e3853ce93e7a57098", size = 988046, upload-time = "2026-08-17T19:49:13.282Z" },
+    { url = "https://files.pythonhosted.org/packages/68/c9/7756717408d3d0dfea3f046c9466144b28afde39ff69d5808f2475dcd7f5/tiktoken-0.14.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:6eb94895c45f26bb8f5546e5fd8a069efcf6e3f108ea9d5cbe3bf6f7f3983438", size = 1096261, upload-time = "2026-08-17T19:49:14.351Z" },
+    { url = "https://files.pythonhosted.org/packages/79/29/46ad8061f57bd9f8b2ea0aa82bf574e0f2aa040b0857a1582adba9957899/tiktoken-0.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:86951a971c53979ec857bd8c4a32dc227ab0fd33f6c12a3bd62d3fbf5f0bfcaa", size = 1040183, upload-time = "2026-08-17T19:49:15.707Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/7c/3184d17b868456f17b60b1a75f5ec0405618a43aa753336df341d8f11781/tiktoken-0.14.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:e2eca764c53490f8930dbce329e0769f11108d87d908282a80c5c130e26e7037", size = 1186719, upload-time = "2026-08-17T19:49:16.84Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e8/46de4400d5bf859f640feee85bd7e32235f68ddf25db53c63be78e581e3a/tiktoken-0.14.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:26cc4b4840fa0e9f4b72ed489883e12f57e00d1021ca794720e3c29a12f0edef", size = 1204660, upload-time = "2026-08-17T19:49:17.987Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ce/af8964c38bc8226dd8950305b7a255fa33345d5572f78af7275a313d28e0/tiktoken-0.14.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2fc834fbe3f6a0736905c36ab709537e6840dbd63b982dc9e0216ae7d305ba1a", size = 1250932, upload-time = "2026-08-17T19:49:19.28Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/4b/323631116fc986d9cc5bbeb2b8223c7c85e61a8bb94ea5ab4951023b149b/tiktoken-0.14.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ca4db6ff5c5bf600f9b7761a0070ed44dfe5797a76bd432fb978bc480ef40c58", size = 1315190, upload-time = "2026-08-17T19:49:20.467Z" },
+    { url = "https://files.pythonhosted.org/packages/18/8b/ba48a73729c9270989b36f37ab2ed5525e52690d715097c9fa791aaa5d05/tiktoken-0.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:7aab286a020660a039097912a088236b985d18a3090d73f136c4413d29d37ca0", size = 987717, upload-time = "2026-08-17T19:49:21.704Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/10/b73b7e319179e0f60b32475f783b044f9cece872c53b6662664e9084b0d0/tiktoken-0.14.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:14b47e3674f2624803a8acc8fb367b7e24fc53055f9df3296482fe9a3a34a232", size = 1096280, upload-time = "2026-08-17T19:49:22.779Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/6b/09999a9bf1d559670d1680e8f8e419ac0e2c5f6aac82e9bfdf70f260b30a/tiktoken-0.14.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:19d643d701fdaa70e5b9c7f8f96abcaffe77ca5e482a3a1a7dde46feb4284695", size = 1040433, upload-time = "2026-08-17T19:49:23.998Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7b/8537be0836f3df99b2a636b44399bfa43cd757f2b8b4097dacb794cf24a7/tiktoken-0.14.0-cp315-cp315-manylinux_2_28_aarch64.whl", hash = "sha256:e4ddf863b59347deaa92302dcd90e5eb003cdc9be06ec2b692c38d1bdd9efd49", size = 1186989, upload-time = "2026-08-17T19:49:25.021Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9d/f9c56d7a943a4468abf9ef37661bb9b8e0cd3aa8aa87368c7146cc3f3222/tiktoken-0.14.0-cp315-cp315-manylinux_2_28_x86_64.whl", hash = "sha256:60c47ca69ddda0dea8256fffd12e1b86f4b59734a20e4a70c61f63cc5f021df4", size = 1204615, upload-time = "2026-08-17T19:49:26.37Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/d2/98a38579db25c4a8a84e31dd95d9072ec5f21f7e70de591da0412e29b25b/tiktoken-0.14.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:728303a072163130c5b477b1f20d6211895569c1d5302c24ffc93a3009160871", size = 1251828, upload-time = "2026-08-17T19:49:27.423Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/83/467be424746c039c5493c0f4102feab16b9b48eb6f5c089b2a2438e3cde2/tiktoken-0.14.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:3c5349c9f916283bba32bec8af69b763e4faa304dc004d0eaaea66a3cf004c1f", size = 1316260, upload-time = "2026-08-17T19:49:29.101Z" },
+    { url = "https://files.pythonhosted.org/packages/02/ee/ddf46ca78e371f5890e96b6e7d089a85b3536432be219851eb0481786ca8/tiktoken-0.14.0-cp315-cp315-win_amd64.whl", hash = "sha256:1b6e4adcfd285c44502aed51df98aaaca4f0fea028165dbf8a9e857b9f98d8ea", size = 988230, upload-time = "2026-08-17T19:49:30.246Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/00/5162e90c851a28da18ed382d34898b79a8022548e5619a64e14c03ce7c3d/tiktoken-0.14.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:11d8211b290855d2721334ff17dd9b3a17bfb26872be01f25d73612ef7ece890", size = 1096186, upload-time = "2026-08-17T19:49:31.656Z" },
+    { url = "https://files.pythonhosted.org/packages/65/97/a5a7bfccf25b1bb65e82bae8edff11ac3c9c041c374b7b4a823d60c38133/tiktoken-0.14.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:d0781223705199b289faa59601bb9c2441712d4c600dd13c43d8fd6a33d22cd5", size = 1039947, upload-time = "2026-08-17T19:49:32.848Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/ba/ef427fc638f1439181c5e12dd26b70e881861f89c007aa7e5b36300f8342/tiktoken-0.14.0-cp315-cp315t-manylinux_2_28_aarch64.whl", hash = "sha256:2ea70afba6b9eddbf22c165142e5f0a2ad7aa36a452873c48b57bb2aeb8492ae", size = 1186997, upload-time = "2026-08-17T19:49:34.121Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/88/2f3f85a968cdc514152129af0a060ebcccb067005a2f29b0d5ef3c838514/tiktoken-0.14.0-cp315-cp315t-manylinux_2_28_x86_64.whl", hash = "sha256:78571efc311c30b73f31eb949a921d6dac39a5d9dc42d1cfa8f8db157b3447b1", size = 1205211, upload-time = "2026-08-17T19:49:35.284Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/f6/80760e98a08e6649d2d68afb6035af713121dfb615acce8c4f73810ec438/tiktoken-0.14.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86f66c85e796f5d05d5c4a60ec1d40cbfebc47a32464053528c797163fa9ab89", size = 1251479, upload-time = "2026-08-17T19:49:36.419Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/84/50966fb6918a0fb9b32721277e5342bf729a2d74350074d662fbedf9772e/tiktoken-0.14.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:149d97453c4c98c04b081d64a85e635921269b532710d6faf81e9e82b790e7d3", size = 1316673, upload-time = "2026-08-17T19:49:37.756Z" },
+    { url = "https://files.pythonhosted.org/packages/35/5e/9b01afd037bfa22a0033963fa091e0f75b6fb15cd85bffb42ff86e697323/tiktoken-0.14.0-cp315-cp315t-win_amd64.whl", hash = "sha256:561e7580f84a79859af1ef6f676968e9030fcc3fe195700b15235bca64f009c9", size = 987929, upload-time = "2026-08-17T19:49:38.947Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Integrate detector-visible workload measurement into Gitleaks, Presidio, prompt injection, prompt policy, and custom-rule execution across realtime, batch, and shadow paths, using the schema, protocol, and measurement core in the preceding layers.
- Expose a domain-neutral OpenRouter physical-attempt observer and adapt it to risk measurements outside the provider client. Capture retries and nullable provider usage/cost without duplicating scan volume or legacy usage tracking.
- Wire Go publishers/consumers and Python recording. Require `tiktoken>=0.14.0`, initialize the tokenizer off-loop, and bake its cache into the runtime image.
- Preserve clean, failed, cancelled, and skipped outcomes. Anchored batch work and Pub/Sub redelivery retain stable logical identities; local realtime hook invocations remain distinct because no upstream retry identity is available. No prices or customer charges are introduced.

Temporal actions/month ≈ 0 additional, scales with fixed: measurement runs inside existing scanner/activity execution and uses Pub/Sub; no workflow starts, activities, timers, or signals are added.

## Motivation

Findings omit clean scans and policy counts do not describe actual detector work. Measure the content each scanner receives after transformation, while keeping provider accounting separate. Keep the constructor/context migrations and their runtime wiring in one layer so the integrated system remains consistent.
