### PR TITLE
fix(dashboard): reduce Applies To column width in Guardrails table

### DIFF
--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -893,7 +893,7 @@ function PolicyCenterContent() {
     {
       key: "messageTypes",
       header: "Applies To",
-      width: "2.1fr",
+      width: "1.2fr",
       render: (row) => {
         const types = policyMessageTypesForDisplay(row.policy.messageTypes);
         const typeSet = new Set(types);

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -79,13 +79,11 @@ import type { Role } from "@gram/client/models/components/role.js";
 import {
   RULE_CATEGORY_META,
   DETECTION_RULES,
-  POLICY_MESSAGE_TYPE_META,
   RULE_FAMILY_OF,
   RULE_FAMILY_ORDER,
   type DetectionRule,
   type RuleCategory,
   type PolicyAction,
-  type PolicyMessageType,
 } from "./policy-data";
 import { cn } from "@/lib/utils";
 import { dateTimeFormatters, HumanizeDateTime } from "@/lib/dates";
@@ -93,12 +91,7 @@ import { useDetectionRulesStore } from "./detection-rules-data";
 import { useTelemetry } from "@/contexts/Telemetry";
 import { useRoutes } from "@/routes";
 import { Outlet } from "react-router";
-import {
-  ACTION_OPTIONS,
-  ALL_POLICY_MESSAGE_TYPES,
-  categoriesToPayload,
-  policyMessageTypesForForm,
-} from "./policy-form";
+import { ACTION_OPTIONS, categoriesToPayload } from "./policy-form";
 import {
   getPolicyDeleteImpactText,
   getPolicyDeleteRuleListItems,
@@ -382,17 +375,6 @@ type PolicyRow = { kind: PolicyKind; policy: RiskPolicy };
 
 const USER_SEARCH_RESULT_LIMIT = 10;
 
-const TOOL_CALL_MESSAGE_TYPES = new Set<PolicyMessageType>([
-  "tool_request",
-  "tool_response",
-]);
-
-function policyMessageTypesForDisplay(
-  messageTypes?: string[],
-): PolicyMessageType[] {
-  return [...policyMessageTypesForForm(messageTypes)];
-}
-
 function policyAudienceSummary(row: PolicyRow): string {
   if (row.kind === "prompt") {
     return "Everyone";
@@ -471,34 +453,6 @@ function compareMembersByName(a: AccessMember, b: AccessMember): number {
 
 function compareRolesByName(a: Role, b: Role): number {
   return a.name.localeCompare(b.name);
-}
-
-function hasOnlyToolCallMessageTypes(types: Set<PolicyMessageType>): boolean {
-  return (
-    types.size === TOOL_CALL_MESSAGE_TYPES.size &&
-    [...types].every((type) => TOOL_CALL_MESSAGE_TYPES.has(type))
-  );
-}
-
-function messageTypesSummary(
-  selectedMessageTypes: Set<PolicyMessageType>,
-): string {
-  if (selectedMessageTypes.size === ALL_POLICY_MESSAGE_TYPES.length) {
-    return "All types";
-  }
-
-  if (hasOnlyToolCallMessageTypes(selectedMessageTypes)) {
-    return "Tool Calls";
-  }
-
-  if (
-    selectedMessageTypes.size === 1 &&
-    selectedMessageTypes.has("tool_request")
-  ) {
-    return "Tool Requests";
-  }
-
-  return `${selectedMessageTypes.size} of ${ALL_POLICY_MESSAGE_TYPES.length} types selected`;
 }
 
 function isPromptPolicy(policy: RiskPolicy): boolean {
@@ -889,39 +843,6 @@ function PolicyCenterContent() {
           <SeverityBadge score={row.policy.score} />
         </span>
       ),
-    },
-    {
-      key: "messageTypes",
-      header: "Applies To",
-      width: "1.2fr",
-      render: (row) => {
-        const types = policyMessageTypesForDisplay(row.policy.messageTypes);
-        const typeSet = new Set(types);
-        const tooltip = types
-          .map((type) => POLICY_MESSAGE_TYPE_META[type].label)
-          .join(", ");
-
-        if (
-          typeSet.size === ALL_POLICY_MESSAGE_TYPES.length ||
-          hasOnlyToolCallMessageTypes(typeSet)
-        ) {
-          return (
-            <SimpleTooltip tooltip={tooltip}>
-              <span className="text-muted-foreground text-sm">
-                {messageTypesSummary(typeSet)}
-              </span>
-            </SimpleTooltip>
-          );
-        }
-
-        return (
-          <span className="text-muted-foreground text-sm">
-            {types
-              .map((type) => POLICY_MESSAGE_TYPE_META[type].label)
-              .join(", ")}
-          </span>
-        );
-      },
     },
     {
       key: "audience",

--- a/client/dashboard/src/pages/security/policy-form.ts
+++ b/client/dashboard/src/pages/security/policy-form.ts
@@ -1,9 +1,7 @@
 import celExamples from "./cel-examples.json";
 import {
   DETECTION_RULES,
-  POLICY_MESSAGE_TYPE_META,
   type PolicyAction,
-  type PolicyMessageType,
   type RuleCategory,
 } from "./policy-data";
 import { ruleIdToPresidioEntity } from "./rule-ids";
@@ -58,10 +56,6 @@ export const CATEGORY_LEVEL_DETECTORS: Set<RuleCategory> = new Set([
   "destructive_tool",
   "cli_destructive",
 ]);
-
-export const ALL_POLICY_MESSAGE_TYPES = Object.keys(
-  POLICY_MESSAGE_TYPE_META,
-) as Array<PolicyMessageType>;
 
 export type CategoriesPayload = {
   sources: string[];
@@ -189,20 +183,6 @@ export function pinnedHiddenRuleIds(presidioEntities?: string[]): Set<string> {
     }
   }
   return pinned;
-}
-
-export function policyMessageTypesForForm(
-  messageTypes?: string[],
-): Set<PolicyMessageType> {
-  if (!messageTypes?.length) {
-    return new Set(ALL_POLICY_MESSAGE_TYPES);
-  }
-
-  return new Set(
-    messageTypes.filter((type): type is PolicyMessageType =>
-      ALL_POLICY_MESSAGE_TYPES.includes(type as PolicyMessageType),
-    ),
-  );
 }
 
 /** Example scope CEL snippets offered beneath the include field — narrow a


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the Guardrails policy table layout where the rightmost kebab menu was cut off and difficult to click.

## Changes

- **Removed the "Applies To" column entirely** from the policies table
- Cleaned up now-unused helper functions and imports:
  - `TOOL_CALL_MESSAGE_TYPES` constant
  - `policyMessageTypesForDisplay` function
  - `hasOnlyToolCallMessageTypes` function
  - `messageTypesSummary` function
  - Unused imports (`POLICY_MESSAGE_TYPE_META`, `PolicyMessageType`, `ALL_POLICY_MESSAGE_TYPES`, `policyMessageTypesForForm`)

## Result

The table now has 8 columns (previously 9):
- Policy
- Action
- Status
- Severity
- Audience
- Created
- Updated
- Actions (kebab menu)

All columns fit within the viewport and the kebab menu is accessible.

## Testing

**Updated table without "Applies To" column:**

![Guardrails table without Applies To column](https://cursor.com/artifacts/c/art-9a6d4e55-765e-452b-baaa-aa6c3b60dd70)

**Kebab menu is accessible and functional:**

![Kebab menu open](https://cursor.com/artifacts/c/art-8134b98e-1866-4cbf-a118-843fd558edcd)

- [x] Type-check passes
- [x] Manual UI verification complete - all columns fit within viewport
- [x] Kebab menu is clickable and displays action menu

Fixes AGE-3400
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3400](https://linear.app/speakeasy/issue/AGE-3400/bug-fit-all-columns-in-guardrails-policy-table)

<div><a href="https://cursor.com/agents/bc-3b04e9b9-0602-4921-8b34-8ab54fd3554b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b04e9b9-0602-4921-8b34-8ab54fd3554b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the "Applies To" column from the Guardrails policy table so all remaining columns fit within the viewport and the row kebab menu stays accessible. Also cleans up the now-unused helper functions and imports. Resolves AGE-3400.

<sup>Written for commit 155439e2c59d14d35028e7614df1c0dcc29e3f28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

