### PR TITLE
fix: stop plugin rollout minting API keys that auth cannot find

### DIFF
--- a/.changeset/plugin-key-real-actor.md
+++ b/.changeset/plugin-key-real-actor.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Stop the plugin rollout sweep from minting API keys under the `system` placeholder creator, and rewrite existing orphaned keys onto a real org member so auth can find them.

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -248,6 +248,7 @@ const (
 
 	ComponentKey                   = attribute.Key("gram.component")
 	DBDeletedRowsCountKey          = attribute.Key("gram.db.deleted_rows_count")
+	DBUpdatedRowsCountKey          = attribute.Key("gram.db.updated_rows_count")
 	DeploymentIDKey                = attribute.Key("gram.deployment.id")
 	DeploymentFunctionsAccessIDKey = attribute.Key("gram.deployment.functions.access_id")
 	DeploymentFunctionsIDKey       = attribute.Key("gram.deployment.functions.id")
@@ -1380,6 +1381,8 @@ func SlogComponent(v string) slog.Attr      { return slog.String(string(Componen
 
 func DBDeletedRowsCount(v int64) attribute.KeyValue { return DBDeletedRowsCountKey.Int64(v) }
 func SlogDBDeletedRowsCount(v int64) slog.Attr      { return slog.Int64(string(DBDeletedRowsCountKey), v) }
+func DBUpdatedRowsCount(v int64) attribute.KeyValue { return DBUpdatedRowsCountKey.Int64(v) }
+func SlogDBUpdatedRowsCount(v int64) slog.Attr      { return slog.Int64(string(DBUpdatedRowsCountKey), v) }
 
 func DeploymentID(v string) attribute.KeyValue { return DeploymentIDKey.String(v) }
 func SlogDeploymentID(v string) slog.Attr      { return slog.String(string(DeploymentIDKey), v) }

--- a/server/internal/background/activities.go
+++ b/server/internal/background/activities.go
@@ -978,6 +978,13 @@ func (a *Activities) ListPluginPublishCandidates(ctx context.Context, input acti
 	return result, nil
 }
 
+func (a *Activities) RepairOrphanedAPIKeyCreators(ctx context.Context) error {
+	if err := a.pluginPublisher.RepairOrphanedAPIKeyCreators(ctx); err != nil {
+		return fmt.Errorf("repair orphaned api key creators: %w", err)
+	}
+	return nil
+}
+
 func (a *Activities) PublishPluginProject(ctx context.Context, input plugins.PublishProjectInput) (*plugins.PublishProjectResult, error) {
 	result, err := a.pluginPublisher.PublishProject(ctx, input)
 	if err != nil {

--- a/server/internal/background/activities/plugin_publisher.go
+++ b/server/internal/background/activities/plugin_publisher.go
@@ -74,17 +74,6 @@ func (p *PluginPublisher) ListCandidates(ctx context.Context, input ListPluginPu
 		after = *input.AfterProjectID
 	}
 
-	// Heal keys minted under a placeholder creator before listing, so the
-	// subsequent actor lookup sees a real users.id and already-published
-	// hooks/MCP keys start authenticating without a republish.
-	repaired, err := keysrepo.New(p.db).RepairOrphanedAPIKeyCreators(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("repair orphaned api key creators: %w", err)
-	}
-	if repaired > 0 {
-		p.logger.InfoContext(ctx, "repaired orphaned api key creators")
-	}
-
 	rows, err := pluginsrepo.New(p.db).ListPluginPublishCandidates(ctx, pluginsrepo.ListPluginPublishCandidatesParams{
 		AfterProjectID: after,
 		ResultLimit:    limit,
@@ -108,6 +97,21 @@ func (p *PluginPublisher) ListCandidates(ctx context.Context, input ListPluginPu
 	}
 
 	return &ListPluginPublishCandidatesResult{Candidates: candidates}, nil
+}
+
+func (p *PluginPublisher) RepairOrphanedAPIKeyCreators(ctx context.Context) error {
+	if p.db == nil {
+		return fmt.Errorf("database is not configured")
+	}
+
+	repaired, err := keysrepo.New(p.db).RepairOrphanedAPIKeyCreators(ctx)
+	if err != nil {
+		return fmt.Errorf("repair orphaned api key creators: %w", err)
+	}
+	if repaired > 0 {
+		p.logger.InfoContext(ctx, "repaired orphaned api key creators")
+	}
+	return nil
 }
 
 func (p *PluginPublisher) PublishProject(ctx context.Context, input plugins.PublishProjectInput) (*plugins.PublishProjectResult, error) {

--- a/server/internal/background/activities/plugin_publisher.go
+++ b/server/internal/background/activities/plugin_publisher.go
@@ -84,7 +84,7 @@ func (p *PluginPublisher) ListCandidates(ctx context.Context, input ListPluginPu
 
 	candidates := make([]PluginPublishCandidate, 0, len(rows))
 	for _, row := range rows {
-		if row.CreatedByUserID == "" || row.CreatedByUserID == "system" {
+		if !plugins.UsableAPIKeyCreatorID(row.CreatedByUserID) {
 			p.logger.WarnContext(ctx, "plugin publish candidate has no real actor",
 				attr.SlogProjectID(row.ProjectID.String()),
 				attr.SlogUserID(row.CreatedByUserID),
@@ -109,7 +109,7 @@ func (p *PluginPublisher) RepairOrphanedAPIKeyCreators(ctx context.Context) erro
 		return fmt.Errorf("repair orphaned api key creators: %w", err)
 	}
 	if repaired > 0 {
-		p.logger.InfoContext(ctx, "repaired orphaned api key creators")
+		p.logger.InfoContext(ctx, "repaired orphaned api key creators", attr.SlogDBUpdatedRowsCount(repaired))
 	}
 	return nil
 }

--- a/server/internal/background/activities/plugin_publisher.go
+++ b/server/internal/background/activities/plugin_publisher.go
@@ -82,7 +82,7 @@ func (p *PluginPublisher) ListCandidates(ctx context.Context, input ListPluginPu
 		return nil, fmt.Errorf("repair orphaned api key creators: %w", err)
 	}
 	if repaired > 0 {
-		p.logger.InfoContext(ctx, "repaired orphaned api key creators", slog.Int64("repaired", repaired))
+		p.logger.InfoContext(ctx, "repaired orphaned api key creators")
 	}
 
 	rows, err := pluginsrepo.New(p.db).ListPluginPublishCandidates(ctx, pluginsrepo.ListPluginPublishCandidatesParams{

--- a/server/internal/background/activities/plugin_publisher.go
+++ b/server/internal/background/activities/plugin_publisher.go
@@ -13,6 +13,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	keysrepo "github.com/speakeasy-api/gram/server/internal/keys/repo"
 	"github.com/speakeasy-api/gram/server/internal/plugins"
 	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
 )
@@ -73,6 +74,17 @@ func (p *PluginPublisher) ListCandidates(ctx context.Context, input ListPluginPu
 		after = *input.AfterProjectID
 	}
 
+	// Heal keys minted under a placeholder creator before listing, so the
+	// subsequent actor lookup sees a real users.id and already-published
+	// hooks/MCP keys start authenticating without a republish.
+	repaired, err := keysrepo.New(p.db).RepairOrphanedAPIKeyCreators(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("repair orphaned api key creators: %w", err)
+	}
+	if repaired > 0 {
+		p.logger.InfoContext(ctx, "repaired orphaned api key creators", slog.Int64("repaired", repaired))
+	}
+
 	rows, err := pluginsrepo.New(p.db).ListPluginPublishCandidates(ctx, pluginsrepo.ListPluginPublishCandidatesParams{
 		AfterProjectID: after,
 		ResultLimit:    limit,
@@ -83,6 +95,12 @@ func (p *PluginPublisher) ListCandidates(ctx context.Context, input ListPluginPu
 
 	candidates := make([]PluginPublishCandidate, 0, len(rows))
 	for _, row := range rows {
+		if row.CreatedByUserID == "" || row.CreatedByUserID == "system" {
+			p.logger.WarnContext(ctx, "plugin publish candidate has no real actor",
+				attr.SlogProjectID(row.ProjectID.String()),
+				attr.SlogUserID(row.CreatedByUserID),
+			)
+		}
 		candidates = append(candidates, PluginPublishCandidate{
 			ProjectID:       row.ProjectID,
 			CreatedByUserID: row.CreatedByUserID,

--- a/server/internal/background/plugin_generator_rollout.go
+++ b/server/internal/background/plugin_generator_rollout.go
@@ -150,6 +150,14 @@ func PluginGeneratorRolloutWorkflow(ctx workflow.Context, input PluginGeneratorR
 
 			futures := make([]workflow.Future, 0, end-start)
 			for _, candidate := range candidates.Candidates[start:end] {
+				if candidate.CreatedByUserID == "" || candidate.CreatedByUserID == "system" {
+					result.Skipped++
+					workflow.GetLogger(ctx).Warn("plugin project publish skipped: no real actor",
+						"project_id", candidate.ProjectID.String(),
+						"created_by_user_id", candidate.CreatedByUserID,
+					)
+					continue
+				}
 				futures = append(futures, workflow.ExecuteActivity(ctx, a.PublishPluginProject, plugins.PublishProjectInput{
 					ProjectID:       candidate.ProjectID,
 					CreatedByUserID: candidate.CreatedByUserID,

--- a/server/internal/background/plugin_generator_rollout.go
+++ b/server/internal/background/plugin_generator_rollout.go
@@ -120,6 +120,12 @@ func PluginGeneratorRolloutWorkflow(ctx workflow.Context, input PluginGeneratorR
 		}
 	}
 
+	if input.AfterProjectID == nil {
+		if err := workflow.ExecuteActivity(ctx, a.RepairOrphanedAPIKeyCreators).Get(ctx, nil); err != nil {
+			return nil, fmt.Errorf("repair orphaned api key creators: %w", err)
+		}
+	}
+
 	after := input.AfterProjectID
 	for {
 		if workflow.GetInfo(ctx).GetContinueAsNewSuggested() {

--- a/server/internal/background/plugin_generator_rollout.go
+++ b/server/internal/background/plugin_generator_rollout.go
@@ -37,6 +37,17 @@ const (
 	pluginGeneratorRolloutInterval         = 1 * time.Hour
 	pluginGeneratorRolloutDefaultBatchSize = int32(100)
 	pluginGeneratorRolloutConcurrency      = 5
+
+	// pluginGeneratorRolloutRepairChangeID versions the orphaned-key repair
+	// activity that now runs at the start of a fresh sweep. In-flight
+	// executions started before this change have ListPluginPublishCandidates
+	// as their first recorded command; GetVersion returns DefaultVersion on
+	// those replays so they keep that sequence.
+	pluginGeneratorRolloutRepairChangeID = "plugin-rollout-repair-orphaned-creators"
+
+	// pluginGeneratorRolloutRepairVersion is the current command sequence:
+	// repair once on a fresh sweep, then list candidates.
+	pluginGeneratorRolloutRepairVersion = 1
 )
 
 type PluginGeneratorRolloutInput struct {
@@ -120,7 +131,7 @@ func PluginGeneratorRolloutWorkflow(ctx workflow.Context, input PluginGeneratorR
 		}
 	}
 
-	if input.AfterProjectID == nil {
+	if workflow.GetVersion(ctx, pluginGeneratorRolloutRepairChangeID, workflow.DefaultVersion, pluginGeneratorRolloutRepairVersion) == pluginGeneratorRolloutRepairVersion && input.AfterProjectID == nil {
 		if err := workflow.ExecuteActivity(ctx, a.RepairOrphanedAPIKeyCreators).Get(ctx, nil); err != nil {
 			return nil, fmt.Errorf("repair orphaned api key creators: %w", err)
 		}

--- a/server/internal/background/plugin_generator_rollout.go
+++ b/server/internal/background/plugin_generator_rollout.go
@@ -167,7 +167,7 @@ func PluginGeneratorRolloutWorkflow(ctx workflow.Context, input PluginGeneratorR
 
 			futures := make([]workflow.Future, 0, end-start)
 			for _, candidate := range candidates.Candidates[start:end] {
-				if candidate.CreatedByUserID == "" || candidate.CreatedByUserID == "system" {
+				if !plugins.UsableAPIKeyCreatorID(candidate.CreatedByUserID) {
 					result.Skipped++
 					workflow.GetLogger(ctx).Warn("plugin project publish skipped: no real actor",
 						"project_id", candidate.ProjectID.String(),

--- a/server/internal/background/plugin_generator_rollout_test.go
+++ b/server/internal/background/plugin_generator_rollout_test.go
@@ -220,6 +220,45 @@ func TestPluginGeneratorRolloutWorkflow_RepairsOnceOnFreshRun(t *testing.T) {
 	require.Equal(t, 1, repairs)
 }
 
+func TestPluginGeneratorRolloutWorkflow_SkipsRepairOnPreVersionReplay(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.OnGetVersion(pluginGeneratorRolloutRepairChangeID, workflow.DefaultVersion, pluginGeneratorRolloutRepairVersion).Return(workflow.DefaultVersion)
+
+	env.RegisterActivityWithOptions(
+		func(context.Context) error {
+			t.Fatal("repair must not run when GetVersion returns DefaultVersion")
+			return nil
+		},
+		activity.RegisterOptions{Name: "RepairOrphanedAPIKeyCreators"},
+	)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ bgactivities.ListPluginPublishCandidatesInput) (*bgactivities.ListPluginPublishCandidatesResult, error) {
+			return &bgactivities.ListPluginPublishCandidatesResult{Candidates: nil}, nil
+		},
+		activity.RegisterOptions{Name: "ListPluginPublishCandidates"},
+	)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ plugins.PublishProjectInput) (*plugins.PublishProjectResult, error) {
+			t.Fatal("publish should not run when there are no candidates")
+			return nil, nil
+		},
+		activity.RegisterOptions{Name: "PublishPluginProject"},
+	)
+
+	env.ExecuteWorkflow(PluginGeneratorRolloutWorkflow, PluginGeneratorRolloutInput{
+		BatchSize:      10,
+		CommitMessage:  "Update plugin packages",
+		AfterProjectID: nil,
+		Carried:        PluginGeneratorRolloutResult{Scanned: 0, Published: 0, Skipped: 0, Conflicted: 0, Failed: 0},
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+}
+
 func TestPluginGeneratorRolloutWorkflow_SkipsRepairOnContinuedRun(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/background/plugin_generator_rollout_test.go
+++ b/server/internal/background/plugin_generator_rollout_test.go
@@ -15,6 +15,13 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/plugins"
 )
 
+func registerPluginRolloutRepairNoop(env *testsuite.TestWorkflowEnvironment) {
+	env.RegisterActivityWithOptions(
+		func(context.Context) error { return nil },
+		activity.RegisterOptions{Name: "RepairOrphanedAPIKeyCreators"},
+	)
+}
+
 // When continue-as-new fires mid-sweep, the workflow must carry the pagination
 // cursor (and running tallies) into the next run. Otherwise a large rollout
 // restarts at the first page every time and never advances past the point where
@@ -24,6 +31,7 @@ func TestPluginGeneratorRolloutWorkflow_ContinueAsNewCarriesPaginationCursor(t *
 
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
+	registerPluginRolloutRepairNoop(env)
 
 	id1 := uuid.New()
 	id2 := uuid.New()
@@ -82,6 +90,7 @@ func TestPluginGeneratorRolloutWorkflow_ResumesFromCarriedCursor(t *testing.T) {
 
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
+	registerPluginRolloutRepairNoop(env)
 
 	resumeFrom := uuid.New()
 	next := uuid.New()
@@ -127,6 +136,7 @@ func TestPluginGeneratorRolloutWorkflow_SkipsPlaceholderActor(t *testing.T) {
 
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestWorkflowEnvironment()
+	registerPluginRolloutRepairNoop(env)
 
 	placeholder := uuid.New()
 	realUser := uuid.New()
@@ -168,4 +178,83 @@ func TestPluginGeneratorRolloutWorkflow_SkipsPlaceholderActor(t *testing.T) {
 	require.NoError(t, env.GetWorkflowResult(&result))
 	require.Equal(t, 1, published)
 	require.Equal(t, PluginGeneratorRolloutResult{Scanned: 2, Published: 1, Skipped: 1, Conflicted: 0, Failed: 0}, result)
+}
+
+func TestPluginGeneratorRolloutWorkflow_RepairsOnceOnFreshRun(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	repairs := 0
+	env.RegisterActivityWithOptions(
+		func(context.Context) error {
+			repairs++
+			return nil
+		},
+		activity.RegisterOptions{Name: "RepairOrphanedAPIKeyCreators"},
+	)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ bgactivities.ListPluginPublishCandidatesInput) (*bgactivities.ListPluginPublishCandidatesResult, error) {
+			return &bgactivities.ListPluginPublishCandidatesResult{Candidates: nil}, nil
+		},
+		activity.RegisterOptions{Name: "ListPluginPublishCandidates"},
+	)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ plugins.PublishProjectInput) (*plugins.PublishProjectResult, error) {
+			t.Fatal("publish should not run when there are no candidates")
+			return nil, nil
+		},
+		activity.RegisterOptions{Name: "PublishPluginProject"},
+	)
+
+	env.ExecuteWorkflow(PluginGeneratorRolloutWorkflow, PluginGeneratorRolloutInput{
+		BatchSize:      10,
+		CommitMessage:  "Update plugin packages",
+		AfterProjectID: nil,
+		Carried:        PluginGeneratorRolloutResult{Scanned: 0, Published: 0, Skipped: 0, Conflicted: 0, Failed: 0},
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, 1, repairs)
+}
+
+func TestPluginGeneratorRolloutWorkflow_SkipsRepairOnContinuedRun(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	resumeFrom := uuid.New()
+	env.RegisterActivityWithOptions(
+		func(context.Context) error {
+			t.Fatal("repair must not rerun after continue-as-new")
+			return nil
+		},
+		activity.RegisterOptions{Name: "RepairOrphanedAPIKeyCreators"},
+	)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ bgactivities.ListPluginPublishCandidatesInput) (*bgactivities.ListPluginPublishCandidatesResult, error) {
+			return &bgactivities.ListPluginPublishCandidatesResult{Candidates: nil}, nil
+		},
+		activity.RegisterOptions{Name: "ListPluginPublishCandidates"},
+	)
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ plugins.PublishProjectInput) (*plugins.PublishProjectResult, error) {
+			t.Fatal("publish should not run when there are no candidates")
+			return nil, nil
+		},
+		activity.RegisterOptions{Name: "PublishPluginProject"},
+	)
+
+	env.ExecuteWorkflow(PluginGeneratorRolloutWorkflow, PluginGeneratorRolloutInput{
+		BatchSize:      10,
+		CommitMessage:  "Update plugin packages",
+		AfterProjectID: &resumeFrom,
+		Carried:        PluginGeneratorRolloutResult{Scanned: 10, Published: 3, Skipped: 5, Conflicted: 0, Failed: 2},
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
 }

--- a/server/internal/background/plugin_generator_rollout_test.go
+++ b/server/internal/background/plugin_generator_rollout_test.go
@@ -121,3 +121,51 @@ func TestPluginGeneratorRolloutWorkflow_ResumesFromCarriedCursor(t *testing.T) {
 	require.NoError(t, env.GetWorkflowResult(&result))
 	require.Equal(t, PluginGeneratorRolloutResult{Scanned: 11, Published: 4, Skipped: 5, Failed: 2}, result)
 }
+
+func TestPluginGeneratorRolloutWorkflow_SkipsPlaceholderActor(t *testing.T) {
+	t.Parallel()
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+
+	placeholder := uuid.New()
+	realUser := uuid.New()
+	published := 0
+
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, _ bgactivities.ListPluginPublishCandidatesInput) (*bgactivities.ListPluginPublishCandidatesResult, error) {
+			return &bgactivities.ListPluginPublishCandidatesResult{
+				Candidates: []bgactivities.PluginPublishCandidate{
+					{ProjectID: placeholder, CreatedByUserID: "system"},
+					{ProjectID: realUser, CreatedByUserID: "user_3"},
+				},
+			}, nil
+		},
+		activity.RegisterOptions{Name: "ListPluginPublishCandidates"},
+	)
+
+	env.RegisterActivityWithOptions(
+		func(_ context.Context, input plugins.PublishProjectInput) (*plugins.PublishProjectResult, error) {
+			require.NotEqual(t, "system", input.CreatedByUserID)
+			require.Equal(t, realUser, input.ProjectID)
+			published++
+			return &plugins.PublishProjectResult{RepoURL: "https://example.com/repo", Skipped: false}, nil
+		},
+		activity.RegisterOptions{Name: "PublishPluginProject"},
+	)
+
+	env.ExecuteWorkflow(PluginGeneratorRolloutWorkflow, PluginGeneratorRolloutInput{
+		BatchSize:      10,
+		CommitMessage:  "Update plugin packages",
+		AfterProjectID: nil,
+		Carried:        PluginGeneratorRolloutResult{Scanned: 0, Published: 0, Skipped: 0, Conflicted: 0, Failed: 0},
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	var result PluginGeneratorRolloutResult
+	require.NoError(t, env.GetWorkflowResult(&result))
+	require.Equal(t, 1, published)
+	require.Equal(t, PluginGeneratorRolloutResult{Scanned: 2, Published: 1, Skipped: 1, Conflicted: 0, Failed: 0}, result)
+}

--- a/server/internal/background/worker.go
+++ b/server/internal/background/worker.go
@@ -497,6 +497,7 @@ func NewTemporalWorker(
 	temporalWorker.RegisterActivity(activities.GCPublishOutboxDeadLetters)
 	// Plugin publishing activities
 	temporalWorker.RegisterActivity(activities.ListPluginPublishCandidates)
+	temporalWorker.RegisterActivity(activities.RepairOrphanedAPIKeyCreators)
 	temporalWorker.RegisterActivity(activities.PublishPluginProject)
 	// Spend rule evaluation activities
 	temporalWorker.RegisterActivity(activities.ReassertSessionQuarantines)

--- a/server/internal/keys/orphaned_creator_test.go
+++ b/server/internal/keys/orphaned_creator_test.go
@@ -1,0 +1,111 @@
+package keys_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+
+	gen "github.com/speakeasy-api/gram/server/gen/keys"
+	"github.com/speakeasy-api/gram/server/internal/auth"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	keysrepo "github.com/speakeasy-api/gram/server/internal/keys/repo"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+func TestRepairOrphanedAPIKeyCreators_RewritesPlaceholderCreator(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestKeysService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	rawKey := "gram_local_" + uuid.NewString()
+	keyHash, err := auth.GetAPIKeyHash(rawKey)
+	require.NoError(t, err)
+
+	created, err := keysrepo.New(ti.conn).CreateAPIKey(ctx, keysrepo.CreateAPIKeyParams{
+		OrganizationID:  authCtx.ActiveOrganizationID,
+		ProjectID:       uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
+		CreatedByUserID: "system",
+		Name:            "plugins-hooks-20260708-120102-abc123",
+		KeyPrefix:       rawKey[:16],
+		KeyHash:         keyHash,
+		Scopes:          []string{"hooks"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "system", created.CreatedByUserID)
+
+	_, err = keysrepo.New(ti.conn).GetAPIKeyByKeyHash(ctx, keyHash)
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+
+	_, err = ti.keyAuth.KeyBasedAuth(ctx, rawKey, []string{"hooks"})
+	require.Error(t, err)
+	var oopsErr *oops.ShareableError
+	require.ErrorAs(t, err, &oopsErr)
+	require.Equal(t, oops.CodeUnauthorized, oopsErr.Code)
+	require.Contains(t, oopsErr.Error(), "api key not found")
+
+	listed, err := ti.service.ListKeys(ctx, &gen.ListKeysPayload{SessionToken: nil})
+	require.NoError(t, err)
+	for _, key := range listed.Keys {
+		require.NotEqual(t, created.ID.String(), key.ID, "orphaned key must not appear on the Keys page")
+	}
+
+	repaired, err := keysrepo.New(ti.conn).RepairOrphanedAPIKeyCreators(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), repaired)
+
+	resolved, err := keysrepo.New(ti.conn).GetAPIKeyByKeyHash(ctx, keyHash)
+	require.NoError(t, err)
+	require.Equal(t, created.ID, resolved.ID)
+	require.Equal(t, authCtx.UserID, resolved.CreatedByUserID)
+
+	_, err = ti.keyAuth.KeyBasedAuth(ctx, rawKey, []string{"hooks"})
+	require.NoError(t, err)
+
+	listed, err = ti.service.ListKeys(ctx, &gen.ListKeysPayload{SessionToken: nil})
+	require.NoError(t, err)
+	found := false
+	for _, key := range listed.Keys {
+		if key.ID == created.ID.String() {
+			found = true
+			require.Equal(t, authCtx.UserID, key.CreatedByUserID)
+		}
+	}
+	require.True(t, found, "repaired key must appear on the Keys page")
+}
+
+func TestRepairOrphanedAPIKeyCreators_IsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestKeysService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	rawKey := "gram_local_" + uuid.NewString()
+	keyHash, err := auth.GetAPIKeyHash(rawKey)
+	require.NoError(t, err)
+
+	_, err = keysrepo.New(ti.conn).CreateAPIKey(ctx, keysrepo.CreateAPIKeyParams{
+		OrganizationID:  authCtx.ActiveOrganizationID,
+		ProjectID:       uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
+		CreatedByUserID: "system",
+		Name:            "plugins-mcp-20260708-120102-def456",
+		KeyPrefix:       rawKey[:16],
+		KeyHash:         keyHash,
+		Scopes:          []string{"consumer"},
+	})
+	require.NoError(t, err)
+
+	first, err := keysrepo.New(ti.conn).RepairOrphanedAPIKeyCreators(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), first)
+
+	second, err := keysrepo.New(ti.conn).RepairOrphanedAPIKeyCreators(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), second)
+}

--- a/server/internal/keys/orphaned_creator_test.go
+++ b/server/internal/keys/orphaned_creator_test.go
@@ -1,6 +1,7 @@
 package keys_test
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/google/uuid"
@@ -48,11 +49,14 @@ func TestRepairOrphanedAPIKeyCreators_RewritesPlaceholderCreator(t *testing.T) {
 	require.Equal(t, oops.CodeUnauthorized, oopsErr.Code)
 	require.Contains(t, oopsErr.Error(), "api key not found")
 
+	// The Keys page deliberately keeps listing the key while it is unusable --
+	// hiding it would leave the owner with a row they can neither inspect nor
+	// delete -- so it must be visible both before and after the repair.
 	listed, err := ti.service.ListKeys(ctx, &gen.ListKeysPayload{SessionToken: nil})
 	require.NoError(t, err)
-	for _, key := range listed.Keys {
-		require.NotEqual(t, created.ID.String(), key.ID, "orphaned key must not appear on the Keys page")
-	}
+	require.True(t, slices.ContainsFunc(listed.Keys, func(key *gen.Key) bool {
+		return key.ID == created.ID.String()
+	}), "unrepaired key must still appear on the Keys page")
 
 	repaired, err := keysrepo.New(ti.conn).RepairOrphanedAPIKeyCreators(ctx)
 	require.NoError(t, err)

--- a/server/internal/keys/queries.sql
+++ b/server/internal/keys/queries.sql
@@ -26,11 +26,13 @@ WHERE key_hash = @key_hash
   AND deleted IS FALSE;
 
 -- name: ListAPIKeysByOrganization :many
--- JOIN users matches GetAPIKeyByKeyHash so the Keys page cannot list a key
--- auth will never find (created_by_user_id that is not a users.id).
+-- Deliberately does NOT join users the way GetAPIKeyByKeyHash does. A key
+-- whose created_by_user_id is not a users.id is unusable (auth's join drops
+-- it), but hiding it here would leave the owner with an invisible row they
+-- cannot inspect or delete. RepairOrphanedAPIKeyCreators repoints those rows
+-- instead; the durable guarantee belongs on a foreign key, not on this SELECT.
 SELECT api_keys.*
 FROM api_keys
-JOIN users ON users.id = api_keys.created_by_user_id
 WHERE api_keys.organization_id = @organization_id
   AND api_keys.deleted IS FALSE
   AND NOT EXISTS (

--- a/server/internal/keys/queries.sql
+++ b/server/internal/keys/queries.sql
@@ -26,8 +26,11 @@ WHERE key_hash = @key_hash
   AND deleted IS FALSE;
 
 -- name: ListAPIKeysByOrganization :many
-SELECT *
+-- JOIN users matches GetAPIKeyByKeyHash so the Keys page cannot list a key
+-- auth will never find (created_by_user_id that is not a users.id).
+SELECT api_keys.*
 FROM api_keys
+JOIN users ON users.id = api_keys.created_by_user_id
 WHERE api_keys.organization_id = @organization_id
   AND api_keys.deleted IS FALSE
   AND NOT EXISTS (
@@ -38,7 +41,33 @@ WHERE api_keys.organization_id = @organization_id
       AND li.api_key_id = api_keys.id
       AND li.deleted IS FALSE
   )
-ORDER BY created_at DESC;
+ORDER BY api_keys.created_at DESC;
+
+-- name: RepairOrphanedAPIKeyCreators :execrows
+-- Points API keys whose created_by_user_id is not a users.id (including the
+-- 'system' placeholder minted by the plugin rollout sweep) at the oldest
+-- connected member of their organization. GetAPIKeyByKeyHash JOINs users on
+-- that column, so these keys authenticate as 401 until this rewrite. This is
+-- a deliberate cross-tenant repair — unlike tenant-scoped queries it is not
+-- constrained to a project_id.
+UPDATE api_keys k
+SET
+  created_by_user_id = member.user_id,
+  updated_at = clock_timestamp()
+FROM (
+  SELECT DISTINCT ON (our.organization_id)
+    our.organization_id,
+    our.user_id
+  FROM organization_user_relationships our
+  JOIN users u ON u.id = our.user_id
+  WHERE our.deleted IS FALSE
+    AND our.user_id IS NOT NULL
+    AND u.deleted_at IS NULL
+  ORDER BY our.organization_id, our.created_at ASC, our.user_id ASC
+) member
+WHERE k.organization_id = member.organization_id
+  AND k.deleted IS FALSE
+  AND NOT EXISTS (SELECT 1 FROM users u WHERE u.id = k.created_by_user_id);
 
 -- name: IsAPIKeyManagedByActiveLiteLLMInstance :one
 SELECT EXISTS (

--- a/server/internal/keys/repo/queries.sql.go
+++ b/server/internal/keys/repo/queries.sql.go
@@ -233,8 +233,9 @@ func (q *Queries) IsAPIKeyManagedByActiveLiteLLMInstance(ctx context.Context, ar
 }
 
 const listAPIKeysByOrganization = `-- name: ListAPIKeysByOrganization :many
-SELECT id, organization_id, project_id, created_by_user_id, name, key_prefix, key_hash, scopes, subject_urn, delegated_grants, delegated_grants_version, expires_at, created_at, updated_at, deleted_at, deleted, last_accessed_at
+SELECT api_keys.id, api_keys.organization_id, api_keys.project_id, api_keys.created_by_user_id, api_keys.name, api_keys.key_prefix, api_keys.key_hash, api_keys.scopes, api_keys.subject_urn, api_keys.delegated_grants, api_keys.delegated_grants_version, api_keys.expires_at, api_keys.created_at, api_keys.updated_at, api_keys.deleted_at, api_keys.deleted, api_keys.last_accessed_at
 FROM api_keys
+JOIN users ON users.id = api_keys.created_by_user_id
 WHERE api_keys.organization_id = $1
   AND api_keys.deleted IS FALSE
   AND NOT EXISTS (
@@ -245,9 +246,11 @@ WHERE api_keys.organization_id = $1
       AND li.api_key_id = api_keys.id
       AND li.deleted IS FALSE
   )
-ORDER BY created_at DESC
+ORDER BY api_keys.created_at DESC
 `
 
+// JOIN users matches GetAPIKeyByKeyHash so the Keys page cannot list a key
+// auth will never find (created_by_user_id that is not a users.id).
 func (q *Queries) ListAPIKeysByOrganization(ctx context.Context, organizationID string) ([]ApiKey, error) {
 	rows, err := q.db.Query(ctx, listAPIKeysByOrganization, organizationID)
 	if err != nil {
@@ -284,6 +287,41 @@ func (q *Queries) ListAPIKeysByOrganization(ctx context.Context, organizationID 
 		return nil, err
 	}
 	return items, nil
+}
+
+const repairOrphanedAPIKeyCreators = `-- name: RepairOrphanedAPIKeyCreators :execrows
+UPDATE api_keys k
+SET
+  created_by_user_id = member.user_id,
+  updated_at = clock_timestamp()
+FROM (
+  SELECT DISTINCT ON (our.organization_id)
+    our.organization_id,
+    our.user_id
+  FROM organization_user_relationships our
+  JOIN users u ON u.id = our.user_id
+  WHERE our.deleted IS FALSE
+    AND our.user_id IS NOT NULL
+    AND u.deleted_at IS NULL
+  ORDER BY our.organization_id, our.created_at ASC, our.user_id ASC
+) member
+WHERE k.organization_id = member.organization_id
+  AND k.deleted IS FALSE
+  AND NOT EXISTS (SELECT 1 FROM users u WHERE u.id = k.created_by_user_id)
+`
+
+// Points API keys whose created_by_user_id is not a users.id (including the
+// 'system' placeholder minted by the plugin rollout sweep) at the oldest
+// connected member of their organization. GetAPIKeyByKeyHash JOINs users on
+// that column, so these keys authenticate as 401 until this rewrite. This is
+// a deliberate cross-tenant repair — unlike tenant-scoped queries it is not
+// constrained to a project_id.
+func (q *Queries) RepairOrphanedAPIKeyCreators(ctx context.Context) (int64, error) {
+	result, err := q.db.Exec(ctx, repairOrphanedAPIKeyCreators)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const updateAPIKeyLastAccessedAt = `-- name: UpdateAPIKeyLastAccessedAt :exec

--- a/server/internal/keys/repo/queries.sql.go
+++ b/server/internal/keys/repo/queries.sql.go
@@ -235,7 +235,6 @@ func (q *Queries) IsAPIKeyManagedByActiveLiteLLMInstance(ctx context.Context, ar
 const listAPIKeysByOrganization = `-- name: ListAPIKeysByOrganization :many
 SELECT api_keys.id, api_keys.organization_id, api_keys.project_id, api_keys.created_by_user_id, api_keys.name, api_keys.key_prefix, api_keys.key_hash, api_keys.scopes, api_keys.subject_urn, api_keys.delegated_grants, api_keys.delegated_grants_version, api_keys.expires_at, api_keys.created_at, api_keys.updated_at, api_keys.deleted_at, api_keys.deleted, api_keys.last_accessed_at
 FROM api_keys
-JOIN users ON users.id = api_keys.created_by_user_id
 WHERE api_keys.organization_id = $1
   AND api_keys.deleted IS FALSE
   AND NOT EXISTS (
@@ -249,8 +248,11 @@ WHERE api_keys.organization_id = $1
 ORDER BY api_keys.created_at DESC
 `
 
-// JOIN users matches GetAPIKeyByKeyHash so the Keys page cannot list a key
-// auth will never find (created_by_user_id that is not a users.id).
+// Deliberately does NOT join users the way GetAPIKeyByKeyHash does. A key
+// whose created_by_user_id is not a users.id is unusable (auth's join drops
+// it), but hiding it here would leave the owner with an invisible row they
+// cannot inspect or delete. RepairOrphanedAPIKeyCreators repoints those rows
+// instead; the durable guarantee belongs on a foreign key, not on this SELECT.
 func (q *Queries) ListAPIKeysByOrganization(ctx context.Context, organizationID string) ([]ApiKey, error) {
 	rows, err := q.db.Query(ctx, listAPIKeysByOrganization, organizationID)
 	if err != nil {

--- a/server/internal/plugins/default_plugin_test.go
+++ b/server/internal/plugins/default_plugin_test.go
@@ -10,12 +10,15 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
+	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	keysrepo "github.com/speakeasy-api/gram/server/internal/keys/repo"
 	"github.com/speakeasy-api/gram/server/internal/mcpservers"
 	"github.com/speakeasy-api/gram/server/internal/plugins"
 	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
@@ -406,7 +409,7 @@ func TestListPluginPublishCandidates_IncludesNeverPublishedDefaultPlugin(t *test
 	// This project has a Default plugin but has never published — no
 	// plugin_github_connections row and no plugins-mcp API key. It must
 	// still show up as a candidate (the periodic safety net for a lost
-	// initial-publish enqueue), with a 'system' actor fallback.
+	// initial-publish enqueue), with a real org member as the actor.
 	_, err := queries.CreateDefaultPlugin(ctx, pluginsrepo.CreateDefaultPluginParams{
 		OrganizationID: authCtx.ActiveOrganizationID,
 		ProjectID:      *authCtx.ProjectID,
@@ -420,7 +423,7 @@ func TestListPluginPublishCandidates_IncludesNeverPublishedDefaultPlugin(t *test
 	require.NoError(t, err)
 	require.Len(t, candidates, 1)
 	require.Equal(t, *authCtx.ProjectID, candidates[0].ProjectID)
-	require.Equal(t, "system", candidates[0].CreatedByUserID)
+	require.Equal(t, authCtx.UserID, candidates[0].CreatedByUserID)
 }
 
 func TestListPluginPublishCandidates_ExcludesProjectWithoutDefaultPlugin(t *testing.T) {
@@ -471,4 +474,108 @@ func TestListPluginPublishCandidates_IncludesConnectedProjectWithoutDefaultPlugi
 	require.NoError(t, err)
 	require.Len(t, candidates, 1)
 	require.Equal(t, *authCtx.ProjectID, candidates[0].ProjectID)
+	require.Equal(t, authCtx.UserID, candidates[0].CreatedByUserID)
+}
+
+func TestListPluginPublishCandidates_FallsBackWhenPluginsMCPKeyHasPlaceholderCreator(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	queries := pluginsrepo.New(ti.conn)
+
+	_, err := queries.CreateDefaultPlugin(ctx, pluginsrepo.CreateDefaultPluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+
+	keyHash, err := auth.GetAPIKeyHash("gram_local_" + uuid.NewString())
+	require.NoError(t, err)
+	_, err = keysrepo.New(ti.conn).CreateAPIKey(ctx, keysrepo.CreateAPIKeyParams{
+		OrganizationID:  authCtx.ActiveOrganizationID,
+		ProjectID:       uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
+		CreatedByUserID: "system",
+		Name:            "plugins-mcp-20260708-120102-abc123",
+		KeyPrefix:       "gram_local_abcde",
+		KeyHash:         keyHash,
+		Scopes:          []string{"consumer"},
+	})
+	require.NoError(t, err)
+
+	candidates, err := queries.ListPluginPublishCandidates(ctx, pluginsrepo.ListPluginPublishCandidatesParams{
+		AfterProjectID: uuid.Nil,
+		ResultLimit:    100,
+	})
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	require.Equal(t, *authCtx.ProjectID, candidates[0].ProjectID)
+	require.Equal(t, authCtx.UserID, candidates[0].CreatedByUserID)
+}
+
+func TestListPluginPublishCandidates_EmptyActorWhenOrgHasNoMember(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	queries := pluginsrepo.New(ti.conn)
+
+	_, err := queries.CreateDefaultPlugin(ctx, pluginsrepo.CreateDefaultPluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, testrepo.New(ti.conn).ForceSoftDeleteOrganizationUserRelationshipsFixture(ctx, authCtx.ActiveOrganizationID))
+
+	candidates, err := queries.ListPluginPublishCandidates(ctx, pluginsrepo.ListPluginPublishCandidatesParams{
+		AfterProjectID: uuid.Nil,
+		ResultLimit:    100,
+	})
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	require.Equal(t, *authCtx.ProjectID, candidates[0].ProjectID)
+	require.Empty(t, candidates[0].CreatedByUserID)
+}
+
+func TestPublishProject_RejectsPlaceholderCreator(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	_, err := ti.service.PublishProject(ctx, plugins.PublishProjectInput{
+		ProjectID:       *authCtx.ProjectID,
+		CreatedByUserID: "system",
+		CommitMessage:   "Update plugin packages",
+		SkipIfUnchanged: true,
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "real user")
+}
+
+func TestPublishProject_RejectsUnknownCreator(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	_, err := ti.service.PublishProject(ctx, plugins.PublishProjectInput{
+		ProjectID:       *authCtx.ProjectID,
+		CreatedByUserID: "user_does_not_exist",
+		CommitMessage:   "Update plugin packages",
+		SkipIfUnchanged: true,
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "does not exist")
 }

--- a/server/internal/plugins/default_plugin_test.go
+++ b/server/internal/plugins/default_plugin_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
+	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 )
 
 func TestEnsureDefaultPlugin_CreatesWhenMissing(t *testing.T) {
@@ -577,5 +578,32 @@ func TestPublishProject_RejectsUnknownCreator(t *testing.T) {
 		SkipIfUnchanged: true,
 	})
 	require.Error(t, err)
-	require.ErrorContains(t, err, "does not exist")
+	require.ErrorContains(t, err, "not a member of the organization")
+}
+
+func TestPublishProject_RejectsForeignOrgCreator(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	_, err := usersrepo.New(ti.conn).UpsertUser(ctx, usersrepo.UpsertUserParams{
+		ID:          "user_foreign_org",
+		Email:       "foreign-org-creator@example.test",
+		DisplayName: "Foreign",
+		PhotoUrl:    pgtype.Text{},
+		Admin:       false,
+	})
+	require.NoError(t, err)
+
+	_, err = ti.service.PublishProject(ctx, plugins.PublishProjectInput{
+		ProjectID:       *authCtx.ProjectID,
+		CreatedByUserID: "user_foreign_org",
+		CommitMessage:   "Update plugin packages",
+		SkipIfUnchanged: true,
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "not a member of the organization")
 }

--- a/server/internal/plugins/default_plugin_test.go
+++ b/server/internal/plugins/default_plugin_test.go
@@ -517,6 +517,63 @@ func TestListPluginPublishCandidates_FallsBackWhenPluginsMCPKeyHasPlaceholderCre
 	require.Equal(t, authCtx.UserID, candidates[0].CreatedByUserID)
 }
 
+func TestListPluginPublishCandidates_FallsBackWhenNewestKeyCreatorLeftOrg(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestPluginsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	queries := pluginsrepo.New(ti.conn)
+
+	_, err := queries.CreateDefaultPlugin(ctx, pluginsrepo.CreateDefaultPluginParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		ProjectID:      *authCtx.ProjectID,
+	})
+	require.NoError(t, err)
+
+	_, err = usersrepo.New(ti.conn).UpsertUser(ctx, usersrepo.UpsertUserParams{
+		ID:          "user_departed_member",
+		Email:       "departed-member@example.test",
+		DisplayName: "Departed",
+		PhotoUrl:    pgtype.Text{},
+		Admin:       false,
+	})
+	require.NoError(t, err)
+	require.NoError(t, testrepo.New(ti.conn).CreateOrganizationUserRelationshipFixture(ctx, testrepo.CreateOrganizationUserRelationshipFixtureParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		UserID:         pgtype.Text{String: "user_departed_member", Valid: true},
+	}))
+
+	keyHash, err := auth.GetAPIKeyHash("gram_local_" + uuid.NewString())
+	require.NoError(t, err)
+	_, err = keysrepo.New(ti.conn).CreateAPIKey(ctx, keysrepo.CreateAPIKeyParams{
+		OrganizationID:  authCtx.ActiveOrganizationID,
+		ProjectID:       uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
+		CreatedByUserID: "user_departed_member",
+		Name:            "plugins-mcp-20260708-120102-abc123",
+		KeyPrefix:       "gram_local_abcde",
+		KeyHash:         keyHash,
+		Scopes:          []string{"consumer"},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, testrepo.New(ti.conn).ForceSoftDeleteOrganizationUserRelationship(ctx, testrepo.ForceSoftDeleteOrganizationUserRelationshipParams{
+		OrganizationID: authCtx.ActiveOrganizationID,
+		UserID:         pgtype.Text{String: "user_departed_member", Valid: true},
+	}))
+
+	candidates, err := queries.ListPluginPublishCandidates(ctx, pluginsrepo.ListPluginPublishCandidatesParams{
+		AfterProjectID: uuid.Nil,
+		ResultLimit:    100,
+	})
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	require.Equal(t, *authCtx.ProjectID, candidates[0].ProjectID)
+	require.Equal(t, authCtx.UserID, candidates[0].CreatedByUserID)
+}
+
 func TestListPluginPublishCandidates_EmptyActorWhenOrgHasNoMember(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -54,6 +54,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	ghclient "github.com/speakeasy-api/gram/server/internal/thirdparty/github"
+	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
@@ -1821,12 +1822,26 @@ type PublishProjectResult struct {
 	Skipped bool
 }
 
+// usableAPIKeyCreatorID reports whether userID can be written to
+// api_keys.created_by_user_id such that GetAPIKeyByKeyHash (which JOINs
+// users) will find the key. The empty string and the historical 'system'
+// placeholder fail that JOIN.
+func usableAPIKeyCreatorID(userID string) bool {
+	return userID != "" && userID != "system"
+}
+
 func (s *Service) PublishProject(ctx context.Context, input PublishProjectInput) (*PublishProjectResult, error) {
+	if !usableAPIKeyCreatorID(input.CreatedByUserID) {
+		return nil, fmt.Errorf("created by user id must be a real user")
+	}
+	if _, err := usersrepo.New(s.db).GetUser(ctx, input.CreatedByUserID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("created by user id %q does not exist", input.CreatedByUserID)
+		}
+		return nil, fmt.Errorf("get created by user: %w", err)
+	}
 	if s.github == nil {
 		return nil, fmt.Errorf("github publishing is not configured")
-	}
-	if input.CreatedByUserID == "" {
-		return nil, fmt.Errorf("created by user id is required")
 	}
 
 	project, err := projectsrepo.New(s.db).GetProjectWithOrganizationMetadata(ctx, input.ProjectID)
@@ -2595,6 +2610,16 @@ func (s *Service) persistPluginAPIKeys(
 		return fmt.Errorf("begin transaction: %w", err)
 	}
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
+
+	if !usableAPIKeyCreatorID(input.Actor.CreatedByUserID) {
+		return fmt.Errorf("refusing to mint plugin api key without a real creator")
+	}
+	if _, err := usersrepo.New(tx).GetUser(ctx, input.Actor.CreatedByUserID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("refusing to mint plugin api key: creator %q is not a user", input.Actor.CreatedByUserID)
+		}
+		return fmt.Errorf("get plugin api key creator: %w", err)
+	}
 
 	keysQ := keysrepo.New(tx)
 	for _, candidate := range candidates {

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -1822,16 +1822,20 @@ type PublishProjectResult struct {
 	Skipped bool
 }
 
-// usableAPIKeyCreatorID reports whether userID can be written to
-// api_keys.created_by_user_id such that GetAPIKeyByKeyHash (which JOINs
-// users) will find the key. The empty string and the historical 'system'
-// placeholder fail that JOIN.
-func usableAPIKeyCreatorID(userID string) bool {
+// UsableAPIKeyCreatorID reports whether userID is shaped like a value that can
+// be written to api_keys.created_by_user_id such that GetAPIKeyByKeyHash (which
+// JOINs users) will find the key. The empty string and the historical 'system'
+// placeholder fail that JOIN. This is the cheap shape check only -- it says
+// nothing about whether the id belongs to a current member of the target
+// organization, which requirePluginAPIKeyCreator establishes against the
+// database. Exported so the rollout workflow can drop a placeholder candidate
+// deterministically, without a second copy of the sentinel values.
+func UsableAPIKeyCreatorID(userID string) bool {
 	return userID != "" && userID != "system"
 }
 
 func requirePluginAPIKeyCreator(ctx context.Context, db usersrepo.DBTX, organizationID, userID string) error {
-	if !usableAPIKeyCreatorID(userID) {
+	if !UsableAPIKeyCreatorID(userID) {
 		return fmt.Errorf("created by user id must be a real user")
 	}
 	members, err := usersrepo.New(db).GetConnectedUsersByIDs(ctx, usersrepo.GetConnectedUsersByIDsParams{
@@ -1848,7 +1852,7 @@ func requirePluginAPIKeyCreator(ctx context.Context, db usersrepo.DBTX, organiza
 }
 
 func (s *Service) PublishProject(ctx context.Context, input PublishProjectInput) (*PublishProjectResult, error) {
-	if !usableAPIKeyCreatorID(input.CreatedByUserID) {
+	if !UsableAPIKeyCreatorID(input.CreatedByUserID) {
 		return nil, fmt.Errorf("created by user id must be a real user")
 	}
 

--- a/server/internal/plugins/impl.go
+++ b/server/internal/plugins/impl.go
@@ -54,9 +54,9 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	ghclient "github.com/speakeasy-api/gram/server/internal/thirdparty/github"
-	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
+	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
 )
 
 // GitHub usernames: 1-39 chars, starts with alphanumeric, alphanumeric or hyphen.
@@ -1830,23 +1830,37 @@ func usableAPIKeyCreatorID(userID string) bool {
 	return userID != "" && userID != "system"
 }
 
+func requirePluginAPIKeyCreator(ctx context.Context, db usersrepo.DBTX, organizationID, userID string) error {
+	if !usableAPIKeyCreatorID(userID) {
+		return fmt.Errorf("created by user id must be a real user")
+	}
+	members, err := usersrepo.New(db).GetConnectedUsersByIDs(ctx, usersrepo.GetConnectedUsersByIDsParams{
+		Ids:            []string{userID},
+		OrganizationID: organizationID,
+	})
+	if err != nil {
+		return fmt.Errorf("get plugin api key creator: %w", err)
+	}
+	if len(members) == 0 {
+		return fmt.Errorf("created by user id %q is not a member of the organization", userID)
+	}
+	return nil
+}
+
 func (s *Service) PublishProject(ctx context.Context, input PublishProjectInput) (*PublishProjectResult, error) {
 	if !usableAPIKeyCreatorID(input.CreatedByUserID) {
 		return nil, fmt.Errorf("created by user id must be a real user")
-	}
-	if _, err := usersrepo.New(s.db).GetUser(ctx, input.CreatedByUserID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, fmt.Errorf("created by user id %q does not exist", input.CreatedByUserID)
-		}
-		return nil, fmt.Errorf("get created by user: %w", err)
-	}
-	if s.github == nil {
-		return nil, fmt.Errorf("github publishing is not configured")
 	}
 
 	project, err := projectsrepo.New(s.db).GetProjectWithOrganizationMetadata(ctx, input.ProjectID)
 	if err != nil {
 		return nil, fmt.Errorf("get project with organization metadata: %w", err)
+	}
+	if err := requirePluginAPIKeyCreator(ctx, s.db, project.ID, input.CreatedByUserID); err != nil {
+		return nil, err
+	}
+	if s.github == nil {
+		return nil, fmt.Errorf("github publishing is not configured")
 	}
 
 	actorDisplayName := "Gram"
@@ -2611,14 +2625,8 @@ func (s *Service) persistPluginAPIKeys(
 	}
 	defer o11y.NoLogDefer(func() error { return tx.Rollback(ctx) })
 
-	if !usableAPIKeyCreatorID(input.Actor.CreatedByUserID) {
-		return fmt.Errorf("refusing to mint plugin api key without a real creator")
-	}
-	if _, err := usersrepo.New(tx).GetUser(ctx, input.Actor.CreatedByUserID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return fmt.Errorf("refusing to mint plugin api key: creator %q is not a user", input.Actor.CreatedByUserID)
-		}
-		return fmt.Errorf("get plugin api key creator: %w", err)
+	if err := requirePluginAPIKeyCreator(ctx, tx, input.OrganizationID, input.Actor.CreatedByUserID); err != nil {
+		return fmt.Errorf("refusing to mint plugin api key: %w", err)
 	}
 
 	keysQ := keysrepo.New(tx)

--- a/server/internal/plugins/queries.sql
+++ b/server/internal/plugins/queries.sql
@@ -621,9 +621,8 @@ WHERE project_id = @project_id;
 -- PublishProject's membership check does not reject the publish and skip
 -- the fallback. A project with no such actor still appears so pagination
 -- can advance; the actor id is empty and PublishProject refuses to mint.
--- This is a deliberate cross-project
--- sweep, so unlike the tenant-scoped queries it is not constrained to a
--- single project_id. The after_project_id filter is applied inside each
+-- This is a deliberate cross-project sweep, so unlike the tenant-scoped
+-- queries it is not constrained to a single project_id. The after_project_id filter is applied inside each
 -- UNION branch rather than the outer query -- sqlc's analyzer can't resolve
 -- an outer WHERE referencing the derived table's alias once a LATERAL join
 -- follows it ("table alias does not exist").
@@ -667,58 +666,6 @@ LEFT JOIN LATERAL (
 ) k ON TRUE
 ORDER BY cp.project_id ASC
 LIMIT @result_limit;
-
--- name: ListOrgPluginPublishTargets :many
--- Lists every project in one organization that has a GitHub plugin connection,
--- with a real users.id as the publish actor: the creator of the project's
--- newest plugins-mcp API key when that id is a current connected member of
--- the organization, otherwise the organization's oldest connected member.
--- Like ListPluginPublishCandidates this is a deliberate cross-project
--- sweep, but it is constrained to a single organization rather than
--- scanning globally.
-SELECT
-  targets.project_id,
-  targets.created_by_user_id
-FROM (
-  SELECT
-    c.project_id,
-    COALESCE(
-      k.created_by_user_id,
-      (
-        SELECT our.user_id
-        FROM organization_user_relationships our
-        JOIN users u ON u.id = our.user_id
-        WHERE our.organization_id = p.organization_id
-          AND our.deleted IS FALSE
-          AND our.user_id IS NOT NULL
-          AND u.deleted_at IS NULL
-        ORDER BY our.created_at ASC, our.user_id ASC
-        LIMIT 1
-      )
-    ) AS created_by_user_id
-  FROM plugin_github_connections c
-  JOIN projects p ON p.id = c.project_id AND p.deleted IS FALSE
-  LEFT JOIN LATERAL (
-    SELECT ak.created_by_user_id
-    FROM api_keys ak
-    JOIN users u ON u.id = ak.created_by_user_id
-    JOIN organization_user_relationships our
-      ON our.user_id = ak.created_by_user_id
-     AND our.organization_id = p.organization_id
-     AND our.deleted IS FALSE
-    WHERE ak.project_id = c.project_id
-      AND ak.deleted IS FALSE
-      AND ak.name LIKE 'plugins-mcp-%'
-      AND u.deleted_at IS NULL
-    ORDER BY ak.created_at DESC
-    LIMIT 1
-  ) k ON TRUE
-  WHERE p.organization_id = @organization_id
-) targets
-WHERE targets.created_by_user_id IS NOT NULL
-  AND targets.created_by_user_id <> ''
-  AND targets.created_by_user_id <> 'system'
-ORDER BY targets.project_id ASC;
 
 -- name: GetGitHubConnectionByMarketplaceToken :one
 -- Resolves a marketplace proxy URL token to the upstream connection. The token

--- a/server/internal/plugins/queries.sql
+++ b/server/internal/plugins/queries.sql
@@ -614,10 +614,13 @@ WHERE project_id = @project_id;
 -- unchanged project is cheap -- SkipIfUnchanged short-circuits on the
 -- fingerprint check before any GitHub/key work. Each row carries a real
 -- users.id as the publish actor: the creator of the project's newest
--- plugins-mcp API key when that id exists in users (the same JOIN
--- GetAPIKeyByKeyHash uses), otherwise the organization's oldest connected
--- member. A project with no such actor still appears so pagination can
--- advance; the actor id is empty and PublishProject refuses to mint.
+-- plugins-mcp API key when that id is a current connected member of the
+-- project's organization (users row plus a non-deleted
+-- organization_user_relationships row), otherwise the organization's
+-- oldest connected member. A former member still in users is skipped so
+-- PublishProject's membership check does not reject the publish and skip
+-- the fallback. A project with no such actor still appears so pagination
+-- can advance; the actor id is empty and PublishProject refuses to mint.
 -- This is a deliberate cross-project
 -- sweep, so unlike the tenant-scoped queries it is not constrained to a
 -- single project_id. The after_project_id filter is applied inside each
@@ -651,9 +654,14 @@ LEFT JOIN LATERAL (
   SELECT ak.created_by_user_id
   FROM api_keys ak
   JOIN users u ON u.id = ak.created_by_user_id
+  JOIN organization_user_relationships our
+    ON our.user_id = ak.created_by_user_id
+   AND our.organization_id = p.organization_id
+   AND our.deleted IS FALSE
   WHERE ak.project_id = cp.project_id
     AND ak.deleted IS FALSE
     AND ak.name LIKE 'plugins-mcp-%'
+    AND u.deleted_at IS NULL
   ORDER BY ak.created_at DESC
   LIMIT 1
 ) k ON TRUE
@@ -663,10 +671,11 @@ LIMIT @result_limit;
 -- name: ListOrgPluginPublishTargets :many
 -- Lists every project in one organization that has a GitHub plugin connection,
 -- with a real users.id as the publish actor: the creator of the project's
--- newest plugins-mcp API key when that id exists in users, otherwise the
--- organization's oldest connected member. Like ListPluginPublishCandidates
--- this is a deliberate cross-project sweep, but it is constrained to a
--- single organization rather than scanning globally.
+-- newest plugins-mcp API key when that id is a current connected member of
+-- the organization, otherwise the organization's oldest connected member.
+-- Like ListPluginPublishCandidates this is a deliberate cross-project
+-- sweep, but it is constrained to a single organization rather than
+-- scanning globally.
 SELECT
   targets.project_id,
   targets.created_by_user_id
@@ -693,9 +702,14 @@ FROM (
     SELECT ak.created_by_user_id
     FROM api_keys ak
     JOIN users u ON u.id = ak.created_by_user_id
+    JOIN organization_user_relationships our
+      ON our.user_id = ak.created_by_user_id
+     AND our.organization_id = p.organization_id
+     AND our.deleted IS FALSE
     WHERE ak.project_id = c.project_id
       AND ak.deleted IS FALSE
       AND ak.name LIKE 'plugins-mcp-%'
+      AND u.deleted_at IS NULL
     ORDER BY ak.created_at DESC
     LIMIT 1
   ) k ON TRUE

--- a/server/internal/plugins/queries.sql
+++ b/server/internal/plugins/queries.sql
@@ -612,10 +612,13 @@ WHERE project_id = @project_id;
 -- crash between commit and enqueue), this sweep picks it up within one tick
 -- instead of leaving it stuck until a human notices. Republishing an
 -- unchanged project is cheap -- SkipIfUnchanged short-circuits on the
--- fingerprint check before any GitHub/key work. Each row carries the user
--- that created the project's most recent plugins-mcp API key as the
--- publish actor, falling back to 'system' for a project that has never
--- published (no such key exists yet). This is a deliberate cross-project
+-- fingerprint check before any GitHub/key work. Each row carries a real
+-- users.id as the publish actor: the creator of the project's newest
+-- plugins-mcp API key when that id exists in users (the same JOIN
+-- GetAPIKeyByKeyHash uses), otherwise the organization's oldest connected
+-- member. A project with no such actor still appears so pagination can
+-- advance; the actor id is empty and PublishProject refuses to mint.
+-- This is a deliberate cross-project
 -- sweep, so unlike the tenant-scoped queries it is not constrained to a
 -- single project_id. The after_project_id filter is applied inside each
 -- UNION branch rather than the outer query -- sqlc's analyzer can't resolve
@@ -623,7 +626,21 @@ WHERE project_id = @project_id;
 -- follows it ("table alias does not exist").
 SELECT
   cp.project_id,
-  COALESCE(k.created_by_user_id, 'system') AS created_by_user_id
+  COALESCE(
+    k.created_by_user_id,
+    (
+      SELECT our.user_id
+      FROM organization_user_relationships our
+      JOIN users u ON u.id = our.user_id
+      WHERE our.organization_id = p.organization_id
+        AND our.deleted IS FALSE
+        AND our.user_id IS NOT NULL
+        AND u.deleted_at IS NULL
+      ORDER BY our.created_at ASC, our.user_id ASC
+      LIMIT 1
+    ),
+    ''
+  ) AS created_by_user_id
 FROM (
   SELECT c.project_id FROM plugin_github_connections c WHERE c.project_id > @after_project_id
   UNION
@@ -631,12 +648,13 @@ FROM (
 ) cp
 JOIN projects p ON p.id = cp.project_id AND p.deleted IS FALSE
 LEFT JOIN LATERAL (
-  SELECT created_by_user_id
-  FROM api_keys
-  WHERE project_id = cp.project_id
-    AND deleted IS FALSE
-    AND name LIKE 'plugins-mcp-%'
-  ORDER BY created_at DESC
+  SELECT ak.created_by_user_id
+  FROM api_keys ak
+  JOIN users u ON u.id = ak.created_by_user_id
+  WHERE ak.project_id = cp.project_id
+    AND ak.deleted IS FALSE
+    AND ak.name LIKE 'plugins-mcp-%'
+  ORDER BY ak.created_at DESC
   LIMIT 1
 ) k ON TRUE
 ORDER BY cp.project_id ASC
@@ -644,27 +662,49 @@ LIMIT @result_limit;
 
 -- name: ListOrgPluginPublishTargets :many
 -- Lists every project in one organization that has a GitHub plugin connection,
--- with the actor user for each (the creator of the project's most recent
--- plugins-mcp API key), so an org-level setting change (e.g. browser login)
--- can be republished to all of the org's marketplaces. Like
--- ListPluginPublishCandidates this is a deliberate cross-project sweep, but it is
--- constrained to a single organization rather than scanning globally.
+-- with a real users.id as the publish actor: the creator of the project's
+-- newest plugins-mcp API key when that id exists in users, otherwise the
+-- organization's oldest connected member. Like ListPluginPublishCandidates
+-- this is a deliberate cross-project sweep, but it is constrained to a
+-- single organization rather than scanning globally.
 SELECT
-  c.project_id,
-  k.created_by_user_id
-FROM plugin_github_connections c
-JOIN projects p ON p.id = c.project_id AND p.deleted IS FALSE
-JOIN LATERAL (
-  SELECT created_by_user_id
-  FROM api_keys
-  WHERE project_id = c.project_id
-    AND deleted IS FALSE
-    AND name LIKE 'plugins-mcp-%'
-  ORDER BY created_at DESC
-  LIMIT 1
-) k ON TRUE
-WHERE p.organization_id = @organization_id
-ORDER BY c.project_id ASC;
+  targets.project_id,
+  targets.created_by_user_id
+FROM (
+  SELECT
+    c.project_id,
+    COALESCE(
+      k.created_by_user_id,
+      (
+        SELECT our.user_id
+        FROM organization_user_relationships our
+        JOIN users u ON u.id = our.user_id
+        WHERE our.organization_id = p.organization_id
+          AND our.deleted IS FALSE
+          AND our.user_id IS NOT NULL
+          AND u.deleted_at IS NULL
+        ORDER BY our.created_at ASC, our.user_id ASC
+        LIMIT 1
+      )
+    ) AS created_by_user_id
+  FROM plugin_github_connections c
+  JOIN projects p ON p.id = c.project_id AND p.deleted IS FALSE
+  LEFT JOIN LATERAL (
+    SELECT ak.created_by_user_id
+    FROM api_keys ak
+    JOIN users u ON u.id = ak.created_by_user_id
+    WHERE ak.project_id = c.project_id
+      AND ak.deleted IS FALSE
+      AND ak.name LIKE 'plugins-mcp-%'
+    ORDER BY ak.created_at DESC
+    LIMIT 1
+  ) k ON TRUE
+  WHERE p.organization_id = @organization_id
+) targets
+WHERE targets.created_by_user_id IS NOT NULL
+  AND targets.created_by_user_id <> ''
+  AND targets.created_by_user_id <> 'system'
+ORDER BY targets.project_id ASC;
 
 -- name: GetGitHubConnectionByMarketplaceToken :one
 -- Resolves a marketplace proxy URL token to the upstream connection. The token

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -878,21 +878,43 @@ func (q *Queries) ListAgentPluginCompatibilityIssuesForProject(ctx context.Conte
 
 const listOrgPluginPublishTargets = `-- name: ListOrgPluginPublishTargets :many
 SELECT
-  c.project_id,
-  k.created_by_user_id
-FROM plugin_github_connections c
-JOIN projects p ON p.id = c.project_id AND p.deleted IS FALSE
-JOIN LATERAL (
-  SELECT created_by_user_id
-  FROM api_keys
-  WHERE project_id = c.project_id
-    AND deleted IS FALSE
-    AND name LIKE 'plugins-mcp-%'
-  ORDER BY created_at DESC
-  LIMIT 1
-) k ON TRUE
-WHERE p.organization_id = $1
-ORDER BY c.project_id ASC
+  targets.project_id,
+  targets.created_by_user_id
+FROM (
+  SELECT
+    c.project_id,
+    COALESCE(
+      k.created_by_user_id,
+      (
+        SELECT our.user_id
+        FROM organization_user_relationships our
+        JOIN users u ON u.id = our.user_id
+        WHERE our.organization_id = p.organization_id
+          AND our.deleted IS FALSE
+          AND our.user_id IS NOT NULL
+          AND u.deleted_at IS NULL
+        ORDER BY our.created_at ASC, our.user_id ASC
+        LIMIT 1
+      )
+    ) AS created_by_user_id
+  FROM plugin_github_connections c
+  JOIN projects p ON p.id = c.project_id AND p.deleted IS FALSE
+  LEFT JOIN LATERAL (
+    SELECT ak.created_by_user_id
+    FROM api_keys ak
+    JOIN users u ON u.id = ak.created_by_user_id
+    WHERE ak.project_id = c.project_id
+      AND ak.deleted IS FALSE
+      AND ak.name LIKE 'plugins-mcp-%'
+    ORDER BY ak.created_at DESC
+    LIMIT 1
+  ) k ON TRUE
+  WHERE p.organization_id = $1
+) targets
+WHERE targets.created_by_user_id IS NOT NULL
+  AND targets.created_by_user_id <> ''
+  AND targets.created_by_user_id <> 'system'
+ORDER BY targets.project_id ASC
 `
 
 type ListOrgPluginPublishTargetsRow struct {
@@ -901,11 +923,11 @@ type ListOrgPluginPublishTargetsRow struct {
 }
 
 // Lists every project in one organization that has a GitHub plugin connection,
-// with the actor user for each (the creator of the project's most recent
-// plugins-mcp API key), so an org-level setting change (e.g. browser login)
-// can be republished to all of the org's marketplaces. Like
-// ListPluginPublishCandidates this is a deliberate cross-project sweep, but it is
-// constrained to a single organization rather than scanning globally.
+// with a real users.id as the publish actor: the creator of the project's
+// newest plugins-mcp API key when that id exists in users, otherwise the
+// organization's oldest connected member. Like ListPluginPublishCandidates
+// this is a deliberate cross-project sweep, but it is constrained to a
+// single organization rather than scanning globally.
 func (q *Queries) ListOrgPluginPublishTargets(ctx context.Context, organizationID string) ([]ListOrgPluginPublishTargetsRow, error) {
 	rows, err := q.db.Query(ctx, listOrgPluginPublishTargets, organizationID)
 	if err != nil {
@@ -1025,7 +1047,21 @@ func (q *Queries) ListPluginEnvironmentConfigsForProject(ctx context.Context, ar
 const listPluginPublishCandidates = `-- name: ListPluginPublishCandidates :many
 SELECT
   cp.project_id,
-  COALESCE(k.created_by_user_id, 'system') AS created_by_user_id
+  COALESCE(
+    k.created_by_user_id,
+    (
+      SELECT our.user_id
+      FROM organization_user_relationships our
+      JOIN users u ON u.id = our.user_id
+      WHERE our.organization_id = p.organization_id
+        AND our.deleted IS FALSE
+        AND our.user_id IS NOT NULL
+        AND u.deleted_at IS NULL
+      ORDER BY our.created_at ASC, our.user_id ASC
+      LIMIT 1
+    ),
+    ''
+  ) AS created_by_user_id
 FROM (
   SELECT c.project_id FROM plugin_github_connections c WHERE c.project_id > $1
   UNION
@@ -1033,12 +1069,13 @@ FROM (
 ) cp
 JOIN projects p ON p.id = cp.project_id AND p.deleted IS FALSE
 LEFT JOIN LATERAL (
-  SELECT created_by_user_id
-  FROM api_keys
-  WHERE project_id = cp.project_id
-    AND deleted IS FALSE
-    AND name LIKE 'plugins-mcp-%'
-  ORDER BY created_at DESC
+  SELECT ak.created_by_user_id
+  FROM api_keys ak
+  JOIN users u ON u.id = ak.created_by_user_id
+  WHERE ak.project_id = cp.project_id
+    AND ak.deleted IS FALSE
+    AND ak.name LIKE 'plugins-mcp-%'
+  ORDER BY ak.created_at DESC
   LIMIT 1
 ) k ON TRUE
 ORDER BY cp.project_id ASC
@@ -1067,10 +1104,13 @@ type ListPluginPublishCandidatesRow struct {
 // crash between commit and enqueue), this sweep picks it up within one tick
 // instead of leaving it stuck until a human notices. Republishing an
 // unchanged project is cheap -- SkipIfUnchanged short-circuits on the
-// fingerprint check before any GitHub/key work. Each row carries the user
-// that created the project's most recent plugins-mcp API key as the
-// publish actor, falling back to 'system' for a project that has never
-// published (no such key exists yet). This is a deliberate cross-project
+// fingerprint check before any GitHub/key work. Each row carries a real
+// users.id as the publish actor: the creator of the project's newest
+// plugins-mcp API key when that id exists in users (the same JOIN
+// GetAPIKeyByKeyHash uses), otherwise the organization's oldest connected
+// member. A project with no such actor still appears so pagination can
+// advance; the actor id is empty and PublishProject refuses to mint.
+// This is a deliberate cross-project
 // sweep, so unlike the tenant-scoped queries it is not constrained to a
 // single project_id. The after_project_id filter is applied inside each
 // UNION branch rather than the outer query -- sqlc's analyzer can't resolve

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -903,9 +903,14 @@ FROM (
     SELECT ak.created_by_user_id
     FROM api_keys ak
     JOIN users u ON u.id = ak.created_by_user_id
+    JOIN organization_user_relationships our
+      ON our.user_id = ak.created_by_user_id
+     AND our.organization_id = p.organization_id
+     AND our.deleted IS FALSE
     WHERE ak.project_id = c.project_id
       AND ak.deleted IS FALSE
       AND ak.name LIKE 'plugins-mcp-%'
+      AND u.deleted_at IS NULL
     ORDER BY ak.created_at DESC
     LIMIT 1
   ) k ON TRUE
@@ -924,10 +929,11 @@ type ListOrgPluginPublishTargetsRow struct {
 
 // Lists every project in one organization that has a GitHub plugin connection,
 // with a real users.id as the publish actor: the creator of the project's
-// newest plugins-mcp API key when that id exists in users, otherwise the
-// organization's oldest connected member. Like ListPluginPublishCandidates
-// this is a deliberate cross-project sweep, but it is constrained to a
-// single organization rather than scanning globally.
+// newest plugins-mcp API key when that id is a current connected member of
+// the organization, otherwise the organization's oldest connected member.
+// Like ListPluginPublishCandidates this is a deliberate cross-project
+// sweep, but it is constrained to a single organization rather than
+// scanning globally.
 func (q *Queries) ListOrgPluginPublishTargets(ctx context.Context, organizationID string) ([]ListOrgPluginPublishTargetsRow, error) {
 	rows, err := q.db.Query(ctx, listOrgPluginPublishTargets, organizationID)
 	if err != nil {
@@ -1072,9 +1078,14 @@ LEFT JOIN LATERAL (
   SELECT ak.created_by_user_id
   FROM api_keys ak
   JOIN users u ON u.id = ak.created_by_user_id
+  JOIN organization_user_relationships our
+    ON our.user_id = ak.created_by_user_id
+   AND our.organization_id = p.organization_id
+   AND our.deleted IS FALSE
   WHERE ak.project_id = cp.project_id
     AND ak.deleted IS FALSE
     AND ak.name LIKE 'plugins-mcp-%'
+    AND u.deleted_at IS NULL
   ORDER BY ak.created_at DESC
   LIMIT 1
 ) k ON TRUE
@@ -1106,10 +1117,13 @@ type ListPluginPublishCandidatesRow struct {
 // unchanged project is cheap -- SkipIfUnchanged short-circuits on the
 // fingerprint check before any GitHub/key work. Each row carries a real
 // users.id as the publish actor: the creator of the project's newest
-// plugins-mcp API key when that id exists in users (the same JOIN
-// GetAPIKeyByKeyHash uses), otherwise the organization's oldest connected
-// member. A project with no such actor still appears so pagination can
-// advance; the actor id is empty and PublishProject refuses to mint.
+// plugins-mcp API key when that id is a current connected member of the
+// project's organization (users row plus a non-deleted
+// organization_user_relationships row), otherwise the organization's
+// oldest connected member. A former member still in users is skipped so
+// PublishProject's membership check does not reject the publish and skip
+// the fallback. A project with no such actor still appears so pagination
+// can advance; the actor id is empty and PublishProject refuses to mint.
 // This is a deliberate cross-project
 // sweep, so unlike the tenant-scoped queries it is not constrained to a
 // single project_id. The after_project_id filter is applied inside each

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -876,84 +876,6 @@ func (q *Queries) ListAgentPluginCompatibilityIssuesForProject(ctx context.Conte
 	return items, nil
 }
 
-const listOrgPluginPublishTargets = `-- name: ListOrgPluginPublishTargets :many
-SELECT
-  targets.project_id,
-  targets.created_by_user_id
-FROM (
-  SELECT
-    c.project_id,
-    COALESCE(
-      k.created_by_user_id,
-      (
-        SELECT our.user_id
-        FROM organization_user_relationships our
-        JOIN users u ON u.id = our.user_id
-        WHERE our.organization_id = p.organization_id
-          AND our.deleted IS FALSE
-          AND our.user_id IS NOT NULL
-          AND u.deleted_at IS NULL
-        ORDER BY our.created_at ASC, our.user_id ASC
-        LIMIT 1
-      )
-    ) AS created_by_user_id
-  FROM plugin_github_connections c
-  JOIN projects p ON p.id = c.project_id AND p.deleted IS FALSE
-  LEFT JOIN LATERAL (
-    SELECT ak.created_by_user_id
-    FROM api_keys ak
-    JOIN users u ON u.id = ak.created_by_user_id
-    JOIN organization_user_relationships our
-      ON our.user_id = ak.created_by_user_id
-     AND our.organization_id = p.organization_id
-     AND our.deleted IS FALSE
-    WHERE ak.project_id = c.project_id
-      AND ak.deleted IS FALSE
-      AND ak.name LIKE 'plugins-mcp-%'
-      AND u.deleted_at IS NULL
-    ORDER BY ak.created_at DESC
-    LIMIT 1
-  ) k ON TRUE
-  WHERE p.organization_id = $1
-) targets
-WHERE targets.created_by_user_id IS NOT NULL
-  AND targets.created_by_user_id <> ''
-  AND targets.created_by_user_id <> 'system'
-ORDER BY targets.project_id ASC
-`
-
-type ListOrgPluginPublishTargetsRow struct {
-	ProjectID       uuid.UUID
-	CreatedByUserID string
-}
-
-// Lists every project in one organization that has a GitHub plugin connection,
-// with a real users.id as the publish actor: the creator of the project's
-// newest plugins-mcp API key when that id is a current connected member of
-// the organization, otherwise the organization's oldest connected member.
-// Like ListPluginPublishCandidates this is a deliberate cross-project
-// sweep, but it is constrained to a single organization rather than
-// scanning globally.
-func (q *Queries) ListOrgPluginPublishTargets(ctx context.Context, organizationID string) ([]ListOrgPluginPublishTargetsRow, error) {
-	rows, err := q.db.Query(ctx, listOrgPluginPublishTargets, organizationID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []ListOrgPluginPublishTargetsRow
-	for rows.Next() {
-		var i ListOrgPluginPublishTargetsRow
-		if err := rows.Scan(&i.ProjectID, &i.CreatedByUserID); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listPluginAssignments = `-- name: ListPluginAssignments :many
 SELECT pa.id, pa.plugin_id, pa.organization_id, pa.principal_urn, pa.created_at, pa.updated_at
 FROM plugin_assignments pa
@@ -1124,9 +1046,8 @@ type ListPluginPublishCandidatesRow struct {
 // PublishProject's membership check does not reject the publish and skip
 // the fallback. A project with no such actor still appears so pagination
 // can advance; the actor id is empty and PublishProject refuses to mint.
-// This is a deliberate cross-project
-// sweep, so unlike the tenant-scoped queries it is not constrained to a
-// single project_id. The after_project_id filter is applied inside each
+// This is a deliberate cross-project sweep, so unlike the tenant-scoped
+// queries it is not constrained to a single project_id. The after_project_id filter is applied inside each
 // UNION branch rather than the outer query -- sqlc's analyzer can't resolve
 // an outer WHERE referencing the derived table's alias once a LATERAL join
 // follows it ("table alias does not exist").


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes DNO-1031: the scheduled plugin generator rollout minted `plugins-hooks-*` / `plugins-mcp-*` API keys with `created_by_user_id = 'system'` on a project's first publish. `GetAPIKeyByKeyHash` joins `users` on that column, so every request presenting those keys returned `unauthorized: api key not found`. The keys still appeared on the Keys page (no join), were embedded in published marketplace plugins, and never worked.

- `ListPluginPublishCandidates` now resolves a real `users.id`: the newest usable `plugins-mcp-*` key creator who is still a connected org member, otherwise the org's oldest connected member. An empty actor is still returned so pagination can advance; `PublishProject` refuses to mint.
- `PublishProject` / `persistPluginAPIKeys` reject `''`, `'system'`, and ids that are not an active member of the target organization.
- `RepairOrphanedAPIKeyCreators` rewrites existing keys whose creator is not a user onto that org's oldest member. The hourly rollout runs this once at the start of a fresh sweep, version-gated with `workflow.GetVersion` so in-flight executions keep their pre-deploy command sequence.
- `ListAPIKeysByOrganization` is deliberately left unjoined. An inner join on `users` would hide an unusable key from its owner — for up to an hour after deploy every affected org's plugin keys would disappear from the Keys page, and any row the repair does not reach becomes one the owner can neither inspect nor delete. The repair makes that state transient; the durable invariant belongs on the deferred foreign key.
- `ListOrgPluginPublishTargets` is deleted. It has no Go caller anywhere in the repo (only sqlc output references it, here and on `main`), so resolving an actor in it was maintenance on a query nothing runs.
- `plugins.UsableAPIKeyCreatorID` is exported so the rollout workflow, the candidate listing, and the publish check share one definition of the `''` / `'system'` sentinels instead of three copies, and the repair logs its row count (`gram.db.updated_rows_count`) so the sweep's one mutation is observable.

A foreign key on `api_keys.created_by_user_id` is left as a follow-up: migrations ship in their own PR, and `ON DELETE SET NULL` conflicts with the current `NOT NULL` column.

Temporal actions/month ≈ 720 starts + ~720 repair activities + list/publish pages, scales with projects (hourly safety-net sweep; GetVersion markers are workflow-task only).

### Why bind a human at all

The honest modelling fix is to let a machine-minted, org-wide credential have no human creator: make `created_by_user_id` nullable and `LEFT JOIN` in `GetAPIKeyByKeyHash`. That is not this PR. `authCtx.UserID` has ~429 call sites, many of them `urn.NewPrincipal(PrincipalTypeUser, authCtx.UserID)` on the audit path, so a nullable identity there is a separate change with its own blast radius. Nothing downstream relies on the plugin key's creator as an identity claim — per-developer attribution for hooks comes from the OTEL logs sidechannel, not `authCtx.Email` — and a dashboard-initiated publish already binds the publishing user the same way. So this restores parity with the human publish path and defers the modelling fix to the foreign-key PR.

The repair's `NOT EXISTS (users)` predicate is intentionally not narrowed to plugin key names: there is no hard-delete path for `users` anywhere in the codebase (`DisableUser` is a soft delete, and `GetAPIKeyByKeyHash` does not filter `deleted_at`), so in practice the only rows it matches are the `'system'` placeholders this PR is about.

## Motivation

A `'system'` placeholder made newly minted plugin keys unlistable by auth. The actor must be a real, current org member both when listing candidates and when persisting keys, and existing orphaned rows need a one-time rewrite. Adding that rewrite as a new first activity without `GetVersion` would nondeterministically fail any rollout still replaying after deploy.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-1031](https://linear.app/speakeasy/issue/DNO-1031/plugin-rollout-sweep-mints-api-keys-with-created-by-user-id-system)
