### PR TITLE
feat: expose organization event feed through platform MCP

### DIFF
--- a/.changeset/platform-mcp-organization-events.md
+++ b/.changeset/platform-mcp-organization-events.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Add a Platform MCP tool that lists recent organization Event Feed entries for admins.

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -98,6 +98,10 @@ type platformMCPConfig struct {
 	// EventFeed reads the org-scoped OpenTelemetry event feed. Nil keeps the
 	// tool visible as unavailable rather than returning an empty list.
 	EventFeed platformmcp.EventFeedReader
+	// LogsEnabled is the same product-feature gate the dashboard Event Feed
+	// uses. Nil, or a false result for the caller's organization, withholds
+	// live organization-event reads.
+	LogsEnabled platformmcp.FeatureChecker
 
 	LocalFixture *platformMCPLocalFixtureConfig
 }
@@ -325,7 +329,7 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 		WithDataExports(config.Encryption, config.DashboardURL).
 		WithDataExportMutations(config.AuditLogger, config.DashboardURL).
 		WithRecentToolCalls(config.RecentToolCalls, config.DashboardURL).
-		WithOrganizationEvents(config.EventFeed, config.DashboardURL)
+		WithOrganizationEvents(config.EventFeed, config.LogsEnabled, config.DashboardURL)
 	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, config.SessionCapture, platformReader, readiness, budgets.Diagnostics).
 		WithDrilldown(config.TelemetryDrilldown, config.JWTSigningKey, budgets.SensitiveDiagnostics, budgets.DrilldownVolume, platformmcp.NewPostgresDrilldownAuditor(config.DB))
 	sessionRecall := platformmcp.NewSessionRecallService(config.Logger, config.DB, platformrepo.New(config.DB), audit.NewLogger(), config.SessionPortability, budgets.SensitiveSessionRecall)
@@ -661,7 +665,7 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 		WithDataExports(config.Encryption, config.DashboardURL).
 		WithDataExportMutations(config.AuditLogger, config.DashboardURL).
 		WithRecentToolCalls(config.RecentToolCalls, config.DashboardURL).
-		WithOrganizationEvents(config.EventFeed, config.DashboardURL)
+		WithOrganizationEvents(config.EventFeed, config.LogsEnabled, config.DashboardURL)
 	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, config.SessionCapture, platformReader, readiness, budgets.Diagnostics).
 		WithDrilldown(config.TelemetryDrilldown, config.JWTSigningKey, budgets.SensitiveDiagnostics, budgets.DrilldownVolume, platformmcp.NewPostgresDrilldownAuditor(config.DB))
 	sessionRecall := platformmcp.NewSessionRecallService(config.Logger, config.DB, platformrepo.New(config.DB), audit.NewLogger(), config.SessionPortability, budgets.SensitiveSessionRecall)

--- a/server/cmd/gram/platform_mcp.go
+++ b/server/cmd/gram/platform_mcp.go
@@ -95,7 +95,11 @@ type platformMCPConfig struct {
 	// RecentToolCalls reads only the bounded Tool Logs summary path.
 	// Nil keeps the tool visible as unavailable rather than returning an empty list.
 	RecentToolCalls platformmcp.RecentToolCallReader
-	LocalFixture    *platformMCPLocalFixtureConfig
+	// EventFeed reads the org-scoped OpenTelemetry event feed. Nil keeps the
+	// tool visible as unavailable rather than returning an empty list.
+	EventFeed platformmcp.EventFeedReader
+
+	LocalFixture *platformMCPLocalFixtureConfig
 }
 
 var platformMCPLocalFixtureLoopbackCIDRBlocks = []string{"127.0.0.0/8", "::1/128"}
@@ -320,7 +324,8 @@ func configureLocalFixturePlatformMCP(ctx context.Context, config platformMCPCon
 	platformReader := platformmcp.NewPostgresReader(config.Logger, config.DB).
 		WithDataExports(config.Encryption, config.DashboardURL).
 		WithDataExportMutations(config.AuditLogger, config.DashboardURL).
-		WithRecentToolCalls(config.RecentToolCalls, config.DashboardURL)
+		WithRecentToolCalls(config.RecentToolCalls, config.DashboardURL).
+		WithOrganizationEvents(config.EventFeed, config.DashboardURL)
 	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, config.SessionCapture, platformReader, readiness, budgets.Diagnostics).
 		WithDrilldown(config.TelemetryDrilldown, config.JWTSigningKey, budgets.SensitiveDiagnostics, budgets.DrilldownVolume, platformmcp.NewPostgresDrilldownAuditor(config.DB))
 	sessionRecall := platformmcp.NewSessionRecallService(config.Logger, config.DB, platformrepo.New(config.DB), audit.NewLogger(), config.SessionPortability, budgets.SensitiveSessionRecall)
@@ -655,7 +660,8 @@ func configureBrowserPlatformMCP(ctx context.Context, config platformMCPConfig) 
 	platformReader := platformmcp.NewPostgresReader(config.Logger, config.DB).
 		WithDataExports(config.Encryption, config.DashboardURL).
 		WithDataExportMutations(config.AuditLogger, config.DashboardURL).
