### PR TITLE
chore: implement risk workload recording and projection

### DIFF
--- a/server/internal/metering/definition.go
+++ b/server/internal/metering/definition.go
@@ -18,6 +18,7 @@ type Definition struct {
 	unit              Unit
 	measurementMethod MeasurementMethod
 	scopeKind         scopeKind
+	stripeExportable  bool
 }
 
 const (
@@ -29,6 +30,23 @@ const (
 
 	// MeterMCPBandwidthEgress measures application-visible MCP response body bytes.
 	MeterMCPBandwidthEgress MeterID = "gram.mcp.bandwidth.egress"
+
+	// Risk evaluation meters measure detector-qualified scanned volume.
+	MeterRiskGitleaksRealtime        MeterID = "gram.risk.evaluation.gitleaks.realtime"
+	MeterRiskGitleaksBatch           MeterID = "gram.risk.evaluation.gitleaks.batch"
+	MeterRiskGitleaksShadow          MeterID = "gram.risk.evaluation.gitleaks.shadow"
+	MeterRiskPresidioRealtime        MeterID = "gram.risk.evaluation.presidio.realtime"
+	MeterRiskPresidioBatch           MeterID = "gram.risk.evaluation.presidio.batch"
+	MeterRiskPresidioShadow          MeterID = "gram.risk.evaluation.presidio.shadow"
+	MeterRiskPromptInjectionRealtime MeterID = "gram.risk.evaluation.prompt_injection.realtime"
+	MeterRiskPromptInjectionBatch    MeterID = "gram.risk.evaluation.prompt_injection.batch"
+	MeterRiskPromptInjectionShadow   MeterID = "gram.risk.evaluation.prompt_injection.shadow"
+	MeterRiskPromptPolicyRealtime    MeterID = "gram.risk.evaluation.prompt_policy.realtime"
+	MeterRiskPromptPolicyBatch       MeterID = "gram.risk.evaluation.prompt_policy.batch"
+	MeterRiskPromptPolicyShadow      MeterID = "gram.risk.evaluation.prompt_policy.shadow"
+	MeterRiskCustomRulesRealtime     MeterID = "gram.risk.evaluation.custom_rules.realtime"
+	MeterRiskCustomRulesBatch        MeterID = "gram.risk.evaluation.custom_rules.batch"
+	MeterRiskCustomRulesShadow       MeterID = "gram.risk.evaluation.custom_rules.shadow"
 
 	// UnitSTokens is the Gram-owned Speakeasy token workload unit.
 	UnitSTokens Unit = "stokens"
@@ -51,6 +69,7 @@ func AgentSessionStorage() Definition {
 		unit:              UnitSTokens,
 		measurementMethod: MeasurementTiktokenO200kBase,
 		scopeKind:         scopeKindProject,
+		stripeExportable:  true,
 	}
 }
 
@@ -62,6 +81,7 @@ func MCPBandwidthIngress() Definition {
 		unit:              UnitBytes,
 		measurementMethod: MeasurementHTTPBodyBytes,
 		scopeKind:         scopeKindProject,
+		stripeExportable:  true,
 	}
 }
 
