### PR TITLE
chore: test the paused-worktree resume path in a browser

### DIFF
--- a/.github/workflows/wake-stack-e2e.yml
+++ b/.github/workflows/wake-stack-e2e.yml
@@ -65,6 +65,15 @@ jobs:
             ${{ env.GOCACHE }}
             ${{ env.GOMODCACHE }}
 
+      # `./zero --agent` opts a fresh checkout into the SHA-pinned recommended
+      # skill set, which clones a private repo the runner has no credentials
+      # for -- `fatal: could not read Username for 'https://github.com'` -- and
+      # takes the whole boot down with it. zero only writes this key when it is
+      # absent, so setting it first is enough. Agent skills have no bearing on
+      # what this job tests.
+      - name: Opt out of the recommended agent skills
+        run: printf '[env]\nUSE_RECOMMENDED_SKILLS = "false"\n' > mise.local.toml
+
       # The same command a developer or a cloud agent runs on a fresh checkout:
       # tools, deps, keys, TLS, infra, migrations, seed, then every daemon. The
       # suite needs a stack that has genuinely been through this, because what

--- a/.github/workflows/wake-stack-e2e.yml
+++ b/.github/workflows/wake-stack-e2e.yml
@@ -100,6 +100,15 @@ jobs:
           CLICKHOUSE_MIGRATION_ENGINE = "golang-migrate"
           TOML
 
+      # `mise run seed`, the last step of the boot, builds its local fixtures
+      # around whoever `git config user.email` says you are, and a runner is
+      # nobody. Any identity will do -- the suite logs in through dev-idp,
+      # which provisions on the spot.
+      - name: Give the seed someone to be
+        run: |
+          git config user.email "wake-stack-e2e@example.com"
+          git config user.name "Wake Stack E2E"
+
       # The same command a developer or a cloud agent runs on a fresh checkout:
       # tools, deps, keys, TLS, infra, migrations, seed, then every daemon. The
       # suite needs a stack that has genuinely been through this, because what

--- a/.github/workflows/wake-stack-e2e.yml
+++ b/.github/workflows/wake-stack-e2e.yml
@@ -33,12 +33,22 @@ concurrency:
 
 jobs:
   wake-stack-e2e:
+    # Booting the stack applies the Postgres migrations, and Atlas refuses to
+    # apply a directory using `atlas:txtar` checks without a login. A fork PR
+    # gets no secrets, so it would fail on that rather than on anything it
+    # changed -- skip instead, and let a maintainer run it by hand.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: blacksmith-8vcpu-ubuntu-2404
     # A cold boot compiles the Go server and pulls every infra image before the
     # suite starts; the suite itself then pauses and wakes that stack twice.
     timeout-minutes: 45
     env:
       GOMAXPROCS: 8
+      # `mise db:migrate` shells out to `atlas migrate apply`, and the
+      # migration directory uses checks that are gated behind an account.
+      ATLAS_TOKEN: ${{ secrets.ATLAS_TOKEN }}
     steps:
       - name: Checkout
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
@@ -71,8 +81,24 @@ jobs:
       # takes the whole boot down with it. zero only writes this key when it is
       # absent, so setting it first is enough. Agent skills have no bearing on
       # what this job tests.
-      - name: Opt out of the recommended agent skills
-        run: printf '[env]\nUSE_RECOMMENDED_SKILLS = "false"\n' > mise.local.toml
+      # Two things `./zero --agent` would otherwise decide by asking, on a
+      # runner with nobody to ask:
+      #
+      # - the recommended agent skill set, which it opts a fresh checkout into
+      #   and which clones a private repo the runner cannot authenticate to
+      #   (`fatal: could not read Username for 'https://github.com'`);
+      # - the ClickHouse migration engine, where it prompts for an Atlas Pro
+      #   login and only skips the question when the engine is already chosen.
+      #
+      # zero writes neither key when one is already present, so seeding the
+      # file settles both. Neither has any bearing on what this job tests.
+      - name: Answer zero's questions before it asks them
+        run: |
+          cat > mise.local.toml <<'TOML'
+          [env]
+          USE_RECOMMENDED_SKILLS = "false"
+          CLICKHOUSE_MIGRATION_ENGINE = "golang-migrate"
+          TOML
 
       # The same command a developer or a cloud agent runs on a fresh checkout:
       # tools, deps, keys, TLS, infra, migrations, seed, then every daemon. The