-		WithRecentToolCalls(config.RecentToolCalls, config.DashboardURL)
+		WithRecentToolCalls(config.RecentToolCalls, config.DashboardURL).
+		WithOrganizationEvents(config.EventFeed, config.DashboardURL)
 	diagnostics := platformmcp.NewDiagnosticsService(config.DB, config.Telemetry, config.SessionCapture, platformReader, readiness, budgets.Diagnostics).
 		WithDrilldown(config.TelemetryDrilldown, config.JWTSigningKey, budgets.SensitiveDiagnostics, budgets.DrilldownVolume, platformmcp.NewPostgresDrilldownAuditor(config.DB))
 	sessionRecall := platformmcp.NewSessionRecallService(config.Logger, config.DB, platformrepo.New(config.DB), audit.NewLogger(), config.SessionPortability, budgets.SensitiveSessionRecall)

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -1670,6 +1670,7 @@ func newStartCommand() *cli.Command {
 				TelemetryDrilldown:      telemetryrepo.New(chDB),
 				RecentToolCalls:         telemetryrepo.New(chDB),
 				EventFeed:               otelchrepo.New(chDB),
+				LogsEnabled:             platformmcp.FeatureChecker(logsEnabled),
 				SessionCapture:          platformmcp.FeatureChecker(sessionCaptureEnabled),
 				SessionPortability:      platformmcp.FeatureChecker(sessionPortabilityEnabled),
 				LocalFixture:            platformFixture,

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -106,6 +106,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/organizations"
 	orgRepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	otelsvc "github.com/speakeasy-api/gram/server/internal/otel"
+	otelchrepo "github.com/speakeasy-api/gram/server/internal/otel/chrepo"
 	"github.com/speakeasy-api/gram/server/internal/packages"
 	"github.com/speakeasy-api/gram/server/internal/platformmcp"
 	"github.com/speakeasy-api/gram/server/internal/platformmcp/localfixture"
@@ -1668,6 +1669,7 @@ func newStartCommand() *cli.Command {
 				Telemetry:               telemetryrepo.New(chDB),
 				TelemetryDrilldown:      telemetryrepo.New(chDB),
 				RecentToolCalls:         telemetryrepo.New(chDB),
+				EventFeed:               otelchrepo.New(chDB),
 				SessionCapture:          platformmcp.FeatureChecker(sessionCaptureEnabled),
 				SessionPortability:      platformmcp.FeatureChecker(sessionPortabilityEnabled),
 				LocalFixture:            platformFixture,

--- a/server/internal/platformmcp/adapters.go
+++ b/server/internal/platformmcp/adapters.go
@@ -295,6 +295,7 @@ type PostgresReader struct {
 	dataExports         *DataExportReadService
 	dataExportMutations *dataExportMutationService
 	recentToolCalls     *RecentToolCallReadService
+	eventFeed           *EventFeedReadService
 }
 
 func NewPostgresReader(logger *slog.Logger, db *pgxpool.Pool) *PostgresReader {
@@ -309,6 +310,7 @@ func NewPostgresReader(logger *slog.Logger, db *pgxpool.Pool) *PostgresReader {
 		dataExports:         nil,
 		dataExportMutations: nil,
 		recentToolCalls:     nil,
+		eventFeed:           nil,
 	}
 }
 

--- a/server/internal/platformmcp/descriptor_test.go
+++ b/server/internal/platformmcp/descriptor_test.go
@@ -206,6 +206,7 @@ func TestAssistantAudienceExcludesConnectionScopedTools(t *testing.T) {
 		"find_mcp",
 		"get_mcp",
 		"list_recent_tool_calls",
+		"list_organization_events",
 		"update_mcp_metadata",
 		"register_catalog_mcp",
 		"register_remote_mcp",

--- a/server/internal/platformmcp/feedback.go
+++ b/server/internal/platformmcp/feedback.go
@@ -389,6 +389,7 @@ var knownPlatformMCPToolNames = map[string]struct{}{
 	"list_data_exports":                     {},
 	"create_data_export":                    {},
 	"list_recent_tool_calls":                {},
+	"list_organization_events":              {},
 	"search_mcp_catalog":                    {},
 	"inspect_mcp_candidate":                 {},
 	"register_catalog_mcp":                  {},

--- a/server/internal/platformmcp/freshness.go
+++ b/server/internal/platformmcp/freshness.go
@@ -64,6 +64,7 @@ var (
 	diagnosticsWindowSpec = windowSpec{Fallback: DiagnosticWindowLastHour, Max: DiagnosticWindowLastDay}
 	drilldownWindowSpec   = windowSpec{Fallback: DiagnosticWindowLastDay, Max: DiagnosticWindowLastDay}
 	metricsWindowSpec     = windowSpec{Fallback: DiagnosticWindowLastDay, Max: DiagnosticWindowLastWeek}
+	eventFeedWindowSpec   = windowSpec{Fallback: DiagnosticWindowLastDay, Max: DiagnosticWindowLastWeek}
 )
 
 // ErrDiagnosticWindowInvalid is returned for a window outside the closed set.

--- a/server/internal/platformmcp/freshness_test.go
+++ b/server/internal/platformmcp/freshness_test.go
@@ -42,6 +42,9 @@ func TestResolveWindow_DefaultsAndClosedSet(t *testing.T) {
 		{name: "drilldown refuses a week", spec: drilldownWindowSpec, requested: "7d", wantErr: ErrDiagnosticWindowTooLong},
 		{name: "metrics allow a week", spec: metricsWindowSpec, requested: "7d", want: DiagnosticWindowLastWeek, wantSpan: 7 * 24 * time.Hour},
 		{name: "metrics refuse a month", spec: metricsWindowSpec, requested: "30d", wantErr: ErrDiagnosticWindowTooLong},
+		{name: "event feed defaults to a day", spec: eventFeedWindowSpec, requested: "", want: DiagnosticWindowLastDay, wantSpan: 24 * time.Hour},
+		{name: "event feed allows a week", spec: eventFeedWindowSpec, requested: "7d", want: DiagnosticWindowLastWeek, wantSpan: 7 * 24 * time.Hour},
+		{name: "event feed refuses a month", spec: eventFeedWindowSpec, requested: "30d", wantErr: ErrDiagnosticWindowTooLong},
 	}
 
 	for _, test := range tests {

--- a/server/internal/platformmcp/operational_reads_integration_test.go
+++ b/server/internal/platformmcp/operational_reads_integration_test.go
@@ -39,15 +39,6 @@ func TestOperationalReadersRequireHTTPSDashboardURL(t *testing.T) {
 	require.False(t, validDashboardURL(mustParseURL(t, "https://user@app.getgram.test")))
 }
 
-func TestRecentToolCallsRequirePostgres(t *testing.T) {
-	t.Parallel()
-
-	reader := NewPostgresReader(testenv.NewLogger(t), nil).
-		WithRecentToolCalls(&recordingRecentToolCallReader{}, mustParseURL(t, "https://app.getgram.test"))
-	_, err := reader.ListRecentToolCalls(t.Context(), Principal{OrganizationID: "organization"}, ListRecentToolCallsInput{ProjectSlug: "project"})
-	require.ErrorIs(t, err, ErrUnavailable)
-}
-
 func TestListDataExportsReturnsSafeStructuredConfiguration(t *testing.T) {
 	t.Parallel()
 
@@ -426,15 +417,6 @@ func TestRecentToolCallTargetOmitsUnclassifiedShadowSource(t *testing.T) {
 		TargetLabel: "npx --yes package --token private",
 	})
 	require.Empty(t, target)
-}
-
-func TestOrganizationEventsRequirePostgres(t *testing.T) {
-	t.Parallel()
-
-	reader := NewPostgresReader(testenv.NewLogger(t), nil).
-		WithOrganizationEvents(&recordingEventFeedReader{}, alwaysEnabledFeature, mustParseURL(t, "https://app.getgram.test"))
-	_, err := reader.ListOrganizationEvents(t.Context(), Principal{OrganizationID: "organization"}, ListOrganizationEventsInput{})
-	require.ErrorIs(t, err, ErrUnavailable)
 }
 
 func TestOrganizationEventsRequireLogsFeature(t *testing.T) {

--- a/server/internal/platformmcp/operational_reads_integration_test.go
+++ b/server/internal/platformmcp/operational_reads_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/url"
 	"strings"
 	"testing"
@@ -431,8 +432,20 @@ func TestOrganizationEventsRequirePostgres(t *testing.T) {
 	t.Parallel()
 
 	reader := NewPostgresReader(testenv.NewLogger(t), nil).
-		WithOrganizationEvents(&recordingEventFeedReader{}, mustParseURL(t, "https://app.getgram.test"))
+		WithOrganizationEvents(&recordingEventFeedReader{}, alwaysEnabledFeature, mustParseURL(t, "https://app.getgram.test"))
 	_, err := reader.ListOrganizationEvents(t.Context(), Principal{OrganizationID: "organization"}, ListOrganizationEventsInput{})
+	require.ErrorIs(t, err, ErrUnavailable)
+}
+
+func TestOrganizationEventsRequireLogsFeature(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_organization_events_require_logs")
+	require.NoError(t, err)
+	reader := NewPostgresReader(testenv.NewLogger(t), conn).
+		WithOrganizationEvents(&recordingEventFeedReader{}, nil, mustParseURL(t, "https://app.getgram.test"))
+	_, err = reader.ListOrganizationEvents(ctx, Principal{OrganizationID: "organization"}, ListOrganizationEventsInput{})
 	require.ErrorIs(t, err, ErrUnavailable)
 }
 
@@ -457,7 +470,7 @@ func TestListOrganizationEventsUsesBoundedSafeProjection(t *testing.T) {
 		ResourceAttributes: `{"service.name":"payments","user.id":"private-user-key"}`,
 	}}}
 	reader := NewPostgresReader(testenv.NewLogger(t), conn).
-		WithOrganizationEvents(events, mustParseURL(t, "https://app.getgram.test"))
+		WithOrganizationEvents(events, alwaysEnabledFeature, mustParseURL(t, "https://app.getgram.test"))
 	reader.eventFeed.now = func() time.Time { return fixedNow }
 
 	output, err := reader.ListOrganizationEvents(ctx, principal, ListOrganizationEventsInput{})
@@ -500,7 +513,7 @@ func TestListOrganizationEventsRejectsInvalidKindAndHonorsLimit(t *testing.T) {
 	principal, _ := seedRegistrationLifecycle(t, ctx, conn)
 	events := &recordingEventFeedReader{}
 	reader := NewPostgresReader(testenv.NewLogger(t), conn).
-		WithOrganizationEvents(events, mustParseURL(t, "https://app.getgram.test"))
+		WithOrganizationEvents(events, alwaysEnabledFeature, mustParseURL(t, "https://app.getgram.test"))
 
 	_, err = reader.ListOrganizationEvents(ctx, principal, ListOrganizationEventsInput{Kind: "trace"})
 	require.ErrorContains(t, err, "kind must be one of log, span")
@@ -509,6 +522,81 @@ func TestListOrganizationEventsRejectsInvalidKindAndHonorsLimit(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{chrepo.EventKindSpan}, events.params.Kinds)
 	require.Equal(t, maxOrganizationEventLimit+1, events.params.Limit)
+}
+
+func TestListOrganizationEventsRefusesWhenLogsDisabled(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_organization_events_logs_disabled")
+	require.NoError(t, err)
+	principal, _ := seedRegistrationLifecycle(t, ctx, conn)
+	events := &recordingEventFeedReader{rows: []chrepo.EventLogRow{{
+		TimeUnixNano:       time.Now().UnixNano(),
+		Kind:               chrepo.EventKindLog,
+		Source:             "payments",
+		Name:               "must-not-be-read",
+		BodyPreview:        "",
+		TraceID:            "",
+		SpanID:             "",
+		ProjectID:          "project-id",
+		Attributes:         `{"secret":"private-attr"}`,
+		ResourceAttributes: "",
+	}}}
+	reader := NewPostgresReader(testenv.NewLogger(t), conn).
+		WithOrganizationEvents(events, alwaysDisabledFeature, mustParseURL(t, "https://app.getgram.test"))
+
+	_, err = reader.ListOrganizationEvents(ctx, principal, ListOrganizationEventsInput{})
+	require.ErrorIs(t, err, errOrganizationEventsDisabled)
+	require.Empty(t, events.params.OrganizationID)
+
+	result, ok := organizationEventsToolResult(err)
+	require.True(t, ok)
+	require.True(t, result.IsError)
+	text, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	require.JSONEq(t, `{"code":"feature_unavailable","feature":"logs","message":"The Event Feed is not enabled for this organization."}`, text.Text)
+}
+
+func TestListOrganizationEventsReportsMoreWhenPageOverflows(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_organization_events_overflow")
+	require.NoError(t, err)
+	principal, _ := seedRegistrationLifecycle(t, ctx, conn)
+	fixedNow := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	rows := make([]chrepo.EventLogRow, maxOrganizationEventLimit+1)
+	for i := range rows {
+		rows[i] = chrepo.EventLogRow{
+			TimeUnixNano:       fixedNow.Add(-time.Duration(i) * time.Minute).UnixNano(),
+			Kind:               chrepo.EventKindLog,
+			Source:             "payments",
+			Name:               fmt.Sprintf("event-%d", i),
+			BodyPreview:        "",
+			TraceID:            "",
+			SpanID:             "",
+			ProjectID:          "project-id",
+			Attributes:         `{"secret":"private-attr"}`,
+			ResourceAttributes: "",
+		}
+	}
+	events := &recordingEventFeedReader{rows: rows}
+	reader := NewPostgresReader(testenv.NewLogger(t), conn).
+		WithOrganizationEvents(events, alwaysEnabledFeature, mustParseURL(t, "https://app.getgram.test"))
+	reader.eventFeed.now = func() time.Time { return fixedNow }
+
+	output, err := reader.ListOrganizationEvents(ctx, principal, ListOrganizationEventsInput{Limit: maxOrganizationEventLimit})
+	require.NoError(t, err)
+	require.True(t, output.More)
+	require.Len(t, output.Events, maxOrganizationEventLimit)
+	require.Equal(t, "event-0", output.Events[0].Name)
+	require.Equal(t, fmt.Sprintf("event-%d", maxOrganizationEventLimit-1), output.Events[len(output.Events)-1].Name)
+	require.Equal(t, maxOrganizationEventLimit+1, events.params.Limit)
+
+	encoded, err := json.Marshal(output)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), "private-attr")
 }
 
 type recordingEventFeedReader struct {
@@ -520,4 +608,12 @@ type recordingEventFeedReader struct {
 func (r *recordingEventFeedReader) ListEventLog(_ context.Context, params chrepo.ListEventLogParams) ([]chrepo.EventLogRow, error) {
 	r.params = params
 	return r.rows, r.err
+}
+
+func alwaysEnabledFeature(context.Context, string) (bool, error) {
+	return true, nil
+}
+
+func alwaysDisabledFeature(context.Context, string) (bool, error) {
+	return false, nil
 }

--- a/server/internal/platformmcp/operational_reads_integration_test.go
+++ b/server/internal/platformmcp/operational_reads_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	dataexportsrepo "github.com/speakeasy-api/gram/server/internal/dataexports/repo"
 	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	"github.com/speakeasy-api/gram/server/internal/otel/chrepo"
 	telemetryrepo "github.com/speakeasy-api/gram/server/internal/telemetry/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
@@ -424,4 +425,99 @@ func TestRecentToolCallTargetOmitsUnclassifiedShadowSource(t *testing.T) {
 		TargetLabel: "npx --yes package --token private",
 	})
 	require.Empty(t, target)
+}
+
+func TestOrganizationEventsRequirePostgres(t *testing.T) {
+	t.Parallel()
+
+	reader := NewPostgresReader(testenv.NewLogger(t), nil).
+		WithOrganizationEvents(&recordingEventFeedReader{}, mustParseURL(t, "https://app.getgram.test"))
+	_, err := reader.ListOrganizationEvents(t.Context(), Principal{OrganizationID: "organization"}, ListOrganizationEventsInput{})
+	require.ErrorIs(t, err, ErrUnavailable)
+}
+
+func TestListOrganizationEventsUsesBoundedSafeProjection(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_organization_events")
+	require.NoError(t, err)
+	principal, _ := seedRegistrationLifecycle(t, ctx, conn)
+	fixedNow := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	events := &recordingEventFeedReader{rows: []chrepo.EventLogRow{{
+		TimeUnixNano:       fixedNow.Add(-time.Minute).UnixNano(),
+		Kind:               chrepo.EventKindLog,
+		Source:             "payments",
+		Name:               "refund.completed",
+		BodyPreview:        "refund issued",
+		TraceID:            "trace-id-must-not-leave",
+		SpanID:             "span-id-must-not-leave",
+		ProjectID:          "project-id",
+		Attributes:         `{"user.email":"person@example.test","secret":"private-attr"}`,
+		ResourceAttributes: `{"service.name":"payments","user.id":"private-user-key"}`,
+	}}}
+	reader := NewPostgresReader(testenv.NewLogger(t), conn).
+		WithOrganizationEvents(events, mustParseURL(t, "https://app.getgram.test"))
+	reader.eventFeed.now = func() time.Time { return fixedNow }
+
+	output, err := reader.ListOrganizationEvents(ctx, principal, ListOrganizationEventsInput{})
+	require.NoError(t, err)
+	require.Equal(t, DiagnosticWindowLastDay, output.Window.Window)
+	require.False(t, output.More)
+	require.Len(t, output.Events, 1)
+	require.Equal(t, "log", output.Events[0].Kind)
+	require.Equal(t, "payments", output.Events[0].Source)
+	require.Equal(t, "refund.completed", output.Events[0].Name)
+	require.Equal(t, "refund issued", output.Events[0].BodyPreview)
+	require.Equal(t, "project-id", output.Events[0].ProjectID)
+	require.True(t, strings.HasSuffix(output.EventFeedURL, "/data/event-feed"))
+
+	require.Equal(t, principal.OrganizationID, events.params.OrganizationID)
+	require.Equal(t, fixedNow.Add(-24*time.Hour).UnixNano(), events.params.TimeStart)
+	require.Equal(t, fixedNow.UnixNano(), events.params.TimeEnd)
+	require.Empty(t, events.params.Kinds)
+	require.Empty(t, events.params.Sources)
+	require.Empty(t, events.params.Names)
+	require.Empty(t, events.params.Search)
+	require.Zero(t, events.params.CursorTimeUnixNano)
+	require.Equal(t, defaultOrganizationEventLimit+1, events.params.Limit)
+
+	encoded, err := json.Marshal(output)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), "trace-id-must-not-leave")
+	require.NotContains(t, string(encoded), "span-id-must-not-leave")
+	require.NotContains(t, string(encoded), "person@example.test")
+	require.NotContains(t, string(encoded), "private-attr")
+	require.NotContains(t, string(encoded), "private-user-key")
+}
+
+func TestListOrganizationEventsRejectsInvalidKindAndHonorsLimit(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_organization_events_filters")
+	require.NoError(t, err)
+	principal, _ := seedRegistrationLifecycle(t, ctx, conn)
+	events := &recordingEventFeedReader{}
+	reader := NewPostgresReader(testenv.NewLogger(t), conn).
+		WithOrganizationEvents(events, mustParseURL(t, "https://app.getgram.test"))
+
+	_, err = reader.ListOrganizationEvents(ctx, principal, ListOrganizationEventsInput{Kind: "trace"})
+	require.ErrorContains(t, err, "kind must be one of log, span")
+
+	_, err = reader.ListOrganizationEvents(ctx, principal, ListOrganizationEventsInput{Limit: 200, Kind: "span"})
+	require.NoError(t, err)
+	require.Equal(t, []string{chrepo.EventKindSpan}, events.params.Kinds)
+	require.Equal(t, maxOrganizationEventLimit+1, events.params.Limit)
+}
+
+type recordingEventFeedReader struct {
+	params chrepo.ListEventLogParams
+	rows   []chrepo.EventLogRow
+	err    error
+}
+
+func (r *recordingEventFeedReader) ListEventLog(_ context.Context, params chrepo.ListEventLogParams) ([]chrepo.EventLogRow, error) {
+	r.params = params
+	return r.rows, r.err
 }