@@ -73,18 +93,70 @@ func MCPBandwidthEgress() Definition {
 		unit:              UnitBytes,
 		measurementMethod: MeasurementHTTPBodyBytes,
 		scopeKind:         scopeKindProject,
+		stripeExportable:  true,
+	}
+}
+
+// RiskEvaluationDefinition returns the registered detector-and-mode workload definition.
+func RiskEvaluationDefinition(detector, executionMode string) (Definition, bool) {
+	id, ok := RiskEvaluationMeterID(detector, executionMode)
+	if !ok {
+		var zero Definition
+		return zero, false
+	}
+	return Definition{
+		id:                id,
+		version:           1,
+		unit:              UnitSTokens,
+		measurementMethod: MeasurementTiktokenO200kBase,
+		scopeKind:         scopeKindProject,
+		stripeExportable:  false,
+	}, true
+}
+
+// RiskEvaluationMeterID returns the registered meter identity for a detector and mode.
+func RiskEvaluationMeterID(detector, executionMode string) (MeterID, bool) {
+	var ids [3]MeterID
+	switch detector {
+	case "gitleaks":
+		ids = [3]MeterID{MeterRiskGitleaksRealtime, MeterRiskGitleaksBatch, MeterRiskGitleaksShadow}
+	case "presidio":
+		ids = [3]MeterID{MeterRiskPresidioRealtime, MeterRiskPresidioBatch, MeterRiskPresidioShadow}
+	case "prompt_injection":
+		ids = [3]MeterID{MeterRiskPromptInjectionRealtime, MeterRiskPromptInjectionBatch, MeterRiskPromptInjectionShadow}
+	case "prompt_policy":
+		ids = [3]MeterID{MeterRiskPromptPolicyRealtime, MeterRiskPromptPolicyBatch, MeterRiskPromptPolicyShadow}
+	case "custom_rules":
+		ids = [3]MeterID{MeterRiskCustomRulesRealtime, MeterRiskCustomRulesBatch, MeterRiskCustomRulesShadow}
+	default:
+		return "", false
+	}
+
+	switch executionMode {
+	case "realtime":
+		return ids[0], true
+	case "batch":
+		return ids[1], true
+	case "shadow":
+		return ids[2], true
+	default:
+		return "", false
 	}
 }
 
 // LookupDefinition returns a registered meter definition by identity.
 func LookupDefinition(id MeterID, version uint32) (Definition, bool) {
-	for _, definition := range [...]Definition{
-		AgentSessionStorage(),
-		MCPBandwidthIngress(),
-		MCPBandwidthEgress(),
-	} {
+	for _, definition := range [...]Definition{AgentSessionStorage(), MCPBandwidthIngress(), MCPBandwidthEgress()} {
 		if id == definition.id && version == definition.version {
 			return definition, true
+		}
+	}
+	for _, detector := range [...]string{"gitleaks", "presidio", "prompt_injection", "prompt_policy", "custom_rules"} {
+		for _, mode := range [...]string{"realtime", "batch", "shadow"} {
+			definition, _ := RiskEvaluationDefinition(detector, mode)
+			if id == definition.id && version == definition.version {
+				return definition, true
+			}
 		}
 	}
 	var zero Definition

--- a/server/internal/metering/handler_stripe.go
+++ b/server/internal/metering/handler_stripe.go
@@ -125,6 +125,10 @@ func (e *MeterReadingStripeExporter) Handle(ctx context.Context, reading *meteri
 	if !ok {
 		return fmt.Errorf("meter %q version %d is not registered", reading.GetMeterId(), reading.GetMeterVersion())
 	}
+	if !definition.stripeExportable {
+		e.recordReadingOutcome(ctx, stripeExportOutcomeIneligible)
+		return nil
+	}
 	if e.stripeCatalog == nil {
 		return errors.New("stripe catalog is not configured")
 	}

--- a/server/internal/metering/handler_stripe_test.go
+++ b/server/internal/metering/handler_stripe_test.go
@@ -165,6 +165,31 @@ func TestMeterReadingStripeExporterAcknowledgesCatalogMiss(t *testing.T) {
 	require.Equal(t, map[string]int64{"ineligible": 1}, stripeExportReadingOutcomes(t, reader))
 }
 
+func TestMeterReadingStripeExporterHardExcludesRiskMeters(t *testing.T) {
+	t.Parallel()
+
+	client := &captureV2MeterEventClient{inputs: nil, err: errors.New("must not be called")}
+	meterProvider, reader := newStripeExporterMetricReader(t)
+	exporter := metering.NewMeterReadingStripeExporter(
+		testenv.NewLogger(t),
+		meterProvider,
+		nil,
+		client,
+		metering.StripeCatalogFunc(func(metering.Definition) (string, error) {
+			return "misconfigured-risk-meter", nil
+		}),
+		true,
+	)
+	reading := new(meteringv1.MeterReading)
+	reading.SetKind(meteringv1.MeterReading_KIND_USAGE)
+	reading.SetMeterId(string(metering.MeterRiskGitleaksRealtime))
+	reading.SetMeterVersion(1)
+
+	require.NoError(t, exporter.Handle(t.Context(), reading, gcp.MessageMetadata{}))
+	require.Empty(t, client.inputs)
+	require.Equal(t, map[string]int64{"ineligible": 1}, stripeExportReadingOutcomes(t, reader))
+}
+
 func TestMeterReadingStripeExporterNacksCatalogError(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/riskmeter/chrepo/queries.go
+++ b/server/internal/riskmeter/chrepo/queries.go
@@ -1,0 +1,120 @@
+// Package chrepo persists raw risk evaluation measurements to ClickHouse.
+package chrepo
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/Masterminds/squirrel"
+	"github.com/google/uuid"
+)
+
+var sq = squirrel.StatementBuilder.PlaceholderFormat(squirrel.Question)
+
+// EvaluationRow is one validated risk_evaluations row.
+type EvaluationRow struct {
+	// ID identifies this physical attempt and is unchanged on redelivery.
+	ID uuid.UUID
+	// EvaluationID identifies the logical evaluation across retries.
+	EvaluationID uuid.UUID
+	// OrganizationID identifies the tenant that requested the evaluation.
+	OrganizationID string
+	// ProjectID identifies the evaluated project's tenant boundary.
+	ProjectID uuid.UUID
+	// OperationID anchors the evaluation independently of batch grouping.
+	OperationID string
+	// Detector identifies the independently measured scanner class.
+	Detector string
+	// ExecutionMode distinguishes realtime, batch, and shadow execution.
+	ExecutionMode string
+	// Outcome records whether the attempt completed, failed, cancelled, or skipped.
+	Outcome string
+	// RecordKind separates scan volume from physical inference accounting.
+	RecordKind string
+	// OccurredAt is the attempt's start time.
+	OccurredAt time.Time
+	// ProducedAt is when the terminal measurement was published.
+	ProducedAt time.Time
+	// InsertedAt is when this delivery reached the consumer.
+	InsertedAt time.Time
+	// STokens is canonical scan volume; nil means unknown rather than zero.
+	STokens *int64
+	// MeasurementMethod versions the canonical tokenizer contract.
+	MeasurementMethod string
+	// Model identifies the provider model used by an inference attempt.
+	Model string
+	// ProviderRequestID identifies the physical request when supplied by the provider.
+	ProviderRequestID string
+	// PromptTokens retains provider-reported input usage; nil means unavailable.
+	PromptTokens *int64
+	// CompletionTokens retains provider-reported output usage; nil means unavailable.
+	CompletionTokens *int64
+	// CostUSD retains provider-reported cost; nil must not become a known zero.
+	CostUSD *float64
+	// MeasurementError distinguishes failed tokenization from unmeasured work.
+	MeasurementError bool
+	// PolicyID identifies the policy whose evaluation caused this work.
+	PolicyID string
+	// PolicyVersion distinguishes changes to the evaluated policy.
+	PolicyVersion int64
+}
+
+// Queries writes risk evaluation measurements.
+type Queries struct {
+	conn clickhouse.Conn
+}
+
+// New creates a risk evaluation repository backed by conn.
+func New(conn clickhouse.Conn) *Queries {
+	return &Queries{conn: conn}
+}
+
+// InsertRiskEvaluations synchronously inserts a nonempty batch.
+func (q *Queries) InsertRiskEvaluations(ctx context.Context, rows []EvaluationRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	builder := sq.Insert("risk_evaluations").Columns(
+		"id", "evaluation_id", "organization_id", "project_id", "operation_id",
+		"detector", "execution_mode", "outcome", "record_kind", "occurred_at",
+		"produced_at", "inserted_at", "stokens", "measurement_method", "model",
+		"provider_request_id", "prompt_tokens", "completion_tokens", "cost_usd",
+		"measurement_error", "policy_id", "policy_version",
+	)
+	for _, row := range rows {
+		var stokens, promptTokens, completionTokens, costUSD any
+		if row.STokens != nil {
+			stokens = *row.STokens
+		}
+		if row.PromptTokens != nil {
+			promptTokens = *row.PromptTokens
+		}
+		if row.CompletionTokens != nil {
+			completionTokens = *row.CompletionTokens
+		}
+		if row.CostUSD != nil {
+			costUSD = *row.CostUSD
+		}
+		builder = builder.Values(
+			row.ID, row.EvaluationID, row.OrganizationID, row.ProjectID, row.OperationID,
+			row.Detector, row.ExecutionMode, row.Outcome, row.RecordKind,
+			row.OccurredAt.Format("2006-01-02 15:04:05.999999999"),
+			row.ProducedAt.Format("2006-01-02 15:04:05.999999999"),
+			row.InsertedAt.Format("2006-01-02 15:04:05.999999999"),
+			stokens, row.MeasurementMethod, row.Model, row.ProviderRequestID,
+			promptTokens, completionTokens, costUSD, row.MeasurementError,
+			row.PolicyID, row.PolicyVersion,
+		)
+	}
+	query, args, err := builder.ToSql()
+	if err != nil {
+		return fmt.Errorf("build risk_evaluations insert query: %w", err)
+	}
+	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{"async_insert": 0}))
+	if err := q.conn.Exec(ctx, query, args...); err != nil {
+		return fmt.Errorf("insert risk_evaluations: %w", err)
+	}
+	return nil
+}

--- a/server/internal/riskmeter/consumer/ch_writer.go
+++ b/server/internal/riskmeter/consumer/ch_writer.go
@@ -1,0 +1,286 @@
+// Package consumer persists risk evaluation events and projects billable volume.
+package consumer
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+
+	meteringv1 "github.com/speakeasy-api/gram/infra/gen/gram/metering/v1"
+	"github.com/speakeasy-api/gram/infra/pkg/gcp"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/metering"
+	meteringchrepo "github.com/speakeasy-api/gram/server/internal/metering/chrepo"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
+	riskmeterchrepo "github.com/speakeasy-api/gram/server/internal/riskmeter/chrepo"
+	"github.com/speakeasy-api/gram/server/internal/streams"
+)
+
+const (
+	meterWriterSkipped  = "gram.risk_evaluation_ch_writer.records_skipped"
+	meterWriterInserted = "gram.risk_evaluation_ch_writer.records_inserted"
+)
+
+// EvaluationInserter persists validated raw risk evaluation measurements.
+type EvaluationInserter interface {
+	InsertRiskEvaluations(context.Context, []riskmeterchrepo.EvaluationRow) error
+}
+
+// RiskEvaluationCHWriter persists raw terminal records and projects positive
+// completed scan volume into the existing workload meter ledger.
+type RiskEvaluationCHWriter struct {
+	logger             *slog.Logger
+	evaluationInserter EvaluationInserter
+	readingInserter    metering.ReadingInserter
+	recordsSkipped     metric.Int64Counter
+	recordsInserted    metric.Int64Counter
+}
+
+// NewRiskEvaluationCHWriter creates the risk measurement ClickHouse subscriber.
+func NewRiskEvaluationCHWriter(
+	logger *slog.Logger,
+	meterProvider metric.MeterProvider,
+	evaluationInserter EvaluationInserter,
+	readingInserter metering.ReadingInserter,
+) *RiskEvaluationCHWriter {
+	logger = logger.With(attr.SlogComponent("risk-evaluation-ch-writer"))
+	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/riskmeter")
+	skipped, err := meter.Int64Counter(meterWriterSkipped, metric.WithDescription("Risk measurement messages dropped as unprocessable"))
+	if err != nil {
+		logger.ErrorContext(context.Background(), "create metric", attr.SlogMetricName(meterWriterSkipped), attr.SlogError(err))
+	}
+	inserted, err := meter.Int64Counter(meterWriterInserted, metric.WithDescription("Risk measurement rows attempted for ClickHouse insertion"))
+	if err != nil {
+		logger.ErrorContext(context.Background(), "create metric", attr.SlogMetricName(meterWriterInserted), attr.SlogError(err))
+	}
+	return &RiskEvaluationCHWriter{
+		logger:             logger,
+		evaluationInserter: evaluationInserter,
+		readingInserter:    readingInserter,
+		recordsSkipped:     skipped,
+		recordsInserted:    inserted,
+	}
+}
+
+var _ streams.BatchResultHandler[*meteringv1.RiskEvaluation] = (*RiskEvaluationCHWriter)(nil)
+
+// HandleBatchWithResult acknowledges poison messages and stages retry only for
+// valid messages covered by a failed insert.
+func (w *RiskEvaluationCHWriter) HandleBatchWithResult(ctx context.Context, batch []gcp.BatchMessage[*meteringv1.RiskEvaluation]) error {
+	insertedAt := time.Now().UTC()
+	rawRows := make([]riskmeterchrepo.EvaluationRow, 0, len(batch))
+	rawCovered := make([]int, 0, len(batch))
+	readingByID := make(map[uuid.UUID]int, len(batch))
+	readingRows := make([]meteringchrepo.ReadingRow, 0, len(batch))
+	readingCovered := make([][]int, 0, len(batch))
+
+	for i, item := range batch {
+		raw, reading, err := riskEvaluationRows(item.Message, insertedAt)
+		if err != nil {
+			messageID := ""
+			if item.Message != nil {
+				messageID = item.Message.GetId()
+			}
+			w.logger.ErrorContext(ctx, "skipping unprocessable risk measurement", attr.SlogMessageID(messageID), attr.SlogError(err))
+			if w.recordsSkipped != nil {
+				w.recordsSkipped.Add(ctx, 1)
+			}
+			continue
+		}
+		rawRows = append(rawRows, raw)
+		rawCovered = append(rawCovered, i)
+		if reading == nil {
+			continue
+		}
+		if prior, duplicate := readingByID[reading.ID]; duplicate {
+			readingCovered[prior] = append(readingCovered[prior], i)
+			if reading.ProducedAt.After(readingRows[prior].ProducedAt) {
+				readingRows[prior] = *reading
+			}
+			continue
+		}
+		readingByID[reading.ID] = len(readingRows)
+		readingRows = append(readingRows, *reading)
+		readingCovered = append(readingCovered, []int{i})
+	}
+
+	if len(rawRows) > 0 {
+		err := w.evaluationInserter.InsertRiskEvaluations(ctx, rawRows)
+		w.recordInsert(ctx, int64(len(rawRows)), err)
+		if err != nil {
+			err = fmt.Errorf("insert raw risk evaluations: %w", err)
+			w.stageFailure(ctx, batch, rawCovered, err)
+			return nil
+		}
+	}
+	if len(readingRows) > 0 {
+		err := w.readingInserter.InsertReadings(ctx, readingRows)
+		if err != nil {
+			err = fmt.Errorf("insert risk evaluation meter readings: %w", err)
+			covered := make([]int, 0, len(readingRows))
+			for _, indices := range readingCovered {
+				covered = append(covered, indices...)
+			}
+			w.stageFailure(ctx, batch, covered, err)
+		}
+	}
+	return nil
+}
+
+func (w *RiskEvaluationCHWriter) recordInsert(ctx context.Context, count int64, err error) {
+	if w.recordsInserted != nil {
+		w.recordsInserted.Add(ctx, count, metric.WithAttributes(attr.Outcome(o11y.OutcomeFromError(err))))
+	}
+}
+
+func (w *RiskEvaluationCHWriter) stageFailure(ctx context.Context, batch []gcp.BatchMessage[*meteringv1.RiskEvaluation], covered []int, err error) {
+	w.logger.ErrorContext(ctx, "insert risk measurement batch", attr.SlogError(err))
+	span := trace.SpanFromContext(ctx)
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+	for _, i := range covered {
+		batch[i].Fail(err)
+	}
+}
+
+func riskEvaluationRows(message *meteringv1.RiskEvaluation, insertedAt time.Time) (riskmeterchrepo.EvaluationRow, *meteringchrepo.ReadingRow, error) {
+	if message == nil {
+		return riskmeterchrepo.EvaluationRow{}, nil, fmt.Errorf("message is nil")
+	}
+	id, err := uuid.Parse(message.GetId())
+	if err != nil {
+		return riskmeterchrepo.EvaluationRow{}, nil, fmt.Errorf("parse id: %w", err)
+	}
+	if id == uuid.Nil {
+		return riskmeterchrepo.EvaluationRow{}, nil, fmt.Errorf("id must not be zero")
+	}
+	evaluationID, err := uuid.Parse(message.GetEvaluationId())
+	if err != nil {
+		return riskmeterchrepo.EvaluationRow{}, nil, fmt.Errorf("parse evaluation id: %w", err)
+	}
+	projectID, err := uuid.Parse(message.GetProjectId())
+	if err != nil {
+		return riskmeterchrepo.EvaluationRow{}, nil, fmt.Errorf("parse project id: %w", err)
+	}
+	occurredAt, err := time.Parse(time.RFC3339Nano, message.GetOccurredAt())
+	if err != nil {
+		return riskmeterchrepo.EvaluationRow{}, nil, fmt.Errorf("parse occurred at: %w", err)
+	}
+	producedAt, err := time.Parse(time.RFC3339Nano, message.GetProducedAt())
+	if err != nil {
+		return riskmeterchrepo.EvaluationRow{}, nil, fmt.Errorf("parse produced at: %w", err)
+	}
+	if producedAt.Before(occurredAt) {
+		return riskmeterchrepo.EvaluationRow{}, nil, fmt.Errorf("produced at precedes occurred at")
+	}
+	evaluation := riskmeter.Evaluation{
+		OrganizationID: message.GetOrganizationId(), ProjectID: message.GetProjectId(), OperationID: message.GetOperationId(),
+		Detector: message.GetDetector(), ExecutionMode: message.GetExecutionMode(), PolicyID: message.GetPolicyId(),
+		PolicyVersion: message.GetPolicyVersion(), OccurredAt: occurredAt,
+	}
+	if err := riskmeter.ValidateEvaluation(evaluation); err != nil {
+		return riskmeterchrepo.EvaluationRow{}, nil, fmt.Errorf("validate evaluation: %w", err)
+	}
+	detector, _ := riskmeter.DetectorLabel(evaluation.Detector)
+	executionMode, _ := riskmeter.ExecutionModeLabel(evaluation.ExecutionMode)
+	if evaluationID.String() != riskmeter.EvaluationID(evaluation) {
+		return riskmeterchrepo.EvaluationRow{}, nil, fmt.Errorf("evaluation id does not match logical identity")
+	}
+	if err := riskmeter.ValidateOutcome(message.GetOutcome()); err != nil {
+		return riskmeterchrepo.EvaluationRow{}, nil, fmt.Errorf("validate outcome: %w", err)
+	}
+	outcome, _ := riskmeter.OutcomeLabel(message.GetOutcome())
+	if message.GetMeasurementMethod() != riskmeter.MeasurementMethod {
+		return riskmeterchrepo.EvaluationRow{}, nil, fmt.Errorf("invalid measurement method %q", message.GetMeasurementMethod())
+	}
+	if message.HasStokens() && message.GetStokens() < 0 {
+		return riskmeterchrepo.EvaluationRow{}, nil, fmt.Errorf("stokens must not be negative")
+	}
+	if message.HasPromptTokens() && message.GetPromptTokens() < 0 {
+		return riskmeterchrepo.EvaluationRow{}, nil, fmt.Errorf("prompt tokens must not be negative")
+	}
+	if message.HasCompletionTokens() && message.GetCompletionTokens() < 0 {
+		return riskmeterchrepo.EvaluationRow{}, nil, fmt.Errorf("completion tokens must not be negative")
+	}
+	if message.HasCostUsd() && (message.GetCostUsd() < 0 || math.IsNaN(message.GetCostUsd()) || math.IsInf(message.GetCostUsd(), 0)) {
+		return riskmeterchrepo.EvaluationRow{}, nil, fmt.Errorf("cost usd must be finite and nonnegative")
+	}
+	switch message.GetRecordKind() {
+	case riskmeter.RecordKindScan:
+		if message.HasStokens() && message.GetMeasurementError() {
+			return riskmeterchrepo.EvaluationRow{}, nil, fmt.Errorf("scan with measurement error must not contain known stokens")
+		}
+		if message.HasPromptTokens() || message.HasCompletionTokens() || message.HasCostUsd() || message.GetModel() != "" || message.GetProviderRequestId() != "" {
+			return riskmeterchrepo.EvaluationRow{}, nil, fmt.Errorf("scan must not contain inference accounting")
+		}
+	case riskmeter.RecordKindInference:
+		if message.HasStokens() || message.GetMeasurementError() {
+			return riskmeterchrepo.EvaluationRow{}, nil, fmt.Errorf("inference must not contain scan volume")
+		}
+	default:
+		return riskmeterchrepo.EvaluationRow{}, nil, fmt.Errorf("invalid record kind %q", message.GetRecordKind())
+	}
+
+	var stokenCount, promptTokens, completionTokens *int64
+	var costUSD *float64
+	if message.HasStokens() {
+		value := message.GetStokens()
+		stokenCount = &value
+	}
+	if message.HasPromptTokens() {
+		value := message.GetPromptTokens()
+		promptTokens = &value
+	}
+	if message.HasCompletionTokens() {
+		value := message.GetCompletionTokens()
+		completionTokens = &value
+	}
+	if message.HasCostUsd() {
+		value := message.GetCostUsd()
+		costUSD = &value
+	}
+	raw := riskmeterchrepo.EvaluationRow{
+		ID: id, EvaluationID: evaluationID, OrganizationID: evaluation.OrganizationID, ProjectID: projectID,
+		OperationID: evaluation.OperationID, Detector: detector, ExecutionMode: executionMode,
+		Outcome: outcome, RecordKind: message.GetRecordKind(), OccurredAt: occurredAt, ProducedAt: producedAt,
+		InsertedAt: insertedAt, STokens: stokenCount, MeasurementMethod: message.GetMeasurementMethod(), Model: message.GetModel(),
+		ProviderRequestID: message.GetProviderRequestId(), PromptTokens: promptTokens, CompletionTokens: completionTokens,
+		CostUSD: costUSD, MeasurementError: message.GetMeasurementError(), PolicyID: evaluation.PolicyID, PolicyVersion: evaluation.PolicyVersion,
+	}
+	if message.GetRecordKind() != riskmeter.RecordKindScan || message.GetOutcome() != riskmeter.OutcomeCompleted || stokenCount == nil || *stokenCount == 0 {
+		return raw, nil, nil
+	}
+	definition, ok := metering.RiskEvaluationDefinition(detector, executionMode)
+	if !ok {
+		return riskmeterchrepo.EvaluationRow{}, nil, fmt.Errorf("risk meter definition is not registered")
+	}
+	attributes := map[string]string{
+		"policy_id":      evaluation.PolicyID,
+		"policy_version": strconv.FormatInt(evaluation.PolicyVersion, 10),
+	}
+	usage, err := metering.NewUsage(metering.UsageInput{
+		Meter: definition, Scope: metering.ProjectScope(evaluation.OrganizationID, projectID), OperationID: evaluationID.String(),
+		Value: *stokenCount, OccurredAt: occurredAt.UTC(), ProducedAt: producedAt.UTC(), Source: "risk_evaluation",
+		Attributes: attributes,
+	})
+	if err != nil {
+		return riskmeterchrepo.EvaluationRow{}, nil, fmt.Errorf("build risk meter reading: %w", err)
+	}
+	meterID, _ := metering.RiskEvaluationMeterID(detector, executionMode)
+	reading := &meteringchrepo.ReadingRow{
+		ID: usage.ID(), OrganizationID: evaluation.OrganizationID, ProjectID: projectID, MeterID: string(meterID),
+		OperationID: evaluationID.String(), Unit: string(metering.UnitSTokens), MeasurementMethod: string(metering.MeasurementTiktokenO200kBase),
+		Value: *stokenCount, OccurredAt: occurredAt.UTC(), ProducedAt: producedAt.UTC(), InsertedAt: insertedAt,
+		CorrectsReadingID: nil, Attributes: attributes,
+	}
+	return raw, reading, nil
+}

