### PR TITLE
fix(audit): carry the acting surface into the spend-cap workflow

### DIFF
--- a/.changeset/spend-cap-acting-surface.md
+++ b/.changeset/spend-cap-acting-surface.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Attribute spend-cap changes to the surface the request came through, by carrying it into the workflow payload, so a customer's own change is no longer recorded as an unattributed write.

--- a/server/internal/audit/surface.go
+++ b/server/internal/audit/surface.go
@@ -124,3 +124,18 @@ func actingIdentityFromContext(ctx context.Context) actingIdentity {
 		return actingIdentity{Surface: SurfaceUnknown, ClientID: clientID}
 	}
 }
+
+// SurfaceFromContext is how a request is acting, for callers that must carry
+// the surface across a boundary a context cannot cross.
+//
+// Audit normally derives this at the moment of the write, which is where the
+// signals are richest. Work handed to Temporal breaks that: the activity runs
+// in a worker with none of the request's context, so a caller that schedules
+// work on a user's behalf has to capture the surface at schedule time and pass
+// it through the workflow payload the way it already passes the actor.
+//
+// Prefer letting audit derive the surface wherever the write happens in the
+// request's own goroutine. Reach for this only at a handoff.
+func SurfaceFromContext(ctx context.Context) Surface {
+	return actingIdentityFromContext(ctx).Surface
+}

--- a/server/internal/audit/surface_internal_test.go
+++ b/server/internal/audit/surface_internal_test.go
@@ -181,6 +181,26 @@ func TestActingIdentityFromContext_ClientIDOnlyFromOAuthClient(t *testing.T) {
 	})
 }
 
+// TestSurfaceFromContext_MatchesDerivation guards the exported accessor against
+// drifting from the derivation it wraps. Callers use it to carry a surface
+// across a Temporal boundary, so a divergence here would silently mislabel
+// every write on the far side.
+func TestSurfaceFromContext_MatchesDerivation(t *testing.T) {
+	t.Parallel()
+
+	for _, ctx := range []context.Context{
+		t.Context(),
+		sessionContext(t, "session_test"),
+		contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
+			ActiveOrganizationID: "org_test",
+			APIKeyID:             "key_test",
+		}),
+		contextvalues.SetActingSurface(t.Context(), string(SurfaceSystem)),
+	} {
+		require.Equal(t, actingIdentityFromContext(ctx).Surface, SurfaceFromContext(ctx))
+	}
+}
+
 // TestKnownSurfaces_AreLowCardinality pins the size of the set. The column is
 // faceted in the audit feed, so growth here is a product decision rather than
 // something a new surface should pick up silently.

