### PR TITLE
feat(watchdog): clarify active exposure filter on hover

### DIFF
--- a/.changeset/watchdog-exposure-hover-isolation.md
+++ b/.changeset/watchdog-exposure-hover-isolation.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Highlight one category at a time in the Watchdog exposure bar by dimming the other slices on hover, and give Custom Rules its own color so no category reads as inactive grey.

--- a/client/dashboard/src/pages/security/riskTrendChartData.ts
+++ b/client/dashboard/src/pages/security/riskTrendChartData.ts
@@ -1,10 +1,5 @@
 import { formatChartLabel } from "@/components/chart/chartUtils";
-import {
-  ACCENT_RED,
-  OTHER_SERIES,
-  SERIES,
-  SEVERITY,
-} from "@/components/chart/palette";
+import { ACCENT_RED, SERIES, SEVERITY } from "@/components/chart/palette";
 import type { ChartDataset } from "chart.js";
 import { RULE_CATEGORY_META, type RuleCategory } from "./policy-data";
 
@@ -15,9 +10,9 @@ type TimestampedLineDataset = ChartDataset<
 
 // Editorial severity-first ramp from the shared chart palette: the worst
 // category (secrets) takes the one red accent, the next tiers take the
-// severity oranges, the rest walk the neutral ink ramp (lightness repeats are
-// fine — lines read by legend label, not hue), and "custom" recedes to the
-// Other neutral.
+// severity oranges, and the rest walk the neutral ink ramp (lightness repeats
+// are fine — lines read by legend label, not hue). No category takes a grey:
+// grey is reserved for the dimmed/inactive state in the exposure bar.
 function riskCategoryChartColors(
   series: readonly string[],
 ): Array<{ category: RuleCategory; color: string }> {
@@ -34,7 +29,7 @@ function riskCategoryChartColors(
     { category: "destructive_tool", color: series[1]! },
     { category: "cli_destructive", color: series[2]! },
     { category: "account_identity", color: series[3]! },
-    { category: "custom", color: OTHER_SERIES },
+    { category: "custom", color: series[7]! },
   ];
 }
 

--- a/client/dashboard/src/pages/security/watchdog/ExposureBar.tsx
+++ b/client/dashboard/src/pages/security/watchdog/ExposureBar.tsx
@@ -1,4 +1,7 @@
-import { useSeriesColors } from "@/components/chart/useSeriesColors";
+import {
+  useIsDarkTheme,
+  useSeriesColors,
+} from "@/components/chart/useSeriesColors";
 import { useState } from "react";
 import { Text } from "@/components/ui/Text";
 import { cn } from "@/lib/utils";
@@ -7,7 +10,11 @@ import { RULE_CATEGORY_META, type RuleCategory } from "../policy-data";
 import { getRiskCategoryChartColor } from "../riskTrendChartData";
 
 const FALLBACK_SLICE_COLOR = "hsl(0, 0%, 60%)";
