### PR TITLE
fix: redirect the legacy Platform MCP URL to headless mode

### DIFF
--- a/.changeset/headless-mode-platform-mcp-entry.md
+++ b/.changeset/headless-mode-platform-mcp-entry.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+Set up Platform MCP from headless mode instead of a separate settings page, and keep old `/platform-mcp` links working by redirecting them there.

--- a/client/dashboard/src/App.tsx
+++ b/client/dashboard/src/App.tsx
@@ -462,7 +462,8 @@ const routesToNavActions = (
         !route.unauthenticated &&
         !route.outsideMainLayout &&
         Boolean(route.component) &&
-        Boolean(route.title),
+        Boolean(route.title) &&
+        !route.legacyRedirect,
     )
     .map(([key, route]) =>
       routeToNavAction(route, group, `${idPrefix}-${key}`),

--- a/client/dashboard/src/pages/org/PlatformMCPRedirect.tsx
+++ b/client/dashboard/src/pages/org/PlatformMCPRedirect.tsx
@@ -1,0 +1,19 @@
+import { useOrgRoutes } from "@/routes";
+import { Navigate, useSearchParams } from "react-router";
+
+/**
+ * Legacy route target: Platform MCP setup now lives in headless mode, so the
+ * old standalone page redirects there. The `entrySource` deep link is carried
+ * along, since the CTAs that pointed here used it to attribute the onboarding
+ * workflow. `setup=1` is dropped: headless mode opens on the agent picker the
+ * flag used to unfold, so there is nothing left for it to switch on.
+ */
+export default function PlatformMCPRedirect(): JSX.Element {
+  const orgRoutes = useOrgRoutes();
+  const [searchParams] = useSearchParams();
+  const entrySource = searchParams.get("entrySource");
+  const suffix = entrySource
+    ? `?entrySource=${encodeURIComponent(entrySource)}`
+    : "";
+  return <Navigate to={`${orgRoutes.headless.href()}${suffix}`} replace />;
+}

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -84,6 +84,7 @@ import OrgIdentity from "./pages/org/OrgIdentity";
 import OrgAIIntegrations from "./pages/org/OrgAIIntegrations";
 import OrgLogs from "./pages/org/OrgLogs";
 import HeadlessMode from "./pages/org/HeadlessMode";
+import PlatformMCPRedirect from "./pages/org/PlatformMCPRedirect";
 import OrgSkills from "./pages/org/OrgSkills";
 import ExternalCredentialDetail from "./pages/org/external-services/ExternalCredentialDetail";
 import {
@@ -1194,6 +1195,14 @@ const ORG_ROUTE_STRUCTURE = {
     url: "skills",
     icon: "terminal",
     component: OrgSkills,
+  },
+  // Legacy URL: Platform MCP setup is what headless mode does now, so the old
+  // standalone page redirects there. Kept out of the sidebar.
+  platformMcp: {
+    title: "Platform MCP",
+    url: "platform-mcp",
+    icon: "plug-zap",
+    component: PlatformMCPRedirect,
   },
   aiIntegrations: {
     title: "AI Integrations",

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -174,6 +174,11 @@ type AppRouteBasic = {
   subPages?: AppRoutesBasic;
   unauthenticated?: boolean;
   outsideMainLayout?: boolean;
+  // This route only exists to resolve an old URL: its component redirects
+  // elsewhere. Surfaces that enumerate routes as destinations (the command
+  // palette) skip it, so a bookmark keeps working without the dead entry
+  // being offered as somewhere to go.
+  legacyRedirect?: boolean;
   // Release stage badge shown on this route's nav entry. Use sparingly —
   // only for features that are genuinely pre-GA. Page-level badges live on
   // <Page.Section.Title stage="..." /> and must be set separately.
@@ -224,6 +229,7 @@ type RouteEntry = {
       unauthenticated?: boolean;
       subPages?: Record<string, RouteEntry>;
       outsideMainLayout?: boolean;
+      legacyRedirect?: boolean;
     }
 );
 
@@ -1197,11 +1203,12 @@ const ORG_ROUTE_STRUCTURE = {
     component: OrgSkills,
   },
   // Legacy URL: Platform MCP setup is what headless mode does now, so the old
-  // standalone page redirects there. Kept out of the sidebar.
+  // standalone page redirects there. Kept out of the sidebar, and flagged so
+  // the command palette does not offer it as a destination either.
   platformMcp: {
     title: "Platform MCP",
     url: "platform-mcp",
-    icon: "plug-zap",
+    legacyRedirect: true,
     component: PlatformMCPRedirect,
   },
   aiIntegrations: {


### PR DESCRIPTION
## Summary

Follow-up to #6138, which removed the standalone Platform MCP page. Restores `/<org>/platform-mcp` as a legacy redirect to headless mode, and adds the changeset that PR shipped without.

- `PlatformMCPRedirect` renders `<Navigate replace>` to the headless route, following the same pattern the Detection Rules legacy route uses. The `entrySource` deep link is carried across, since the org home CTA used it to attribute the onboarding workflow. `setup=1` is dropped — headless mode opens on the agent picker that flag used to unfold, so there is nothing left for it to switch on.
- The route entry is kept out of the sidebar, so the URL resolves without the nav item coming back.

## Motivation

#6138 deleted the route outright, so anything still pointing at `/<org>/platform-mcp` — bookmarks, links in docs, older support threads — 404s. cubic flagged this on that PR; the fix was ready before it merged but the branch was already locked in the merge queue, so it lands here instead.

Verified against a local stack: `/<org>/platform-mcp?entrySource=organization_home` survives the login round-trip and resolves to `/<org>/headless?entrySource=organization_home`.

https://claude.ai/code/session_018G4WU7MWxr8b5p7CcizF5z

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the legacy `/org/platform-mcp` URL as a redirect to headless mode, so old bookmarks and links no longer 404. The redirect carries the `entrySource` deep link and drops `setup=1` (headless mode opens on the agent picker that flag used to unfold). The route stays out of the sidebar and the command palette, and the PR adds the changeset the previous one shipped without.

<sup>Written for commit 1fb44474e7d78186a1d09f1ed8af5a23660ce963. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

