### PR TITLE
feat: fold the Platform MCP page into headless mode

### DIFF
--- a/client/dashboard/src/App.css
+++ b/client/dashboard/src/App.css
@@ -434,6 +434,45 @@ html.chat-launching::view-transition-new(root) {
   animation: nav-shimmer 1.2s ease-in-out infinite;
 }
 
+/* The Headless mode tab advertises itself while the user is anywhere else: the
+   brand rainbow travels through the label and the rest of it stays the tab's
+   own tone. Both background-clip spellings are set — without the -webkit one
+   the gradient paints the span's whole box and the tab's pill shows through
+   it as a ghosted slab. */
+@keyframes mode-shimmer {
+  0% {
+    background-position: 200% center;
+  }
+  100% {
+    background-position: -200% center;
+  }
+}
+
+.mode-shimmer {
+  background-image: linear-gradient(
+    90deg,
+    currentColor 0 34%,
+    var(--color-brand-swift) 40%,
+    var(--color-brand-ruby) 45%,
+    var(--color-brand-terraform) 52%,
+    var(--color-brand-java) 58%,
+    currentColor 66% 100%
+  );
+  background-size: 200% auto;
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: mode-shimmer 3.6s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mode-shimmer {
+    animation: none;
+    background-image: none;
+    -webkit-text-fill-color: currentColor;
+  }
+}
+
 .dark .nav-shimmer {
   background: linear-gradient(
     90deg,

--- a/client/dashboard/src/components/mode-switcher.tsx
+++ b/client/dashboard/src/components/mode-switcher.tsx
@@ -52,6 +52,7 @@ function ModeSegment({
   icon,
   active,
   onInk,
+  shimmer,
   href,
   onSelect,
 }: {
@@ -59,6 +60,7 @@ function ModeSegment({
   icon: IconName;
   active: boolean;
   onInk: boolean;
+  shimmer: boolean;
   href: string;
   onSelect: (href: string) => void;
 }) {
@@ -92,7 +94,10 @@ function ModeSegment({
       style={{ width: `${SEGMENT_WIDTH_REM}rem` }}
     >
       <Icon name={icon} className="h-3 w-3" />
-      {label}
+      {/* The shimmer paints the label from a gradient clipped to the glyphs, so
+          it needs its own element — on the anchor it would swallow the icon
+          too. */}
+      <span className={shimmer ? "mode-shimmer" : undefined}>{label}</span>
     </a>
   );
 }
@@ -106,7 +111,7 @@ export function ModeSwitcher({ mode }: { mode: Mode }): JSX.Element | null {
   const orgRoutes = useOrgRoutes();
   const { orgSlug } = useSlugs();
   const location = useLocation();
-  const { switchTo, phase } = useModeSwitch();
+  const { switchTo, phase, to } = useModeSwitch();
   const enabled = useModeSwitcherEnabled();
   const path = location.pathname + location.search + location.hash;
 
@@ -125,7 +130,12 @@ export function ModeSwitcher({ mode }: { mode: Mode }): JSX.Element | null {
         : (rememberedCanvasPath(orgSlug) ?? orgRoutes.home.href()),
     headless: orgRoutes.headless.href(),
   };
-  const activeIndex = MODES.findIndex((entry) => entry.mode === mode);
+  // The route only swaps midway through the switch, so `mode` still names the
+  // mode being left for the first beat of it. The pill (and the type under it)
+  // follows the destination from the click instead, so it travels while the
+  // pane shrinks rather than jumping into place once the new route mounts.
+  const activeMode = to ?? mode;
+  const activeIndex = MODES.findIndex((entry) => entry.mode === activeMode);
   // Ink while a switch is in flight (the tab grid is behind it) and while
   // headless mode is mounted; light over the dashboard at rest.
   const onInk = mode === "headless" || phase !== "idle";
@@ -166,12 +176,14 @@ export function ModeSwitcher({ mode }: { mode: Mode }): JSX.Element | null {
           style={{
             width: `${SEGMENT_WIDTH_REM}rem`,
             transform: `translateX(${activeIndex * SEGMENT_WIDTH_REM}rem)`,
-            // Slow enough to read as the pill travelling between segments, on
-            // the same curve the pane animation uses.
+            // Slow enough to read as the pill travelling between segments.
+            // Symmetric ease rather than the panes' fast-out curve: over 120px
+            // that curve is two-thirds done in its first fifth, so the pill
+            // reads as snapping to the other tab instead of crossing to it.
             // The shorthand replaces the class-level transition-colors, so the
             // ink/light swap has to be listed here too or it snaps.
             transition:
-              "transform 620ms cubic-bezier(0.32, 0.72, 0, 1), background-color 500ms ease",
+              "transform 620ms cubic-bezier(0.65, 0.02, 0.28, 1), background-color 500ms ease",
           }}
         />
         {MODES.map((entry) => (
@@ -179,8 +191,12 @@ export function ModeSwitcher({ mode }: { mode: Mode }): JSX.Element | null {
             key={entry.mode}
             label={entry.label}
             icon={entry.icon}
-            active={entry.mode === mode}
+            active={entry.mode === activeMode}
             onInk={onInk}
+            // Headless is new, so its tab advertises itself until the user is
+            // actually in it — a still label next to the one they are reading
+            // never gets noticed.
+            shimmer={entry.mode === "headless" && activeMode !== "headless"}
             href={hrefs[entry.mode]}
             onSelect={(href) => switchTo(mode, entry.mode, href)}
           />

--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -82,7 +82,6 @@ export function OrgSidebar({
     orgRoutes.domains,
     orgRoutes.logs,
     orgRoutes.skills,
-    orgRoutes.platformMcp,
     orgRoutes.aiIntegrations,
     orgRoutes.webhooks,
     orgRoutes.externalServices,
@@ -131,7 +130,6 @@ export function OrgSidebar({
     orgRoutes.domains,
     orgRoutes.logs,
     orgRoutes.skills,
-    orgRoutes.platformMcp,
     orgRoutes.aiIntegrations,
     orgRoutes.webhooks,
     orgRoutes.externalServices,
@@ -215,7 +213,6 @@ export function OrgSidebar({
                   { item: orgRoutes.domains, scope: orgReadOrAdmin },
                   { item: orgRoutes.logs, scope: orgReadOrAdmin },
                   { item: orgRoutes.skills, scope: "org:admin" },
-                  { item: orgRoutes.platformMcp, scope: "org:admin" },
                   { item: orgRoutes.aiIntegrations, scope: orgReadOrAdmin },
                   { item: orgRoutes.webhooks, scope: orgReadOrAdmin },
                 ]}

--- a/client/dashboard/src/components/page-header.tsx
+++ b/client/dashboard/src/components/page-header.tsx
@@ -99,7 +99,6 @@ function PageHeaderTitle({
 //     kept in the URL for backwards compatibility but was renamed.
 const breadcrumbSubstitutions = {
   mcp: "MCP",
-  "platform-mcp": "Platform MCP",
   "shadow-mcp": "Shadow MCP",
   sdks: "SDKs",
   "add-openapi": "Add OpenAPI",

--- a/client/dashboard/src/pages/org/HeadlessContent.test.tsx
+++ b/client/dashboard/src/pages/org/HeadlessContent.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 
 import { HeadlessContent } from "./HeadlessContent";
+import { MemoryRouter } from "react-router";
 
 vi.mock("@/components/require-scope", () => ({
   RequireScope: ({ children }: { children: React.ReactNode }) => (
@@ -34,7 +35,11 @@ const agentNames = (container: HTMLElement) =>
 
 describe("HeadlessContent", () => {
   it("offers a catch-all agent last", () => {
-    const { container } = render(<HeadlessContent />);
+    const { container } = render(
+      <MemoryRouter>
+        <HeadlessContent />
+      </MemoryRouter>,
+    );
 
     const names = agentNames(container);
     expect(names).toContain("Other agent");
@@ -43,7 +48,11 @@ describe("HeadlessContent", () => {
   });
 
   it("still lists the certified agents ahead of it", () => {
-    const { container } = render(<HeadlessContent />);
+    const { container } = render(
+      <MemoryRouter>
+        <HeadlessContent />
+      </MemoryRouter>,
+    );
 
     expect(agentNames(container).slice(0, -1)).toEqual([
       "Claude Code",

--- a/client/dashboard/src/pages/org/HeadlessContent.test.tsx
+++ b/client/dashboard/src/pages/org/HeadlessContent.test.tsx
@@ -34,6 +34,23 @@ const agentNames = (container: HTMLElement) =>
   );
 
 describe("HeadlessContent", () => {
+  it("describes the control-plane workflows available to the agent", () => {
+    render(
+      <MemoryRouter>
+        <HeadlessContent />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Connect your agent" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Administer the control plane from the agent you already work in. Deploy and Manage MCP gateway servers, Review security policies and deep dive your AI usage data.",
+      ),
+    ).toBeTruthy();
+  });
+
   it("offers a catch-all agent last", () => {
     const { container } = render(
       <MemoryRouter>

--- a/client/dashboard/src/pages/org/HeadlessContent.tsx
+++ b/client/dashboard/src/pages/org/HeadlessContent.tsx
@@ -10,6 +10,7 @@ import { PlatformMCPOnboardingContent } from "./PlatformMCP";
 import { RequireScope } from "@/components/require-scope";
 import { SourceSurface } from "@gram/client/models/components/startonboardingrequestbody.js";
 import { useOrgRoutes } from "@/routes";
+import { useSearchParams } from "react-router";
 import { useState } from "react";
 
 // The agents the Platform MCP walkthrough supports, with the same brand marks
@@ -31,6 +32,10 @@ const STEPS = [
   { index: "02", label: "Run one command" },
   { index: "03", label: "Approve access" },
 ];
+
+function entrySourceFromQuery(value: string | null) {
+  return Object.values(SourceSurface).find((surface) => surface === value);
+}
 
 function clientFamilyForAgent(agentID: string): ClientFamily {
   switch (agentID) {
@@ -65,6 +70,13 @@ export function HeadlessContent(): JSX.Element {
 
 function HeadlessHero(): JSX.Element {
   const orgRoutes = useOrgRoutes();
+  const [searchParams] = useSearchParams();
+  // Where the user came from, when they arrived through a dashboard CTA rather
+  // than the mode strip. Falls back to the settings surface, which is what
+  // landing here directly means.
+  const entrySource =
+    entrySourceFromQuery(searchParams.get("entrySource")) ??
+    SourceSurface.PlatformMcpSettings;
   const [setupOpen, setSetupOpen] = useState(false);
   const [selectedAgent, setSelectedAgent] = useState<ClientFamily>();
   const openSetup = () => {
@@ -212,7 +224,7 @@ function HeadlessHero(): JSX.Element {
         sheetOnly
         setupOpen={setupOpen}
         onSetupOpenChange={setSetupOpen}
-        initialSourceSurface={SourceSurface.PlatformMcpSettings}
+        initialSourceSurface={entrySource}
         initialClient={selectedAgent}
         onSetupComplete={() => orgRoutes.home.goTo()}
       />

--- a/client/dashboard/src/pages/org/HeadlessContent.tsx
+++ b/client/dashboard/src/pages/org/HeadlessContent.tsx
@@ -115,18 +115,16 @@ function HeadlessHero(): JSX.Element {
             Platform MCP
           </span>
           <h1 className="text-default-fixed-light font-display text-[48px] leading-[0.9] font-thin tracking-[-0.045em] lg:text-[68px]">
-            Connect your
-            <br />
-            coding agent
+            Connect your agent
           </h1>
         </div>
         <p
           className="max-w-md text-base leading-relaxed"
           style={{ color: "var(--text-muted-fixed-light)" }}
         >
-          Drive Speakeasy from the agent you already work in — install reviewed
-          MCP servers, distribute them, and see what they are doing, without
-          leaving your terminal.
+          Administer the control plane from the agent you already work in.
+          Deploy and Manage MCP gateway servers, Review security policies and
+          deep dive your AI usage data.
         </p>
 
         <div className="flex flex-col items-center gap-3">
@@ -137,7 +135,7 @@ function HeadlessHero(): JSX.Element {
             // it reads as invisible until hover.
             className="bg-surface-primary-fixed-light hover:bg-surface-tertiary-fixed-light [&_*]:text-default-fixed-dark"
           >
-            <Button.Text>Connect your coding agent</Button.Text>
+            <Button.Text>Connect your agent</Button.Text>
             <Button.RightIcon>
               <ArrowRight className="h-4 w-4" />
             </Button.RightIcon>

--- a/client/dashboard/src/pages/org/OrgHome.test.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.test.tsx
@@ -94,7 +94,7 @@ vi.mock("@/routes", () => ({
     // Used by the welcome banner's route cards.
     home: { href: () => "/acme" },
     setup: { href: () => "/acme/setup" },
-    platformMcp: { href: () => "/acme/platform-mcp" },
+    headless: { href: () => "/acme/headless" },
   }),
   useRoutes: ({ projectSlug }: { projectSlug?: string }) => ({
     exploreDemo: { href: () => "/explore-demo" },

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.test.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.test.tsx
@@ -83,7 +83,7 @@ vi.mock("@/routes", () => ({
   useOrgRoutes: () => ({
     home: { href: () => "/acme" },
     setup: { href: () => "/acme/setup" },
-    platformMcp: { href: () => "/acme/platform-mcp" },
+    headless: { href: () => "/acme/headless" },
   }),
   useRoutes: ({ projectSlug }: { projectSlug?: string }) => ({
     exploreDemo: { href: () => "/explore-demo" },
@@ -216,7 +216,7 @@ describe("OrgWelcomeBanner", () => {
     render(<OrgWelcomeBanner />);
 
     expect(hrefFor("Set up Platform MCP")).toBe(
-      "/acme/platform-mcp?setup=1&entrySource=organization_home",
+      "/acme/headless?entrySource=organization_home",
     );
     expect(hrefFor("Begin rollout")).toBe("/acme/setup");
     expect(screen.queryByText("Announcement")).toBeNull();

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
@@ -112,7 +112,7 @@ export function OrgWelcomeBanner(): JSX.Element | null {
   const recommendedId = recommendedWelcomeCardId(cardIds);
 
   const projectRoutes = useRoutes({ projectSlug: startProject?.slug });
-  const platformMcpHref = `${orgRoutes.platformMcp.href()}?setup=1&entrySource=organization_home`;
+  const platformMcpHref = `${orgRoutes.headless.href()}?entrySource=organization_home`;
   const cards: RouteCard[] = cardIds.map((id, i) => {
     const recommended = id === recommendedId;
     const index = String(i + 1).padStart(2, "0");

--- a/client/dashboard/src/pages/org/PlatformMCP.tsx
+++ b/client/dashboard/src/pages/org/PlatformMCP.tsx
@@ -32,7 +32,6 @@ import {
   type PlatformMCPInstallMethod,
 } from "./platform-mcp-install-walkthrough";
 import type { PlatformMCPOnboardingState } from "@gram/client/models/components/platformmcponboardingstate.js";
-import { RequireScope } from "@/components/require-scope";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { Spinner } from "@/components/ui/Spinner";
 import { Text } from "@/components/ui/Text";
@@ -99,36 +98,6 @@ function starterPrompt(
   }
 
   return "Help me add a reviewed MCP server to a project. Show the available catalogue options and eligible projects, then ask me to choose one of each. Inspect the chosen server and collect only its declared non-secret configuration, including declared URL values where applicable. Register it privately, send me to the secure dashboard setup when needed, verify it is ready, and add it to that project's existing Default plugin. Do not ask me to paste API keys, tokens, passwords, OAuth codes, client secrets, or secret headers into chat. Do not ask me for the MCP server endpoint itself; use the reviewed catalogue entry selected for this project.";
-}
-
-function platformMcpEntrySource(
-  value: string | null,
-): SourceSurfaceValue | undefined {
-  return Object.values(SourceSurface).find((surface) => surface === value);
-}
-
-export default function PlatformMCP(): JSX.Element {
-  const [searchParams] = useSearchParams();
-  const sourceSurface = platformMcpEntrySource(searchParams.get("entrySource"));
-  const currentProjectSlug = searchParams.get("projectSlug") ?? undefined;
-  const openFromCta = searchParams.get("setup") === "1" && !!sourceSurface;
-
-  return (
-    <Page>
-      <Page.Header>
-        <Page.Header.Breadcrumbs />
-      </Page.Header>
-      <Page.Body>
-        <RequireScope scope="org:admin" level="page">
-          <PlatformMCPOnboardingContent
-            currentProjectSlug={currentProjectSlug}
-            initialSourceSurface={sourceSurface}
-            autoOpen={openFromCta}
-          />
-        </RequireScope>
-      </Page.Body>
-    </Page>
-  );
 }
 
 export function PlatformMCPOnboardingContent({

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -83,7 +83,6 @@ import OrgHome from "./pages/org/OrgHome";
 import OrgIdentity from "./pages/org/OrgIdentity";
 import OrgAIIntegrations from "./pages/org/OrgAIIntegrations";
 import OrgLogs from "./pages/org/OrgLogs";
-import PlatformMCP from "./pages/org/PlatformMCP";
 import HeadlessMode from "./pages/org/HeadlessMode";
 import OrgSkills from "./pages/org/OrgSkills";
 import ExternalCredentialDetail from "./pages/org/external-services/ExternalCredentialDetail";
@@ -1195,13 +1194,6 @@ const ORG_ROUTE_STRUCTURE = {
     url: "skills",
     icon: "terminal",
     component: OrgSkills,
-  },
-  platformMcp: {
-    title: "Platform MCP",
-    url: "platform-mcp",
-    icon: "plug-zap",
-    stage: "preview",
-    component: PlatformMCP,
   },
   aiIntegrations: {
     title: "AI Integrations",


### PR DESCRIPTION
## Summary

Removes the standalone **Platform MCP** page from the org Settings nav and folds it into headless mode, then makes the Headless tab in the mode strip actually noticeable.

- Drops the `platformMcp` route, its sidebar nav item (and the two active-group lists it appeared in), and its breadcrumb title. The exported `PlatformMCPOnboardingContent` stays — headless mode and the Plugins card both render it, so only the page shell around it is gone.
- The org home "Set up Platform MCP" card now links to `/<org>/headless?entrySource=organization_home`. `HeadlessContent` reads that param and passes it through as the onboarding source surface, which was previously hardcoded, so the CTA attribution survives the move.
- Adds `.mode-shimmer` in `App.css`, next to the existing `.nav-shimmer`: the brand tech colours travel as a band through the Headless label while the rest of it keeps the tab's own tone. The tab only shimmers while the user is somewhere else. It sets both `background-clip: text` spellings — with only the unprefixed one the gradient paints the span's whole box and the pill geometry ghosts through the label as a rounded slab.
- Fixes the sliding indicator in the mode strip. Its position was derived from the route's own `mode`, which does not change until the route swaps ~1.3s into the switch — by then the strip has remounted, so the pill teleported instead of travelling. It now follows `to` from the switch context, so it moves on the click. Its curve also moves off the panes' `cubic-bezier(0.32, 0.72, 0, 1)`, which covered two-thirds of the 120px in the first fifth of the transition and read as a snap.

## Motivation

Headless mode already is the Platform MCP setup surface — same walkthrough, same sheets, same admin gate — so keeping a second entry point under Settings meant two routes to the same flow and a nav item that had to carry a PREVIEW badge to explain itself.

That leaves the mode strip as the only way in, which it was not doing much to earn: a still, muted "Headless" label sitting next to the tab the user is already reading. The shimmer is what advertises it, and the pill teleporting rather than sliding made the switch itself read as a page swap rather than a mode change.

https://claude.ai/code/session_018G4WU7MWxr8b5p7CcizF5z

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the standalone Platform MCP settings page and makes headless mode the single setup surface for Platform MCP. The org home CTA now links to the Headless tab with its entry-source attribution intact, the tab advertises itself with a brand shimmer while the user is elsewhere, and the mode strip's indicator slides to the destination instead of teleporting after the new route mounts. The headless onboarding copy was also refreshed to describe the control-plane workflows.

**Bug Fixes**
- The indicator read the route's own `mode`, which only swapped midway through the switch; it now follows the click destination and uses a symmetric ease so the crossing reads as a travel, not a snap.

**Migration**
- URLs under `/…/platform-mcp` no longer resolve; the walkthrough now lives at `/…/headless`.

<sup>Written for commit b7a7d96f52a2b9c76bc847b566e6f79f2859332c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