--- a/server/internal/riskmeter/consumer/ch_writer_test.go
+++ b/server/internal/riskmeter/consumer/ch_writer_test.go
@@ -1,0 +1,156 @@
+package consumer_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	meteringv1 "github.com/speakeasy-api/gram/infra/gen/gram/metering/v1"
+	"github.com/speakeasy-api/gram/infra/pkg/gcp"
+	meteringchrepo "github.com/speakeasy-api/gram/server/internal/metering/chrepo"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter/chrepo"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter/consumer"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+type captureEvaluationInserter struct {
+	rows []chrepo.EvaluationRow
+}
+
+func (c *captureEvaluationInserter) InsertRiskEvaluations(_ context.Context, rows []chrepo.EvaluationRow) error {
+	c.rows = append(c.rows, rows...)
+	return nil
+}
+
+type captureReadingInserter struct {
+	rows []meteringchrepo.ReadingRow
+}
+
+func (c *captureReadingInserter) InsertReadings(_ context.Context, rows []meteringchrepo.ReadingRow) error {
+	c.rows = append(c.rows, rows...)
+	return nil
+}
+
+func TestWriterPreservesRetriesAndProjectsLogicalVolumeOnce(t *testing.T) {
+	t.Parallel()
+
+	evaluation := testEvaluation()
+	first := testRiskEvaluation(uuid.NewString(), evaluation, riskmeter.OutcomeCompleted, riskmeter.RecordKindScan)
+	first.SetStokens(12)
+	second := testRiskEvaluation(uuid.NewString(), evaluation, riskmeter.OutcomeCompleted, riskmeter.RecordKindScan)
+	second.SetStokens(12)
+	raw := &captureEvaluationInserter{rows: nil}
+	readings := &captureReadingInserter{rows: nil}
+	writer := consumer.NewRiskEvaluationCHWriter(testenv.NewLogger(t), testenv.NewMeterProvider(t), raw, readings)
+
+	require.NoError(t, writer.HandleBatchWithResult(t.Context(), []gcp.BatchMessage[*meteringv1.RiskEvaluation]{{Message: first}, {Message: second}}))
+	require.Len(t, raw.rows, 2)
+	require.NotEqual(t, raw.rows[0].ID, raw.rows[1].ID)
+	require.Equal(t, raw.rows[0].EvaluationID, raw.rows[1].EvaluationID)
+	require.Len(t, readings.rows, 1)
+	require.Equal(t, int64(12), readings.rows[0].Value)
+	require.Equal(t, evaluation.OperationID, raw.rows[0].OperationID)
+	require.Equal(t, "gitleaks", raw.rows[0].Detector)
+	require.Equal(t, "batch", raw.rows[0].ExecutionMode)
+	require.Equal(t, "completed", raw.rows[0].Outcome)
+	require.Equal(t, riskmeter.EvaluationID(evaluation), readings.rows[0].OperationID)
+}
+
+func TestWriterPersistsCompletedCleanZeroWithoutVolume(t *testing.T) {
+	t.Parallel()
+
+	message := testRiskEvaluation(uuid.NewString(), testEvaluation(), riskmeter.OutcomeCompleted, riskmeter.RecordKindScan)
+	message.SetStokens(0)
+	raw := &captureEvaluationInserter{rows: nil}
+	readings := &captureReadingInserter{rows: nil}
+	writer := consumer.NewRiskEvaluationCHWriter(testenv.NewLogger(t), testenv.NewMeterProvider(t), raw, readings)
+
+	require.NoError(t, writer.HandleBatchWithResult(t.Context(), []gcp.BatchMessage[*meteringv1.RiskEvaluation]{{Message: message}}))
+	require.Len(t, raw.rows, 1)
+	require.NotNil(t, raw.rows[0].STokens)
+	require.Zero(t, *raw.rows[0].STokens)
+	require.Empty(t, readings.rows)
+}
+
+func TestWriterPersistsUnknownScanAndAcknowledgesPoison(t *testing.T) {
+	t.Parallel()
+
+	message := testRiskEvaluation(uuid.NewString(), testEvaluation(), riskmeter.OutcomeSkipped, riskmeter.RecordKindScan)
+	zeroID := testRiskEvaluation(uuid.Nil.String(), testEvaluation(), riskmeter.OutcomeSkipped, riskmeter.RecordKindScan)
+	zeroProjectEvaluation := testEvaluation()
+	zeroProjectEvaluation.ProjectID = uuid.Nil.String()
+	zeroProject := testRiskEvaluation(uuid.NewString(), zeroProjectEvaluation, riskmeter.OutcomeSkipped, riskmeter.RecordKindScan)
+	unknownDetector := testRiskEvaluation(uuid.NewString(), testEvaluation(), riskmeter.OutcomeSkipped, riskmeter.RecordKindScan)
+	unknownDetector.SetDetector(meteringv1.RiskEvaluation_Detector(99))
+	unknownOutcome := testRiskEvaluation(uuid.NewString(), testEvaluation(), riskmeter.OutcomeSkipped, riskmeter.RecordKindScan)
+	unknownOutcome.SetOutcome(meteringv1.RiskEvaluation_Outcome(99))
+	raw := &captureEvaluationInserter{rows: nil}
+	readings := &captureReadingInserter{rows: nil}
+	writer := consumer.NewRiskEvaluationCHWriter(testenv.NewLogger(t), testenv.NewMeterProvider(t), raw, readings)
+
+	require.NoError(t, writer.HandleBatchWithResult(t.Context(), []gcp.BatchMessage[*meteringv1.RiskEvaluation]{
+		{Message: zeroID},
+		{Message: zeroProject},
+		{Message: unknownDetector},
+		{Message: unknownOutcome},
+		{Message: message},
+	}))
+	require.Len(t, raw.rows, 1)
+	require.Nil(t, raw.rows[0].STokens)
+	require.False(t, raw.rows[0].MeasurementError)
+	require.Empty(t, readings.rows)
+}
+
+func TestWriterPreservesUnknownInferenceAccountingWithoutVolume(t *testing.T) {
+	t.Parallel()
+
+	message := testRiskEvaluation(uuid.NewString(), testEvaluation(), riskmeter.OutcomeFailed, riskmeter.RecordKindInference)
+	message.SetModel("openai/gpt-5")
+	raw := &captureEvaluationInserter{rows: nil}
+	readings := &captureReadingInserter{rows: nil}
+	writer := consumer.NewRiskEvaluationCHWriter(testenv.NewLogger(t), testenv.NewMeterProvider(t), raw, readings)
+
+	require.NoError(t, writer.HandleBatchWithResult(t.Context(), []gcp.BatchMessage[*meteringv1.RiskEvaluation]{{Message: message}}))
+	require.Len(t, raw.rows, 1)
+	require.Nil(t, raw.rows[0].CostUSD)
+	require.Nil(t, raw.rows[0].PromptTokens)
+	require.Nil(t, raw.rows[0].CompletionTokens)
+	require.Nil(t, raw.rows[0].STokens)
+	require.Empty(t, readings.rows)
+}
+
+func testRiskEvaluation(id string, evaluation riskmeter.Evaluation, outcome meteringv1.RiskEvaluation_Outcome, recordKind string) *meteringv1.RiskEvaluation {
+	message := new(meteringv1.RiskEvaluation)
+	message.SetId(id)
+	message.SetEvaluationId(riskmeter.EvaluationID(evaluation))
+	message.SetOrganizationId(evaluation.OrganizationID)
+	message.SetProjectId(evaluation.ProjectID)
+	message.SetOperationId(evaluation.OperationID)
+	message.SetDetector(evaluation.Detector)
+	message.SetExecutionMode(evaluation.ExecutionMode)
+	message.SetOutcome(outcome)
+	message.SetRecordKind(recordKind)
+	message.SetOccurredAt(evaluation.OccurredAt.Format(time.RFC3339Nano))
+	message.SetProducedAt(evaluation.OccurredAt.Add(time.Second).Format(time.RFC3339Nano))
+	message.SetMeasurementMethod(riskmeter.MeasurementMethod)
+	message.SetPolicyId(evaluation.PolicyID)
+	message.SetPolicyVersion(evaluation.PolicyVersion)
+	return message
+}
+
+func testEvaluation() riskmeter.Evaluation {
+	return riskmeter.Evaluation{
+		OrganizationID: "org_test",
+		ProjectID:      "11111111-1111-1111-1111-111111111111",
+		OperationID:    riskmeter.OperationID("message", "a:b", "3"),
+		Detector:       riskmeter.DetectorGitleaks,
+		ExecutionMode:  riskmeter.ModeBatch,
+		PolicyID:       "policy_test",
+		PolicyVersion:  3,
+		OccurredAt:     time.Date(2026, time.September, 6, 12, 0, 0, 0, time.UTC),
+	}
+}

