### PR TITLE
mig: add risk evaluation measurement schema

### DIFF
--- a/server/clickhouse/local/golang_migrate/20260906145644_risk-evaluations.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260906145644_risk-evaluations.down.sql
@@ -1,0 +1,2 @@
+-- reverse: create "risk_evaluations" table
+DROP TABLE `risk_evaluations`;

--- a/server/clickhouse/local/golang_migrate/20260906145644_risk-evaluations.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260906145644_risk-evaluations.up.sql
@@ -1,0 +1,31 @@
+-- create "risk_evaluations" table
+CREATE TABLE `risk_evaluations` (
+  `id` UUID COMMENT 'Unique physical attempt UUID stable across Pub/Sub redelivery.',
+  `evaluation_id` UUID COMMENT 'Deterministic logical detector evaluation UUID.',
+  `organization_id` String COMMENT 'Organization that owns the evaluated workload.',
+  `project_id` UUID COMMENT 'Project that owns the evaluated workload.',
+  `operation_id` String COMMENT 'Stable caller-defined identity input for the logical evaluation.',
+  `detector` LowCardinality(String) COMMENT 'Detector class.',
+  `execution_mode` LowCardinality(String) COMMENT 'Execution mode: realtime, batch, or shadow.',
+  `outcome` LowCardinality(String) COMMENT 'Terminal outcome: completed, failed, cancelled, or skipped.',
+  `record_kind` LowCardinality(String) COMMENT 'Measurement kind: scan or inference.',
+  `occurred_at` DateTime64(9, 'UTC') COMMENT 'UTC time when the physical attempt started.',
+  `produced_at` DateTime64(9, 'UTC') COMMENT 'UTC time when the physical attempt completed.',
+  `inserted_at` DateTime64(9, 'UTC') DEFAULT now64(9) COMMENT 'UTC time when ClickHouse received the row.',
+  `stokens` Nullable(Int64) COMMENT 'Detector-visible s-token volume. NULL means unknown or not applicable.',
+  `measurement_method` LowCardinality(String) COMMENT 'Tokenizer used for scan volume.',
+  `model` String DEFAULT '' COMMENT 'Inference model, empty when not applicable.',
+  `provider_request_id` String DEFAULT '' COMMENT 'Provider request identity when reported.',
+  `prompt_tokens` Nullable(Int64) COMMENT 'Provider-reported prompt tokens, NULL when unknown.',
+  `completion_tokens` Nullable(Int64) COMMENT 'Provider-reported completion tokens, NULL when unknown.',
+  `cost_usd` Nullable(Float64) COMMENT 'Provider-reported USD cost, NULL when unknown.',
+  `measurement_error` Bool COMMENT 'True when scan volume could not be measured.',
+  `policy_id` String DEFAULT '' COMMENT 'Diagnostic policy attribution.',
+  `policy_version` Int64 DEFAULT '0' COMMENT 'Diagnostic policy version.',
+  INDEX `idx_risk_evaluations_occurred_at` ((occurred_at)) TYPE minmax GRANULARITY 1,
+  CONSTRAINT `risk_evaluation_identity_valid` CHECK ((id != toUUID('00000000-0000-0000-0000-000000000000')) AND (evaluation_id != toUUID('00000000-0000-0000-0000-000000000000')) AND (project_id != toUUID('00000000-0000-0000-0000-000000000000')) AND notEmpty(trimBoth(organization_id)) AND notEmpty(trimBoth(operation_id))),
+  CONSTRAINT `risk_evaluation_dimensions_valid` CHECK (((detector = 'gitleaks') OR (detector = 'presidio') OR (detector = 'prompt_injection') OR (detector = 'prompt_policy') OR (detector = 'custom_rules')) AND ((execution_mode = 'realtime') OR (execution_mode = 'batch') OR (execution_mode = 'shadow')) AND ((outcome = 'completed') OR (outcome = 'failed') OR (outcome = 'cancelled') OR (outcome = 'skipped')) AND ((record_kind = 'scan') OR (record_kind = 'inference'))),
+  CONSTRAINT `risk_evaluation_measurement_valid` CHECK ((measurement_method = 'tiktoken_o200k_base') AND (policy_version >= 0) AND ((stokens IS NULL) OR (stokens >= 0)) AND ((prompt_tokens IS NULL) OR (prompt_tokens >= 0)) AND ((completion_tokens IS NULL) OR (completion_tokens >= 0)) AND ((cost_usd IS NULL) OR (isFinite(cost_usd) AND (cost_usd >= 0)))),
+  CONSTRAINT `risk_evaluation_kind_valid` CHECK (((record_kind = 'scan') AND ((stokens IS NULL) OR (NOT measurement_error)) AND (model = '') AND (provider_request_id = '') AND (prompt_tokens IS NULL) AND (completion_tokens IS NULL) AND (cost_usd IS NULL)) OR ((record_kind = 'inference') AND (stokens IS NULL) AND (NOT measurement_error)))
+) ENGINE = ReplacingMergeTree(produced_at)
+PRIMARY KEY (`organization_id`, `project_id`, `detector`, `execution_mode`) ORDER BY (`organization_id`, `project_id`, `detector`, `execution_mode`, `id`) PARTITION BY (toYYYYMM(occurred_at)) SETTINGS index_granularity = 8192 COMMENT 'Raw terminal risk measurement attempts with physical-id redelivery convergence';

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:MhpqfJ7zpqJFHj8tTSuf/LSR4G8nAb1BhTzjluF9PCM=
+h1:odq0HfLO8m6BdVMddSPieVNYosM1KabLB8McbbLLczI=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -99,3 +99,4 @@ h1:MhpqfJ7zpqJFHj8tTSuf/LSR4G8nAb1BhTzjluF9PCM=
 20260902193942_openclaw-usage-rows.up.sql h1:FLrJnV85T8U/HUgIeHFhfyTFEKaRBMwxudBpFNu+RG8=
 20260904141331_tenant-reporting-dimensions.up.sql h1:M529LrMZ0R04erQuo/ftTFMQostnvNFJpN50HZToSFE=
 20260904165443_mcp-bandwidth-meter-readings.up.sql h1:ve0lzIwI6dz2YM9yXqEwdvHKGX0TLvfk2OyzY7VFR5A=
