### PR TITLE
fix: restore list view toggles and source page details lost in the MCP refactor

### DIFF
--- a/.changeset/restore-list-view-toggles.md
+++ b/.changeset/restore-list-view-toggles.md
@@ -2,4 +2,4 @@
 "dashboard": patch
 ---
 
-Restore the grid/table view toggle on the MCP servers and sources lists and the plugin skills section, and add a search box to the Environments page.
+Restore the grid/table view toggle on the MCP servers and sources lists and the plugin skills section, add a search box to the Environments page, and bring back the source page's MCP servers list, OpenAPI document and function manifest viewer, and function runtime and sizing details.

--- a/.changeset/restore-list-view-toggles.md
+++ b/.changeset/restore-list-view-toggles.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Restore the grid/table view toggle on the MCP servers and sources lists and the plugin skills section, and add a search box to the Environments page.

--- a/client/dashboard/package.json
+++ b/client/dashboard/package.json
@@ -71,6 +71,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.4.0",
+    "fflate": "^0.8.3",
     "lucide-react": "catalog:",
     "monaco-editor": "^0.56.0",
     "motion": "^13.1.0",

--- a/client/dashboard/src/components/mcp/mcp-table-rows.tsx
+++ b/client/dashboard/src/components/mcp/mcp-table-rows.tsx
@@ -1,0 +1,257 @@
+import { SourceMcpIcon } from "@/components/sources/SourceCard";
+import { Badge } from "@/components/ui/Badge";
+import { CopyButton } from "@/components/ui/CopyButton";
+import { DotRow } from "@/components/ui/DotRow";
+import { Text } from "@/components/ui/Text";
+import { useMcpUrl } from "@/hooks/useToolsetUrl";
+import { mcpServerRouteParam } from "@/lib/sources";
+import { useRoutes } from "@/routes";
+import type { McpServer } from "@gram/client/models/components/mcpserver.js";
+import type { MetaMcpServer } from "@gram/client/models/components/metamcpserver.js";
+import type { ToolsetEntry } from "@gram/client/models/components/toolsetentry.js";
+import { useLatestDeployment } from "@gram/client/react-query/latestDeployment.js";
+import { AlertTriangleIcon, Link2, Network } from "lucide-react";
+import { useMemo } from "react";
+import {
+  useCatalogIconMap,
+  useExternalMcpOAuthConfigStatus,
+} from "../sources/sources-hooks";
+
+/**
+ * The table rows of the /mcp listing: one per backend kind, mirroring the
+ * three cards of the grid view. All three fill the same four columns — Name,
+ * Kind, Address, Contents — so the kinds line up in one table.
+ *
+ * TODO(AGE-1902): collapse into one row once Hosted (toolset-backed) servers
+ * also source from mcp_servers.
+ */
+
+const CELL = "px-3 py-3";
+
+function NameCell({
+  name,
+  title,
+  children,
+}: {
+  name: string;
+  title?: string;
+  children?: React.ReactNode;
+}): JSX.Element {
+  return (
+    <td className={CELL}>
+      <div className="flex items-center gap-2">
+        <Text
+          variant="subheading"
+          as="div"
+          className="group-hover:text-primary min-w-0 truncate text-sm transition-colors"
+          title={title ?? name}
+        >
+          {name}
+        </Text>
+        {children}
+      </div>
+    </td>
+  );
+}
+
+/** A Hosted server: a toolset Speakeasy serves itself. */
+export function MCPTableRow({
+  toolset,
+}: {
+  toolset: ToolsetEntry;
+}): JSX.Element {
+  const routes = useRoutes();
+  const { url: mcpUrl } = useMcpUrl(toolset);
+  const catalogIconMap = useCatalogIconMap();
+  const { data: deploymentResult } = useLatestDeployment();
+  const oauthStatus = useExternalMcpOAuthConfigStatus(toolset.slug);
+
+  const externalMcpLogoUrl = useMemo(() => {
+    const externalMcpUrn = toolset.toolUrns?.find((urn) =>
+      urn.includes(":externalmcp:"),
+    );
+    const slug = externalMcpUrn?.split(":")[2];
+    if (!slug) return undefined;
+    const matchingMcp = deploymentResult?.deployment?.externalMcps?.find(
+      (mcp) => mcp.slug === slug,
+    );
+    return matchingMcp?.registryServerSpecifier
+      ? catalogIconMap.get(matchingMcp.registryServerSpecifier)
+      : undefined;
+  }, [toolset.toolUrns, catalogIconMap, deploymentResult]);
+
+  const handleClick = () => {
+    if (oauthStatus === "required-unconfigured") {
+      routes.mcp.details.authentication.goTo(toolset.slug);
+    } else {
+      routes.mcp.details.goTo(toolset.slug);
+    }
+  };
+
+  // Same reading as MCPCard: a proxy-only toolset can't count its tools until
+  // someone signs in, so neither "1 tool" nor "0 tools" would be true.
+  const isProxyOnly =
+    toolset.tools.length > 0 &&
+    toolset.tools.every(
+      (tool) => tool.type === "externalmcp" && tool.name.endsWith(":proxy"),
+    );
+  const toolCount = toolset.tools.filter(
+    (tool) => !(tool.type === "externalmcp" && tool.name.endsWith(":proxy")),
+  ).length;
+
+  return (
+    <DotRow
+      onClick={handleClick}
+      icon={
+        externalMcpLogoUrl ? (
+          <img
+            src={externalMcpLogoUrl}
+            alt={toolset.name}
+            className="h-6 w-6 object-contain"
+          />
+        ) : (
+          <Network className="text-muted-foreground h-5 w-5" />
+        )
+      }
+    >
+      <NameCell name={toolset.name}>
+        {oauthStatus === "required-unconfigured" && (
+          <Badge variant="warning">
+            <Badge.LeftIcon>
+              <AlertTriangleIcon />
+            </Badge.LeftIcon>
+            <Badge.Text>OAuth Required</Badge.Text>
+          </Badge>
+        )}
+      </NameCell>
+      <td className={CELL}>
+        <Badge variant="neutral">Hosted</Badge>
+      </td>
+      <td className={`max-w-xs ${CELL}`}>
+        {mcpUrl ? (
+          // The copy button must sit above the row's click handler.
+          <div
+            className="relative z-20 flex items-center gap-1.5"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Text small muted className="truncate font-mono text-xs">
+              {mcpUrl.replace(/^https?:\/\//, "")}
+            </Text>
+            <CopyButton
+              text={mcpUrl}
+              size="sm"
+              icon={Link2}
+              tooltip="Copy MCP URL"
+            />
+          </div>
+        ) : (
+          <Text small muted>
+            —
+          </Text>
+        )}
+      </td>
+      <td className={CELL}>
+        <Text small muted>
+          {isProxyOnly
+            ? "Tools listed once you sign in"
+            : `${toolCount} ${toolCount === 1 ? "tool" : "tools"}`}
+        </Text>
+      </td>
+    </DotRow>
+  );
+}
+
+/** A Gateway Endpoint: a meta MCP server fronting member servers. */
+export function GatewayTableRow({
+  gateway,
+}: {
+  gateway: MetaMcpServer;
+}): JSX.Element {
+  const routes = useRoutes();
+  const memberCount = gateway.memberCount ?? 0;
+  return (
+    <DotRow
+      onClick={() => routes.mcp.gateway.overview.goTo(gateway.id)}
+      icon={<Network className="text-muted-foreground h-5 w-5" />}
+    >
+      <NameCell name={gateway.name} />
+      <td className={CELL}>
+        <Badge variant="neutral">Gateway</Badge>
+      </td>
+      {/* A gateway's address is minted per endpoint, not per gateway, so
+          there is nothing to show at the listing level. */}
+      <td className={CELL}>
+        <Text small muted>
+          —
+        </Text>
+      </td>
+      <td className={CELL}>
+        <Text small muted>
+          {`${memberCount} ${memberCount === 1 ? "member" : "members"}`}
+        </Text>
+      </td>
+    </DotRow>
+  );
+}
+
+/** A remote, tunneled, or unproxied server: an mcp_servers row. */
+export function MCPServerTableRow({
+  server,
+}: {
+  server: McpServer;
+}): JSX.Element {
+  const routes = useRoutes();
+  const kindLabel = server.unproxiedMcpServerId
+    ? "Unproxied"
+    : server.tunneledMcpServerId
+      ? "Tunneled"
+      : "Remote";
+  return (
+    <DotRow
+      onClick={() => routes.mcp.x.overview.goTo(mcpServerRouteParam(server))}
+      icon={
+        <SourceMcpIcon
+          mcpServerId={server.id}
+          className="h-5 w-5 object-contain"
+        />
+      }
+    >
+      <NameCell
+        name={server.name || "MCP Server"}
+        title={server.name ?? undefined}
+      />
+      <td className={CELL}>
+        <Badge variant="neutral">{kindLabel}</Badge>
+      </td>
+      <td className={CELL}>
+        <Text small muted className="truncate font-mono text-xs">
+          {server.slug ?? "No slug yet"}
+        </Text>
+      </td>
+      <td className={CELL}>
+        <Text small muted>
+          —
+        </Text>
+      </td>
+    </DotRow>
+  );
+}
+
+export function MCPTableRowSkeleton(): JSX.Element {
+  return (
+    <DotRow>
+      <td className={CELL}>
+        <div className="bg-muted h-4 w-2/3 animate-pulse" />
+      </td>
+      <td className={CELL}>
+        <div className="bg-muted h-5 w-14 animate-pulse rounded-full" />
+      </td>
+      <td className={CELL}>
+        <div className="bg-muted h-3.5 w-40 animate-pulse" />
+      </td>
+      <td className={CELL}>
+        <div className="bg-muted h-3.5 w-12 animate-pulse" />
+      </td>
+    </DotRow>
+  );
+}

--- a/client/dashboard/src/components/mcp/mcp-table-rows.tsx
+++ b/client/dashboard/src/components/mcp/mcp-table-rows.tsx
@@ -80,13 +80,11 @@ export function MCPTableRow({
       : undefined;
   }, [toolset.toolUrns, catalogIconMap, deploymentResult]);
 
-  const handleClick = () => {
-    if (oauthStatus === "required-unconfigured") {
-      routes.mcp.details.authentication.goTo(toolset.slug);
-    } else {
-      routes.mcp.details.goTo(toolset.slug);
-    }
-  };
+  // A server still waiting on OAuth setup opens on that step, as the card does.
+  const href =
+    oauthStatus === "required-unconfigured"
+      ? routes.mcp.details.authentication.href(toolset.slug)
+      : routes.mcp.details.href(toolset.slug);
 
   // Same reading as MCPCard: a proxy-only toolset can't count its tools until
   // someone signs in, so neither "1 tool" nor "0 tools" would be true.
@@ -101,7 +99,8 @@ export function MCPTableRow({
 
   return (
     <DotRow
-      onClick={handleClick}
+      href={href}
+      ariaLabel={`Open MCP server ${toolset.name}`}
       icon={
         externalMcpLogoUrl ? (
           <img
@@ -171,7 +170,8 @@ export function GatewayTableRow({
   const memberCount = gateway.memberCount ?? 0;
   return (
     <DotRow
-      onClick={() => routes.mcp.gateway.overview.goTo(gateway.id)}
+      href={routes.mcp.gateway.overview.href(gateway.id)}
+      ariaLabel={`Open gateway ${gateway.name}`}
       icon={<Network className="text-muted-foreground h-5 w-5" />}
     >
       <NameCell name={gateway.name} />
@@ -208,7 +208,8 @@ export function MCPServerTableRow({
       : "Remote";
   return (
     <DotRow
-      onClick={() => routes.mcp.x.overview.goTo(mcpServerRouteParam(server))}
+      href={routes.mcp.x.overview.href(mcpServerRouteParam(server))}
+      ariaLabel={`Open MCP server ${server.name || "MCP Server"}`}
       icon={
         <SourceMcpIcon
           mcpServerId={server.id}
@@ -224,7 +225,12 @@ export function MCPServerTableRow({
         <Badge variant="neutral">{kindLabel}</Badge>
       </td>
       <td className={CELL}>
-        <Text small muted className="truncate font-mono text-xs">
+        <Text
+          small
+          muted
+          className="truncate font-mono text-xs"
+          title={server.slug ?? undefined}
+        >
           {server.slug ?? "No slug yet"}
         </Text>
       </td>

--- a/client/dashboard/src/components/monaco-editor.lazy.tsx
+++ b/client/dashboard/src/components/monaco-editor.lazy.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+const MonacoEditorLazy = React.lazy(() =>
+  import("@/components/monaco-editor").then((mod) => ({
+    default: mod.MonacoEditor,
+  })),
+);
+
+export default MonacoEditorLazy;

--- a/client/dashboard/src/components/monaco-editor.tsx
+++ b/client/dashboard/src/components/monaco-editor.tsx
@@ -1,0 +1,121 @@
+import { cn } from "@/lib/utils";
+import Editor, { loader, OnMount } from "@monaco-editor/react";
+import { useConfig as useMoonshineConfig } from "@/components/ui/hooks/useConfig";
+import type * as Monaco from "monaco-editor";
+import * as monaco from "monaco-editor";
+import { useEffect, useRef } from "react";
+
+// oxlint-disable import/default -- Vite ?worker URL imports lack named defaults
+import editorWorker from "monaco-editor/editor/editor.worker.js?worker";
+import jsonWorker from "monaco-editor/language/json/json.worker.js?worker";
+import cssWorker from "monaco-editor/language/css/css.worker.js?worker";
+import htmlWorker from "monaco-editor/language/html/html.worker.js?worker";
+import tsWorker from "monaco-editor/language/typescript/ts.worker.js?worker";
+
+self.MonacoEnvironment = {
+  getWorker(_, label) {
+    switch (label) {
+      case "json":
+        return new jsonWorker();
+      case "css":
+      case "scss":
+      case "less":
+        return new cssWorker();
+      case "html":
+      case "handlebars":
+      case "razor":
+        return new htmlWorker();
+      case "typescript":
+      case "javascript":
+        return new tsWorker();
+      default:
+        return new editorWorker();
+    }
+  },
+};
+
+loader.config({ monaco });
+
+interface MonacoEditorProps {
+  value: string;
+  language: string;
+  className?: string;
+  readOnly?: boolean;
+  height?: string;
+  wordWrap?: "on" | "off" | "wordWrapColumn" | "bounded";
+}
+
+/**
+ * MonacoEditor component with theme integration and virtual scrolling.
+ *
+ * This component uses Monaco Editor (the same editor as VS Code) which provides
+ * excellent performance for large files through virtual scrolling - only visible
+ * lines are rendered, making it handle files with tens of thousands of lines smoothly.
+ */
+export function MonacoEditor({
+  value,
+  language,
+  className,
+  readOnly = true,
+  height = "100%",
+  wordWrap = "off",
+}: MonacoEditorProps): JSX.Element {
+  const { theme } = useMoonshineConfig();
+  const editorRef = useRef<Monaco.editor.IStandaloneCodeEditor | null>(null);
+
+  const handleEditorDidMount: OnMount = (editor, _monaco) => {
+    editorRef.current = editor;
+
+    // Configure editor options for better UX
+    editor.updateOptions({
+      readOnly,
+      minimap: { enabled: true },
+      scrollBeyondLastLine: false,
+      renderWhitespace: "selection",
+      fontSize: 12,
+      fontFamily:
+        'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
+      lineNumbers: "on",
+      folding: true,
+      automaticLayout: true,
+      wordWrap,
+    });
+  };
+
+  // Update editor theme when Moonshine theme changes
+  useEffect(() => {
+    if (editorRef.current) {
+      monaco.editor.setTheme(theme === "dark" ? "vs-dark" : "vs");
+    }
+  }, [theme]);
+
+  return (
+    <div className={cn("overflow-hidden", className)}>
+      <Editor
+        height={height}
+        language={language}
+        value={value}
+        theme={theme === "dark" ? "vs-dark" : "vs"}
+        onMount={handleEditorDidMount}
+        options={{
+          readOnly,
+          minimap: { enabled: true },
+          scrollBeyondLastLine: false,
+          renderWhitespace: "selection",
+          fontSize: 12,
+          fontFamily:
+            'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
+          lineNumbers: "on",
+          folding: true,
+          automaticLayout: true,
+          wordWrap,
+        }}
+        loading={
+          <div className="flex h-full items-center justify-center">
+            <div className="text-muted-foreground">Loading editor...</div>
+          </div>
+        }
+      />
+    </div>
+  );
+}

--- a/client/dashboard/src/components/monaco-editor.tsx
+++ b/client/dashboard/src/components/monaco-editor.tsx
@@ -1,9 +1,7 @@
 import { cn } from "@/lib/utils";
-import Editor, { loader, OnMount } from "@monaco-editor/react";
+import Editor, { loader } from "@monaco-editor/react";
 import { useConfig as useMoonshineConfig } from "@/components/ui/hooks/useConfig";
-import type * as Monaco from "monaco-editor";
 import * as monaco from "monaco-editor";
-import { useEffect, useRef } from "react";
 
 // oxlint-disable import/default -- Vite ?worker URL imports lack named defaults
 import editorWorker from "monaco-editor/editor/editor.worker.js?worker";
@@ -34,7 +32,15 @@ self.MonacoEnvironment = {
   },
 };
 
-loader.config({ monaco });
+// Point @monaco-editor/react at the bundled monaco. Guarded: a second call after
+// init throws, but it's the same instance, so swallow the duplicate. The CEL
+// editor on the security pages configures the same loader and carries the
+// same guard, so either may load first.
+try {
+  loader.config({ monaco });
+} catch {
+  // already configured by another Monaco entry point this session
+}
 
 interface MonacoEditorProps {
   value: string;
@@ -61,33 +67,6 @@ export function MonacoEditor({
   wordWrap = "off",
 }: MonacoEditorProps): JSX.Element {
   const { theme } = useMoonshineConfig();
-  const editorRef = useRef<Monaco.editor.IStandaloneCodeEditor | null>(null);
-
-  const handleEditorDidMount: OnMount = (editor, _monaco) => {
-    editorRef.current = editor;
-
-    // Configure editor options for better UX
-    editor.updateOptions({
-      readOnly,
-      minimap: { enabled: true },
-      scrollBeyondLastLine: false,
-      renderWhitespace: "selection",
-      fontSize: 12,
-      fontFamily:
-        'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
-      lineNumbers: "on",
-      folding: true,
-      automaticLayout: true,
-      wordWrap,
-    });
-  };
-
-  // Update editor theme when Moonshine theme changes
-  useEffect(() => {
-    if (editorRef.current) {
-      monaco.editor.setTheme(theme === "dark" ? "vs-dark" : "vs");
-    }
-  }, [theme]);
 
   return (
     <div className={cn("overflow-hidden", className)}>
@@ -96,7 +75,6 @@ export function MonacoEditor({
         language={language}
         value={value}
         theme={theme === "dark" ? "vs-dark" : "vs"}
-        onMount={handleEditorDidMount}
         options={{
           readOnly,
           minimap: { enabled: true },

--- a/client/dashboard/src/components/monaco-editor.tsx
+++ b/client/dashboard/src/components/monaco-editor.tsx
@@ -87,6 +87,9 @@ export function MonacoEditor({
           folding: true,
           automaticLayout: true,
           wordWrap,
+          // Embedded in a page that scrolls: once the editor reaches its own
+          // end, hand the wheel back to the page rather than trapping it.
+          scrollbar: { alwaysConsumeMouseWheel: false },
         }}
         loading={
           <div className="flex h-full items-center justify-center">

--- a/client/dashboard/src/components/sources/SourceContentViewer.tsx
+++ b/client/dashboard/src/components/sources/SourceContentViewer.tsx
@@ -5,7 +5,7 @@ import { SkeletonCode } from "@/components/ui/Skeleton";
 import { Text } from "@/components/ui/Text";
 import { useProject } from "@/contexts/Auth";
 import { useSlugs } from "@/contexts/Sdk";
-import { useLatestDeployment } from "@/hooks/toolTypes";
+import { useActiveDeployment } from "@/hooks/toolTypes";
 import { getServerURL } from "@/lib/utils";
 import { useQuery } from "@tanstack/react-query";
 import { Suspense } from "react";
@@ -106,7 +106,7 @@ export function SourceContentViewer({
 }): React.JSX.Element {
   const project = useProject();
   const { projectSlug } = useSlugs();
-  const { data: deploymentResult } = useLatestDeployment();
+  const { data: deploymentResult } = useActiveDeployment();
   const isOpenAPI = sourceKind === "openapi";
 
   // The serve endpoints take the underlying file's id, not the deployment

--- a/client/dashboard/src/components/sources/SourceContentViewer.tsx
+++ b/client/dashboard/src/components/sources/SourceContentViewer.tsx
@@ -1,0 +1,188 @@
+import MonacoEditorLazy from "@/components/monaco-editor.lazy";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { SkeletonCode } from "@/components/ui/Skeleton";
+import { Text } from "@/components/ui/Text";
+import { useProject } from "@/contexts/Auth";
+import { useSlugs } from "@/contexts/Sdk";
+import { useLatestDeployment } from "@/hooks/toolTypes";
+import { getServerURL } from "@/lib/utils";
+import { useQuery } from "@tanstack/react-query";
+import { Suspense } from "react";
+
+type SourceContent = { content: string; language: string };
+
+/**
+ * The file behind a source, as text.
+ *
+ * The serve endpoints stream the raw file rather than JSON, so they sit
+ * outside the generated SDK. An OpenAPI document is shown as it was pushed,
+ * pretty-printed when it is JSON. A function arrives as a zip bundle, so the
+ * manifest inside it — the tool definitions — is what gets shown; the bundled
+ * code is the fallback for a bundle without one.
+ */
+function useSourceContent(
+  assetId: string | undefined,
+  isOpenAPI: boolean,
+  projectId: string,
+  projectSlug: string | undefined,
+) {
+  return useQuery<SourceContent>({
+    queryKey: ["sourceContent", assetId, isOpenAPI],
+    enabled: !!assetId,
+    throwOnError: false,
+    retry: (failureCount, error) => {
+      // A 404 is a missing file, which a retry won't fix.
+      if (error instanceof Error && error.message.includes("404")) return false;
+      return failureCount < 2;
+    },
+    queryFn: async () => {
+      if (!assetId) throw new Error("No source provided");
+
+      const url = new URL(
+        isOpenAPI ? "/rpc/assets.serveOpenAPIv3" : "/rpc/assets.serveFunction",
+        getServerURL(),
+      );
+      url.searchParams.set("id", assetId);
+      url.searchParams.set("project_id", projectId);
+
+      const request = new Request(url.toString(), {
+        method: "GET",
+        credentials: "include",
+      });
+      if (projectSlug) {
+        request.headers.set("gram-project", projectSlug);
+      }
+
+      const response = await fetch(request);
+      if (!response.ok) {
+        throw new Error(
+          `Failed to load: ${response.status} ${response.statusText}`,
+        );
+      }
+
+      if (isOpenAPI) {
+        const text = await response.text();
+        try {
+          return {
+            content: JSON.stringify(JSON.parse(text), null, 2),
+            language: "json",
+          };
+        } catch {
+          return { content: text, language: "yaml" };
+        }
+      }
+
+      // Loaded on demand: the zip reader is only needed on this one screen.
+      const { unzipSync, strFromU8 } = await import("fflate");
+      const unzipped = unzipSync(new Uint8Array(await response.arrayBuffer()));
+      const manifest = unzipped["manifest.json"];
+      if (manifest) {
+        return {
+          content: JSON.stringify(JSON.parse(strFromU8(manifest)), null, 2),
+          language: "json",
+        };
+      }
+      const code = unzipped["functions.js"];
+      if (code) {
+        return { content: strFromU8(code), language: "javascript" };
+      }
+      throw new Error("No readable content found in bundle");
+    },
+  });
+}
+
+/**
+ * The source's file, read in place: the OpenAPI document itself, or the tool
+ * manifest extracted from a function bundle.
+ */
+export function SourceContentViewer({
+  sourceKind,
+  assetId,
+}: {
+  sourceKind: "openapi" | "function";
+  /** The deployment asset id, as the rest of the source page is keyed. */
+  assetId: string;
+}): React.JSX.Element {
+  const project = useProject();
+  const { projectSlug } = useSlugs();
+  const { data: deploymentResult } = useLatestDeployment();
+  const isOpenAPI = sourceKind === "openapi";
+
+  // The serve endpoints take the underlying file's id, not the deployment
+  // asset's, so resolve one from the other the way the download button does.
+  const deployment = deploymentResult?.deployment;
+  const asset = isOpenAPI
+    ? deployment?.openapiv3Assets?.find((a) => a.id === assetId)
+    : deployment?.functionsAssets?.find((a) => a.id === assetId);
+
+  const { data, isLoading, error, refetch } = useSourceContent(
+    asset?.assetId,
+    isOpenAPI,
+    project.id,
+    projectSlug,
+  );
+
+  let body: React.ReactNode;
+  if (isLoading || (!asset && !deployment)) {
+    body = (
+      <div className="p-6">
+        <SkeletonCode lines={16} />
+      </div>
+    );
+  } else if (error) {
+    body = (
+      <div className="flex flex-col items-center gap-4 py-8 text-center">
+        <Text className="text-destructive">
+          {error instanceof Error ? error.message : "Failed to fetch content"}
+        </Text>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => {
+            void refetch();
+          }}
+        >
+          <Button.Text>Retry</Button.Text>
+        </Button>
+      </div>
+    );
+  } else if (data) {
+    body = (
+      <Suspense
+        fallback={
+          <div className="p-6">
+            <SkeletonCode lines={16} />
+          </div>
+        }
+      >
+        <MonacoEditorLazy
+          value={data.content}
+          language={data.language}
+          height="min(70vh, 720px)"
+          wordWrap="on"
+        />
+      </Suspense>
+    );
+  } else {
+    body = (
+      <Text muted small className="py-8 text-center">
+        No content available
+      </Text>
+    );
+  }
+
+  return (
+    <Card.Dashboard
+      title={isOpenAPI ? "OpenAPI document" : "Function manifest"}
+      tooltip={
+        isOpenAPI
+          ? "The document as it was pushed. Tools are generated from its operations."
+          : "The tool definitions extracted from the function bundle, which is what a server built from this source starts with."
+      }
+      bodyClassName="p-0"
+    >
+      {body}
+    </Card.Dashboard>
+  );
+}

--- a/client/dashboard/src/components/sources/SourceDetailPanel.tsx
+++ b/client/dashboard/src/components/sources/SourceDetailPanel.tsx
@@ -476,6 +476,10 @@ export function SourceDetail({
           </Card.Dashboard>
         )}
 
+        {/* Where the source is used comes before what it produced: the
+            servers are what someone landing here is usually after. */}
+        <SourceServersPanel toolUrns={toolUrns} isPage />
+
         <Card.Dashboard
           title="Tools"
           bodyClassName={tools.length === 0 ? undefined : "p-0"}
@@ -511,8 +515,6 @@ export function SourceDetail({
             </ol>
           )}
         </Card.Dashboard>
-
-        <SourceServersPanel toolUrns={toolUrns} isPage />
 
         <SourceVersionsPanel activeDeploymentId={deployment?.id} />
       </div>

--- a/client/dashboard/src/components/sources/SourceDetailPanel.tsx
+++ b/client/dashboard/src/components/sources/SourceDetailPanel.tsx
@@ -180,7 +180,11 @@ function SourceServersPanel({
   isPage: boolean;
 }): React.JSX.Element | null {
   const routes = useRoutes();
-  const { data, isLoading } = useListToolsets();
+  // A failed server list must not take the source page down with it, nor
+  // read as "no servers": the tools and file above are still worth showing.
+  const { data, isLoading, isError } = useListToolsets(undefined, undefined, {
+    throwOnError: false,
+  });
 
   const servers = useMemo(() => {
     if (toolUrns.length === 0) return [];
@@ -191,6 +195,13 @@ function SourceServersPanel({
   }, [data, toolUrns]);
 
   if (!isPage) {
+    if (isError) {
+      return (
+        <Text small muted>
+          Couldn&apos;t load the servers this source is used in.
+        </Text>
+      );
+    }
     if (servers.length === 0) return null;
     return (
       <div className="flex flex-col gap-3">
@@ -228,9 +239,11 @@ function SourceServersPanel({
     >
       {servers.length === 0 ? (
         <Text muted small>
-          {isLoading
-            ? "Loading servers\u2026"
-            : "No server carries this source's tools yet. Build one from it to expose them."}
+          {isError
+            ? "Couldn't load the project's servers. Reload to try again."
+            : isLoading
+              ? "Loading servers\u2026"
+              : "No server carries this source's tools yet. Build one from it to expose them."}
         </Text>
       ) : (
         <ul className="divide-border divide-y">

--- a/client/dashboard/src/components/sources/SourceDetailPanel.tsx
+++ b/client/dashboard/src/components/sources/SourceDetailPanel.tsx
@@ -367,17 +367,18 @@ export function SourceDetail({
   const { data: assetsResult } = useListAssets();
 
   const deployment = deploymentResult?.deployment;
+  // Looked up by kind so the function branch keeps its own type: only
+  // functions carry a runtime and sizing, which the facts below read.
+  const functionAsset =
+    sourceKind === "function"
+      ? deployment?.functionsAssets?.find((a) => a.id === assetId)
+      : undefined;
   const asset =
     sourceKind === "openapi"
       ? deployment?.openapiv3Assets?.find((a) => a.id === assetId)
-      : deployment?.functionsAssets?.find((a) => a.id === assetId);
+      : functionAsset;
 
   const file = assetsResult?.assets?.find((a) => a.id === asset?.assetId);
-  // Only functions carry a runtime and sizing.
-  const functionAsset =
-    sourceKind === "function"
-      ? (deployment?.functionsAssets?.find((a) => a.id === assetId) ?? null)
-      : null;
 
   const isPage = variant === "page";
 

--- a/client/dashboard/src/components/sources/SourceDetailPanel.tsx
+++ b/client/dashboard/src/components/sources/SourceDetailPanel.tsx
@@ -10,11 +10,12 @@ import { useLatestDeployment, useListTools } from "@/hooks/toolTypes";
 import { getServerURL } from "@/lib/utils";
 import { useListAssets } from "@gram/client/react-query/listAssets.js";
 import { useListDeployments } from "@gram/client/react-query/listDeployments.js";
+import { useListToolsets } from "@gram/client/react-query/listToolsets.js";
 import { useRoutes } from "@/routes";
 import type { Tool } from "@/lib/toolTypes";
 import { cn } from "@/lib/utils";
 import { Download, Loader2 } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { toast } from "sonner";
 
 // Sizes are shown to give a sense of scale, not for accounting, so a single
@@ -30,6 +31,17 @@ function formatBytes(bytes: number): string {
   }
   return `${value.toFixed(value >= 10 ? 0 : 1)} ${units[unit]}`;
 }
+
+function formatMemory(mib: number): string {
+  if (mib < 1024) return `${mib} MiB`;
+  const gib = mib / 1024;
+  return Number.isInteger(gib) ? `${gib} GiB` : `${gib.toFixed(1)} GiB`;
+}
+
+// Mirror server/internal/constants/functions.go — applied at deploy time when
+// the per-source value is NULL.
+const DEFAULT_FUNCTION_MEMORY_MIB = 1024;
+const DEFAULT_FUNCTION_SCALE = 2;
 
 // The serve endpoints stream the raw file rather than JSON, so they sit
 // outside the generated SDK: fetch them by hand and hand the blob to an
@@ -152,6 +164,117 @@ function SourceVersionsPanel({
 }
 
 /** One labelled fact: label left, value right, in both surfaces. */
+/**
+ * The MCP servers a source's tools are part of.
+ *
+ * Hosted servers are toolsets, and a toolset names its tools by URN, so the
+ * link from a source to the servers built from it runs through the tools it
+ * produced. Servers backed by mcp_servers rows carry no tools and so can't be
+ * built from a source.
+ */
+function SourceServersPanel({
+  toolUrns,
+  isPage,
+}: {
+  toolUrns: string[];
+  isPage: boolean;
+}): React.JSX.Element | null {
+  const routes = useRoutes();
+  const { data, isLoading } = useListToolsets();
+
+  const servers = useMemo(() => {
+    if (toolUrns.length === 0) return [];
+    const urns = new Set(toolUrns);
+    return (data?.toolsets ?? []).filter((toolset) =>
+      toolset.toolUrns?.some((urn) => urns.has(urn)),
+    );
+  }, [data, toolUrns]);
+
+  if (!isPage) {
+    if (servers.length === 0) return null;
+    return (
+      <div className="flex flex-col gap-3">
+        <Text className="text-muted-foreground text-xs font-semibold tracking-wide uppercase">
+          Used in
+        </Text>
+        <ul className="flex flex-col gap-1">
+          {servers.map((toolset) => (
+            <li key={toolset.id}>
+              <routes.mcp.details.Link
+                params={[toolset.slug]}
+                className="text-sm"
+              >
+                {toolset.name}
+              </routes.mcp.details.Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  }
+
+  return (
+    <Card.Dashboard
+      title="MCP servers"
+      tooltip="The hosted servers that carry tools generated from this source."
+      bodyClassName={servers.length === 0 ? undefined : "p-0"}
+      action={
+        servers.length > 0 ? (
+          <Text muted className="text-xs">
+            {`${servers.length} server${servers.length === 1 ? "" : "s"}`}
+          </Text>
+        ) : undefined
+      }
+    >
+      {servers.length === 0 ? (
+        <Text muted small>
+          {isLoading
+            ? "Loading servers\u2026"
+            : "No server carries this source's tools yet. Build one from it to expose them."}
+        </Text>
+      ) : (
+        <ul className="divide-border divide-y">
+          {servers.map((toolset) => {
+            const count = toolset.toolUrns?.length ?? 0;
+            return (
+              <li
+                key={toolset.id}
+                className="flex items-center justify-between gap-4 px-6 py-3"
+              >
+                <div className="flex min-w-0 flex-col gap-0.5">
+                  <routes.mcp.details.Link
+                    params={[toolset.slug]}
+                    className="truncate text-sm font-medium"
+                  >
+                    {toolset.name}
+                  </routes.mcp.details.Link>
+                  <Text muted className="truncate font-mono text-xs">
+                    {toolset.slug}
+                  </Text>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <Badge variant="neutral">
+                    <Badge.Text>
+                      {toolset.mcpEnabled
+                        ? toolset.mcpIsPublic
+                          ? "Public"
+                          : "Private"
+                        : "Disabled"}
+                    </Badge.Text>
+                  </Badge>
+                  <Text muted className="text-xs">
+                    {`${count} tool${count === 1 ? "" : "s"}`}
+                  </Text>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </Card.Dashboard>
+  );
+}
+
 function SourceFact({
   label,
   isPage,
@@ -250,14 +373,24 @@ export function SourceDetail({
       : deployment?.functionsAssets?.find((a) => a.id === assetId);
 
   const file = assetsResult?.assets?.find((a) => a.id === asset?.assetId);
+  // Only functions carry a runtime and sizing.
+  const functionAsset =
+    sourceKind === "function"
+      ? (deployment?.functionsAssets?.find((a) => a.id === assetId) ?? null)
+      : null;
 
   const isPage = variant === "page";
 
-  const tools = (toolsResult?.tools ?? []).filter((tool: Tool) =>
-    sourceKind === "openapi"
-      ? tool.type === "http" && tool.openapiv3DocumentId === assetId
-      : tool.type === "function" && tool.functionId === assetId,
+  const tools = useMemo(
+    () =>
+      (toolsResult?.tools ?? []).filter((tool: Tool) =>
+        sourceKind === "openapi"
+          ? tool.type === "http" && tool.openapiv3DocumentId === assetId
+          : tool.type === "function" && tool.functionId === assetId,
+      ),
+    [toolsResult, sourceKind, assetId],
   );
+  const toolUrns = useMemo(() => tools.map((tool) => tool.toolUrn), [tools]);
 
   const toolsSummary = isToolsError
     ? "Couldn't load this source's tools. A server built from it still starts with everything the source produced."
@@ -277,6 +410,31 @@ export function SourceDetail({
           </SourceFact>
           <SourceFact label="Type" isPage={isPage}>
             {file.contentType}
+          </SourceFact>
+        </>
+      )}
+      {functionAsset && (
+        <>
+          <SourceFact label="Runtime" isPage={isPage}>
+            {functionAsset.runtime}
+          </SourceFact>
+          <SourceFact
+            label="Memory"
+            isPage={isPage}
+            tooltip="Memory each instance of this function runs with. The default applies when the source sets none."
+          >
+            {formatMemory(
+              functionAsset.memoryMib ?? DEFAULT_FUNCTION_MEMORY_MIB,
+            )}
+            {functionAsset.memoryMib == null && " (default)"}
+          </SourceFact>
+          <SourceFact
+            label="Instances"
+            isPage={isPage}
+            tooltip="How many instances of this function run at once. The default applies when the source sets none."
+          >
+            {functionAsset.scale ?? DEFAULT_FUNCTION_SCALE}
+            {functionAsset.scale == null && " (default)"}
           </SourceFact>
         </>
       )}
@@ -339,6 +497,8 @@ export function SourceDetail({
           )}
         </Card.Dashboard>
 
+        <SourceServersPanel toolUrns={toolUrns} isPage />
+
         <SourceVersionsPanel activeDeploymentId={deployment?.id} />
       </div>
     );
@@ -395,6 +555,8 @@ export function SourceDetail({
           </div>
         </div>
       )}
+
+      <SourceServersPanel toolUrns={toolUrns} isPage={false} />
 
       {!isLoading && !isToolsError && tools.length === 0 && (
         <Text small muted>

--- a/client/dashboard/src/components/sources/SourceDetailPanel.tsx
+++ b/client/dashboard/src/components/sources/SourceDetailPanel.tsx
@@ -195,14 +195,15 @@ function SourceServersPanel({
   }, [data, toolUrns]);
 
   if (!isPage) {
-    if (isError) {
-      return (
+    // Cached servers survive a failed refetch, as they do on the page: only
+    // an empty list says the failure was the reason.
+    if (servers.length === 0) {
+      return isError ? (
         <Text small muted>
           Couldn&apos;t load the servers this source is used in.
         </Text>
-      );
+      ) : null;
     }
-    if (servers.length === 0) return null;
     return (
       <div className="flex flex-col gap-3">
         <Text className="text-muted-foreground text-xs font-semibold tracking-wide uppercase">

--- a/client/dashboard/src/components/sources/SourceDetailPanel.tsx
+++ b/client/dashboard/src/components/sources/SourceDetailPanel.tsx
@@ -1,3 +1,4 @@
+import { MCPStatusIndicator } from "@/components/mcp/MCPStatusIndicator";
 import { Badge } from "@/components/ui/Badge";
 import { Icon } from "@/components/ui/Icon";
 import { SimpleTooltip } from "@/components/ui/Tooltip";
@@ -266,16 +267,14 @@ function SourceServersPanel({
                     {toolset.slug}
                   </Text>
                 </div>
-                <div className="flex shrink-0 items-center gap-2">
-                  <Badge variant="neutral">
-                    <Badge.Text>
-                      {toolset.mcpEnabled
-                        ? toolset.mcpIsPublic
-                          ? "Public"
-                          : "Private"
-                        : "Disabled"}
-                    </Badge.Text>
-                  </Badge>
+                <div className="flex shrink-0 items-center gap-4">
+                  {/* The same status dot the MCP page uses, so visibility
+                      reads the same color here as it does there. */}
+                  <MCPStatusIndicator
+                    mcpEnabled={toolset.mcpEnabled}
+                    mcpIsPublic={toolset.mcpIsPublic}
+                    size="sm"
+                  />
                   <Text muted className="text-xs">
                     {`${count} tool${count === 1 ? "" : "s"}`}
                   </Text>

--- a/client/dashboard/src/components/sources/SourceDetailPanel.tsx
+++ b/client/dashboard/src/components/sources/SourceDetailPanel.tsx
@@ -7,7 +7,7 @@ import { Card } from "@/components/ui/Card";
 import { Text } from "@/components/ui/Text";
 import { useProject } from "@/contexts/Auth";
 import { useSlugs } from "@/contexts/Sdk";
-import { useLatestDeployment, useListTools } from "@/hooks/toolTypes";
+import { useActiveDeployment, useListTools } from "@/hooks/toolTypes";
 import { getServerURL } from "@/lib/utils";
 import { useListAssets } from "@gram/client/react-query/listAssets.js";
 import { useListDeployments } from "@gram/client/react-query/listDeployments.js";
@@ -370,7 +370,8 @@ export function SourceDetail({
    */
   variant?: "panel" | "page";
 }): React.JSX.Element {
-  const { data: deploymentResult } = useLatestDeployment();
+  const routes = useRoutes();
+  const { data: deploymentResult } = useActiveDeployment();
   const {
     data: toolsResult,
     isLoading,
@@ -458,7 +459,9 @@ export function SourceDetail({
           isPage={isPage}
           tooltip="Every push creates a deployment: a version of all this project's sources and the tools generated from them. This is the newest one, and what the dashboard reads from."
         >
-          {deployment.id}
+          <routes.deployments.deployment.Link params={[deployment.id]}>
+            {deployment.id}
+          </routes.deployments.deployment.Link>
         </SourceFact>
       )}
     </>
@@ -610,7 +613,7 @@ export function SourceDownloadButton({
   const project = useProject();
   const { projectSlug } = useSlugs();
   const [isDownloading, setIsDownloading] = useState(false);
-  const { data: deploymentResult } = useLatestDeployment();
+  const { data: deploymentResult } = useActiveDeployment();
   const { data: assetsResult } = useListAssets();
 
   const isOpenAPI = sourceKind === "openapi";

--- a/client/dashboard/src/components/sources/source-list.test.ts
+++ b/client/dashboard/src/components/sources/source-list.test.ts
@@ -1,0 +1,72 @@
+import type { Deployment } from "@gram/client/models/components/deployment.js";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@gram/client/react-query/latestDeployment.js", () => ({
+  useLatestDeployment: vi.fn(() => ({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+  })),
+}));
+vi.mock("@gram/client/react-query/activeDeployment.js", () => ({
+  useActiveDeployment: vi.fn(() => ({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+  })),
+}));
+
+import { useActiveDeployment } from "@gram/client/react-query/activeDeployment.js";
+import { useLatestDeployment } from "@gram/client/react-query/latestDeployment.js";
+import { sourceAssetId, useProjectSources } from "./source-list";
+
+const mockLatest = vi.mocked(useLatestDeployment);
+const mockActive = vi.mocked(useActiveDeployment);
+
+/** Runs a hook in a throwaway React render and returns its result. */
+function runHook<T>(hook: () => T): T {
+  let result: T | undefined;
+  function Probe() {
+    result = hook();
+    return null;
+  }
+  renderToStaticMarkup(createElement(Probe));
+  return result as T;
+}
+
+function deployment(id: string, status: string, assetSuffix: string) {
+  return {
+    id,
+    status,
+    openapiv3Assets: [
+      { id: `doc-${assetSuffix}`, assetId: `file-${assetSuffix}`, name: "api" },
+    ],
+    functionsAssets: [
+      { id: `fn-${assetSuffix}`, assetId: `bundle-${assetSuffix}`, name: "fn" },
+    ],
+  } as unknown as Deployment;
+}
+
+describe("useProjectSources", () => {
+  it("lists the active deployment's sources, not a newer failed one", () => {
+    // Every push mints new asset ids. Tools are generated from the active
+    // (last completed) deployment, so the ids the tools carry are the
+    // active deployment's — a failed newer push must not swap them out.
+    mockLatest.mockReturnValue({
+      data: { deployment: deployment("dep-new", "failed", "new") },
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useLatestDeployment>);
+    mockActive.mockReturnValue({
+      data: { deployment: deployment("dep-active", "completed", "active") },
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useActiveDeployment>);
+
+    const { sources } = runHook(() => useProjectSources());
+
+    expect(sources.map(sourceAssetId)).toEqual(["doc-active", "fn-active"]);
+  });
+});

--- a/client/dashboard/src/components/sources/source-list.ts
+++ b/client/dashboard/src/components/sources/source-list.ts
@@ -1,10 +1,10 @@
-import { useLatestDeployment } from "@/hooks/toolTypes";
+import { useActiveDeployment } from "@/hooks/toolTypes";
 import { useMemo } from "react";
 
 /**
  * The sources a project has.
  *
- * A "source" is an OpenAPI document or a function in the latest deployment —
+ * A "source" is an OpenAPI document or a function in the active deployment —
  * the two kinds that still produce tools. Sources have no pages of their own
  * beyond the shelf under MCP, so this is the whole of how they are listed.
  */
@@ -27,7 +27,7 @@ export function useProjectSources(): {
   isLoading: boolean;
   isError: boolean;
 } {
-  const { data: deploymentResult, isLoading, isError } = useLatestDeployment();
+  const { data: deploymentResult, isLoading, isError } = useActiveDeployment();
   const deployment = deploymentResult?.deployment;
 
   const sources = useMemo(() => {

--- a/client/dashboard/src/components/sources/source-table-row.tsx
+++ b/client/dashboard/src/components/sources/source-table-row.tsx
@@ -1,0 +1,51 @@
+import { Badge } from "@/components/ui/Badge";
+import { DotRow } from "@/components/ui/DotRow";
+import { Text } from "@/components/ui/Text";
+import { Code, FileCode } from "lucide-react";
+import type { SourceOption } from "./source-list";
+
+/**
+ * One source as a table row: the same source as `SourceCard`, cut for the
+ * table view of the sources shelf. The whole row is the link to the source's
+ * own page, so there is nothing to select here and no actions column.
+ */
+export function SourceTableRow({
+  source,
+  toolCount,
+  href,
+}: {
+  source: SourceOption;
+  /** Undefined while the tool list is still loading. */
+  toolCount: number | undefined;
+  href: string;
+}): JSX.Element {
+  const Icon = source.kind === "openapi" ? FileCode : Code;
+  return (
+    <DotRow
+      icon={<Icon className="text-muted-foreground size-5" />}
+      href={href}
+      ariaLabel={`View source ${source.name}`}
+    >
+      <td className="px-3 py-3">
+        <Text
+          variant="subheading"
+          as="div"
+          className="group-hover:text-primary truncate text-sm transition-colors"
+          title={source.name}
+        >
+          {source.name}
+        </Text>
+      </td>
+      <td className="px-3 py-3">
+        <Badge variant="neutral">
+          {source.kind === "openapi" ? "OpenAPI document" : "Function"}
+        </Badge>
+      </td>
+      <td className="px-3 py-3">
+        <Text small muted>
+          {toolCount ?? "—"}
+        </Text>
+      </td>
+    </DotRow>
+  );
+}

--- a/client/dashboard/src/hooks/toolTypes.ts
+++ b/client/dashboard/src/hooks/toolTypes.ts
@@ -10,6 +10,11 @@ import {
 } from "@gram/client/models/operations/listresources.js";
 import { QueryHookOptions } from "@gram/client/react-query/_types.js";
 import {
+  ActiveDeploymentQueryData,
+  ActiveDeploymentQueryError,
+  useActiveDeployment as useActiveDeploymentQuery,
+} from "@gram/client/react-query/activeDeployment.js";
+import {
   LatestDeploymentQueryData,
   LatestDeploymentQueryError,
   useLatestDeployment as useLatestDeploymentQuery,
@@ -141,4 +146,22 @@ export function useLatestDeployment(
     staleTime: 1000 * 60 * 60, // 1 hour
     ...options,
   });
+}
+
+/**
+ * Hook for fetching the active deployment: the newest one that completed.
+ *
+ * This is the deployment tools are generated from, and the one `tools.list`
+ * reads by default. Anything that joins deployment assets to tools — the
+ * sources pages, tool counts per source — must key on this rather than on
+ * the latest deployment, which may be a failed push whose assets carry fresh
+ * ids that no tool refers to.
+ */
+export function useActiveDeployment(
+  options?: QueryHookOptions<
+    ActiveDeploymentQueryData,
+    ActiveDeploymentQueryError
+  >,
+): ReturnType<typeof useActiveDeploymentQuery> {
+  return useActiveDeploymentQuery(undefined, undefined, options);
 }

--- a/client/dashboard/src/pages/environments/Environments.tsx
+++ b/client/dashboard/src/pages/environments/Environments.tsx
@@ -11,7 +11,7 @@ import { useRoutes } from "@/routes";
 import { Environment } from "@gram/client/models/components/environment.js";
 import { useCreateEnvironmentMutation } from "@gram/client/react-query/createEnvironment.js";
 import { ArrowRight, Blocks, Plus } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Outlet } from "react-router";
 import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
@@ -41,6 +41,18 @@ function EnvironmentsInner() {
     useState(false);
   const [environmentName, setEnvironmentName] = useState("");
   const [cloneSource, setCloneSource] = useState<Environment | null>(null);
+  const [search, setSearch] = useState("");
+
+  const filteredEnvironments = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return environments;
+    return environments.filter(
+      (environment) =>
+        environment.name.toLowerCase().includes(query) ||
+        environment.slug.toLowerCase().includes(query) ||
+        (environment.description?.toLowerCase().includes(query) ?? false),
+    );
+  }, [environments, search]);
 
   const createEnvironmentMutation = useCreateEnvironmentMutation({
     onSuccess: async (data) => {
@@ -91,6 +103,11 @@ function EnvironmentsInner() {
         primaryAction={
           environments.length > 0 ? newEnvironmentButton : undefined
         }
+        search={{
+          value: search,
+          onChange: setSearch,
+          placeholder: "Search environments...",
+        }}
         isEmpty={environments.length === 0}
         empty={{
           icon: "blocks",
@@ -100,8 +117,15 @@ function EnvironmentsInner() {
           action: newEnvironmentButton,
         }}
       >
+        {filteredEnvironments.length === 0 ? (
+          // The project has environments; this search just matches none of
+          // them, so the toolbar stays put rather than the empty state above.
+          <Text muted className="py-8 text-center">
+            {`No environments matching “${search}”`}
+          </Text>
+        ) : null}
         <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
-          {environments.map((environment) => (
+          {filteredEnvironments.map((environment) => (
             <EnvironmentCard
               key={environment.id}
               environment={environment}

--- a/client/dashboard/src/pages/mcp/MCP.tsx
+++ b/client/dashboard/src/pages/mcp/MCP.tsx
@@ -3,7 +3,15 @@ import { BuiltInMCPCard } from "@/components/mcp/BuiltInMCPCard";
 import { GatewayCard } from "@/components/mcp/GatewayCard";
 import { MCPCard, MCPCardSkeleton } from "@/components/mcp/MCPCard";
 import { MCPServerCard } from "@/components/mcp/MCPServerCard";
+import {
+  GatewayTableRow,
+  MCPServerTableRow,
+  MCPTableRow,
+  MCPTableRowSkeleton,
+} from "@/components/mcp/mcp-table-rows";
 import { Page } from "@/components/page-layout";
+import { DotTable } from "@/components/ui/DotTable";
+import { useViewMode } from "@/components/ui/ViewToggle/use-view-mode";
 import { SimpleTooltip } from "@/components/ui/Tooltip";
 import { Text } from "@/components/ui/Text";
 import { useProjectSlugForRequests } from "@/contexts/Sdk";
@@ -149,6 +157,7 @@ function MCPOverview() {
     toolsets.isError || isMcpServersError || isGatewaysError;
 
   const [search, setSearch] = useState("");
+  const [viewMode, setViewMode] = useViewMode();
   const mcpFilters = useMcpDimensionFilters(MCP_FILTERS);
 
   const plugins = useMemo(() => pluginsResult?.plugins ?? [], [pluginsResult]);
@@ -309,6 +318,7 @@ function MCPOverview() {
               onClear={mcpFilters.clearValue as (id: string) => void}
               onClearAll={mcpFilters.clearAll}
             />
+            <Page.Toolbar.ViewAs value={viewMode} onChange={setViewMode} />
             <Page.Toolbar.Refresh
               onRefresh={handleRefresh}
               isRefreshing={isRefreshing}
@@ -327,7 +337,7 @@ function MCPOverview() {
               ? `No MCP servers matching “${search}”`
               : "No MCP servers match your filters"}
           </Text>
-        ) : (
+        ) : viewMode === "grid" ? (
           <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
             {isLoading ? (
               <>
@@ -348,6 +358,36 @@ function MCPOverview() {
               </>
             )}
           </div>
+        ) : (
+          <DotTable
+            headers={[
+              { label: "Name" },
+              { label: "Kind" },
+              { label: "Address" },
+              // Kind-dependent: tool count for hosted servers, member count
+              // for gateways, nothing yet for mcp_servers-backed rows.
+              { label: "Contents" },
+            ]}
+          >
+            {isLoading ? (
+              <>
+                <MCPTableRowSkeleton />
+                <MCPTableRowSkeleton />
+              </>
+            ) : (
+              <>
+                {filteredGateways.map((gateway) => (
+                  <GatewayTableRow key={gateway.id} gateway={gateway} />
+                ))}
+                {filteredToolsets.map((toolset) => (
+                  <MCPTableRow key={toolset.id} toolset={toolset} />
+                ))}
+                {filteredMcpServers.map((server) => (
+                  <MCPServerTableRow key={server.id} server={server} />
+                ))}
+              </>
+            )}
+          </DotTable>
         )}
       </div>
       {builtInSection}

--- a/client/dashboard/src/pages/mcp/sources/SourceDetail.tsx
+++ b/client/dashboard/src/pages/mcp/sources/SourceDetail.tsx
@@ -45,8 +45,8 @@ export default function SourceDetailRoute(): JSX.Element {
         notFound={{
           title: isError ? "Couldn't load this source" : "Source not found",
           description: isError
-            ? "The project's latest deployment could not be fetched. Reload to try again."
-            : "This source is not in the project's latest deployment. It may have been replaced by a newer one.",
+            ? "The project's active deployment could not be fetched. Reload to try again."
+            : "This source is not in the project's active deployment. It may have been replaced by a newer one.",
           backTo: routes.mcp.sources.href(),
         }}
       />
@@ -62,8 +62,8 @@ export default function SourceDetailRoute(): JSX.Element {
       title={source?.name ?? "Source"}
       description={
         kind === "openapi"
-          ? "An OpenAPI document in this project's latest deployment."
-          : "A function in this project's latest deployment."
+          ? "An OpenAPI document in this project's active deployment."
+          : "A function in this project's active deployment."
       }
       breadcrumbSubstitutions={{ [sourceId ?? ""]: source?.name }}
       primaryAction={

--- a/client/dashboard/src/pages/mcp/sources/SourceDetail.tsx
+++ b/client/dashboard/src/pages/mcp/sources/SourceDetail.tsx
@@ -1,4 +1,5 @@
 import { DetailPage } from "@/components/page-templates";
+import { SourceContentViewer } from "@/components/sources/SourceContentViewer";
 import {
   SourceDetail as SourceDetailBody,
   SourceDownloadButton,
@@ -95,6 +96,15 @@ export default function SourceDetailRoute(): JSX.Element {
               variant="page"
             />
           ),
+        },
+        {
+          id: "content",
+          label: kind === "openapi" ? "OpenAPI document" : "Function manifest",
+          // Rendered only once the source is known: the viewer keys its fetch
+          // on the kind, and a wrong guess would request the wrong endpoint.
+          content: source ? (
+            <SourceContentViewer sourceKind={kind} assetId={sourceId!} />
+          ) : null,
         },
       ]}
     />

--- a/client/dashboard/src/pages/mcp/sources/Sources.tsx
+++ b/client/dashboard/src/pages/mcp/sources/Sources.tsx
@@ -4,9 +4,13 @@ import {
   sourceAssetId,
   useProjectSources,
 } from "@/components/sources/source-list";
+import { SourceTableRow } from "@/components/sources/source-table-row";
 import { Button } from "@/components/ui/Button";
+import { DotTable } from "@/components/ui/DotTable";
 import { Text } from "@/components/ui/Text";
+import { useViewMode } from "@/components/ui/ViewToggle/use-view-mode";
 import { useProject } from "@/contexts/Auth";
+import { useListTools } from "@/hooks/toolTypes";
 import { useRoutes } from "@/routes";
 import { McpTabs } from "../McpTabs";
 import {
@@ -16,6 +20,7 @@ import {
   type OptionsById,
 } from "@/components/filters";
 import { useMemo, useState } from "react";
+import { Outlet } from "react-router";
 
 // The one thing that distinguishes one source from another at a glance, and
 // the only facet the deployment carries for them.
@@ -29,7 +34,6 @@ const SOURCE_FILTER_OPTIONS: OptionsById = {
     { value: "function", label: "Function" },
   ],
 };
-import { Outlet } from "react-router";
 
 export function SourcesRoot(): JSX.Element {
   return <Outlet />;
@@ -48,7 +52,29 @@ export default function Sources(): JSX.Element {
   const project = useProject();
   const { sources, isLoading } = useProjectSources();
   const [search, setSearch] = useState("");
+  const [viewMode, setViewMode] = useViewMode();
   const kindFilters = useFilterState(SOURCE_FILTERS);
+
+  // The table shows how many tools each source produced. Cards leave that to
+  // the detail page, so the fetch only matters in table view, but it is the
+  // same query the detail page makes and is cached across the two.
+  const { data: toolsResult } = useListTools(undefined, undefined, {
+    enabled: viewMode === "table",
+  });
+  const toolCounts = useMemo(() => {
+    if (!toolsResult) return undefined;
+    const counts = new Map<string, number>();
+    for (const tool of toolsResult.tools) {
+      const id =
+        tool.type === "http"
+          ? tool.openapiv3DocumentId
+          : tool.type === "function"
+            ? tool.functionId
+            : undefined;
+      if (id) counts.set(id, (counts.get(id) ?? 0) + 1);
+    }
+    return counts;
+  }, [toolsResult]);
 
   const selectedKinds = kindFilters.values["kind"];
   const filtered = useMemo(() => {
@@ -89,6 +115,7 @@ export default function Sources(): JSX.Element {
         onClear: kindFilters.clearValue as (id: string) => void,
         onClearAll: kindFilters.clearAll,
       }}
+      viewToggle={{ value: viewMode, onChange: setViewMode }}
       isLoading={isLoading}
       isEmpty={sources.length === 0}
       hideToolbar={sources.length === 0}
@@ -106,19 +133,38 @@ export default function Sources(): JSX.Element {
           No sources match the current search and filters.
         </Text>
       ) : null}
-      <div className="@2xl/main:grid-cols-2 grid grid-cols-1 gap-4">
-        {filtered.map((source) => (
-          <SourceCard
-            key={source.key}
-            source={source}
-            // A source has an address of its own here, rather than a sheet:
-            // this page is where someone is sent to look one up.
-            onInspect={() =>
-              routes.mcp.sources.detail.goTo(sourceAssetId(source))
-            }
-          />
-        ))}
-      </div>
+      {viewMode === "grid" ? (
+        <div className="@2xl/main:grid-cols-2 grid grid-cols-1 gap-4">
+          {filtered.map((source) => (
+            <SourceCard
+              key={source.key}
+              source={source}
+              // A source has an address of its own here, rather than a sheet:
+              // this page is where someone is sent to look one up.
+              onInspect={() =>
+                routes.mcp.sources.detail.goTo(sourceAssetId(source))
+              }
+            />
+          ))}
+        </div>
+      ) : filtered.length > 0 ? (
+        <DotTable
+          headers={[{ label: "Name" }, { label: "Kind" }, { label: "Tools" }]}
+        >
+          {filtered.map((source) => (
+            <SourceTableRow
+              key={source.key}
+              source={source}
+              toolCount={
+                toolCounts
+                  ? (toolCounts.get(sourceAssetId(source)) ?? 0)
+                  : undefined
+              }
+              href={routes.mcp.sources.detail.href(sourceAssetId(source))}
+            />
+          ))}
+        </DotTable>
+      ) : null}
     </ResourceListPage>
   );
 }

--- a/client/dashboard/src/pages/plugins/PluginDetail.tsx
+++ b/client/dashboard/src/pages/plugins/PluginDetail.tsx
@@ -715,7 +715,6 @@ export default function PluginDetail(): JSX.Element | null {
               <PluginSkillsSection
                 key={pluginId!}
                 pluginId={pluginId!}
-                viewMode="grid"
                 onMutated={(message) => offerPublish(message)}
               />
             </RequireScope>

--- a/client/dashboard/src/pages/plugins/PluginSkillsSection.tsx
+++ b/client/dashboard/src/pages/plugins/PluginSkillsSection.tsx
@@ -7,7 +7,8 @@ import { DotTable } from "@/components/ui/DotTable";
 import { SearchBar } from "@/components/ui/SearchBar";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { Text } from "@/components/ui/Text";
-import type { ViewMode } from "@/components/ui/ViewToggle/use-view-mode";
+import { ViewToggle } from "@/components/ui/ViewToggle";
+import { useViewMode } from "@/components/ui/ViewToggle/use-view-mode";
 import { useProject } from "@/contexts/Auth";
 import { useDrainInfiniteQuery } from "@/hooks/useDrainInfiniteQuery";
 import { useRoutes } from "@/routes";
@@ -39,12 +40,9 @@ import { SectionEmptyState } from "./SectionEmptyState";
  */
 export function PluginSkillsSection({
   pluginId,
-  viewMode,
   onMutated,
 }: {
   pluginId: string;
-  /** Page-level entry layout shared with the server section. */
-  viewMode: ViewMode;
   /** Invoked after a successful change, e.g. to offer a marketplace publish. */
   onMutated: (message: string) => void;
 }): JSX.Element {
@@ -52,6 +50,8 @@ export function PluginSkillsSection({
   const queryClient = useQueryClient();
   const [isAddSkillOpen, setIsAddSkillOpen] = useState(false);
   const [search, setSearch] = useState("");
+  // Grid or table, remembered across list pages under one key.
+  const [viewMode, setViewMode] = useViewMode();
 
   const distributionsQuery = useSkillDistributionsInfinite(
     { pluginId, limit: 50 },
@@ -206,12 +206,19 @@ export function PluginSkillsSection({
         </SettingsSection.Header>
         <div className="flex items-center gap-2">
           {distributions.length > 0 && (
-            <SearchBar
-              value={search}
-              onChange={setSearch}
-              placeholder="Search skills"
-              className="h-9 w-56"
-            />
+            <>
+              <SearchBar
+                value={search}
+                onChange={setSearch}
+                placeholder="Search skills"
+                className="h-9 w-56"
+              />
+              <ViewToggle
+                value={viewMode}
+                onChange={setViewMode}
+                itemClassName="h-9"
+              />
+            </>
           )}
           <RequireScope
             scope="skill:write"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,6 +333,9 @@ importers:
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
       lucide-react:
         specifier: 'catalog:'
         version: 1.28.0(react@19.2.8)
@@ -5100,6 +5103,9 @@ packages:
 
   fflate@0.4.9:
     resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -11813,6 +11819,8 @@ snapshots:
   fetchdts@0.1.7: {}
 
   fflate@0.4.9: {}
+
+  fflate@0.8.3: {}
 
   figures@6.1.0:
     dependencies:


### PR DESCRIPTION
## Summary

Restores several dashboard surfaces lost in recent refactors of the MCP and sources pages, and gives the Environments page the search box the MCP page has.

**List view toggles**

- **MCP > Servers** regains `Page.Toolbar.ViewAs`. The table rows deleted in #6012 are rebuilt in `components/mcp/mcp-table-rows.tsx`, one per backend kind (hosted toolset, gateway, `mcp_servers`-backed), showing what the current cards show: name, kind badge, address, and tool or member count. The old rows leaned on activity indicators and endpoint counts that no longer exist, so this is a rewrite against today's card content rather than a revert.
- **MCP > Sources** regains the toggle through `ResourceListPage`'s `viewToggle` prop. The table shows name, kind, and a tool count; the tool list is only fetched in table view and shares its cache with the source detail page. New `components/sources/source-table-row.tsx`.
- **Plugin detail > Skills** owns its view mode via `useViewMode` and renders a `ViewToggle` beside its search box. The section still had a working table branch, but `PluginDetail` was passing a hardcoded `viewMode="grid"` since the sidebar-nav conversion, so the table was unreachable. The prop is removed.

All toggles share the single `gram-view-mode` preference, so a choice on one page carries to the others.

**Source detail page**

- **MCP servers.** A new card lists the hosted servers whose tool URNs include tools generated from this source, with visibility and tool count, linking to each server. The side sheet used by the create-from-source flow gets a compact "Used in" list from the same component.
- **Content viewer.** A second page section renders the OpenAPI document (pretty-printed JSON, or YAML as pushed) or the manifest extracted from the function bundle in a read-only Monaco editor. `components/monaco-editor.tsx` and its lazy wrapper are restored from before #6012, and `fflate` is re-added as a dependency for reading the bundle zip; both load on demand so no other page pays for them.
- **Function details.** The Details card gains Runtime, Memory, and Instances rows for function sources, showing the deploy-time defaults when the source sets none. The Active deployment row links to the deployment page.
- **Active deployment, not latest.** The sources list, detail page, content viewer, and create-from-source flow now read `deployments.active` (the newest completed deployment) through a new `useActiveDeployment` hook, instead of `deployments.latest`. Every push mints new asset ids, and `tools.list` serves tools from the last completed deployment, so a failed push made the two sides of every join disagree: tool counts read 0 and the MCP servers card came up empty. A unit test pins the behavior.

**Environments** passes `search` to `ResourceListPage`, filtering on name, slug, and description. `isEmpty` stays bound to the unfiltered count so a search with no matches keeps the toolbar and shows a "no matches" line instead of the first-run empty state.

## Motivation

#6012 folded the standalone Sources section into the MCP page and replaced the tabbed source detail page with a single-section one. Along the way it dropped the source's MCP Servers tab, its OpenAPI specification tab and function manifest dialog, and the runtime, memory, and instance facts for functions. The table view toggle added in #1894 went with it on the MCP servers and sources lists, and had earlier become unreachable on the plugin skills section when that page moved to a sidebar layout. Only the Catalog kept it.

Users who prefer the denser table view lost it without a replacement, and a source page that can't say which servers use it or show the file behind it is missing the two things people go there for.

The Environments page was the one card list under `ResourceListPage` without a search box, which stands out next to the MCP page it sits beside in the sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9AvB2B9cghwNE5QbzsBkb