--- a/server/internal/riskmeter/recorder.go
+++ b/server/internal/riskmeter/recorder.go
@@ -1,0 +1,377 @@
+// Package riskmeter records detector workload and inference measurements.
+package riskmeter
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	meteringv1 "github.com/speakeasy-api/gram/infra/gen/gram/metering/v1"
+	"github.com/speakeasy-api/gram/infra/pkg/gcp"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/stokens"
+)
+
+const (
+	// DetectorGitleaks identifies Gitleaks work.
+	DetectorGitleaks = meteringv1.RiskEvaluation_DETECTOR_GITLEAKS
+	// DetectorPresidio identifies Presidio work.
+	DetectorPresidio = meteringv1.RiskEvaluation_DETECTOR_PRESIDIO
+	// DetectorPromptInjection identifies prompt-injection classifier work.
+	DetectorPromptInjection = meteringv1.RiskEvaluation_DETECTOR_PROMPT_INJECTION
+	// DetectorPromptPolicy identifies prompt-policy judge work.
+	DetectorPromptPolicy = meteringv1.RiskEvaluation_DETECTOR_PROMPT_POLICY
+	// DetectorCustomRules identifies custom CEL rule work.
+	DetectorCustomRules = meteringv1.RiskEvaluation_DETECTOR_CUSTOM_RULES
+
+	// ModeRealtime identifies synchronous request-path work.
+	ModeRealtime = meteringv1.RiskEvaluation_EXECUTION_MODE_REALTIME
+	// ModeBatch identifies stored-message batch work.
+	ModeBatch = meteringv1.RiskEvaluation_EXECUTION_MODE_BATCH
+	// ModeShadow identifies asynchronous shadow work.
+	ModeShadow = meteringv1.RiskEvaluation_EXECUTION_MODE_SHADOW
+
+	// OutcomeCompleted identifies successful evaluation completion.
+	OutcomeCompleted = meteringv1.RiskEvaluation_OUTCOME_COMPLETED
+	// OutcomeFailed identifies failed evaluation completion.
+	OutcomeFailed = meteringv1.RiskEvaluation_OUTCOME_FAILED
+	// OutcomeCancelled identifies cancelled evaluation completion.
+	OutcomeCancelled = meteringv1.RiskEvaluation_OUTCOME_CANCELLED
+	// OutcomeSkipped identifies eligible work that could not be attempted.
+	OutcomeSkipped = meteringv1.RiskEvaluation_OUTCOME_SKIPPED
+
+	// RecordKindScan identifies detector scan completion.
+	RecordKindScan = "scan"
+	// RecordKindInference identifies one physical provider request.
+	RecordKindInference = "inference"
+
+	// MeasurementMethod identifies the canonical tokenizer used for scan volume.
+	MeasurementMethod = "tiktoken_o200k_base"
+
+	publishTimeout = 10 * time.Second
+)
+
+// Evaluation identifies one logical detector evaluation.
+type Evaluation struct {
+	// OrganizationID identifies the organization that owns the workload.
+	OrganizationID string
+
+	// ProjectID identifies the project that owns the workload.
+	ProjectID string
+
+	// OperationID is the caller's stable logical operation identity.
+	OperationID string
+
+	// Detector identifies the detector class.
+	Detector meteringv1.RiskEvaluation_Detector
+
+	// ExecutionMode distinguishes realtime, batch, and shadow work.
+	ExecutionMode meteringv1.RiskEvaluation_ExecutionMode
+
+	// PolicyID is diagnostic policy attribution.
+	PolicyID string
+
+	// PolicyVersion is the diagnostic policy version.
+	PolicyVersion int64
+
+	// OccurredAt is the UTC time when evaluation work started.
+	OccurredAt time.Time
+}
+
+// Inference captures provider-reported accounting for one physical request.
+type Inference struct {
+	// Model identifies the provider model.
+	Model string
+
+	// ProviderRequestID is the provider's physical request identity.
+	ProviderRequestID string
+
+	// PromptTokens is nil when the provider did not report prompt usage.
+	PromptTokens *int64
+
+	// CompletionTokens is nil when the provider did not report completion usage.
+	CompletionTokens *int64
+
+	// CostUSD is nil when the provider did not report request cost.
+	CostUSD *float64
+}
+
+// Recorder publishes terminal risk measurement events.
+type Recorder struct {
+	logger    *slog.Logger
+	publisher gcp.Publisher[*meteringv1.RiskEvaluation]
+	codec     *stokens.Codec
+}
+
+// NewRecorder creates a risk measurement recorder.
+func NewRecorder(logger *slog.Logger, publisher gcp.Publisher[*meteringv1.RiskEvaluation]) *Recorder {
+	return &Recorder{
+		logger:    logger.With(attr.SlogComponent("risk-meter")),
+		publisher: publisher,
+		codec:     stokens.NewCodec(),
+	}
+}
+
+// Record publishes one terminal scan attempt. A nil fragments slice records an
+// unknown scan volume, while a non-nil empty slice records a known zero.
+func (r *Recorder) Record(ctx context.Context, evaluation Evaluation, fragments []string, outcome meteringv1.RiskEvaluation_Outcome, inference *Inference) error {
+	if r == nil {
+		return nil
+	}
+
+	if inference != nil {
+		err := fmt.Errorf("risk scan measurement must not include inference accounting")
+		r.logger.ErrorContext(ctx, "build risk scan measurement", attr.SlogError(err))
+		return err
+	}
+	message, err := r.newMessage(evaluation, RecordKindScan, outcome, nil)
+	if err != nil {
+		r.logger.ErrorContext(ctx, "build risk scan measurement", attr.SlogError(err))
+		return err
+	}
+	if fragments != nil {
+		measurementCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), publishTimeout)
+		count, countErr := r.codec.Count(measurementCtx, fragments...)
+		cancel()
+		if countErr != nil {
+			message.SetMeasurementError(true)
+			r.logger.ErrorContext(measurementCtx, "measure risk scan volume", attr.SlogError(countErr))
+		} else {
+			message.SetStokens(int64(count))
+		}
+	}
+	message.SetProducedAt(time.Now().UTC().Format(time.RFC3339Nano))
+
+	publishCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), publishTimeout)
+	defer cancel()
+	return r.publish(publishCtx, message)
+}
+
+// RecordInference publishes provider accounting for one physical inference
+// request. Inference records intentionally have no s-token volume.
+func (r *Recorder) RecordInference(ctx context.Context, evaluation Evaluation, outcome meteringv1.RiskEvaluation_Outcome, inference *Inference) error {
+	if r == nil {
+		return nil
+	}
+
+	publishCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), publishTimeout)
+	defer cancel()
+
+	message, err := r.newMessage(evaluation, RecordKindInference, outcome, inference)
+	if err != nil {
+		r.logger.ErrorContext(ctx, "build risk inference measurement", attr.SlogError(err))
+		return err
+	}
+	return r.publish(publishCtx, message)
+}
+
+func (r *Recorder) newMessage(evaluation Evaluation, recordKind string, outcome meteringv1.RiskEvaluation_Outcome, inference *Inference) (*meteringv1.RiskEvaluation, error) {
+	if err := ValidateEvaluation(evaluation); err != nil {
+		return nil, err
+	}
+	if err := ValidateOutcome(outcome); err != nil {
+		return nil, err
+	}
+	if err := validateInference(inference); err != nil {
+		return nil, err
+	}
+
+	physicalID, err := uuid.NewV7()
+	if err != nil {
+		return nil, fmt.Errorf("create physical risk evaluation id: %w", err)
+	}
+	producedAt := time.Now().UTC()
+	message := new(meteringv1.RiskEvaluation)
+	message.SetId(physicalID.String())
+	message.SetEvaluationId(EvaluationID(evaluation))
+	message.SetOrganizationId(evaluation.OrganizationID)
+	message.SetProjectId(evaluation.ProjectID)
+	message.SetOperationId(evaluation.OperationID)
+	message.SetDetector(evaluation.Detector)
+	message.SetExecutionMode(evaluation.ExecutionMode)
+	message.SetOutcome(outcome)
+	message.SetOccurredAt(evaluation.OccurredAt.Format(time.RFC3339Nano))
+	message.SetProducedAt(producedAt.Format(time.RFC3339Nano))
+	message.SetMeasurementMethod(MeasurementMethod)
+	message.SetPolicyId(evaluation.PolicyID)
+	message.SetPolicyVersion(evaluation.PolicyVersion)
+	message.SetRecordKind(recordKind)
+	if inference != nil {
+		message.SetModel(inference.Model)
+		message.SetProviderRequestId(inference.ProviderRequestID)
+		if inference.PromptTokens != nil {
+			message.SetPromptTokens(*inference.PromptTokens)
+		}
+		if inference.CompletionTokens != nil {
+			message.SetCompletionTokens(*inference.CompletionTokens)
+		}
+		if inference.CostUSD != nil {
+			message.SetCostUsd(*inference.CostUSD)
+		}
+	}
+	return message, nil
+}
+
+func (r *Recorder) publish(ctx context.Context, message *meteringv1.RiskEvaluation) error {
+	if r.publisher == nil {
+		err := fmt.Errorf("risk evaluation publisher is not configured")
+		r.logger.ErrorContext(ctx, "publish risk measurement", attr.SlogError(err))
+		return err
+	}
+	if _, err := r.publisher.Publish(ctx, message).Get(ctx); err != nil {
+		err = fmt.Errorf("publish risk evaluation: %w", err)
+		r.logger.ErrorContext(ctx, "publish risk measurement", attr.SlogError(err))
+		return err
+	}
+	return nil
+}
+
+// ValidateEvaluation verifies the metadata required to identify a logical evaluation.
+func ValidateEvaluation(evaluation Evaluation) error {
+	if strings.TrimSpace(evaluation.OrganizationID) == "" {
+		return fmt.Errorf("risk evaluation organization id must not be empty")
+	}
+	projectID, err := uuid.Parse(evaluation.ProjectID)
+	if err != nil {
+		return fmt.Errorf("parse risk evaluation project id: %w", err)
+	}
+	if projectID == uuid.Nil {
+		return fmt.Errorf("risk evaluation project id must not be zero")
+	}
+	if strings.TrimSpace(evaluation.OperationID) == "" {
+		return fmt.Errorf("risk evaluation operation id must not be empty")
+	}
+	if _, ok := DetectorLabel(evaluation.Detector); !ok {
+		return fmt.Errorf("invalid risk evaluation detector %q", evaluation.Detector)
+	}
+	if _, ok := ExecutionModeLabel(evaluation.ExecutionMode); !ok {
+		return fmt.Errorf("invalid risk evaluation execution mode %q", evaluation.ExecutionMode)
+	}
+	if evaluation.PolicyVersion < 0 {
+		return fmt.Errorf("risk evaluation policy version must not be negative")
+	}
+	if evaluation.OccurredAt.IsZero() || evaluation.OccurredAt.Location() != time.UTC {
+		return fmt.Errorf("risk evaluation occurred at must be a nonzero UTC timestamp")
+	}
+	return nil
+}
+
+func validateInference(inference *Inference) error {
+	if inference == nil {
+		return nil
+	}
+	if inference.PromptTokens != nil && *inference.PromptTokens < 0 {
+		return fmt.Errorf("risk inference prompt tokens must not be negative")
+	}
+	if inference.CompletionTokens != nil && *inference.CompletionTokens < 0 {
+		return fmt.Errorf("risk inference completion tokens must not be negative")
+	}
+	if inference.CostUSD != nil && (math.IsNaN(*inference.CostUSD) || math.IsInf(*inference.CostUSD, 0) || *inference.CostUSD < 0) {
+		return fmt.Errorf("risk inference cost must be finite and nonnegative")
+	}
+	return nil
+}
+
+// DetectorLabel returns the canonical persisted label for a known detector.
+func DetectorLabel(detector meteringv1.RiskEvaluation_Detector) (string, bool) {
+	switch detector {
+	case DetectorGitleaks:
+		return "gitleaks", true
+	case DetectorPresidio:
+		return "presidio", true
+	case DetectorPromptInjection:
+		return "prompt_injection", true
+	case DetectorPromptPolicy:
+		return "prompt_policy", true
+	case DetectorCustomRules:
+		return "custom_rules", true
+	default:
+		return "", false
+	}
+}
+
+// ExecutionModeLabel returns the canonical persisted label for a known execution mode.
+func ExecutionModeLabel(mode meteringv1.RiskEvaluation_ExecutionMode) (string, bool) {
+	switch mode {
+	case ModeRealtime:
+		return "realtime", true
+	case ModeBatch:
+		return "batch", true
+	case ModeShadow:
+		return "shadow", true
+	default:
+		return "", false
+	}
+}
+
+// OutcomeLabel returns the canonical persisted label for a known terminal outcome.
+func OutcomeLabel(outcome meteringv1.RiskEvaluation_Outcome) (string, bool) {
+	switch outcome {
+	case OutcomeCompleted:
+		return "completed", true
+	case OutcomeFailed:
+		return "failed", true
+	case OutcomeCancelled:
+		return "cancelled", true
+	case OutcomeSkipped:
+		return "skipped", true
+	default:
+		return "", false
+	}
+}
+
+// ValidateOutcome verifies a terminal evaluation outcome.
+func ValidateOutcome(outcome meteringv1.RiskEvaluation_Outcome) error {
+	if _, ok := OutcomeLabel(outcome); !ok {
+		return fmt.Errorf("invalid risk evaluation outcome %q", outcome)
+	}
+	return nil
+}
+
+type evaluationContextKey struct{}
+
+// WithEvaluation adds logical evaluation metadata to a context.
+func WithEvaluation(ctx context.Context, evaluation Evaluation) context.Context {
+	return context.WithValue(ctx, evaluationContextKey{}, evaluation)
+}
+
+// EvaluationFromContext retrieves logical evaluation metadata from a context.
+func EvaluationFromContext(ctx context.Context) (Evaluation, bool) {
+	evaluation, ok := ctx.Value(evaluationContextKey{}).(Evaluation)
+	return evaluation, ok
+}
+
+// EvaluationID returns the deterministic UUID for a logical evaluation.
+func EvaluationID(evaluation Evaluation) string {
+	executionMode, _ := ExecutionModeLabel(evaluation.ExecutionMode)
+	detector, _ := DetectorLabel(evaluation.Detector)
+	preimage := strings.Join([]string{
+		"gram:risk:evaluation:v1",
+		evaluation.OrganizationID,
+		evaluation.ProjectID,
+		executionMode,
+		detector,
+		evaluation.OperationID,
+	}, "\x00")
+	return uuid.NewSHA1(uuid.NameSpaceURL, []byte(preimage)).String()
+}
+
+// OperationID hashes length-framed identity parts into a bounded identifier.
+func OperationID(parts ...string) string {
+	hash := sha256.New()
+	_, _ = hash.Write([]byte("gram:risk:operation:v1\x00"))
+	var length [8]byte
+	for _, part := range parts {
+		binary.BigEndian.PutUint64(length[:], uint64(len(part)))
+		_, _ = hash.Write(length[:])
+		_, _ = hash.Write([]byte(part))
+	}
+	return "riskop:v1:" + hex.EncodeToString(hash.Sum(nil))
+}