+20260906145644_risk-evaluations.up.sql h1:uJQglwOLSf9HW/1odO0J9G5zvceC8b9K/TcYGki8WoA=

--- a/server/clickhouse/migrations/20260906145636_risk-evaluations.sql
+++ b/server/clickhouse/migrations/20260906145636_risk-evaluations.sql
@@ -1,0 +1,31 @@
+-- Create "risk_evaluations" table
+CREATE TABLE `risk_evaluations` (
+  `id` UUID COMMENT 'Unique physical attempt UUID stable across Pub/Sub redelivery.',
+  `evaluation_id` UUID COMMENT 'Deterministic logical detector evaluation UUID.',
+  `organization_id` String COMMENT 'Organization that owns the evaluated workload.',
+  `project_id` UUID COMMENT 'Project that owns the evaluated workload.',
+  `operation_id` String COMMENT 'Stable caller-defined identity input for the logical evaluation.',
+  `detector` LowCardinality(String) COMMENT 'Detector class.',
+  `execution_mode` LowCardinality(String) COMMENT 'Execution mode: realtime, batch, or shadow.',
+  `outcome` LowCardinality(String) COMMENT 'Terminal outcome: completed, failed, cancelled, or skipped.',
+  `record_kind` LowCardinality(String) COMMENT 'Measurement kind: scan or inference.',
+  `occurred_at` DateTime64(9, 'UTC') COMMENT 'UTC time when the physical attempt started.',
+  `produced_at` DateTime64(9, 'UTC') COMMENT 'UTC time when the physical attempt completed.',
+  `inserted_at` DateTime64(9, 'UTC') DEFAULT now64(9) COMMENT 'UTC time when ClickHouse received the row.',
+  `stokens` Nullable(Int64) COMMENT 'Detector-visible s-token volume. NULL means unknown or not applicable.',
+  `measurement_method` LowCardinality(String) COMMENT 'Tokenizer used for scan volume.',
+  `model` String DEFAULT '' COMMENT 'Inference model, empty when not applicable.',
+  `provider_request_id` String DEFAULT '' COMMENT 'Provider request identity when reported.',
+  `prompt_tokens` Nullable(Int64) COMMENT 'Provider-reported prompt tokens, NULL when unknown.',
+  `completion_tokens` Nullable(Int64) COMMENT 'Provider-reported completion tokens, NULL when unknown.',
+  `cost_usd` Nullable(Float64) COMMENT 'Provider-reported USD cost, NULL when unknown.',
+  `measurement_error` Bool COMMENT 'True when scan volume could not be measured.',
+  `policy_id` String DEFAULT '' COMMENT 'Diagnostic policy attribution.',
+  `policy_version` Int64 DEFAULT '0' COMMENT 'Diagnostic policy version.',
+  INDEX `idx_risk_evaluations_occurred_at` ((occurred_at)) TYPE minmax GRANULARITY 1,
+  CONSTRAINT `risk_evaluation_identity_valid` CHECK ((id != toUUID('00000000-0000-0000-0000-000000000000')) AND (evaluation_id != toUUID('00000000-0000-0000-0000-000000000000')) AND (project_id != toUUID('00000000-0000-0000-0000-000000000000')) AND notEmpty(trimBoth(organization_id)) AND notEmpty(trimBoth(operation_id))),
+  CONSTRAINT `risk_evaluation_dimensions_valid` CHECK (((detector = 'gitleaks') OR (detector = 'presidio') OR (detector = 'prompt_injection') OR (detector = 'prompt_policy') OR (detector = 'custom_rules')) AND ((execution_mode = 'realtime') OR (execution_mode = 'batch') OR (execution_mode = 'shadow')) AND ((outcome = 'completed') OR (outcome = 'failed') OR (outcome = 'cancelled') OR (outcome = 'skipped')) AND ((record_kind = 'scan') OR (record_kind = 'inference'))),
+  CONSTRAINT `risk_evaluation_measurement_valid` CHECK ((measurement_method = 'tiktoken_o200k_base') AND (policy_version >= 0) AND ((stokens IS NULL) OR (stokens >= 0)) AND ((prompt_tokens IS NULL) OR (prompt_tokens >= 0)) AND ((completion_tokens IS NULL) OR (completion_tokens >= 0)) AND ((cost_usd IS NULL) OR (isFinite(cost_usd) AND (cost_usd >= 0)))),
+  CONSTRAINT `risk_evaluation_kind_valid` CHECK (((record_kind = 'scan') AND ((stokens IS NULL) OR (NOT measurement_error)) AND (model = '') AND (provider_request_id = '') AND (prompt_tokens IS NULL) AND (completion_tokens IS NULL) AND (cost_usd IS NULL)) OR ((record_kind = 'inference') AND (stokens IS NULL) AND (NOT measurement_error)))
+) ENGINE = ReplacingMergeTree(produced_at)
+PRIMARY KEY (`organization_id`, `project_id`, `detector`, `execution_mode`) ORDER BY (`organization_id`, `project_id`, `detector`, `execution_mode`, `id`) PARTITION BY (toYYYYMM(occurred_at)) SETTINGS index_granularity = 8192 COMMENT 'Raw terminal risk measurement attempts with physical-id redelivery convergence';

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:TuCj3KjRfAfJmSonve6uhSIZtL2tZyiMwly2WWJLZVw=
+h1:WV5RSLBJLxJcpvuSSTpKr06o7xY4Jy5yn/LHButUcKc=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -104,3 +104,4 @@ h1:TuCj3KjRfAfJmSonve6uhSIZtL2tZyiMwly2WWJLZVw=
 20260902193935_openclaw-usage-rows.sql h1:EqmJwX/4Tf1aQVEvIT2viHC3vWV0/iKonGRY8RXP2qc=
 20260904141320_tenant-reporting-dimensions.sql h1:mPYeUlsGTFGV/rJg3SdOP/CUI3gkbMJc/j6Z/OJFO64=
 20260904165434_mcp-bandwidth-meter-readings.sql h1:aQJUsNzu7EHoldJZ7IZt+yiiqO9Lz5QihNjYvcY2Oxw=