-const INACTIVE_GREY = "hsl(0, 0%, 88%)";
+// The dimmed state has to recede on both canvases, so it takes a neutral per
+// theme: near-white behind the light ramp, near-black behind the lifted dark
+// one. A single fixed grey would out-glow the dark ramp's mid-tone hues.
+const INACTIVE_GREY_LIGHT = "hsl(0, 0%, 88%)";
+const INACTIVE_GREY_DARK = "hsl(0, 0%, 27%)";
 
 function categoryLabel(category: string): string {
   return RULE_CATEGORY_META[category as RuleCategory]?.label ?? category;
@@ -35,6 +42,9 @@ export function ExposureBar({
   onToggleCategory: (category: string) => void;
 }): JSX.Element {
   const seriesColors = useSeriesColors();
+  const inactiveGrey = useIsDarkTheme()
+    ? INACTIVE_GREY_DARK
+    : INACTIVE_GREY_LIGHT;
   const [hovered, setHovered] = useState<string | null>(null);
   const sliceColor = (category: string) =>
     getRiskCategoryChartColor(category, seriesColors) ?? FALLBACK_SLICE_COLOR;
@@ -86,7 +96,7 @@ export function ExposureBar({
                 style={{
                   width: `${Math.max(slice.share * 100, 1)}%`,
                   backgroundColor: dimmed
-                    ? INACTIVE_GREY
+                    ? inactiveGrey
                     : sliceColor(slice.category),
                 }}
               />
@@ -97,9 +107,7 @@ export function ExposureBar({
           {visible.map((slice) => {
             const dimmed = isDimmed(slice.category);
             const isActive = active.has(slice.category);
-            const dotColor = dimmed
-              ? INACTIVE_GREY
-              : sliceColor(slice.category);
+            const dotColor = dimmed ? inactiveGrey : sliceColor(slice.category);
             return (
               <button
                 key={slice.category}

--- a/client/dashboard/src/pages/security/watchdog/ExposureBar.tsx
+++ b/client/dashboard/src/pages/security/watchdog/ExposureBar.tsx
@@ -1,4 +1,5 @@
 import { useSeriesColors } from "@/components/chart/useSeriesColors";
+import { useState } from "react";
 import { Text } from "@/components/ui/Text";
 import { cn } from "@/lib/utils";
 import type { RiskExposureSlice } from "@gram/client/models/components/riskexposureslice.js";
@@ -6,7 +7,7 @@ import { RULE_CATEGORY_META, type RuleCategory } from "../policy-data";
 import { getRiskCategoryChartColor } from "../riskTrendChartData";
 
 const FALLBACK_SLICE_COLOR = "hsl(0, 0%, 60%)";
-const INACTIVE_GREY = "hsl(0, 0%, 75%)";
+const INACTIVE_GREY = "hsl(0, 0%, 88%)";
 
 function categoryLabel(category: string): string {
   return RULE_CATEGORY_META[category as RuleCategory]?.label ?? category;
@@ -18,6 +19,8 @@ function categoryLabel(category: string): string {
  * reads as the same color across the Secure section. Segments and legend
  * entries toggle the signals list's category filter; slices outside the
  * active selection dim so the bar doubles as the filter's state display.
+ * Hovering a segment or legend entry previews that same dimming, so pointing
+ * at a slice isolates it before committing to the filter.
  */
 export function ExposureBar({
   slices,
@@ -32,12 +35,17 @@ export function ExposureBar({
   onToggleCategory: (category: string) => void;
 }): JSX.Element {
   const seriesColors = useSeriesColors();
+  const [hovered, setHovered] = useState<string | null>(null);
   const sliceColor = (category: string) =>
     getRiskCategoryChartColor(category, seriesColors) ?? FALLBACK_SLICE_COLOR;
   const visible = slices.filter((slice) => slice.findings > 0);
   const active = new Set(activeCategories);
+  // Hover previews an isolation of the pointed-at slice, overriding the
+  // committed filter for as long as the pointer stays on the bar or legend.
   const isDimmed = (category: string) =>
-    active.size > 0 && !active.has(category);
+    hovered !== null
+      ? hovered !== category
+      : active.size > 0 && !active.has(category);
 
   if (visible.length === 0) {
     return (
@@ -70,6 +78,10 @@ export function ExposureBar({
                 aria-label={`Filter by ${categoryLabel(slice.category)}`}
                 title={`${categoryLabel(slice.category)} · ${Math.round(slice.share * 100)}%`}
                 onClick={() => onToggleCategory(slice.category)}
+                onMouseEnter={() => setHovered(slice.category)}
+                onMouseLeave={() => setHovered(null)}
+                onFocus={() => setHovered(slice.category)}
+                onBlur={() => setHovered(null)}
                 className="cursor-pointer transition-colors hover:opacity-80"
                 style={{
                   width: `${Math.max(slice.share * 100, 1)}%`,
@@ -94,6 +106,10 @@ export function ExposureBar({
                 type="button"
                 aria-pressed={isActive}
                 onClick={() => onToggleCategory(slice.category)}
+                onMouseEnter={() => setHovered(slice.category)}
+                onMouseLeave={() => setHovered(null)}
+                onFocus={() => setHovered(slice.category)}
+                onBlur={() => setHovered(null)}
                 className={cn(
                   "text-muted-foreground hover:text-foreground inline-flex cursor-pointer items-center gap-1.5 text-xs transition-opacity",
                   dimmed && "opacity-50",

--- a/client/dashboard/src/pages/security/watchdog/ExposureBar.tsx
+++ b/client/dashboard/src/pages/security/watchdog/ExposureBar.tsx
@@ -82,7 +82,7 @@ export function ExposureBar({
                 onMouseLeave={() => setHovered(null)}
                 onFocus={() => setHovered(slice.category)}
                 onBlur={() => setHovered(null)}
-                className="cursor-pointer transition-colors hover:opacity-80"
+                className="cursor-pointer transition-colors"
                 style={{
                   width: `${Math.max(slice.share * 100, 1)}%`,
                   backgroundColor: dimmed

--- a/client/dashboard/src/pages/security/watchdog/ExposureBar.tsx
+++ b/client/dashboard/src/pages/security/watchdog/ExposureBar.tsx
@@ -6,6 +6,7 @@ import { RULE_CATEGORY_META, type RuleCategory } from "../policy-data";
 import { getRiskCategoryChartColor } from "../riskTrendChartData";
 
 const FALLBACK_SLICE_COLOR = "hsl(0, 0%, 60%)";
+const INACTIVE_GREY = "hsl(0, 0%, 75%)";
 
 function categoryLabel(category: string): string {
   return RULE_CATEGORY_META[category as RuleCategory]?.label ?? category;
@@ -59,48 +60,73 @@ export function ExposureBar({
       </div>
       <div className="space-y-3">
         <div className="border-border flex h-3 w-full overflow-hidden rounded-full border">
-          {visible.map((slice) => (
-            <button
-              key={slice.category}
-              type="button"
-              aria-pressed={active.has(slice.category)}
-              aria-label={`Filter by ${categoryLabel(slice.category)}`}
-              title={`${categoryLabel(slice.category)} · ${Math.round(slice.share * 100)}%`}
-              onClick={() => onToggleCategory(slice.category)}
-              className={cn(
-                "cursor-pointer transition-opacity hover:opacity-80",
-                isDimmed(slice.category) && "opacity-30",
-              )}
-              style={{
-                width: `${Math.max(slice.share * 100, 1)}%`,
-                backgroundColor: sliceColor(slice.category),
-              }}
-            />
-          ))}
+          {visible.map((slice) => {
+            const dimmed = isDimmed(slice.category);
+            return (
+              <button
+                key={slice.category}
+                type="button"
+                aria-pressed={active.has(slice.category)}
+                aria-label={`Filter by ${categoryLabel(slice.category)}`}
+                title={`${categoryLabel(slice.category)} · ${Math.round(slice.share * 100)}%`}
+                onClick={() => onToggleCategory(slice.category)}
+                className="cursor-pointer transition-colors hover:opacity-80"
+                style={{
+                  width: `${Math.max(slice.share * 100, 1)}%`,
+                  backgroundColor: dimmed
+                    ? INACTIVE_GREY
+                    : sliceColor(slice.category),
+                }}
+              />
+            );
+          })}
         </div>
         <div className="flex flex-wrap gap-x-4 gap-y-1">
-          {visible.map((slice) => (
-            <button
-              key={slice.category}
-              type="button"
-              aria-pressed={active.has(slice.category)}
-              onClick={() => onToggleCategory(slice.category)}
-              className={cn(
-                "text-muted-foreground hover:text-foreground inline-flex cursor-pointer items-center gap-1.5 text-xs transition-opacity",
-                isDimmed(slice.category) && "opacity-40",
-                active.has(slice.category) && "text-foreground font-medium",
-              )}
-            >
-              <span
-                className="size-2 rounded-full"
-                style={{ backgroundColor: sliceColor(slice.category) }}
-              />
-              {categoryLabel(slice.category)}
-              <span className="text-foreground font-medium tabular-nums">
-                {Math.round(slice.share * 100)}%
-              </span>
-            </button>
-          ))}
+          {visible.map((slice) => {
+            const dimmed = isDimmed(slice.category);
+            const isActive = active.has(slice.category);
+            const dotColor = dimmed
+              ? INACTIVE_GREY
+              : sliceColor(slice.category);
+            return (
+              <button
+                key={slice.category}
+                type="button"
+                aria-pressed={isActive}
+                onClick={() => onToggleCategory(slice.category)}
+                className={cn(
+                  "text-muted-foreground hover:text-foreground inline-flex cursor-pointer items-center gap-1.5 text-xs transition-opacity",
+                  dimmed && "opacity-50",
+                  isActive && "text-foreground font-medium",
+                )}
+              >
+                <span
+                  className={cn(
+                    "size-2 rounded-full transition-shadow",
+                    isActive && "ring-2 ring-offset-1",
+                  )}
+                  style={{
+                    backgroundColor: dotColor,
+                    // Subtle ring in the category's color for active items
+                    ...(isActive && {
+                      ["--tw-ring-color" as string]: sliceColor(slice.category),
+                    }),
+                  }}
+                />
+                {categoryLabel(slice.category)}
+                <span
+                  className={cn(
+                    "tabular-nums",
+                    dimmed
+                      ? "text-muted-foreground"
+                      : "text-foreground font-medium",
+                  )}
+                >
+                  {Math.round(slice.share * 100)}%
+                </span>
+              </button>
+            );
+          })}
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves the visual feedback when filtering by data type on the Watchdog page's Exposure by Data Type bar.

## Changes

- **Inactive bar segments** now turn light-to-mid grey (`hsl(0, 0%, 75%)`) instead of just reducing opacity, making the active segment clearly distinguishable
- **Active legend items** get a subtle ring effect around the color dot for increased vibrance
- **Inactive legend items** have their color dot changed to grey and text opacity reduced

## Before/After

When clicking on a bar segment to filter:
- **Before**: Inactive segments used `opacity-30`, which could still blend with the active segment
- **After**: Inactive segments are clearly grey, creating visual separation

## Testing

- TypeScript type-check passes
- Code formatted with `hk fix`

Closes AGE-3401
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3401](https://linear.app/speakeasy/issue/AGE-3401/feat-clarify-active-exposure-filter-on-hover)

<div><a href="https://cursor.com/agents/bc-053ca290-ce57-4a80-a619-e7d785dbcef7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-053ca290-ce57-4a80-a619-e7d785dbcef7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies which category is active on the Watchdog page's Exposure by Data Type bar, and adds hover preview so pointing at a segment or legend entry dims every other slice before committing to the filter.

- Inactive bar segments and legend dots use a theme-resolved neutral (near-white on light, near-black on dark) instead of opacity, and active legend items get a colored ring.
- The `custom` category no longer uses grey (`OTHER_SERIES`); it takes the brand ice blue so grey means inactive only.
- Adds `onMouseEnter`/`onFocus` handlers to preview the dimmed state on hover or keyboard focus.

Closes AGE-3401.

<sup>Written for commit ba194d46f7749ee24154d372b5cc82a6c1b5e46a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