--- a/server/internal/riskmeter/recorder_test.go
+++ b/server/internal/riskmeter/recorder_test.go
@@ -1,0 +1,129 @@
+package riskmeter_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	meteringv1 "github.com/speakeasy-api/gram/infra/gen/gram/metering/v1"
+	"github.com/speakeasy-api/gram/infra/pkg/gcp"
+	"github.com/speakeasy-api/gram/server/internal/riskmeter"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+type captureRiskPublisher struct {
+	messages []*meteringv1.RiskEvaluation
+}
+
+func (p *captureRiskPublisher) Publish(_ context.Context, message *meteringv1.RiskEvaluation, _ ...gcp.PublishOption) gcp.PublishResult {
+	p.messages = append(p.messages, message)
+	return gcp.NewSuccessPublishResult()
+}
+
+func (p *captureRiskPublisher) Stop(context.Context) error {
+	return nil
+}
+
+func TestLogicalIdentityUsesStableLengthFraming(t *testing.T) {
+	t.Parallel()
+
+	evaluation := testEvaluation()
+	require.Equal(t, "riskop:v1:263386149a3516170cb5ef4abe39a3c21dbb05a97e5085a0a5035b33278ea2d4", evaluation.OperationID)
+	require.Equal(t, "6d2ddb8d-5212-5c5c-b7e3-98531f3cc916", riskmeter.EvaluationID(evaluation))
+	require.NotEqual(t, riskmeter.OperationID("ab", "c"), riskmeter.OperationID("a", "bc"))
+}
+
+func TestCanonicalLabelsRejectUnspecifiedAndUnknownEnums(t *testing.T) {
+	t.Parallel()
+
+	detector, ok := riskmeter.DetectorLabel(riskmeter.DetectorGitleaks)
+	require.True(t, ok)
+	require.Equal(t, "gitleaks", detector)
+	mode, ok := riskmeter.ExecutionModeLabel(riskmeter.ModeBatch)
+	require.True(t, ok)
+	require.Equal(t, "batch", mode)
+	outcome, ok := riskmeter.OutcomeLabel(riskmeter.OutcomeCompleted)
+	require.True(t, ok)
+	require.Equal(t, "completed", outcome)
+
+	_, ok = riskmeter.DetectorLabel(meteringv1.RiskEvaluation_DETECTOR_UNSPECIFIED)
+	require.False(t, ok)
+	_, ok = riskmeter.ExecutionModeLabel(meteringv1.RiskEvaluation_ExecutionMode(99))
+	require.False(t, ok)
+	require.Error(t, riskmeter.ValidateOutcome(meteringv1.RiskEvaluation_OUTCOME_UNSPECIFIED))
+
+	evaluation := testEvaluation()
+	evaluation.Detector = meteringv1.RiskEvaluation_DETECTOR_UNSPECIFIED
+	require.Error(t, riskmeter.ValidateEvaluation(evaluation))
+	evaluation = testEvaluation()
+	evaluation.ExecutionMode = meteringv1.RiskEvaluation_ExecutionMode(99)
+	require.Error(t, riskmeter.ValidateEvaluation(evaluation))
+}
+
+func TestRecorderPublishesUnknownScanAfterCallerCancellation(t *testing.T) {
+	t.Parallel()
+
+	publisher := &captureRiskPublisher{messages: nil}
+	recorder := riskmeter.NewRecorder(testenv.NewLogger(t), publisher)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	require.NoError(t, recorder.Record(ctx, testEvaluation(), nil, riskmeter.OutcomeCancelled, nil))
+	require.Len(t, publisher.messages, 1)
+	message := publisher.messages[0]
+	require.Equal(t, riskmeter.RecordKindScan, message.GetRecordKind())
+	require.False(t, message.GetMeasurementError(), "an unmeasured cancellation is not a tokenizer failure")
+	require.False(t, message.HasStokens())
+}
+
+func TestRecorderPreservesKnownCleanZero(t *testing.T) {
+	t.Parallel()
+
+	publisher := &captureRiskPublisher{messages: nil}
+	recorder := riskmeter.NewRecorder(testenv.NewLogger(t), publisher)
+
+	require.NoError(t, recorder.Record(t.Context(), testEvaluation(), []string{}, riskmeter.OutcomeCompleted, nil))
+	require.Len(t, publisher.messages, 1)
+	message := publisher.messages[0]
+	require.True(t, message.HasStokens())
+	require.Zero(t, message.GetStokens())
+	require.False(t, message.GetMeasurementError())
+}
+
+func TestRecorderKeepsUnknownInferenceAccountingNullable(t *testing.T) {
+	t.Parallel()
+
+	publisher := &captureRiskPublisher{messages: nil}
+	recorder := riskmeter.NewRecorder(testenv.NewLogger(t), publisher)
+
+	inference := &riskmeter.Inference{
+		Model:             "openai/gpt-5",
+		ProviderRequestID: "",
+		PromptTokens:      nil,
+		CompletionTokens:  nil,
+		CostUSD:           nil,
+	}
+	require.NoError(t, recorder.RecordInference(t.Context(), testEvaluation(), riskmeter.OutcomeFailed, inference))
+	require.Len(t, publisher.messages, 1)
+	message := publisher.messages[0]
+	require.Equal(t, riskmeter.RecordKindInference, message.GetRecordKind())
+	require.False(t, message.HasPromptTokens())
+	require.False(t, message.HasCompletionTokens())
+	require.False(t, message.HasCostUsd())
+	require.False(t, message.HasStokens())
+}
+
+func testEvaluation() riskmeter.Evaluation {
+	return riskmeter.Evaluation{
+		OrganizationID: "org_test",
+		ProjectID:      "11111111-1111-1111-1111-111111111111",
+		OperationID:    riskmeter.OperationID("message", "a:b", "3"),
+		Detector:       riskmeter.DetectorGitleaks,
+		ExecutionMode:  riskmeter.ModeBatch,
+		PolicyID:       "policy_test",
+		PolicyVersion:  3,
+		OccurredAt:     time.Date(2026, time.September, 6, 12, 0, 0, 0, time.UTC),
+	}
+}