+20260906145636_risk-evaluations.sql h1:6/TZ5hc2hFSnCXZ24kv+ddSWNgRP5CmE2CA8e7FiK8Y=

--- a/server/clickhouse/schema.sql
+++ b/server/clickhouse/schema.sql
@@ -1256,6 +1256,44 @@ ORDER BY (organization_id, meter_id, project_id, id)
 SETTINGS index_granularity = 8192
 COMMENT 'Raw usage ledger with producer-time stable-id convergence and billing reads requiring FINAL or equivalent id deduplication';
 
+-- Terminal risk measurement attempts. The physical id preserves distinct scan
+-- and inference attempts, while evaluation_id groups retries of the same
+-- logical detector evaluation. Readers must use FINAL before aggregating.
+CREATE TABLE IF NOT EXISTS risk_evaluations (
+    id UUID COMMENT 'Unique physical attempt UUID stable across Pub/Sub redelivery.',
+    evaluation_id UUID COMMENT 'Deterministic logical detector evaluation UUID.',
+    organization_id String COMMENT 'Organization that owns the evaluated workload.',
+    project_id UUID COMMENT 'Project that owns the evaluated workload.',
+    operation_id String COMMENT 'Stable caller-defined identity input for the logical evaluation.',
+    detector LowCardinality(String) COMMENT 'Detector class.',
+    execution_mode LowCardinality(String) COMMENT 'Execution mode: realtime, batch, or shadow.',
+    outcome LowCardinality(String) COMMENT 'Terminal outcome: completed, failed, cancelled, or skipped.',
+    record_kind LowCardinality(String) COMMENT 'Measurement kind: scan or inference.',
+    occurred_at DateTime64(9, 'UTC') COMMENT 'UTC time when the physical attempt started.',
+    produced_at DateTime64(9, 'UTC') COMMENT 'UTC time when the physical attempt completed.',
+    inserted_at DateTime64(9, 'UTC') DEFAULT now64(9) COMMENT 'UTC time when ClickHouse received the row.',
+    stokens Nullable(Int64) COMMENT 'Detector-visible s-token volume. NULL means unknown or not applicable.',
+    measurement_method LowCardinality(String) COMMENT 'Tokenizer used for scan volume.',
+    model String DEFAULT '' COMMENT 'Inference model, empty when not applicable.',
+    provider_request_id String DEFAULT '' COMMENT 'Provider request identity when reported.',
+    prompt_tokens Nullable(Int64) COMMENT 'Provider-reported prompt tokens, NULL when unknown.',
+    completion_tokens Nullable(Int64) COMMENT 'Provider-reported completion tokens, NULL when unknown.',
+    cost_usd Nullable(Float64) COMMENT 'Provider-reported USD cost, NULL when unknown.',
+    measurement_error Bool COMMENT 'True when scan volume could not be measured.',
+    policy_id String DEFAULT '' COMMENT 'Diagnostic policy attribution.',
+    policy_version Int64 DEFAULT 0 COMMENT 'Diagnostic policy version.',
+    CONSTRAINT risk_evaluation_identity_valid CHECK id != toUUID('00000000-0000-0000-0000-000000000000') AND evaluation_id != toUUID('00000000-0000-0000-0000-000000000000') AND project_id != toUUID('00000000-0000-0000-0000-000000000000') AND notEmpty(trimBoth(organization_id)) AND notEmpty(trimBoth(operation_id)),
+    CONSTRAINT risk_evaluation_dimensions_valid CHECK (detector = 'gitleaks' OR detector = 'presidio' OR detector = 'prompt_injection' OR detector = 'prompt_policy' OR detector = 'custom_rules') AND (execution_mode = 'realtime' OR execution_mode = 'batch' OR execution_mode = 'shadow') AND (outcome = 'completed' OR outcome = 'failed' OR outcome = 'cancelled' OR outcome = 'skipped') AND (record_kind = 'scan' OR record_kind = 'inference'),
+    CONSTRAINT risk_evaluation_measurement_valid CHECK measurement_method = 'tiktoken_o200k_base' AND policy_version >= 0 AND (stokens IS NULL OR stokens >= 0) AND (prompt_tokens IS NULL OR prompt_tokens >= 0) AND (completion_tokens IS NULL OR completion_tokens >= 0) AND (cost_usd IS NULL OR (isFinite(cost_usd) AND cost_usd >= 0)),
+    CONSTRAINT risk_evaluation_kind_valid CHECK (record_kind = 'scan' AND (stokens IS NULL OR NOT measurement_error) AND model = '' AND provider_request_id = '' AND prompt_tokens IS NULL AND completion_tokens IS NULL AND cost_usd IS NULL) OR (record_kind = 'inference' AND stokens IS NULL AND NOT measurement_error),
+    INDEX idx_risk_evaluations_occurred_at occurred_at TYPE minmax GRANULARITY 1
+) ENGINE = ReplacingMergeTree(produced_at)
+PARTITION BY toYYYYMM(occurred_at)
+PRIMARY KEY (organization_id, project_id, detector, execution_mode)
+ORDER BY (organization_id, project_id, detector, execution_mode, id)
+SETTINGS index_granularity = 8192
+COMMENT 'Raw terminal risk measurement attempts with physical-id redelivery convergence';
+
 CREATE TABLE IF NOT EXISTS authz_challenges (
     -- Identity
     id UUID DEFAULT generateUUIDv7() COMMENT 'Unique identifier for the challenge entry.',


### PR DESCRIPTION
## Summary

- Add the `risk_evaluations` ClickHouse table for terminal scan and physical inference attempts, including nullable canonical volume and provider accounting.
- Validate identities, detector/mode/outcome dimensions, and scan-versus-inference field combinations. Deduplicate physical event redelivery with a replacing table engine.
- Include matching Atlas and local golang-migrate migrations and checksums. This layer contains no producers, consumers, or pricing changes.

## Motivation

Risk workload measurement needs storage that preserves clean scans, retries, failures, and unknown usage independently of findings. Isolate the additive schema for review before introducing its event contract and runtime integration.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `risk_evaluations` ClickHouse table for storing terminal risk measurement attempts from scans and inference runs. The `ReplacingMergeTree` engine uses a physical attempt ID so Pub/Sub redeliveries converge to the latest attempt without dropping legitimate retries.

**Migration**
- Adds up/down migrations and updates `schema.sql` and Atlas checksums in both migration directories.
- CHECK constraints restrict detector, execution mode, outcome, record kind, and measurement values to supported sets.

<sup>Written for commit 4b24a8557eebc2732f912023befae1db9d9c5def. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

