### PR TITLE
Mirror external MCP tool arguments

### DIFF
--- a/server/internal/externalmcp/mcpclient.go
+++ b/server/internal/externalmcp/mcpclient.go
@@ -2,6 +2,7 @@ package externalmcp
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -289,7 +290,8 @@ func (c *Client) CallTool(ctx context.Context, toolName string, arguments json.R
 	}
 
 	c.beginRequest()
-	callResult, err := c.session.CallTool(ctx, &mcp.CallToolParams{
+	callContext := context.WithValue(ctx, callArgumentsContextKey{}, args)
+	callResult, err := c.session.CallTool(callContext, &mcp.CallToolParams{
 		Meta:           mcp.Meta{},
 		Name:           toolName,
 		Arguments:      args,
@@ -330,6 +332,95 @@ type authRoundTripper struct {
 	wwwAuthenticate string
 }
 
+// callArgumentsContextKey carries the validated arguments for one tools/call
+// request to the transport layer, which is where the SDK exposes the request
+// headers before they are sent to the upstream server.
+type callArgumentsContextKey struct{}
+
+const (
+	mirroredParamHeaderPrefix = "Mcp-Param-"
+	base64HeaderValuePrefix   = "=?base64?"
+	base64HeaderValueSuffix   = "?="
+)
+
+func mirroredToolCallHeaders(arguments map[string]any) map[string]string {
+	if len(arguments) == 0 {
+		return nil
+	}
+
+	headers := make(map[string]string, len(arguments))
+	seenNames := make(map[string]string, len(arguments))
+	conflictingNames := make(map[string]struct{})
+	for name, value := range arguments {
+		headerName := mirroredParamHeaderPrefix + name
+		if !validHeaderFieldName(headerName) {
+			continue
+		}
+		lowerHeaderName := strings.ToLower(headerName)
+		if _, conflicting := conflictingNames[lowerHeaderName]; conflicting {
+			continue
+		}
+		if previousName, exists := seenNames[lowerHeaderName]; exists {
+			delete(headers, previousName)
+			delete(seenNames, lowerHeaderName)
+			conflictingNames[lowerHeaderName] = struct{}{}
+			continue
+		}
+
+		headerValue, ok := mirroredHeaderValue(value)
+		if ok {
+			headers[headerName] = headerValue
+			seenNames[lowerHeaderName] = headerName
+		}
+	}
+
+	return headers
+}
+
+func mirroredHeaderValue(value any) (string, bool) {
+	if stringValue, ok := value.(string); ok {
+		if validHeaderFieldValue(stringValue) {
+			return stringValue, true
+		}
+
+		return base64HeaderValue(stringValue), true
+	}
+
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "", false
+	}
+	return string(encoded), true
+}
+
+func base64HeaderValue(value string) string {
+	return base64HeaderValuePrefix + base64.StdEncoding.EncodeToString([]byte(value)) + base64HeaderValueSuffix
+}
+
+func validHeaderFieldName(name string) bool {
+	for _, char := range name {
+		if (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') || (char >= '0' && char <= '9') {
+			continue
+		}
+		switch char {
+		case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~':
+			continue
+		default:
+			return false
+		}
+	}
+	return name != ""
+}
+
+func validHeaderFieldValue(value string) bool {
+	for _, char := range value {
+		if char == '\r' || char == '\n' || char == 0x7f || char < 0x20 && char != '\t' {
+			return false
+		}
+	}
+	return true
+}
+
 func (rt *authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Configured headers are operator-supplied and are not yet reserved against
 	// the protocol's own header names, so a definition naming Mcp-Method would
@@ -344,6 +435,16 @@ func (rt *authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error)
 		}
 		for k, v := range rt.headers {
 			req.Header.Set(k, v)
+		}
+	}
+	if arguments, ok := req.Context().Value(callArgumentsContextKey{}).(map[string]any); ok {
+		for name, value := range mirroredToolCallHeaders(arguments) {
+			for existingName := range req.Header {
+				if strings.EqualFold(existingName, name) {
+					delete(req.Header, existingName)
+				}
+			}
+			req.Header.Set(name, value)
 		}
 	}
 

--- a/server/internal/externalmcp/mcpclient_discoverprobe_test.go
+++ b/server/internal/externalmcp/mcpclient_discoverprobe_test.go
@@ -79,17 +79,25 @@ func (h *handshakeRecorder) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	result := map[string]any{
+		"protocolVersion": "2025-11-25",
+		"capabilities":    map[string]any{},
+		"serverInfo":      map[string]any{"name": "recorder", "version": "1.0.0"},
+	}
+	if envelope.Method == "tools/call" {
+		result = map[string]any{
+			"content": []any{},
+			"isError": false,
+		}
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Mcp-Session-Id", "test-session")
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"jsonrpc": "2.0",
 		"id":      envelope.ID,
-		"result": map[string]any{
-			"protocolVersion": "2025-11-25",
-			"capabilities":    map[string]any{},
-			"serverInfo":      map[string]any{"name": "recorder", "version": "1.0.0"},
-		},
+		"result":  result,
 	})
 }
 