### PR DESCRIPTION
## Summary

- Implement Go terminal-attempt recording with canonical s-token counting, stable logical evaluation identities, and separate physical-attempt identities.
- Add ClickHouse persistence and a result-aware batch consumer that retains raw outcomes and projects completed positive scan volume into retry-deduplicated workload readings.
- Register detector/mode-qualified meter definitions and explicitly prohibit their Stripe export. Unknown enum values are rejected before projection; canonical identity labels remain stable.
- Keep scanner execution and provider-adapter integration in the next layer. No prices or customer charges are introduced.

## Motivation

Separate measurement semantics and storage projection from the many scanner callsites that consume them. This layer defines how clean scans, unknown volume, failed work, and redeliveries are represented without deriving usage from findings or pricing from diagnostic attributes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a risk workload measurement layer so clean scans, unknown volume, failed work, and redeliveries are represented without deriving usage from findings or pricing from diagnostic attributes. Risk scanner work previously had no usage recording; now each terminal attempt is published, persisted to ClickHouse, and projected into detector/mode-qualified meters.

**New Features**
- `riskmeter.Recorder` emits scan and inference attempts with stable logical evaluation IDs, separate physical attempt IDs, and canonical s-token counts; nil fragments mean unknown volume, empty fragments mean known zero.
- ClickHouse consumer stores every raw outcome and projects only completed positive scan volume into workload readings, deduplicating retries by logical evaluation ID.
- Registers 15 detector/mode-qualified meter definitions and explicitly prohibits their Stripe export; the exporter now records risk readings as ineligible instead of attempting catalog lookup.
- Unknown detector, execution mode, and outcome enum values are rejected before projection, keeping persisted identity labels stable.
- Scanner execution and provider-adapter integration stay in the next layer; no prices or customer charges are introduced.

<sup>Written for commit 3e2ab281009fa31ee1c48aef39dd945663f8a301. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

