### PR TITLE
fix: drop the policy list scope column

### DIFF
--- a/.changeset/policy-scope-dashboard.md
+++ b/.changeset/policy-scope-dashboard.md
@@ -2,4 +2,4 @@
 "dashboard": patch
 ---
 
-Policy scope indicators now reflect category detection scopes and any legacy narrowing. Policy setup saves message type selections as category scopes, preserving the scopes a policy's other categories relied on.
+Policy setup now saves message type selections as category detection scopes, preserving the scopes a policy's other categories relied on.

--- a/client/dashboard/src/pages/security/PolicyCenter.tsx
+++ b/client/dashboard/src/pages/security/PolicyCenter.tsx
@@ -57,7 +57,6 @@ import { parseAsStringLiteral, useQueryState } from "nuqs";
 import { useQueryClient } from "@tanstack/react-query";
 import { useMembers } from "@gram/client/react-query/members.js";
 import { useRiskCreatePolicyMutation } from "@gram/client/react-query/riskCreatePolicy.js";
-import { useRiskCategories } from "@gram/client/react-query/riskCategories.js";
 import {
   invalidateAllRiskListPolicies,
   useRiskListPolicies,
@@ -92,11 +91,7 @@ import { useDetectionRulesStore } from "./detection-rules-data";
 import { useTelemetry } from "@/contexts/Telemetry";
 import { useRoutes } from "@/routes";
 import { Outlet } from "react-router";
-import {
-  ACTION_OPTIONS,
-  categoriesToPayload,
-  policyDetectionCategories,
-} from "./policy-form";
+import { ACTION_OPTIONS, categoriesToPayload } from "./policy-form";
 import {
   getPolicyDeleteImpactText,
   getPolicyDeleteRuleListItems,
@@ -107,7 +102,6 @@ import { BUILTIN_RULE_ID_LIST } from "./detection-rules-data";
 import { SeverityBadge } from "./risk-ui";
 import { policySummary } from "./policy-summary";
 import { policyEnabledActionLabel } from "./policy-enabled";
-import { describePolicyScope, effectivePolicyScopeKinds } from "./policy-scope";
 import {
   togglePolicyEnabledVariables,
   useTogglePolicyEnabled,
@@ -592,11 +586,6 @@ function PolicyCenterContent() {
   const telemetry = useTelemetry();
   const { data, isLoading } = useRiskListPolicies();
   const {
-    data: categoriesData,
-    isLoading: categoriesLoading,
-    isError: categoriesError,
-  } = useRiskCategories();
-  const {
     data: quarantinesData,
     isLoading: quarantinesLoading,
     isError: quarantinesError,
@@ -854,48 +843,6 @@ function PolicyCenterContent() {
           <SeverityBadge score={row.policy.score} />
         </span>
       ),
-    },
-    {
-      key: "messageTypes",
-      header: "Applies To",
-      // Narrower than the column #6128 removed for crowding out the row's
-      // kebab menu; the summary is a short phrase with detail in the tooltip.
-      width: "1.2fr",
-      render: (row) => {
-        // Category recommendations decide the scope, so a failed or pending
-        // fetch must not render partial data as if it were the whole answer.
-        if (categoriesError) {
-          return (
-            <span className="text-muted-foreground text-sm">
-              Scope unavailable
-            </span>
-          );
-        }
-        if (!categoriesData) {
-          return (
-            <span className="text-muted-foreground text-sm">
-              {categoriesLoading ? "Loading scope..." : "Scope unavailable"}
-            </span>
-          );
-        }
-
-        const { summary, tooltip } = describePolicyScope(
-          effectivePolicyScopeKinds({
-            categories: policyDetectionCategories(row.policy),
-            detectionScopes: row.policy.detectionScopes,
-            categoryDefinitions: categoriesData.categories,
-            messageTypes: row.policy.messageTypes,
-            scopeInclude: row.policy.scopeInclude,
-            scopeExempt: row.policy.scopeExempt,
-          }),
-        );
-
-        return (
-          <SimpleTooltip tooltip={tooltip}>
-            <span className="text-muted-foreground text-sm">{summary}</span>
-          </SimpleTooltip>
-        );
-      },
     },
     {
       key: "audience",

--- a/client/dashboard/src/pages/security/policy-scope.test.ts
+++ b/client/dashboard/src/pages/security/policy-scope.test.ts
@@ -3,7 +3,6 @@ import { ALL_POLICY_MESSAGE_TYPES } from "./policy-data";
 import {
   acceptsDetectionScope,
   decodeKindScope,
-  describePolicyScope,
   policyScopeUpdateForCategoryEdit,
   effectivePolicyScopeKinds,
   effectiveScopeKinds,
@@ -639,55 +638,5 @@ describe("policyScopeUpdateForCategoryEdit", () => {
         scopeInclude: `(${customInclude}) && kind in ["tool_request"]`,
       },
     ]);
-  });
-});
-
-describe("describePolicyScope", () => {
-  const scope = (
-    kinds: string[],
-    { custom = false, attachments = false } = {},
-  ) =>
-    describePolicyScope({
-      kinds: new Set(kinds as never),
-      additionalKinds: new Set(attachments ? ["prompt_attachment"] : []),
-      custom,
-      sessionScopedOnly: false,
-    });
-
-  it("summarises whole-surface and tool-call scopes", () => {
-    expect(scope(ALL_POLICY_MESSAGE_TYPES).summary).toBe("All types");
-    expect(scope(["tool_request", "tool_response"]).summary).toBe("Tool Calls");
-  });
-
-  it("never presents a custom CEL scope as a kind list", () => {
-    const described = scope(ALL_POLICY_MESSAGE_TYPES, { custom: true });
-
-    expect(described.summary).toBe("Custom scope");
-    expect(described.tooltip).toContain("At most");
-  });
-
-  it("reports an empty scope as such", () => {
-    expect(scope([])).toEqual({
-      summary: "Nothing in scope",
-      tooltip: "No message types in scope",
-    });
-    expect(scope([], { custom: true }).summary).toBe("Custom scope");
-  });
-
-  it("labels session-scoped detection instead of an empty scope", () => {
-    expect(
-      describePolicyScope({
-        kinds: new Set(),
-        additionalKinds: new Set(),
-        custom: false,
-        sessionScopedOnly: true,
-      }).summary,
-    ).toBe("Session-scoped");
-  });
-
-  it("lists prompt attachments alongside message types", () => {
-    expect(scope(["tool_request"], { attachments: true }).summary).toBe(
-      "Tool Requests, Prompt Attachments",
-    );
   });
 });

--- a/client/dashboard/src/pages/security/policy-scope.ts
+++ b/client/dashboard/src/pages/security/policy-scope.ts
@@ -1,6 +1,5 @@
 import {
   ALL_POLICY_MESSAGE_TYPES,
-  POLICY_MESSAGE_TYPE_META,
   type PolicyMessageType,
 } from "./policy-data";
 
@@ -422,88 +421,4 @@ export function policyScopeUpdateForCategoryEdit({
         ? [...new Set([...(messageTypes ?? []), ...kinds])]
         : [],
   };
-}
-
-const TOOL_CALL_MESSAGE_TYPES = new Set<PolicyMessageType>([
-  "tool_request",
-  "tool_response",
-]);
-
-function hasOnlyToolCallMessageTypes(types: Set<PolicyMessageType>): boolean {
-  return (
-    types.size === TOOL_CALL_MESSAGE_TYPES.size &&
-    [...types].every((type) => TOOL_CALL_MESSAGE_TYPES.has(type))
-  );
-}
-
-function messageTypesSummary(
-  selectedMessageTypes: Set<PolicyMessageType>,
-): string {
-  if (selectedMessageTypes.size === ALL_POLICY_MESSAGE_TYPES.length) {
-    return "All types";
-  }
-
-  if (hasOnlyToolCallMessageTypes(selectedMessageTypes)) {
-    return "Tool Calls";
-  }
-
-  if (
-    selectedMessageTypes.size === 1 &&
-    selectedMessageTypes.has("tool_request")
-  ) {
-    return "Tool Requests";
-  }
-
-  return `${selectedMessageTypes.size} of ${ALL_POLICY_MESSAGE_TYPES.length} types selected`;
-}
-
-/** One-line scope description for the policy list. */
-export function describePolicyScope({
-  kinds,
-  additionalKinds,
-  custom,
-  sessionScopedOnly,
-}: EffectivePolicyScope): { summary: string; tooltip: string } {
-  // Matches the per-category badge in the policy editor: these detectors read
-  // session state, so "no message types" is not the same as "nothing".
-  if (sessionScopedOnly) {
-    return {
-      summary: "Session-scoped",
-      tooltip: "Detected per session, not per message",
-    };
-  }
-
-  const types = ALL_POLICY_MESSAGE_TYPES.filter((type) => kinds.has(type));
-  const labels = [
-    ...types.map((type) => POLICY_MESSAGE_TYPE_META[type].label),
-    ...(additionalKinds.has("prompt_attachment") ? ["Prompt Attachments"] : []),
-  ];
-
-  // A CEL predicate we could not decode may narrow or widen at scan time, so
-  // the decoded kinds are an upper bound and must never be shown as the scope.
-  if (custom) {
-    return {
-      summary: "Custom scope",
-      tooltip: labels.length
-        ? `Custom CEL scope. At most: ${labels.join(", ")}`
-        : "Custom CEL scope",
-    };
-  }
-
-  if (labels.length === 0) {
-    return {
-      summary: "Nothing in scope",
-      tooltip: "No message types in scope",
-    };
-  }
-
-  const typeSet = new Set(types);
-  const summary =
-    additionalKinds.size === 0 &&
-    (typeSet.size === ALL_POLICY_MESSAGE_TYPES.length ||
-      hasOnlyToolCallMessageTypes(typeSet))
-      ? messageTypesSummary(typeSet)
-      : labels.join(", ");
-
-  return { summary, tooltip: labels.join(", ") };
 }


### PR DESCRIPTION
#6092 restored the "Applies To" column that #6128 had removed for crowding out the row's kebab menu. Keeping it removed was the call, so this drops the column again and takes the code that only fed it: `describePolicyScope`, its two summary helpers, the `useRiskCategories` fetch in the policy list, and the matching tests.

The scope resolution itself stays. `effectivePolicyScopeKinds` is still what the onboarding wizard uses to decide the scopes it writes, which was the substance of #6092.

AIS-678.

https://claude.ai/code/session_01BDoR4rSHZNpXdSk1XA7AsJ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the "Applies To" column from the policy list so the row's kebab menu is no longer crowded. The scope resolution logic stays in place for the onboarding wizard, but the column and its supporting code are gone.

<sup>Written for commit 2c858f7b87c29053ab66059bb4ea2d1cd85643fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