--- a/.github/workflows/wake-stack-e2e.yml
+++ b/.github/workflows/wake-stack-e2e.yml
@@ -1,0 +1,99 @@
+# The worktree pause/resume lifecycle, driven in a real browser.
+#
+# Kept out of pr.yaml on purpose. This job boots the entire local stack --
+# compose infra, migrations, seed, every pitchfork daemon -- and then stops and
+# restarts it, which is an order of magnitude heavier and slower than anything
+# in the main PR workflow, and it only has an opinion about a handful of files.
+# It runs when those files change, and on demand.
+name: Worktree pause/resume E2E
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .mise-tasks/pause.sh
+      - .mise-tasks/wake.sh
+      - .mise-tasks/park.mts
+      - .mise-tasks/ensure-stack.sh
+      - .mise-tasks/idle-pause.sh
+      - .mise-tasks/git/workboot.sh
+      - .mise-tasks/test/wake-stack.sh
+      - .config/wt.toml
+      - pitchfork.toml
+      - e2e/**
+      - .github/workflows/wake-stack-e2e.yml
+
+permissions:
+  contents: read
+
+# A second run would boot a second stack on the same ports.
+concurrency:
+  group: wake-stack-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  wake-stack-e2e:
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    # A cold boot compiles the Go server and pulls every infra image before the
+    # suite starts; the suite itself then pauses and wakes that stack twice.
+    timeout-minutes: 45
+    env:
+      GOMAXPROCS: 8
+    steps:
+      - name: Checkout
+        uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
+
+      - name: Setup Mise
+        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          install: true
+          cache: true
+          cache_key_prefix: mise-blacksmith-v1
+          env: false
+
+      - name: Prepare GitHub Actions environment
+        run: mise run github
+
+      - name: Cache Go
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          key: ${{ env.GH_CACHE_GO_KEY }}
+          restore-keys: |
+            ${{ env.GH_CACHE_GO_KEY }}
+            ${{ env.GH_CACHE_GO_KEY_PARTIAL }}
+          path: |
+            ${{ env.GOCACHE }}
+            ${{ env.GOMODCACHE }}
+
+      # The same command a developer or a cloud agent runs on a fresh checkout:
+      # tools, deps, keys, TLS, infra, migrations, seed, then every daemon. The
+      # suite needs a stack that has genuinely been through this, because what
+      # it tests is stopping one and starting it again.
+      - name: Boot the stack
+        run: ./zero --agent
+
+      - name: Test
+        run: mise run test:wake-stack
+
+      # Traces, videos and screenshots for the step that failed. Without these
+      # a failure here is a line of text about a stack that no longer exists.
+      - name: Upload Playwright artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: wake-stack-playwright
+          path: e2e/.playwright
+          retention-days: 7
+          if-no-files-found: ignore
+
+      # `pause` and `wake` run detached and log to the git dir, so their output
+      # never reaches the job log even when they are the thing that broke.
+      - name: Upload stack logs
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: wake-stack-logs
+          path: |
+            .git/gram-stack-*.log
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,9 @@ __pycache__/
 .playwright-mcp
 .playwright-cli
 
+# Traces, videos and screenshots from the e2e suite (mise run test:wake-stack)
+e2e/.playwright
+
 # Riptide artifacts (cloud-synced)
 .humanlayer/tasks/
 

--- a/.mise-tasks/test/wake-stack.sh
+++ b/.mise-tasks/test/wake-stack.sh
@@ -15,10 +15,11 @@ set -e
 # (.github/workflows/wake-stack-e2e.yml), which boots a stack first and runs
 # only when the lifecycle files change.
 
-if [ ! -d node_modules/@playwright/test ]; then
-    echo "Installing the e2e suite's dependencies..." >&2
-    aube install -F @gram/e2e
-fi
+# Unconditional rather than guarded on node_modules: a guard makes this a
+# one-time install, so bumping the runner in e2e/package.json would leave the
+# old one in place and the browser install below would then fetch a build that
+# does not match it. An install that has nothing to do costs about a second.
+aube install -F @gram/e2e
 
 # Separate from the `playwright-cli` browser install: this is Playwright's own
 # CLI, which fetches the build the pinned test runner expects. Idempotent, and

--- a/.mise-tasks/test/wake-stack.sh
+++ b/.mise-tasks/test/wake-stack.sh
@@ -10,9 +10,10 @@ set -e
 # it first would test nothing. The suite calls `ensure-stack` itself, at the
 # step where a booted stack is the precondition rather than the obstacle.
 #
-# Not part of `mise run test` either. It pauses and wakes real containers, takes
-# minutes, and leaves this worktree's stack running -- run it by hand when
-# touching pause/wake/park.
+# Not part of `mise run test` either: it pauses and wakes real containers, takes
+# minutes, and leaves the stack running. In CI it has a workflow of its own
+# (.github/workflows/wake-stack-e2e.yml), which boots a stack first and runs
+# only when the lifecycle files change.
 
 if [ ! -d node_modules/@playwright/test ]; then
     echo "Installing the e2e suite's dependencies..." >&2
@@ -22,6 +23,13 @@ fi
 # Separate from the `playwright-cli` browser install: this is Playwright's own
 # CLI, which fetches the build the pinned test runner expects. Idempotent, and
 # a no-op once the browser is in the shared cache.
-aube exec playwright install chromium
+if [ -n "${CI:-}" ]; then
+    # Chromium's shared libraries are not on a bare runner. `--with-deps` needs
+    # root and only knows how to install them on Debian/Ubuntu, so it stays out
+    # of the developer path, where the browser already works.
+    aube exec playwright install --with-deps chromium
+else
+    aube exec playwright install chromium
+fi
 
 exec aube exec playwright test "$@"

--- a/.mise-tasks/test/wake-stack.sh
+++ b/.mise-tasks/test/wake-stack.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+#MISE description="End-to-end test of the pause/resume worktree lifecycle (drives this worktree's stack)"
+#MISE dir="{{ config_root }}/e2e"
+
+set -e
+
+# Deliberately does NOT depend on `ensure-stack`, unlike `mise run playwright`:
+# the point of this suite is to hit a PAUSED stack, and a dependency that woke
+# it first would test nothing. The suite calls `ensure-stack` itself, at the
+# step where a booted stack is the precondition rather than the obstacle.
+#
+# Not part of `mise run test` either. It pauses and wakes real containers, takes
+# minutes, and leaves this worktree's stack running -- run it by hand when
+# touching pause/wake/park.
+
+if [ ! -d node_modules/@playwright/test ]; then
+    echo "Installing the e2e suite's dependencies..." >&2
+    aube install -F @gram/e2e
+fi
+
+# Separate from the `playwright-cli` browser install: this is Playwright's own
+# CLI, which fetches the build the pinned test runner expects. Idempotent, and
+# a no-op once the browser is in the shared cache.
+aube exec playwright install chromium
+
+exec aube exec playwright test "$@"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@gram/e2e",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "type-check": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.58.0",
+    "@types/node": "^24.13.3"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig } from "@playwright/test";
+
+// Browser tests for the worktree lifecycle: pause the stack, hit its URL, and
+// resume it from the page the parker serves (see `mise run park`). Everything
+// here is deliberately serial and single-worker -- the subject under test is
+// one worktree's containers, which is global mutable state.
+
+const siteURL = process.env["GRAM_SITE_URL"];
+if (!siteURL) {
+  throw new Error(
+    "GRAM_SITE_URL is not set. Run this suite through `mise run test:wake-stack`, " +
+      "which loads the worktree's mise env.",
+  );
+}
+
+export default defineConfig({
+  testDir: "./tests",
+  workers: 1,
+  fullyParallel: false,
+  // A wake starts containers, waits for Postgres and ClickHouse, then builds
+  // and starts the Go server -- minutes on a cold worktree, and the login that
+  // follows needs the server to be answering.
+  timeout: 12 * 60 * 1000,
+  expect: { timeout: 20_000 },
+  // Every retry would pay the pause/wake cost again, and a flake here is
+  // usually a real stack problem worth reading the trace for.
+  retries: 0,
+  reporter: [["list"]],
+  outputDir: "./.playwright",
+  use: {
+    baseURL: siteURL,
+    // vite serves the worktree's self-signed local cert, and the parker serves
+    // the same one so the origin does not change across the handover.
+    ignoreHTTPSErrors: true,
+    trace: "retain-on-failure",
+    video: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+});

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -17,10 +17,12 @@ export default defineConfig({
   testDir: "./tests",
   workers: 1,
   fullyParallel: false,
-  // A wake starts containers, waits for Postgres and ClickHouse, then builds
-  // and starts the Go server -- minutes on a cold worktree, and the login that
-  // follows needs the server to be answering.
-  timeout: 12 * 60 * 1000,
+  // Has to sit above every wait the test sets for itself -- the lock wait, the
+  // exec timeout on a `mise` task that may run a full boot, the wait for the
+  // dashboard to answer. Otherwise this cap binds first and a slow-but-working
+  // run dies with a generic test timeout instead of the specific diagnostic the
+  // step was written to produce. A healthy run takes about three minutes.
+  timeout: 30 * 60 * 1000,
   expect: { timeout: 20_000 },
   // Every retry would pay the pause/wake cost again, and a flake here is
   // usually a real stack problem worth reading the trace for.

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -25,7 +25,9 @@ export default defineConfig({
   // Every retry would pay the pause/wake cost again, and a flake here is
   // usually a real stack problem worth reading the trace for.
   retries: 0,
-  reporter: [["list"]],
+  // The GitHub reporter annotates the failing line in the PR's Files tab; the
+  // list reporter keeps the job log readable on its own.
+  reporter: process.env["CI"] ? [["github"], ["list"]] : [["list"]],
   outputDir: "./.playwright",
   use: {
     baseURL: siteURL,

--- a/e2e/tests/wake-stack.spec.ts
+++ b/e2e/tests/wake-stack.spec.ts
@@ -20,12 +20,22 @@ import path from "node:path";
 const repoRoot = path.resolve(import.meta.dirname, "..", "..");
 
 function run(command: string, args: string[], timeoutMs = 15 * 60_000): string {
-  return execFileSync(command, args, {
-    cwd: repoRoot,
-    encoding: "utf8",
-    timeout: timeoutMs,
-    stdio: ["ignore", "pipe", "inherit"],
-  });
+  try {
+    return execFileSync(command, args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+      timeout: timeoutMs,
+      stdio: ["ignore", "pipe", "inherit"],
+      // A cold `ensure-stack` runs a whole boot through this pipe, and the
+      // default 1 MiB ceiling turns that into ERR_CHILD_PROCESS_STDIO_MAXBUFFER
+      // -- a failure about a buffer, in a suite about a stack.
+      maxBuffer: 64 * 1024 * 1024,
+    });
+  } catch (cause) {
+    // execFileSync's own message is the command line and nothing else, so a
+    // timeout and a task that exited 1 read identically.
+    throw new Error(`\`${[command, ...args].join(" ")}\` failed`, { cause });
+  }
 }
 
 function mise(...args: string[]): string {
@@ -95,11 +105,17 @@ async function waitForNoStackLock(): Promise<void> {
     .toBe(false);
 }
 
-function alive(pid: number): boolean {
+// Identity, not just existence: `wake` kills the parker and the pid is then
+// free to be reused, which a bare `kill(pid, 0)` would report as a parker that
+// outlived its wake. `wake.sh`'s own release_port() makes the same check
+// before it signals anything.
+function parkerAlive(pid: number): boolean {
   try {
-    process.kill(pid, 0);
-    return true;
+    return run("ps", ["-o", "command=", "-p", String(pid)], 10_000).includes(
+      "park",
+    );
   } catch {
+    // `ps` exits non-zero when the pid is gone, which is the answer.
     return false;
   }
 }
@@ -159,7 +175,9 @@ test("a paused worktree serves the resume page and comes back from it", async ({
 
     const pid = parkerPid();
     expect(pid, "no parker pid file, so the site port is dead").not.toBeNull();
-    expect(alive(pid!), "the parker exited after writing its pid").toBe(true);
+    expect(parkerAlive(pid!), "the parker exited after writing its pid").toBe(
+      true,
+    );
   });
 
   await test.step("the dashboard URL answers with the resume page", async () => {
@@ -208,7 +226,7 @@ test("a paused worktree serves the resume page and comes back from it", async ({
     await expect(page.locator("#root")).toBeAttached({ timeout: 10 * 60_000 });
     await expect(page).toHaveTitle("Speakeasy");
 
-    expect(alive(parked!), "the parker outlived the wake").toBe(false);
+    expect(parkerAlive(parked!), "the parker outlived the wake").toBe(false);
     expect(running().length, "the wake started no containers").toBeGreaterThan(
       0,
     );

--- a/e2e/tests/wake-stack.spec.ts
+++ b/e2e/tests/wake-stack.spec.ts
@@ -106,6 +106,28 @@ function alive(pid: number): boolean {
 
 test.describe.configure({ mode: "serial" });
 
+// `pause` and `wake` run detached and log to the git dir, so their output
+// reaches neither the terminal nor the CI job log -- even when they are the
+// thing that broke. Every failure below is otherwise one sentence about a
+// stack whose own account of itself nobody has seen.
+test.afterEach(async ({}, testInfo) => {
+  if (testInfo.status === testInfo.expectedStatus) return;
+  for (const name of ["gram-stack-wake.log", "gram-stack-park.log"]) {
+    let body: string;
+    try {
+      body = fs.readFileSync(marker(name), "utf8");
+    } catch {
+      continue;
+    }
+    // The wake log is mostly redrawn progress spinners and runs to megabytes;
+    // what matters is how it ended.
+    await testInfo.attach(name, {
+      body: body.slice(-64 * 1024),
+      contentType: "text/plain",
+    });
+  }
+});
+
 test("a paused worktree serves the resume page and comes back from it", async ({
   page,
 }) => {

--- a/e2e/tests/wake-stack.spec.ts
+++ b/e2e/tests/wake-stack.spec.ts
@@ -1,0 +1,216 @@
+import { expect, test } from "@playwright/test";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+// The lifecycle a worktree is handed over in: its stack is built, then paused
+// (`.config/wt.toml` -> `git:workboot` -> `mise run pause`), and the developer
+// gets it back by opening the same dashboard URL as always and clicking a
+// button. Nothing else in the repo exercises that handover, and every part of
+// it fails quietly -- a parker that never binds looks like a dead port, a wake
+// that half-runs looks like a broken app -- so this drives the whole thing:
+//
+//   pause -> containers stopped but NOT removed -> the URL still answers with
+//   the resume page -> a plain GET leaves the stack paused -> Resume wakes it
+//   -> the dashboard comes back -> login works against the woken server.
+//
+// Runs against whatever worktree it is invoked in, and leaves that worktree's
+// stack running.
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+
+function run(command: string, args: string[], timeoutMs = 15 * 60_000): string {
+  return execFileSync(command, args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    timeout: timeoutMs,
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+}
+
+function mise(...args: string[]): string {
+  return run("mise", ["run", ...args]);
+}
+
+const gitDir = run("git", ["rev-parse", "--absolute-git-dir"], 10_000).trim();
+const marker = (name: string): string => path.join(gitDir, name);
+
+type Container = { name: string; state: string };
+
+// `-a`, because the point of `pause` is that the containers still exist: a
+// `down` would satisfy "nothing is running" and break every promise the
+// feature makes about waking being fast.
+function containers(): Container[] {
+  const out = run("docker", [
+    "compose",
+    "ps",
+    "-a",
+    "--format",
+    "{{.Name}}\t{{.State}}",
+  ]);
+  return out
+    .split("\n")
+    .filter((line) => line.trim() !== "")
+    .map((line) => {
+      const [name = "", state = ""] = line.split("\t");
+      return { name, state };
+    });
+}
+
+function running(): string[] {
+  return containers()
+    .filter((c) => c.state === "running")
+    .map((c) => c.name);
+}
+
+// The parker writes this only once it is actually listening, so its presence
+// is the difference between "the stack is paused" and "the stack is paused and
+// the URL is dead".
+function parkerPid(): number | null {
+  const raw = fs.readFileSync(marker("gram-stack-parked.pid"), "utf8").trim();
+  const pid = Number(raw);
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
+// `pause` and `wake` serialize behind this, and a wake started from the browser
+// outlives the process that clicked the button -- so a previous run of this
+// suite can still be finishing. Waiting turns a confusing "another pause or
+// wake holds the lock" failure into either a pass or an honest timeout.
+async function waitForNoStackLock(): Promise<void> {
+  await expect
+    .poll(
+      () => {
+        try {
+          fs.lstatSync(marker("gram-stack-lock"));
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      {
+        timeout: 10 * 60_000,
+        message: "a pause or wake from an earlier run still holds the lock",
+      },
+    )
+    .toBe(false);
+}
+
+function alive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+test.describe.configure({ mode: "serial" });
+
+test("a paused worktree serves the resume page and comes back from it", async ({
+  page,
+}) => {
+  await test.step("start from a booted stack", async () => {
+    await waitForNoStackLock();
+
+    // Wakes the stack if it is paused and boots it if it has never run, which
+    // is also the "container gets created" half of the lifecycle: without
+    // containers there is nothing for `pause` to keep.
+    mise("ensure-stack");
+    expect(
+      containers().length,
+      "the worktree has no containers",
+    ).toBeGreaterThan(0);
+  });
+
+  await test.step("pause it", () => {
+    mise("pause");
+
+    expect(
+      running(),
+      "`pause` left containers running; it should stop every profile",
+    ).toEqual([]);
+    expect(
+      containers().length,
+      "`pause` removed the containers; it must stop them, not `down` them",
+    ).toBeGreaterThan(0);
+    expect(fs.existsSync(marker("gram-stack-paused"))).toBe(true);
+
+    const pid = parkerPid();
+    expect(pid, "no parker pid file, so the site port is dead").not.toBeNull();
+    expect(alive(pid!), "the parker exited after writing its pid").toBe(true);
+  });
+
+  await test.step("the dashboard URL answers with the resume page", async () => {
+    const response = await page.goto("/");
+
+    // How the page itself tells the parker apart from the dashboard it is
+    // waiting for; both answer the same origin.
+    expect(response?.headers()["x-gram-parked"]).toBe("1");
+    await expect(page).toHaveTitle("Stack paused");
+    await expect(
+      page.getByRole("heading", { name: "Stack paused" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Resume stack" }),
+    ).toBeVisible();
+  });
+
+  await test.step("loading that page does not wake anything", async () => {
+    // Prefetches, link previews and reconnecting tabs all hit this port. A
+    // stack that wakes on a page load cannot be kept paused, so the wake is
+    // behind the button and nothing else.
+    await page.reload();
+    expect(running(), "a GET on the parked port started the stack").toEqual([]);
+  });
+
+  const parked = parkerPid();
+
+  await test.step("Resume starts the wake", async () => {
+    await page.getByRole("button", { name: "Resume stack" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Resuming stack" }),
+    ).toBeVisible();
+    await expect(page).toHaveTitle("Resuming stack…");
+    // The page stays up for the whole wake -- reloads and second tabs during
+    // it should get the page, not a connection error.
+    await expect(
+      page.getByText(/logs: pitchfork logs dashboard/),
+    ).toBeVisible();
+  });
+
+  await test.step("the page reloads into the dashboard", async () => {
+    // The parker holds the port until `wake` kills it immediately before vite
+    // binds, and the page polls until something without the parker's header
+    // answers. Reaching the real index.html is the whole handover working.
+    await expect(page.locator("#root")).toBeAttached({ timeout: 10 * 60_000 });
+    await expect(page).toHaveTitle("Speakeasy");
+
+    expect(alive(parked!), "the parker outlived the wake").toBe(false);
+    expect(running().length, "the wake started no containers").toBeGreaterThan(
+      0,
+    );
+
+    // Polled rather than asserted outright: `wake` clears the marker only
+    // after `mise run start` returns, and vite answers well before that -- so
+    // the browser is back on the dashboard while the wake is still finishing.
+    await expect
+      .poll(() => fs.existsSync(marker("gram-stack-paused")), {
+        timeout: 5 * 60_000,
+        message: "the stack is up but still marked paused",
+      })
+      .toBe(false);
+  });
+
+  await test.step("login works against the woken stack", async () => {
+    // Not a bonus assertion: the dashboard answering only proves vite is up.
+    // Logging in goes through vite's proxy to the Go server and from there to
+    // Postgres, which is the half of the stack the parker never stood in for.
+    await page.getByRole("button", { name: "Log in" }).click();
+
+    await page.waitForURL((url) => !url.pathname.startsWith("/login"), {
+      timeout: 3 * 60_000,
+    });
+    await expect(page.getByRole("button", { name: "Log in" })).toHaveCount(0);
+  });
+});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig.strict.json",
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", ".playwright"],
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["dom", "es2022"],
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
+    "types": ["node"],
+    "noEmit": true,
+    "skipLibCheck": true
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -573,6 +573,15 @@ importers:
         specifier: 'catalog:'
         version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0)
 
+  e2e:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.58.0
+        version: 1.62.1
+      '@types/node':
+        specifier: ^24.13.3
+        version: 24.13.3
+
   functions:
     devDependencies:
       '@types/node':
@@ -604,7 +613,7 @@ importers:
     devDependencies:
       '@gram-ai/functions':
         specifier: workspace:^
-        version: link:../functions
+        version: 0.18.1
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
         version: 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
@@ -2257,6 +2266,11 @@ packages:
         optional: true
       shiki:
         optional: true
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@pnpm/deps.graph-sequencer@1100.0.1':
     resolution: {integrity: sha512-pOr5+q1fLYKwFN3LAJuGZEnfXDcQ73zqgDHMtGy+K+uIoUqyY+6MeDCWFwfu+4EFuq76I5EPFofoNAI+Bmmq4A==}
@@ -5125,6 +5139,11 @@ packages:
     resolution: {integrity: sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==}
     engines: {node: '>=14.14'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -6254,6 +6273,16 @@ packages:
   pkg-up@3.1.0:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
@@ -8904,6 +8933,10 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       shiki: 4.4.1
+
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
 
   '@pnpm/deps.graph-sequencer@1100.0.1': {}
 
@@ -11819,6 +11852,9 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -13190,6 +13226,14 @@ snapshots:
   pkg-up@3.1.0:
     dependencies:
       find-up: 3.0.0
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   points-on-curve@0.2.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,7 @@ packages:
   - docs
   - evaluation
   - dev-idp-dashboard
+  - e2e
 
 catalog:
   "@ai-sdk/react": ^4.0.69


### PR DESCRIPTION
## Summary

A Playwright suite that drives the paused-worktree handover added in #5978, end to end, against whatever worktree it is run in:

- `mise run pause`, then assert the containers are **stopped but still present** (a `down` would satisfy "nothing is running" while breaking the promise that waking is fast), the `gram-stack-paused` marker is written, and the parker has actually bound the site port.
- Load the worktree's dashboard URL and check it answers with the resume page — `x-gram-parked: 1`, the `Stack paused` heading, the `Resume stack` button.
- Reload, and assert the stack is **still** paused. Prefetches, link previews and reconnecting tabs all hit this port; a page load that wakes the stack is the bug the button exists to prevent.
- Click Resume, assert the panel swaps to the resuming state, then wait for the page to reload into the real dashboard, for the parker to be gone, and for `wake` to clear the paused marker.
- Log in through dev-idp. Not a bonus assertion: vite answering only proves the dev server is up, and login is what exercises the proxy, the Go server and Postgres — the half of the stack the parker never stood in for.

`mise run test:wake-stack` runs it locally. In CI it gets a workflow of its own rather than a job in `pr.yaml`, because it has to boot the entire local stack with `./zero --agent` before it can assert anything — an order of magnitude heavier than everything else in the PR workflow, and it only has an opinion about a handful of files. It runs on changes to those (`pause.sh`, `wake.sh`, `park.mts`, `ensure-stack.sh`, `idle-pause.sh`, `workboot.sh`, `wt.toml`, `pitchfork.toml`, `e2e/**`) and on `workflow_dispatch`.

Two supporting details:

- The suite **does not depend on `ensure-stack`**, unlike `mise run playwright`. A dependency that woke the stack first would leave nothing to test, so it calls it from the step where a booted stack is the precondition rather than the obstacle.
- `pause` and `wake` run detached and write to the git dir, so when the wake is the thing that broke, its output reaches neither the terminal nor a CI job log — the test can only report that the stack is up but still marked paused. A failing test now attaches the tail of the wake and park logs, and the workflow uploads those alongside the Playwright traces.

Two waits are polled rather than asserted outright, because both are genuine orderings rather than flakes: `wake` clears the paused marker only after `mise run start` returns, which is well after vite starts answering; and a wake started from the browser outlives the process that clicked the button, so a previous run can still hold the stack lock.

## Motivation

The pause/wake path fails quietly in every direction. A parker that never binds is indistinguishable from a dead port. A wake that half-runs looks like a broken app. A resume that fires on page load instead of on the button leaves a worktree that will not stay paused. None of these surface until a developer opens the URL and finds the dashboard missing, and none of them are reachable from a unit test — the subject is real containers, a real port handover and a real browser.

It already found one. On a repeated pause/wake cycle the worktree's ClickHouse came back without its `gram` database, so the `server` and `streams` daemons exited 1, `mise run start` failed, and `wake` aborted before clearing the paused marker — leaving a half-up stack that still reads as paused. Not fixed here; this PR is the thing that noticed, and the failure is filed rather than folded into the test.

`@playwright/test` is new to the repo: `npm:@playwright/cli` is the agent-facing driver, not a test runner, and driving a stateful CLI session from a shell script gives up assertions and traces on exactly the failures this is meant to catch. The suite lives in its own `e2e/` workspace package so nothing else picks it up.

---

https://claude.ai/code/session_01DduvrXjyXQg77oHnaF6829