--- a/server/internal/platformmcp/tool_create_data_export.go
+++ b/server/internal/platformmcp/tool_create_data_export.go
@@ -38,7 +38,7 @@ type dataExportMutationService struct {
 // WithDataExportMutations enables creation after the read dependencies have
 // been configured. Secret headers remain dashboard-only.
 func (r *PostgresReader) WithDataExportMutations(auditLogger *audit.Logger, dashboardURL *url.URL) *PostgresReader {
-	if r != nil && r.db != nil && auditLogger != nil && validDashboardURL(dashboardURL) {
+	if auditLogger != nil && validDashboardURL(dashboardURL) {
 		copyURL := *dashboardURL
 		r.dataExportMutations = &dataExportMutationService{db: r.db, audit: auditLogger, dashboardURL: &copyURL}
 	}

--- a/server/internal/platformmcp/tool_data_exports.go
+++ b/server/internal/platformmcp/tool_data_exports.go
@@ -26,7 +26,7 @@ type DataExportReadService struct {
 }
 
 func newDataExportReadService(db *pgxpool.Pool, encryptionClient *encryption.Client, dashboardURL *url.URL) *DataExportReadService {
-	if db == nil || encryptionClient == nil || !validDashboardURL(dashboardURL) {
+	if encryptionClient == nil || !validDashboardURL(dashboardURL) {
 		return nil
 	}
 	copyURL := *dashboardURL
@@ -39,9 +39,7 @@ func validDashboardURL(value *url.URL) bool {
 
 // WithDataExports enables the safe data export inventory on this reader.
 func (r *PostgresReader) WithDataExports(encryptionClient *encryption.Client, dashboardURL *url.URL) *PostgresReader {
-	if r != nil {
-		r.dataExports = newDataExportReadService(r.db, encryptionClient, dashboardURL)
-	}
+	r.dataExports = newDataExportReadService(r.db, encryptionClient, dashboardURL)
 	return r
 }
 

--- a/server/internal/platformmcp/tool_organization_events.go
+++ b/server/internal/platformmcp/tool_organization_events.go
@@ -44,7 +44,7 @@ type EventFeedReadService struct {
 // A missing Logs checker leaves the live tool unregistered: the dashboard Event
 // Feed is gated on that product feature, and a nil checker cannot enforce it.
 func (r *PostgresReader) WithOrganizationEvents(events EventFeedReader, logs FeatureChecker, dashboardURL *url.URL) *PostgresReader {
-	if r != nil && r.db != nil && events != nil && logs != nil && validDashboardURL(dashboardURL) {
+	if events != nil && logs != nil && validDashboardURL(dashboardURL) {
 		copyURL := *dashboardURL
 		r.eventFeed = &EventFeedReadService{events: events, logs: logs, dashboardURL: &copyURL, now: time.Now}
 	}
@@ -74,7 +74,10 @@ type ListOrganizationEventsOutput struct {
 }
 
 func (r *PostgresReader) ListOrganizationEvents(ctx context.Context, principal Principal, input ListOrganizationEventsInput) (ListOrganizationEventsOutput, error) {
-	if r == nil || r.db == nil || r.eventFeed == nil || r.eventFeed.events == nil || r.eventFeed.logs == nil || r.eventFeed.now == nil {
+	// WithOrganizationEvents is the only writer of r.eventFeed and only sets it
+	// once the Event Feed reader, Logs checker and dashboard URL are all present,
+	// so a non-nil service establishes the rest.
+	if r.eventFeed == nil {
 		return ListOrganizationEventsOutput{}, ErrUnavailable
 	}
 	enabled, err := r.eventFeed.logs(ctx, principal.OrganizationID)

--- a/server/internal/platformmcp/tool_organization_events.go
+++ b/server/internal/platformmcp/tool_organization_events.go
@@ -1,0 +1,163 @@
+//nolint:exhaustruct // MCP SDK manifests intentionally rely on documented zero-value optional fields.
+package platformmcp
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	organizationsrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/otel/chrepo"
+)
+
+const (
+	defaultOrganizationEventLimit = 20
+	maxOrganizationEventLimit     = 50
+)
+
+// EventFeedReader is the org-scoped Event Feed page read used by Platform MCP.
+// It returns the merged log/span list; this tool never surfaces attributes.
+type EventFeedReader interface {
+	ListEventLog(ctx context.Context, arg chrepo.ListEventLogParams) ([]chrepo.EventLogRow, error)
+}
+
+// EventFeedReadService owns the Event Feed reader and trusted dashboard URL.
+type EventFeedReadService struct {
+	events       EventFeedReader
+	dashboardURL *url.URL
+	now          func() time.Time
+}
+
+// WithOrganizationEvents enables recent organization-scoped Event Feed summaries.
+func (r *PostgresReader) WithOrganizationEvents(events EventFeedReader, dashboardURL *url.URL) *PostgresReader {
+	if r != nil && r.db != nil && events != nil && validDashboardURL(dashboardURL) {
+		copyURL := *dashboardURL
+		r.eventFeed = &EventFeedReadService{events: events, dashboardURL: &copyURL, now: time.Now}
+	}
+	return r
+}
+
+type ListOrganizationEventsInput struct {
+	Limit  int    `json:"limit,omitempty" jsonschema:"maximum events to return; defaults to 20 and is capped at 50"`
+	Window string `json:"window,omitempty" jsonschema:"observation window: 1h, 24h (default), or 7d"`
+	Kind   string `json:"kind,omitempty" jsonschema:"optional signal kind filter: log or span"`
+}
+
+type OrganizationEvent struct {
+	OccurredAt  string `json:"occurred_at"`
+	Kind        string `json:"kind"`
+	Source      string `json:"source"`
+	Name        string `json:"name"`
+	BodyPreview string `json:"body_preview,omitempty"`
+	ProjectID   string `json:"project_id,omitempty"`
+}
+
+type ListOrganizationEventsOutput struct {
+	Window       ResolvedWindow      `json:"window"`
+	Events       []OrganizationEvent `json:"events"`
+	More         bool                `json:"more"`
+	EventFeedURL string              `json:"event_feed_url"`
+}
+
+func (r *PostgresReader) ListOrganizationEvents(ctx context.Context, principal Principal, input ListOrganizationEventsInput) (ListOrganizationEventsOutput, error) {
+	if r == nil || r.db == nil || r.eventFeed == nil || r.eventFeed.events == nil || r.eventFeed.now == nil {
+		return ListOrganizationEventsOutput{}, ErrUnavailable
+	}
+	kind := strings.ToLower(strings.TrimSpace(input.Kind))
+	if kind != "" && !validOrganizationEventKind(kind) {
+		return ListOrganizationEventsOutput{}, fmt.Errorf("kind must be one of log, span")
+	}
+
+	now := r.eventFeed.now().UTC()
+	window, err := resolveWindow(input.Window, now, eventFeedWindowSpec)
+	if err != nil {
+		return ListOrganizationEventsOutput{}, err
+	}
+	limit := input.Limit
+	if limit <= 0 {
+		limit = defaultOrganizationEventLimit
+	}
+	limit = min(limit, maxOrganizationEventLimit)
+
+	kinds := []string(nil)
+	if kind != "" {
+		kinds = []string{kind}
+	}
+
+	rows, err := r.eventFeed.events.ListEventLog(ctx, chrepo.ListEventLogParams{
+		EventLogFilters: chrepo.EventLogFilters{
+			OrganizationID: principal.OrganizationID,
+			TimeStart:      window.start.UnixNano(),
+			TimeEnd:        window.end.UnixNano(),
+			Kinds:          kinds,
+			Sources:        nil,
+			Names:          nil,
+			Search:         "",
+		},
+		CursorTimeUnixNano: 0,
+		Limit:              limit + 1,
+	})
+	if err != nil {
+		return ListOrganizationEventsOutput{}, fmt.Errorf("list organization events: %w", err)
+	}
+	rows, more := boundedRows(rows, limit)
+	events := make([]OrganizationEvent, 0, len(rows))
+	for _, row := range rows {
+		events = append(events, OrganizationEvent{
+			OccurredAt:  time.Unix(0, row.TimeUnixNano).UTC().Format(time.RFC3339Nano),
+			Kind:        row.Kind,
+			Source:      row.Source,
+			Name:        row.Name,
+			BodyPreview: row.BodyPreview,
+			ProjectID:   row.ProjectID,
+		})
+	}
+	organization, err := organizationsrepo.New(r.db).GetOrganizationMetadata(ctx, principal.OrganizationID)
+	if err != nil {
+		return ListOrganizationEventsOutput{}, fmt.Errorf("resolve organization events organization: %w", err)
+	}
+	return ListOrganizationEventsOutput{
+		Window:       window,
+		Events:       events,
+		More:         more,
+		EventFeedURL: r.eventFeed.dashboardURL.JoinPath(organization.Slug, "data", "event-feed").String(),
+	}, nil
+}
+
+func validOrganizationEventKind(kind string) bool {
+	switch kind {
+	case chrepo.EventKindLog, chrepo.EventKindSpan:
+		return true
+	default:
+		return false
+	}
+}
+
+func registerOrganizationEventTools(reg *Registrar, reader *PostgresReader) {
+	addTool(reg, &mcp.Tool{
+		Name:        "list_organization_events",
+		Title:       "List Organization Events",
+		Description: "List the newest Event Feed entries for the current organization, defaulting to 20 events from the last day. Each event is reduced to when it happened, whether it is a log or a span, its source and name, a short body preview for logs, and the project it belongs to. Constraints: this uses the bounded Event Feed list path and never returns attributes, resource attributes, trace IDs, span IDs, or user identities. The returned dashboard link opens the full Event Feed page.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeNone}, func(ctx context.Context, _ *mcp.CallToolRequest, input ListOrganizationEventsInput) (*mcp.CallToolResult, ListOrganizationEventsOutput, error) {
+		principal, err := principalFromToolContext(ctx)
+		if err != nil {
+			return nil, ListOrganizationEventsOutput{}, err
+		}
+		output, err := reader.ListOrganizationEvents(ctx, principal, input)
+		return nil, output, err
+	})
+}
+
+func registerUnavailableOrganizationEventTools(reg *Registrar) {
+	addTool(reg, &mcp.Tool{
+		Name:        "list_organization_events",
+		Title:       "List Organization Events",
+		Description: "List recent Event Feed entries for the current organization. This is not switched on for your organization yet.",
+		Annotations: readOnlyAnnotations(),
+	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeNone}, unavailableTool("organization_events"))
+}

--- a/server/internal/platformmcp/tool_organization_events.go
+++ b/server/internal/platformmcp/tool_organization_events.go
@@ -3,6 +3,8 @@ package platformmcp
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -19,24 +21,32 @@ const (
 	maxOrganizationEventLimit     = 50
 )
 
+// errOrganizationEventsDisabled is returned when the organization does not
+// have Logs enabled. The dashboard Event Feed uses the same gate.
+var errOrganizationEventsDisabled = errors.New("platform mcp organization events disabled")
+
 // EventFeedReader is the org-scoped Event Feed page read used by Platform MCP.
 // It returns the merged log/span list; this tool never surfaces attributes.
 type EventFeedReader interface {
 	ListEventLog(ctx context.Context, arg chrepo.ListEventLogParams) ([]chrepo.EventLogRow, error)
 }
 
-// EventFeedReadService owns the Event Feed reader and trusted dashboard URL.
+// EventFeedReadService owns the Event Feed reader, the org Logs gate, and the
+// trusted dashboard URL.
 type EventFeedReadService struct {
 	events       EventFeedReader
+	logs         FeatureChecker
 	dashboardURL *url.URL
 	now          func() time.Time
 }
 
 // WithOrganizationEvents enables recent organization-scoped Event Feed summaries.
-func (r *PostgresReader) WithOrganizationEvents(events EventFeedReader, dashboardURL *url.URL) *PostgresReader {
-	if r != nil && r.db != nil && events != nil && validDashboardURL(dashboardURL) {
+// A missing Logs checker leaves the live tool unregistered: the dashboard Event
+// Feed is gated on that product feature, and a nil checker cannot enforce it.
+func (r *PostgresReader) WithOrganizationEvents(events EventFeedReader, logs FeatureChecker, dashboardURL *url.URL) *PostgresReader {
+	if r != nil && r.db != nil && events != nil && logs != nil && validDashboardURL(dashboardURL) {
 		copyURL := *dashboardURL
-		r.eventFeed = &EventFeedReadService{events: events, dashboardURL: &copyURL, now: time.Now}
+		r.eventFeed = &EventFeedReadService{events: events, logs: logs, dashboardURL: &copyURL, now: time.Now}
 	}
 	return r
 }
@@ -64,8 +74,15 @@ type ListOrganizationEventsOutput struct {
 }
 
 func (r *PostgresReader) ListOrganizationEvents(ctx context.Context, principal Principal, input ListOrganizationEventsInput) (ListOrganizationEventsOutput, error) {
-	if r == nil || r.db == nil || r.eventFeed == nil || r.eventFeed.events == nil || r.eventFeed.now == nil {
+	if r == nil || r.db == nil || r.eventFeed == nil || r.eventFeed.events == nil || r.eventFeed.logs == nil || r.eventFeed.now == nil {
 		return ListOrganizationEventsOutput{}, ErrUnavailable
+	}
+	enabled, err := r.eventFeed.logs(ctx, principal.OrganizationID)
+	if err != nil {
+		return ListOrganizationEventsOutput{}, fmt.Errorf("resolve logs feature: %w", err)
+	}
+	if !enabled {
+		return ListOrganizationEventsOutput{}, errOrganizationEventsDisabled
 	}
 	kind := strings.ToLower(strings.TrimSpace(input.Kind))
 	if kind != "" && !validOrganizationEventKind(kind) {
@@ -149,8 +166,30 @@ func registerOrganizationEventTools(reg *Registrar, reader *PostgresReader) {
 			return nil, ListOrganizationEventsOutput{}, err
 		}
 		output, err := reader.ListOrganizationEvents(ctx, principal, input)
-		return nil, output, err
+		if err != nil {
+			if result, ok := organizationEventsToolResult(err); ok {
+				return result, ListOrganizationEventsOutput{}, nil
+			}
+			return nil, ListOrganizationEventsOutput{}, err
+		}
+		return nil, output, nil
 	})
+}
+
+func organizationEventsToolResult(err error) (*mcp.CallToolResult, bool) {
+	if !errors.Is(err, errOrganizationEventsDisabled) {
+		return nil, false
+	}
+	result := featureUnavailableResult{
+		Code:    unavailableCode,
+		Feature: "logs",
+		Message: "The Event Feed is not enabled for this organization.",
+	}
+	content, marshalErr := json.Marshal(result)
+	if marshalErr != nil {
+		return nil, false
+	}
+	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(content)}}, IsError: true}, true
 }
 
 func registerUnavailableOrganizationEventTools(reg *Registrar) {

--- a/server/internal/platformmcp/tool_recent_tool_calls.go
+++ b/server/internal/platformmcp/tool_recent_tool_calls.go
@@ -35,7 +35,7 @@ type RecentToolCallReadService struct {
 
 // WithRecentToolCalls enables recent project-scoped Tool Logs summaries.
 func (r *PostgresReader) WithRecentToolCalls(telemetry RecentToolCallReader, dashboardURL *url.URL) *PostgresReader {
-	if r != nil && r.db != nil && telemetry != nil && validDashboardURL(dashboardURL) {
+	if telemetry != nil && validDashboardURL(dashboardURL) {
 		copyURL := *dashboardURL
 		r.recentToolCalls = &RecentToolCallReadService{telemetry: telemetry, dashboardURL: &copyURL, now: time.Now}
 	}

--- a/server/internal/platformmcp/tools.go
+++ b/server/internal/platformmcp/tools.go
@@ -199,11 +199,17 @@ func newServerWithRiskMutations(reader Reader, catalog Catalog, registrations *R
 		} else {
 			registerRecentToolCallTools(reg, postgresReader)
 		}
+		if postgresReader.eventFeed == nil {
+			registerUnavailableOrganizationEventTools(reg)
+		} else {
+			registerOrganizationEventTools(reg, postgresReader)
+		}
 	} else {
 		registerUnavailableRiskToolsWithMutations(reg, riskMutations)
 		registerUnavailableDataExportTools(reg)
 		registerUnavailableDataExportMutationTool(reg)
 		registerUnavailableRecentToolCallTools(reg)
+		registerUnavailableOrganizationEventTools(reg)
 	}
 	registerSetupResources(reg, setupResources, time.Now)
 	if registrations == nil || !registrations.budgets.Docs.valid() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
DNO-1034

## Summary

Adds `list_organization_events` to Platform MCP so an organization admin can ask for the last *x* Event Feed entries in their organization.

The tool reuses the existing org-scoped OpenTelemetry event-feed read (logs and spans, newest first). Results are a privacy-safe summary: time, kind, source, name, log body preview, and project id. Attributes, resource attributes, trace IDs, span IDs, and user identities are never returned. A dashboard link opens the full Event Feed page.

Default window is the last day (max 7d). Default page size is 20 (capped at 50). An optional `kind` filter accepts `log` or `span`.

## Motivation

Admins already have an Event Feed in the dashboard. They need the same “last N events” question answered through the authenticated Platform MCP surface, following the same bounded-read pattern as `list_recent_tool_calls`.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-1034](https://linear.app/speakeasy/issue/DNO-1034/feat-expose-organization-event-feed-through-platform-mcp)

<div><a href="https://cursor.com/agents/bc-049e23ba-2e60-4046-856c-cc0b78df6fcb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-049e23ba-2e60-4046-856c-cc0b78df6fcb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `list_organization_events` to Platform MCP so org admins can fetch the last N Event Feed entries, gated on the same Logs product feature as the dashboard Event Feed.

- Reuses the org-scoped OpenTelemetry event-feed read and a bounded-read pattern like `list_recent_tool_calls`.
- Returns only privacy-safe summaries — time, kind, source, name, log body preview, and project id — never attributes, trace/span IDs, or user identities.
- Defaults to a 1-day window (max 7d) and 20 events (capped at 50), with an optional `kind` filter; includes a dashboard link to the full Event Feed.
- Returns a feature-unavailable error when the organization lacks Logs.
- Reader builders now gate only on their own dependencies; a nil pool faults at the query instead of returning `ErrUnavailable`.

<sup>Written for commit 53ff2ba3f409d60f42916fe96f49b8a1a13de4e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

