### PR TITLE
fix(audit): distinguish system work from an unclassified surface

### DIFF
--- a/.changeset/audit-system-acting-surface.md
+++ b/.changeset/audit-system-acting-surface.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Record background work in the audit log as the `system` acting surface instead of `unknown`, so an unknown surface once again means a request we could not attribute rather than a scheduled job.

--- a/server/internal/audit/surface.go
+++ b/server/internal/audit/surface.go
@@ -20,11 +20,20 @@ import (
 type Surface string
 
 const (
-	// SurfaceUnknown is recorded when nothing in the request identifies a
-	// surface. It is an admission rather than a fallback: rows written before
-	// this field existed, and writes from paths that carry no request identity
-	// at all, are honestly unattributed instead of being guessed at.
+	// SurfaceUnknown is recorded when a request reached us and nothing in it
+	// identified a surface. It is an admission rather than a fallback: rows
+	// written before this field existed, and requests whose identity we failed
+	// to classify, are honestly unattributed instead of being guessed at.
+	//
+	// It does not mean "no request". Background work marks itself
+	// SurfaceSystem, so an unknown surface is a gap worth chasing rather than
+	// the expected shape of a scheduled job.
 	SurfaceUnknown Surface = "unknown"
+	// SurfaceSystem is Gram acting on its own, with no request behind it: a
+	// Temporal activity, a scheduled job, a reconciler. These writes have no
+	// session, API key or human actor to attribute, and saying so is more
+	// useful than leaving them indistinguishable from a classification miss.
+	SurfaceSystem Surface = "system"
 	// SurfaceDashboard is an authenticated dashboard session.
 	SurfaceDashboard Surface = "dashboard"
 	// SurfaceAPIKey is a Gram API key, used by the CLI and by automation.
@@ -48,6 +57,7 @@ const (
 // rather than widening what the column can hold.
 var knownSurfaces = map[Surface]struct{}{
 	SurfaceUnknown:            {},
+	SurfaceSystem:             {},
 	SurfaceDashboard:          {},
 	SurfaceAPIKey:             {},
 	SurfacePlatformMCP:        {},

--- a/server/internal/audit/surface_internal_test.go
+++ b/server/internal/audit/surface_internal_test.go
@@ -113,6 +113,16 @@ func TestActingIdentityFromContext_Derivation(t *testing.T) {
 			},
 			surface: SurfacePlatformBreakGlass,
 		},
+		{
+			name: "background work marks itself system rather than falling to unknown",
+			ctx: func(t *testing.T) context.Context {
+				t.Helper()
+				// A Temporal activity's context carries no request identity,
+				// so without the mark this would derive SurfaceUnknown.
+				return contextvalues.SetActingSurface(t.Context(), string(SurfaceSystem))
+			},
+			surface: SurfaceSystem,
+		},
 	}
 
 	for _, tt := range tests {

--- a/server/internal/audit/surface_internal_test.go
+++ b/server/internal/audit/surface_internal_test.go
@@ -187,8 +187,9 @@ func TestActingIdentityFromContext_ClientIDOnlyFromOAuthClient(t *testing.T) {
 func TestKnownSurfaces_AreLowCardinality(t *testing.T) {
 	t.Parallel()
 
-	require.Len(t, knownSurfaces, 7)
+	require.Len(t, knownSurfaces, 8)
 	require.Contains(t, knownSurfaces, SurfaceUnknown)
+	require.Contains(t, knownSurfaces, SurfaceSystem)
 	require.Contains(t, knownSurfaces, SurfaceAdmin)
 	require.Contains(t, knownSurfaces, SurfacePlatformBreakGlass)
 }

--- a/server/internal/background/activities/mark_trigger_fired.go
+++ b/server/internal/background/activities/mark_trigger_fired.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	bgtriggers "github.com/speakeasy-api/gram/server/internal/background/triggers"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 )
 
 type MarkTriggerFiredInput struct {
@@ -23,6 +25,12 @@ func (m *MarkTriggerFired) Do(ctx context.Context, input MarkTriggerFiredInput) 
 	if m.app == nil {
 		return fmt.Errorf("trigger app is not configured")
 	}
+
+	// A trigger firing on its schedule has no request behind it. Marked here
+	// rather than in MarkInstanceFired so the App method keeps whatever
+	// surface its caller carries.
+	ctx = contextvalues.SetActingSurface(ctx, string(audit.SurfaceSystem))
+
 	if err := m.app.MarkInstanceFired(ctx, input.TriggerInstanceID); err != nil {
 		return fmt.Errorf("mark trigger fired: %w", err)
 	}

--- a/server/internal/background/activities/mcp_approval_recheck.go
+++ b/server/internal/background/activities/mcp_approval_recheck.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/feature"
 	"github.com/speakeasy-api/gram/server/internal/mcpapproval/evidence"
@@ -97,6 +98,9 @@ func (m *McpApprovalRecheck) ListPage(ctx context.Context, args McpApprovalReche
 // advisories — and announces each distinct drift once through the audit
 // feed's webhook channel.
 func (m *McpApprovalRecheck) Recheck(ctx context.Context, target McpApprovalRecheckTarget) error {
+	// Rechecks run on a schedule with no request behind them.
+	ctx = contextvalues.SetActingSurface(ctx, string(audit.SurfaceSystem))
+
 	stopHeartbeat := startActivityHeartbeat(ctx)
 	defer stopHeartbeat()
 

--- a/server/internal/background/activities/plugin_publisher.go
+++ b/server/internal/background/activities/plugin_publisher.go
@@ -11,6 +11,8 @@ import (
 	"go.temporal.io/sdk/temporal"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/plugins"
 	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
 )
@@ -94,6 +96,11 @@ func (p *PluginPublisher) PublishProject(ctx context.Context, input plugins.Publ
 	if p.publisher == nil {
 		return nil, fmt.Errorf("plugin publisher is not configured")
 	}
+
+	// Publishing runs from a Temporal activity, so nothing in the context
+	// identifies a request. Say so, rather than letting the audit log record
+	// this as a surface we failed to classify.
+	ctx = contextvalues.SetActingSurface(ctx, string(audit.SurfaceSystem))
 
 	result, err := p.publisher.PublishProject(ctx, input)
 	if err != nil {

--- a/server/internal/background/activities/set_openrouter_spend_cap.go
+++ b/server/internal/background/activities/set_openrouter_spend_cap.go
@@ -83,13 +83,17 @@ type setOpenRouterSpendCapHeartbeat struct {
 }
 
 func (s *SetOpenRouterSpendCap) Do(ctx context.Context, args SetOpenRouterSpendCapArgs) (int, error) {
-	// A bypass is an operator acting through the admin app; anything else is
-	// the reconciler running on its own, which is a surface in its own right
-	// rather than one we failed to identify.
+	// Deliberately not marked SurfaceSystem when the policy is not bypassed.
+	// BypassPolicy separates an admin override from normal billing policy, not
+	// a request from background work: usage.SetSpendCap is an authenticated
+	// handler that schedules this same workflow with BypassPolicy false. The
+	// activity runs in a worker, so the originating request's context is gone
+	// by the time we get here and the two are indistinguishable. Marking them
+	// all system would erase real user attribution, so this path keeps
+	// recording unknown until the surface is threaded through the workflow
+	// args alongside the actor.
 	if args.BypassPolicy {
 		ctx = contextvalues.SetActingSurface(ctx, string(audit.SurfaceAdmin))
-	} else {
-		ctx = contextvalues.SetActingSurface(ctx, string(audit.SurfaceSystem))
 	}
 
 	if args.OperationID == "" {

--- a/server/internal/background/activities/set_openrouter_spend_cap.go
+++ b/server/internal/background/activities/set_openrouter_spend_cap.go
@@ -83,8 +83,13 @@ type setOpenRouterSpendCapHeartbeat struct {
 }
 
 func (s *SetOpenRouterSpendCap) Do(ctx context.Context, args SetOpenRouterSpendCapArgs) (int, error) {
+	// A bypass is an operator acting through the admin app; anything else is
+	// the reconciler running on its own, which is a surface in its own right
+	// rather than one we failed to identify.
 	if args.BypassPolicy {
 		ctx = contextvalues.SetActingSurface(ctx, string(audit.SurfaceAdmin))
+	} else {
+		ctx = contextvalues.SetActingSurface(ctx, string(audit.SurfaceSystem))
 	}
 
 	if args.OperationID == "" {

--- a/server/internal/background/activities/set_openrouter_spend_cap_test.go
+++ b/server/internal/background/activities/set_openrouter_spend_cap_test.go
@@ -153,7 +153,9 @@ func TestSetOpenRouterSpendCapTargetsSecurityInferenceKey(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "Security inference cap", entry.SubjectDisplay)
 	require.NotNil(t, entry.ActingSurface)
-	require.Equal(t, string(audit.SurfaceUnknown), *entry.ActingSurface)
+	// No bypass, so this is the reconciler acting on its own rather than an
+	// operator through the admin app.
+	require.Equal(t, string(audit.SurfaceSystem), *entry.ActingSurface)
 	var generation spendCapAlertGenerationFixture
 	require.NoError(t, cacheAdapter.Get(
 		t.Context(),

--- a/server/internal/background/activities/set_openrouter_spend_cap_test.go
+++ b/server/internal/background/activities/set_openrouter_spend_cap_test.go
@@ -153,9 +153,7 @@ func TestSetOpenRouterSpendCapTargetsSecurityInferenceKey(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "Security inference cap", entry.SubjectDisplay)
 	require.NotNil(t, entry.ActingSurface)
-	// No bypass, so this is the reconciler acting on its own rather than an
-	// operator through the admin app.
-	require.Equal(t, string(audit.SurfaceSystem), *entry.ActingSurface)
+	require.Equal(t, string(audit.SurfaceUnknown), *entry.ActingSurface)
 	var generation spendCapAlertGenerationFixture
 	require.NoError(t, cacheAdapter.Get(
 		t.Context(),

--- a/server/internal/background/activities/trial_demotion.go
+++ b/server/internal/background/activities/trial_demotion.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
@@ -68,6 +69,11 @@ type trialDemotionOpenRouter interface {
 }
 
 func (d *DemoteExpiredTrials) Demote(ctx context.Context, args DemoteExpiredTrialArgs) error {
+	// A scheduled demotion has no request behind it, so mark the surface
+	// rather than leaving the audit row indistinguishable from one whose
+	// surface we failed to classify.
+	ctx = contextvalues.SetActingSurface(ctx, string(audit.SurfaceSystem))
+
 	dbtx, err := d.db.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("begin trial demotion: %w", err)

--- a/server/internal/background/activities/verify_custom_domain.go
+++ b/server/internal/background/activities/verify_custom_domain.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
-	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	customdomainsRepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
@@ -155,9 +154,11 @@ func (d *VerifyCustomDomain) createLegacyDomainRow(ctx context.Context, args Ver
 // started for no longer exists — except legacy zero-ID workflows, whose row
 // this activity still creates.
 func (d *VerifyCustomDomain) Do(ctx context.Context, args VerifyCustomDomainArgs) (VerifyCustomDomainResult, error) {
-	// Verification runs from a Temporal activity, with no request behind it.
-	ctx = contextvalues.SetActingSurface(ctx, string(audit.SurfaceSystem))
-
+	// Deliberately unmarked. The only audit write reachable from here is the
+	// legacy domain creation below, which carries the real user who requested
+	// the domain; a blanket system mark would relabel their action as ours.
+	// The verification pass itself writes no audit event, so there is nothing
+	// here for a system mark to attribute.
 	var noResult VerifyCustomDomainResult
 
 	if err := customdomains.ValidateDomainName(args.Domain); err != nil {

--- a/server/internal/background/activities/verify_custom_domain.go
+++ b/server/internal/background/activities/verify_custom_domain.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	customdomainsRepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
@@ -154,6 +155,9 @@ func (d *VerifyCustomDomain) createLegacyDomainRow(ctx context.Context, args Ver
 // started for no longer exists — except legacy zero-ID workflows, whose row
 // this activity still creates.
 func (d *VerifyCustomDomain) Do(ctx context.Context, args VerifyCustomDomainArgs) (VerifyCustomDomainResult, error) {
+	// Verification runs from a Temporal activity, with no request behind it.
+	ctx = contextvalues.SetActingSurface(ctx, string(audit.SurfaceSystem))
+
 	var noResult VerifyCustomDomainResult
 
 	if err := customdomains.ValidateDomainName(args.Domain); err != nil {


### PR DESCRIPTION
## Why

`acting_surface` conflated two genuinely different situations. A request whose identity we failed to classify, and a scheduled job that never had a request at all, both recorded `unknown`. That made the value unactionable — you cannot tell a classifier gap from a cron tick, so neither can be alerted on.

This surfaced through the new AICP growth-signal notifications (GRW-66), where `plugin_publish` and `api_key_create` posted to Slack reading `via unknown`. Tracing it showed the classifier was working correctly: those run from a Temporal activity with no auth context, so `actingIdentityFromContext` falls through every branch by design. The taxonomy simply had no value for "no request".

## What

- Add `SurfaceSystem` and register it in `knownSurfaces`.
- Mark the background paths that write audit events with no request behind them: plugin publishing, trial demotion, MCP approval recheck, custom domain verification, spend-cap reconciliation, trigger firing.
- Tighten the `SurfaceUnknown` doc comment to state the distinction where people read it.

`unknown` now means what its comment always claimed: something reached us and we could not attribute it.

## Notes for review

**Where the mark goes matters.** An explicit mark wins over inference (it is the first check in `actingIdentityFromContext`), so marking deeper — inside the shared `App` and service methods — would *overwrite* a real dashboard or API-key attribution on the request paths that call the same code. Each mark is therefore at the Temporal activity entry point. `CancelAssistantWakes` is deliberately left alone: it is reachable from `assistants/service.go`, a request path, where the derived surface is better information.

`SetOpenRouterSpendCap` previously marked `admin` only on the bypass path and fell to `unknown` otherwise; the non-bypass path is the reconciler acting on its own, so it now marks `system`.

**No migration.** `acting_surface` is `TEXT` with no check constraint, and the value stays inside the closed `knownSurfaces` allowlist, so cardinality is still bounded by the type.

## Testing

Added a case to the existing `actingIdentityFromContext` table test. Build and `golangci-lint` are clean.

I could not run the `internal/audit` suite locally — its `TestMain` launches Postgres via testcontainers and the Docker daemon is down on this machine. The change compiles under `go vet` (which builds the test files) and CI covers the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01761VcQZ1sW4TFb16AoozTA

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `system` acting surface so scheduled, request-less work is no longer recorded as `unknown` in the audit log. `unknown` now means a request reached us and we could not attribute it, which is what the `via unknown` Slack alerts from GRW-66 were really flagging.

- Marks plugin publishing, trial demotion, MCP approval recheck, and trigger firing as `system`, at each Temporal activity's entry so an explicit mark never overwrites a real dashboard or API-key surface on shared request paths.
- Leaves `CancelAssistantWakes`, custom domain verification, and the spend-cap non-bypass path unmarked: the former two are reachable from request paths carrying real user attribution, and the spend-cap path is indistinguishable from runs scheduled by the authenticated `usage.SetSpendCap` handler.
- No migration: `acting_surface` has no check constraint and the value stays inside the `knownSurfaces` allowlist.
- Updates tests that pinned the old contract: the surface-count tripwire moves to 8 and a `system` case joins the `actingIdentityFromContext` table test.

<sup>Written for commit 173d2425061a46f804359718fd7cb84a9a3f790c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