@@ -206,4 +214,21 @@ func TestNewClientConfiguredDiscoverHeaderDoesNotStripRetries(t *testing.T) {
 
 	require.Equal(t, methodServerDiscover, recorder.headerFor("initialize", headerMCPMethod), "the configured header must reach the wire, or the misclassification is never exercised")
 	require.Equal(t, 2, recorder.attemptsFor("initialize"), "a configured Mcp-Method must not classify other requests as the probe")
+}
+
+func TestCallToolMirrorsArgumentsInRequestHeaders(t *testing.T) {
+	t.Parallel()
+
+	recorder := newHandshakeRecorder(func(string, int) int { return 0 })
+	client, err := newDiscoverProbeClient(t, recorder, map[string]string{
+		"Mcp-Param-repo": "configured-repo",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	_, err = client.CallTool(t.Context(), "search", json.RawMessage(`{"owner":"octo-org","repo":"octo-repo"}`))
+	require.NoError(t, err)
+
+	require.Equal(t, "octo-org", recorder.headerFor("tools/call", "Mcp-Param-owner"))
+	require.Equal(t, "octo-repo", recorder.headerFor("tools/call", "Mcp-Param-repo"), "per-call arguments must override configured values")
 }


### PR DESCRIPTION
<!-- dd-meta {"pullId":"3a4df18a-a8a5-44be-9eaa-a9e247a6f720","source":"chat","resourceId":"351071ba-1c8c-4fdf-9be1-49265292b20e","workflowId":"edb80906-86cb-4458-80e1-b0bbcb05c619","codeChangeId":"edb80906-86cb-4458-80e1-b0bbcb05c619","sourceType":"bits_ai_sre"} -->
## Motivation / Summary

Bits AI SRE Investigation • [View in Bits AI SRE Investigation](https://app.datadoghq.com/bits-ai/investigations/1d5cb791-0015-491a-bcf7-b2eafd7a5b71)

External MCP calls sent tool arguments only in JSON-RPC, so MCP 2026-07-28 upstreams such as GitHub could reject valid calls that require mirrored `Mcp-Param-*` headers. This caused otherwise valid calls to fail and increased gateway error volume.

## Changes
- Carry parsed external-MCP tool arguments through the call context to the outbound transport.
- Project valid argument names and values into `Mcp-Param-*` headers, including safe encoding for header-incompatible string values.
- Ensure per-call argument headers override conflicting configured headers.
- Add an integration-style regression test covering `owner`/`repo` propagation and override behavior.

## Testing / Validation
- `gofmt` completed successfully.
- `git diff --check` completed successfully.
- The prescribed `mise run test:server ./internal/externalmcp/` and `mise lint:server` checks could not run because `mise` is unavailable in the environment.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/351071ba-1c8c-4fdf-9be1-49265292b20e)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes external MCP tool calls so tool arguments are mirrored as `Mcp-Param-*` headers on outbound requests, satisfying upstreams like GitHub that require them and reducing gateway errors. Per-call arguments now override any conflicting configured headers.

**Changes**
- Carries parsed tool arguments through the call context to the transport layer.
- Projects valid argument names/values into `Mcp-Param-*` headers, base64-encoding header-incompatible strings.
- Adds an integration test covering `owner`/`repo` propagation and override behavior.

<sup>Written for commit a675a5704d3de1cfacee9392222de1823378a415. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