--- a/server/internal/background/activities/set_openrouter_spend_cap.go
+++ b/server/internal/background/activities/set_openrouter_spend_cap.go
@@ -72,6 +72,11 @@ type SetOpenRouterSpendCapArgs struct {
 	ActorDisplayName *string
 	// BypassPolicy is false for existing and customer-initiated workflows.
 	BypassPolicy bool
+	// ActingSurface is the surface the scheduling request was acting through,
+	// captured at schedule time because this activity runs in a worker with
+	// none of that request's context. Empty on payloads created before the
+	// field existed.
+	ActingSurface string
 }
 
 type setOpenRouterSpendCapHeartbeat struct {
@@ -83,16 +88,19 @@ type setOpenRouterSpendCapHeartbeat struct {
 }
 
 func (s *SetOpenRouterSpendCap) Do(ctx context.Context, args SetOpenRouterSpendCapArgs) (int, error) {
-	// Deliberately not marked SurfaceSystem when the policy is not bypassed.
-	// BypassPolicy separates an admin override from normal billing policy, not
-	// a request from background work: usage.SetSpendCap is an authenticated
-	// handler that schedules this same workflow with BypassPolicy false. The
-	// activity runs in a worker, so the originating request's context is gone
-	// by the time we get here and the two are indistinguishable. Marking them
-	// all system would erase real user attribution, so this path keeps
-	// recording unknown until the surface is threaded through the workflow
-	// args alongside the actor.
-	if args.BypassPolicy {
+	// The scheduling request's surface is carried in the payload, because this
+	// activity runs in a worker where that request's context no longer exists.
+	// BypassPolicy is not a substitute: it separates an admin override from
+	// normal billing policy, and usage.SetSpendCap schedules this same workflow
+	// with it false, so keying the surface off it would stamp customer changes
+	// as admin work.
+	switch {
+	case args.ActingSurface != "":
+		ctx = contextvalues.SetActingSurface(ctx, args.ActingSurface)
+	case args.BypassPolicy:
+		// Payload predates ActingSurface. Only the admin entry point sets
+		// BypassPolicy, so this keeps in-flight admin workflows attributed
+		// across the deploy rather than dropping them to unknown.
 		ctx = contextvalues.SetActingSurface(ctx, string(audit.SurfaceAdmin))
 	}
 

--- a/server/internal/background/activities/set_openrouter_spend_cap_test.go
+++ b/server/internal/background/activities/set_openrouter_spend_cap_test.go
@@ -153,6 +153,8 @@ func TestSetOpenRouterSpendCapTargetsSecurityInferenceKey(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "Security inference cap", entry.SubjectDisplay)
 	require.NotNil(t, entry.ActingSurface)
+	// The args carry no surface, standing in for a payload created before the
+	// field existed, so the worker derives one and finds nothing.
 	require.Equal(t, string(audit.SurfaceUnknown), *entry.ActingSurface)
 	var generation spendCapAlertGenerationFixture
 	require.NoError(t, cacheAdapter.Get(
@@ -162,6 +164,53 @@ func TestSetOpenRouterSpendCapTargetsSecurityInferenceKey(t *testing.T) {
 	))
 	require.Equal(t, "operation_internal_placeholder", generation.OperationID)
 	require.EqualValues(t, 75, generation.MonthlyCredits)
+}
+
+// TestSetOpenRouterSpendCapRecordsThreadedSurface covers the customer path.
+// usage.SetSpendCap is an authenticated handler that schedules this workflow
+// with BypassPolicy false, so the surface has to arrive in the payload: the
+// activity runs in a worker where that request's context is gone, and keying
+// off BypassPolicy would stamp a customer's own change as admin work.
+func TestSetOpenRouterSpendCapRecordsThreadedSurface(t *testing.T) {
+	t.Parallel()
+
+	_, provisioner, db, organizationID := setupPaygChatKeyReconciler(
+		t,
+		"payg",
+		pgtype.Text{String: "subscription_placeholder", Valid: true},
+	)
+	createSpendCapActivityKey(t, db, organizationID, 50)
+	provisioner.On(
+		"RefreshAPIKeyLimit",
+		mock.Anything,
+		organizationID,
+		openrouter.KeyTypeChat,
+		mock.MatchedBy(func(limit *int) bool { return limit != nil && *limit == 60 }),
+	).Run(func(args mock.Arguments) {
+		ctx, ok := args.Get(0).(context.Context)
+		require.True(t, ok)
+		require.NoError(t, openrouterrepo.New(db).UpdateOpenRouterKeyMonthlyCredits(ctx, openrouterrepo.UpdateOpenRouterKeyMonthlyCreditsParams{
+			MonthlyCredits: 60,
+			OrganizationID: organizationID,
+			KeyType:        string(openrouter.KeyTypeChat),
+		}))
+	}).Return(60, nil).Once()
+
+	setter := activities.NewSetOpenRouterSpendCap(testenv.NewLogger(t), db, provisioner, audit.NewLogger(), newSpendCapActivityCache(t))
+	args := spendCapActivityArgs("operation_threaded_placeholder", organizationID, 60)
+	args.ActingSurface = string(audit.SurfaceDashboard)
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestActivityEnvironment()
+	env.RegisterActivity(setter.Do)
+	_, err := env.ExecuteActivity(setter.Do, args)
+	require.NoError(t, err)
+	provisioner.AssertExpectations(t)
+
+	entry, err := audittest.LatestAuditLogByAction(t.Context(), db, audit.ActionOpenRouterAPIKeySetSpendCap)
+	require.NoError(t, err)
+	require.NotNil(t, entry.ActingSurface)
+	require.Equal(t, string(audit.SurfaceDashboard), *entry.ActingSurface)
 }
 
 func spendCapActivityArgs(operationID, organizationID string, limit int) activities.SetOpenRouterSpendCapArgs {

--- a/server/internal/background/openrouter_key_refresh.go
+++ b/server/internal/background/openrouter_key_refresh.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/background/activities"
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
@@ -77,6 +78,7 @@ func (w *OpenRouterKeyRefresher) setOpenRouterSpendCap(ctx context.Context, oper
 		Actor:            actor,
 		ActorDisplayName: actorDisplayName,
 		BypassPolicy:     bypassPolicy,
+		ActingSurface:    string(audit.SurfaceFromContext(ctx)),
 	})
 	var alreadyStarted *serviceerror.WorkflowExecutionAlreadyStarted
 	switch {
@@ -110,6 +112,11 @@ type OpenRouterSpendCapParams struct {
 	ActorDisplayName *string
 	// BypassPolicy is false for existing and customer-initiated workflows.
 	BypassPolicy bool
+	// ActingSurface is the surface the scheduling request was acting through,
+	// captured here because the activity runs in a worker that cannot see it.
+	// Empty on payloads created before this field existed; those keep deriving
+	// their surface in the worker, as they did.
+	ActingSurface string
 }
 
 func OpenRouterSpendCapWorkflow(ctx workflow.Context, params OpenRouterSpendCapParams) error {
@@ -144,6 +151,7 @@ func executeOpenRouterSpendCapWorkflow(ctx workflow.Context, params OpenRouterSp
 		Actor:            params.Actor,
 		ActorDisplayName: params.ActorDisplayName,
 		BypassPolicy:     params.BypassPolicy,
+		ActingSurface:    params.ActingSurface,
 	})
 	if !returnResult {
 		if err := future.Get(ctx, nil); err != nil {

--- a/server/internal/background/openrouter_key_refresh_test.go
+++ b/server/internal/background/openrouter_key_refresh_test.go
@@ -15,7 +15,9 @@ import (
 	temporalmocks "go.temporal.io/sdk/mocks"
 	"go.temporal.io/sdk/testsuite"
 
+	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/background/activities"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	tenv "github.com/speakeasy-api/gram/server/internal/temporal"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -108,6 +110,14 @@ func TestSetOpenRouterSpendCapNormalizesLegacyEmptyKeyType(t *testing.T) {
 		return options.ID == "v1:openrouter-spend-cap:chat:operation_placeholder" &&
 			options.WorkflowIDReusePolicy == enums.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE
 	})
+	// A dashboard session at schedule time must reach the payload: the activity
+	// runs in a worker where this request's context no longer exists.
+	sessionID := "session_placeholder"
+	schedulerCtx := contextvalues.SetAuthContext(t.Context(), &contextvalues.AuthContext{
+		ActiveOrganizationID: "organization_placeholder",
+		UserID:               "user_placeholder",
+		SessionID:            &sessionID,
+	})
 	workflowParams := OpenRouterSpendCapParams{
 		OperationID:      "operation_placeholder",
 		OrganizationID:   "organization_placeholder",
@@ -115,12 +125,13 @@ func TestSetOpenRouterSpendCapNormalizesLegacyEmptyKeyType(t *testing.T) {
 		Limit:            100,
 		Actor:            urn.NewPrincipal(urn.PrincipalTypeUser, "user_placeholder"),
 		ActorDisplayName: nil,
+		ActingSurface:    string(audit.SurfaceDashboard),
 	}
 	temporalClient.On("ExecuteWorkflow", mock.Anything, workflowOptions, mock.Anything, workflowParams).Return(run, nil).Once()
 
 	scheduler := &OpenRouterKeyRefresher{TemporalEnv: tenv.NewEnvironment(temporalClient, "test", "test")}
 	require.NoError(t, scheduler.SetOpenRouterSpendCap(
-		t.Context(),
+		schedulerCtx,
 		"operation_placeholder",
 		"organization_placeholder",
 		openrouter.KeyType(""),
@@ -139,11 +150,13 @@ func TestOpenRouterSpendCapWorkflowsEnforcePolicyMode(t *testing.T) {
 	customerEnv := suite.NewTestWorkflowEnvironment()
 	customerEnv.RegisterActivityWithOptions(func(_ context.Context, args activities.SetOpenRouterSpendCapArgs) (int, error) {
 		require.False(t, args.BypassPolicy)
+		require.Equal(t, string(audit.SurfaceDashboard), args.ActingSurface)
 		return 100, nil
 	}, activity.RegisterOptions{Name: "SetOpenRouterSpendCap"})
 	params := OpenRouterSpendCapParams{
 		OperationID: "operation_placeholder", OrganizationID: "organization_placeholder",
 		Actor: urn.NewPrincipal(urn.PrincipalTypeUser, "user_placeholder"), BypassPolicy: true,
+		ActingSurface: string(audit.SurfaceDashboard),
 	}
 	customerEnv.ExecuteWorkflow(OpenRouterSpendCapWorkflow, params)
 	require.NoError(t, customerEnv.GetWorkflowError())
@@ -151,6 +164,7 @@ func TestOpenRouterSpendCapWorkflowsEnforcePolicyMode(t *testing.T) {
 	adminEnv := suite.NewTestWorkflowEnvironment()
 	adminEnv.RegisterActivityWithOptions(func(_ context.Context, args activities.SetOpenRouterSpendCapArgs) (int, error) {
 		require.True(t, args.BypassPolicy)
+		require.Equal(t, string(audit.SurfaceDashboard), args.ActingSurface)
 		return 100, nil
 	}, activity.RegisterOptions{Name: "SetOpenRouterSpendCap"})
 	params.BypassPolicy = false
@@ -168,16 +182,25 @@ func TestSetAdminOpenRouterSpendCapBypassesPolicy(t *testing.T) {
 		require.True(t, ok)
 		*result = 99
 	}).Return(nil).Once()
+	// The admin app's own session is what makes this admin work; BypassPolicy
+	// only says the billing policy was overridden.
+	adminCtx := contextvalues.SetAdminAuthContext(t.Context(), &contextvalues.AdminAuthContext{
+		SessionID:   "admin_session_placeholder",
+		OIDCSubject: "admin_subject_placeholder",
+		Name:        "Test Operator",
+		Email:       "operator@example.com",
+	})
 	workflowParams := OpenRouterSpendCapParams{
 		OperationID: "admin_operation_placeholder", OrganizationID: "organization_placeholder",
 		KeyType: string(openrouter.KeyTypeInternal), Limit: 100,
 		Actor: urn.NewPrincipal(urn.PrincipalTypeUser, "admin_placeholder"), BypassPolicy: true,
+		ActingSurface: string(audit.SurfaceAdmin),
 	}
 	temporalClient.On("ExecuteWorkflow", mock.Anything, mock.Anything, mock.Anything, workflowParams).Return(run, nil).Once()
 
 	scheduler := &OpenRouterKeyRefresher{TemporalEnv: tenv.NewEnvironment(temporalClient, "test", "test")}
 	result, err := scheduler.SetAdminOpenRouterSpendCap(
-		t.Context(), workflowParams.OperationID, workflowParams.OrganizationID, openrouter.KeyTypeInternal,
+		adminCtx, workflowParams.OperationID, workflowParams.OrganizationID, openrouter.KeyTypeInternal,
 		workflowParams.Limit, workflowParams.Actor, nil,
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
Follow-up to a review finding on #6140 (now merged). cubic pointed out there that keying the surface off `BypassPolicy` would stamp customer spend-cap changes as admin work. That mark was reverted in #6140; this is the actual fix.

## The problem

The spend-cap activity cannot attribute its own writes. It runs in a Temporal worker, so the scheduling request's context is gone by the time it executes, and audit derives the surface at the moment of the write. Every customer spend-cap change therefore recorded `unknown`.

`BypassPolicy` is not a usable stand-in: it separates an admin override from normal billing policy, and `usage.SetSpendCap` — an authenticated org-admin handler — schedules the same workflow with it `false`. Its own doc comment says so: *"BypassPolicy is false for existing and customer-initiated workflows."*

## The fix

Capture the surface at schedule time, where the request is still in hand, and pass it through the payload the way the actor already is. `setOpenRouterSpendCap` is the single scheduling point for both entry points, so the customer path records `dashboard` or `api_key` and the admin path records `admin` — each derived from the request rather than inferred from a policy flag.

`audit.SurfaceFromContext` exports the existing derivation for callers that must carry a surface across a boundary a context cannot cross. It wraps `actingIdentityFromContext` rather than restating it, with a test pinning the two together so they cannot drift.

## Backward compatibility

Payloads created before the field carry an empty surface and keep deriving in the worker exactly as they do today. `BypassPolicy` survives as a fallback for precisely those, so in-flight admin workflows stay attributed across the deploy rather than dropping to `unknown`.

## Testing

The scheduler tests now build real contexts rather than asserting a struct literal, so they prove the threading end to end: a dashboard session at schedule time reaches the payload as `dashboard`, and an admin session reaches it as `admin` without leaning on `BypassPolicy`. Added an activity test that a threaded surface is recorded verbatim, and kept the existing no-surface case to cover legacy payloads.

Local after rebase onto main: 579 tests green across `internal/audit` and `internal/background`, `golangci-lint` 0 issues.

## Not addressed here

`VerifyCustomDomain` has the same shape — its legacy domain creation carries a real requester but writes from a worker, so it records `unknown`. Left alone deliberately to keep this change to one path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01761VcQZ1sW4TFb16AoozTA

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes spend-cap audit attribution so customer spend-cap changes no longer record `unknown`. The activity runs in a Temporal worker where the scheduling request's context is gone, so the acting surface is now captured at schedule time and carried in the workflow payload.

- Customer changes record `dashboard` or `api_key`; admin changes record `admin`, each derived from the request.
- `audit.SurfaceFromContext` exports the existing surface derivation for callers carrying a surface across a context boundary.
- **Backwards compatibility:** payloads created before the field keep deriving in the worker, and `BypassPolicy` stays as a fallback so in-flight admin workflows remain attributed across the deploy.

<sup>Written for commit fcb8a3cdf40f9648f2fd4798df00c6569b20c1a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

