### PR TITLE
chore: replace pr-demo-gif gist hosting with gh CLI attachments

### DIFF
--- a/.agents/skills/pr-demo-gif/SKILL.md
+++ b/.agents/skills/pr-demo-gif/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: pr-demo-gif
-description: >-
-  Use when a pull request proposes user-visible dashboard changes and needs a
-  demo posted to it, such as a screenshot, a screen recording, a demo GIF, or a
-  PR comment showing the change. Covers capturing the dashboard with Playwright
-  and uploading media with `gh pr comment --attach`. Triggers: "add a demo to
-  the PR", "record a GIF", "screenshot this change", "show this in the PR",
-  "unknown flag: --attach", HTTP 404 from `gh pr comment --attach`.
+description: Always use after creating a pull request that proposes user-visible changes.
 ---
 
 # Demos for frontend PRs
@@ -35,7 +29,7 @@ Capture only the changed dashboard behavior and post it as a PR comment. Use one
   Expect at least one row, every row reading `gram_account_type = 'enterprise'`. Two rows is normal, because your dev org and the demo org each own a `default` project. Run `mise run seed` only on zero rows or a non-enterprise tier.
 
 - Invoke Playwright only through `mise run playwright`. The task uses the repo configuration and installs Chromium on demand.
-- Use `./tools/ffmpeg` for any conversion or frame extraction.
+- Use `./tools/ffmpeg` for the trim, frame-extraction, and GIF steps. The PNG path needs no conversion.
 
 The login flow is credential-less: open the dashboard, click **Login** if redirected, and wait for `/speakeasy`. If the first load is blank after a fresh browser install, navigate to the URL again.
 
@@ -114,10 +108,10 @@ The trimmed file is the one you publish, so it is the one section 3 applies to. 
 
 ### GIF fallback
 
-Convert only when the reviewer needs the demo inline where a player will not render, notably GitHub notification emails. Two-pass palette, output beside the WebM:
+Convert only when the reviewer needs the demo inline where a player will not render, notably GitHub notification emails. Convert the trimmed file, not the raw take, so the GIF does not carry the dead air you just removed. Two-pass palette:
 
 ```bash
-./tools/ffmpeg -ss <trim-seconds> -i "$DIR/demo.webm" \
+./tools/ffmpeg -i "$DIR/demo-trimmed.webm" \
   -vf "fps=10,scale=1200:-1:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse" \
   "$DIR/demo.gif"
 ```
@@ -129,10 +123,10 @@ A GIF is hard-refused over 10 MB. Increase the scale toward 1440 for small text,
 You cannot watch a WebM. Extract frames first, then look at them:
 
 ```bash
-./tools/ffmpeg -i "$DIR/demo-trimmed.webm" -vf "fps=1/3,scale=1200:-1" "$DIR/frame-%02d.png"
+./tools/ffmpeg -i "$DIR/demo-trimmed.webm" -vf "fps=1/2,scale=1200:-1" "$DIR/frame-%02d.png"
 ```
 
-Aim for eight to ten frames; raise the interval on a longer clip, because reading twenty near-identical frames is the slowest step in this workflow. Read every extracted frame, or the PNG or GIF for the other paths, and confirm all of the following before running any `--attach` command:
+One frame every two seconds gives eight to ten frames for a trimmed 15 to 20 second take. Raise the interval on anything longer, because reading twenty near-identical frames is the slowest step in this workflow. Read every extracted frame, or the PNG or GIF for the other paths, and confirm all of the following before running any `--attach` command:
 
 1. It shows the changed behavior, and nothing before or after it.
 2. No real identity: the user menu, avatar, and member columns show no real name or email. Dev-idp signs you in as `dev@example.com` in `Local Dev Org`, so this is normally satisfied already. If your stack points at a real identity provider and the sidebar shows your actual name, collapse the sidebar and recapture rather than editing the DOM.
@@ -182,7 +176,7 @@ Keep the numbered list short and aligned with the visible steps.
 
 ## Common mistakes
 
-- **`HTTP 404` from `--attach`** means you lack write access, not that the PR is missing. Attachments need ADMIN, MAINTAIN, or WRITE; READ and TRIAGE both 404. Fine-grained PATs are per-repo, so one minted elsewhere fails on a repo you can otherwise push to. From a fork, fall back to a secret gist: write any text file into `$DIR`, run `gh gist create` on it (binaries passed directly are silently dropped), clone the returned gist repo, copy `$DEMO` in, commit, push with `git -c credential.helper='!gh auth git-credential' push`, then reference the raw URL.
+- **`HTTP 404` from `--attach`** means you lack write access, not that the PR is missing. Attachments need ADMIN, MAINTAIN, or WRITE; READ and TRIAGE both 404. Fine-grained PATs are per-repo, so one minted elsewhere fails on a repo you can otherwise push to. From a fork, fall back to a secret gist: write any text file into `$DIR`, run `gh gist create` on it (binaries passed directly are silently dropped), clone the returned gist repo, copy `$DEMO` in (or `$DIR/demo-trimmed.webm` for a recording, which the video path never assigns to `$DEMO`), commit, push with `git -c credential.helper='!gh auth git-credential' push`, then reference the raw URL.
 - **Uploads stop at the first failure** and the body is written only if at least one file uploaded, so a partial failure posts a comment containing unresolved local paths. Attach one file at a time unless you need them in a single comment.
 - Attaching the demo to the PR body with `gh pr edit` instead of a comment. Use a comment, so the demo sits in the timeline next to the change it describes.
 

--- a/.agents/skills/pr-demo-gif/SKILL.md
+++ b/.agents/skills/pr-demo-gif/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: pr-demo-gif
-description: Use when a pull request proposes user-visible dashboard changes and needs a demo posted to it — a screenshot, a screen recording, a demo GIF, or a PR comment showing the change. Covers capturing the dashboard with Playwright and uploading media with `gh pr comment --attach`. Triggers: "add a demo to the PR", "record a GIF", "screenshot this change", "show this in the PR", "unknown flag: --attach", HTTP 404 from `gh pr comment --attach`.
+description: >-
+  Use when a pull request proposes user-visible dashboard changes and needs a
+  demo posted to it, such as a screenshot, a screen recording, a demo GIF, or a
+  PR comment showing the change. Covers capturing the dashboard with Playwright
+  and uploading media with `gh pr comment --attach`. Triggers: "add a demo to
+  the PR", "record a GIF", "screenshot this change", "show this in the PR",
+  "unknown flag: --attach", HTTP 404 from `gh pr comment --attach`.
 ---
 
 # Demos for frontend PRs
@@ -19,14 +25,14 @@ Capture only the changed dashboard behavior and post it as a PR comment. Use one
 
 ## Prerequisites
 
-- Discover the dashboard URL with `mise run zero:summary` — read the address from the **Gram dashboard** row (don't assume a port). The same table shows whether each service is RUNNING; if the dashboard or server is STOPPED, start the stack with `mise start` first. Dev-idp auto-login is enabled, and the local TLS cert is browser-trusted (mkcert CA in the NSS store, set up by `mise run zero:tls` — rerun that if you see cert errors).
+- Discover the dashboard URL with `mise run zero:summary` — read the address from the **Gram dashboard** row (don't assume a port). The same table shows whether each service is RUNNING. A paused worktree shows **Database** and **ClickHouse** as STOPPED: run `mise run wake` (containers, then daemons) and expect two to four minutes. Do not use `mise start` here, which launches the foreground process-manager TUI and starts only the daemons, leaving the server wedged against a stopped Postgres with no diagnostic. Dev-idp auto-login is enabled, and the local TLS cert is browser-trusted (mkcert CA in the NSS store, set up by `mise run zero:tls` — rerun that if you see cert errors).
 - Use the **`default`** project for all flows — `mise run seed` (the demo seed retargeted at your dev org) provisions exactly one project. Before recording, verify the database is seeded by probing it directly (the connection string is in the **Database** row of `zero:summary`; drop its `&search_path=public` parameter, which `psql` rejects with `invalid URI query parameter`):
 
   ```bash
   psql "postgres://gram:gram@127.0.0.1:<port>/gram?sslmode=disable" -c "SELECT p.slug, om.gram_account_type FROM projects p JOIN organization_metadata om ON om.id = p.organization_id WHERE p.slug = 'default' AND NOT p.deleted;"
   ```
 
-  Expect one row with `gram_account_type = 'enterprise'`. Otherwise run `mise run seed` before continuing.
+  Expect at least one row, every row reading `gram_account_type = 'enterprise'`. Two rows is normal, because your dev org and the demo org each own a `default` project. Run `mise run seed` only on zero rows or a non-enterprise tier.
 
 - Invoke Playwright only through `mise run playwright`. The task uses the repo configuration and installs Chromium on demand.
 - Use `./tools/ffmpeg` for any conversion or frame extraction.
@@ -43,7 +49,7 @@ DIR=.playwright-cli/pr-demos/$PR
 mkdir -p "$DIR"
 ```
 
-Use `-s=pr-demo-$PR` as the session flag in every Playwright command below. `.playwright-cli/` is gitignored at any depth. Relative paths resolve against your current directory, so stay at the repo root for the whole workflow: a path that resolves differently at capture time and at upload time silently breaks the body rewrite in section 4.
+Use `-s=pr-demo-$PR` as the session flag in every Playwright command below. If your tooling runs each command in a fresh shell, these variables do not survive between calls: re-export them in every command, or write the literal paths. `.playwright-cli/` is gitignored at any depth. Relative paths resolve against your current directory, so stay at the repo root for the whole workflow: a path that resolves differently at capture time and at upload time silently breaks the body rewrite in section 4.
 
 ## 1. Rehearse
 
@@ -54,7 +60,7 @@ mise run playwright -s=pr-demo-$PR snapshot
 
 Navigate to the feature and rehearse the exact interaction using snapshot refs. Keep the browser open. Video recording starts only when requested, so rehearsal does not create footage.
 
-Return to the intended starting state before capture. Hide an irrelevant fixed development dock with `eval` only if it obscures the changed behavior; page navigation removes DOM-only adjustments.
+Return to the intended starting state before capture. Hide the fixed development dock with `eval` before every capture, whether or not it obscures the change: it is dev-only chrome and reads as a product bug to a reviewer. Page navigation removes DOM-only adjustments, so re-apply it after navigating.
 
 ## 2. Capture
 
@@ -97,7 +103,14 @@ mise run playwright -s=pr-demo-$PR video-stop
 mise run playwright -s=pr-demo-$PR close
 ```
 
-GitHub renders `.webm` as a video player, so a recording is normally posted as-is with no conversion. If a take goes wrong, stop it, restore the starting state in a new session, and record again. Do not include setup, login, exploration, or unrelated page tours.
+Every `mise run playwright` subcommand costs one to two seconds of process startup, and all of it lands in the recording as dead air. Budget for it: a take with six commands and six seconds of deliberate holds runs near thirty seconds. Trim the lead-in and tail before uploading:
+
+```bash
+./tools/ffmpeg -y -ss <start> -to <end> -i "$DIR/demo.webm" \
+  -c:v libvpx -b:v 1M -crf 30 -an "$DIR/demo-trimmed.webm"
+```
+
+The trimmed file is the one you publish, so it is the one section 3 applies to. GitHub serves `.webm` back as `video/webm` and renders it as a player, so no further conversion is needed. If a take goes wrong, stop it, restore the starting state in a new session, and record again. Do not include setup, login, exploration, or unrelated page tours.
 
 ### GIF fallback
 
@@ -116,14 +129,14 @@ A GIF is hard-refused over 10 MB. Increase the scale toward 1440 for small text,
 You cannot watch a WebM. Extract frames first, then look at them:
 
 ```bash
-./tools/ffmpeg -i "$DIR/demo.webm" -vf "fps=1/2,scale=1200:-1" "$DIR/frame-%02d.png"
+./tools/ffmpeg -i "$DIR/demo-trimmed.webm" -vf "fps=1/3,scale=1200:-1" "$DIR/frame-%02d.png"
 ```
 
-Read every extracted frame, or the PNG or GIF for the other paths, and confirm all of the following before running any `--attach` command:
+Aim for eight to ten frames; raise the interval on a longer clip, because reading twenty near-identical frames is the slowest step in this workflow. Read every extracted frame, or the PNG or GIF for the other paths, and confirm all of the following before running any `--attach` command:
 
 1. It shows the changed behavior, and nothing before or after it.
-2. No real identity: the user menu, avatar, and account settings show no real name or email.
-3. No real organization: check the org switcher, breadcrumbs, and URL bar. `mise run seed` retargets the demo seed at **your own org**, so the rows are synthetic but the chrome around them is not.
+2. No real identity: the user menu, avatar, and member columns show no real name or email. Dev-idp signs you in as `dev@example.com` in `Local Dev Org`, so this is normally satisfied already. If your stack points at a real identity provider and the sidebar shows your actual name, collapse the sidebar and recapture rather than editing the DOM.
+3. No **customer** organization: check the org switcher, breadcrumbs, and URL bar. Your own dev org and Speakeasy's own name are fine; a customer's is not. `mise run seed` retargets the demo seed at **your own org**, so the rows are synthetic but the chrome around them is not.
 4. No secrets: no API keys, tokens, or environment variable values in view.
 5. Within limits: images and GIFs under 10 MB, video under 100 MB.
 
@@ -160,7 +173,7 @@ Set `DEMO="$DIR/demo.png"` or `DEMO="$DIR/demo.gif"` first. The heredoc is inten
 
 ```bash
 env -u GH_TOKEN -u GITHUB_TOKEN mise exec -- gh pr comment "$PR" \
-  --body-file "$DIR/comment.md" --attach "$DIR/demo.webm"
+  --body-file "$DIR/comment.md" --attach "$DIR/demo-trimmed.webm"
 ```
 
 Write that body with the numbered list above the player, and no image reference.
@@ -169,7 +182,7 @@ Keep the numbered list short and aligned with the visible steps.
 
 ## Common mistakes
 
-- **`HTTP 404` from `--attach`** means you lack write access, not that the PR is missing. Attachments need ADMIN, MAINTAIN, or WRITE; READ and TRIAGE both 404. Fine-grained PATs are per-repo, so one minted elsewhere fails on a repo you can otherwise push to. From a fork, fall back to hosting the file in a secret gist (`gh gist create placeholder.md`, then push the binary through the gist's git repo) and referencing its raw URL.
+- **`HTTP 404` from `--attach`** means you lack write access, not that the PR is missing. Attachments need ADMIN, MAINTAIN, or WRITE; READ and TRIAGE both 404. Fine-grained PATs are per-repo, so one minted elsewhere fails on a repo you can otherwise push to. From a fork, fall back to a secret gist: write any text file into `$DIR`, run `gh gist create` on it (binaries passed directly are silently dropped), clone the returned gist repo, copy `$DEMO` in, commit, push with `git -c credential.helper='!gh auth git-credential' push`, then reference the raw URL.
 - **Uploads stop at the first failure** and the body is written only if at least one file uploaded, so a partial failure posts a comment containing unresolved local paths. Attach one file at a time unless you need them in a single comment.
 - Attaching the demo to the PR body with `gh pr edit` instead of a comment. Use a comment, so the demo sits in the timeline next to the change it describes.
 

--- a/.agents/skills/pr-demo-gif/SKILL.md
+++ b/.agents/skills/pr-demo-gif/SKILL.md
@@ -1,13 +1,21 @@
 ---
 name: pr-demo-gif
-description: Always use after creating a pull request that proposes user-visible changes.
+description: Use when a pull request proposes user-visible dashboard changes and needs a demo posted to it — a screenshot, a screen recording, a demo GIF, or a PR comment showing the change. Covers capturing the dashboard with Playwright and uploading media with `gh pr comment --attach`. Triggers: "add a demo to the PR", "record a GIF", "screenshot this change", "show this in the PR", "unknown flag: --attach", HTTP 404 from `gh pr comment --attach`.
 ---
 
 # Demos for frontend PRs
 
-Capture only the changed dashboard behavior and post it as a PR comment. Use one or two PNGs for a static visual change; use a 10–20 second GIF for an interaction.
+Capture only the changed dashboard behavior and post it as a PR comment. Use one or two PNGs for a static visual change; use a 10-20 second WebM recording for an interaction.
 
 **REQUIRED SUB-SKILL:** Use `gram-playwright-cli` for browser commands.
+
+**Uploads cannot be undone.** `gh` attachments have no delete endpoint, and deleting the comment does not unpublish the asset: it stays live at an unauthenticated URL. The inspect step in section 3 is the last reversible moment in this workflow.
+
+| Change type                                 | Capture                      | Publish as                  |
+| ------------------------------------------- | ---------------------------- | --------------------------- |
+| Static visual                               | `screenshot --hires`         | PNG, embedded with alt text |
+| Interaction                                 | `video-start` / `video-stop` | WebM, rendered as a player  |
+| Interaction needing inline email visibility | WebM, then ffmpeg            | GIF, embedded with alt text |
 
 ## Prerequisites
 
@@ -20,18 +28,28 @@ Capture only the changed dashboard behavior and post it as a PR comment. Use one
 
   Expect one row with `gram_account_type = 'enterprise'`. Otherwise run `mise run seed` before continuing.
 
-3. Invoke Playwright only through `mise run playwright`. The task uses the repo configuration and installs Chromium on demand.
-4. Use `./tools/ffmpeg` for GIF conversion.
+- Invoke Playwright only through `mise run playwright`. The task uses the repo configuration and installs Chromium on demand.
+- Use `./tools/ffmpeg` for any conversion or frame extraction.
 
 The login flow is credential-less: open the dashboard, click **Login** if redirected, and wait for `/speakeasy`. If the first load is blank after a fresh browser install, navigate to the URL again.
 
-## 1. Rehearse
+## 0. Namespace everything by PR number
 
-Use a named session so every command reaches the same browser:
+Concurrent agent sessions share a worktree and share the Playwright browser. Key the artifact directory **and** the Playwright session name on the PR number, so two sessions cannot overwrite each other's files or drive each other's browser:
 
 ```bash
-mise run playwright -s=pr-demo open "<dashboard-url>"
-mise run playwright -s=pr-demo snapshot
+PR=<pr-number>
+DIR=.playwright-cli/pr-demos/$PR
+mkdir -p "$DIR"
+```
+
+Use `-s=pr-demo-$PR` as the session flag in every Playwright command below. `.playwright-cli/` is gitignored at any depth. Relative paths resolve against your current directory, so stay at the repo root for the whole workflow: a path that resolves differently at capture time and at upload time silently breaks the body rewrite in section 4.
+
+## 1. Rehearse
+
+```bash
+mise run playwright -s=pr-demo-$PR open "<dashboard-url>"
+mise run playwright -s=pr-demo-$PR snapshot
 ```
 
 Navigate to the feature and rehearse the exact interaction using snapshot refs. Keep the browser open. Video recording starts only when requested, so rehearsal does not create footage.
@@ -40,101 +58,132 @@ Return to the intended starting state before capture. Hide an irrelevant fixed d
 
 ## 2. Capture
 
-Create ignored artifact directories:
-
-```bash
-mkdir -p .playwright-cli/pr-demos /tmp/pr-demo
-```
-
 ### Static change
 
 Prepare the exact frame, then capture a viewport or element screenshot:
 
 ```bash
-mise run playwright -s=pr-demo screenshot --hires --filename=.playwright-cli/pr-demos/demo.png
-mise run playwright -s=pr-demo screenshot <element-ref> --hires --filename=.playwright-cli/pr-demos/demo-detail.png
+mise run playwright -s=pr-demo-$PR screenshot --hires --filename="$DIR/demo.png"
+mise run playwright -s=pr-demo-$PR screenshot <element-ref> --hires --filename="$DIR/demo-detail.png"
 ```
 
-The shared config keeps the CSS viewport at 1440×900 and uses a 2× device scale factor, so `--hires` produces a crisp 2880×1800 viewport image. Use `--full-page` only when the changed layout cannot fit in the viewport.
+The shared config keeps the CSS viewport at 1440x900 and uses a 2x device scale factor, so `--hires` produces a crisp 2880x1800 viewport image. Use `--full-page` only when the changed layout cannot fit in the viewport.
 
 ### Interaction change
 
 Start recording only after the page is ready:
 
 ```bash
-mise run playwright -s=pr-demo video-start .playwright-cli/pr-demos/demo.webm --size=1440x900
-mise run playwright -s=pr-demo video-show-actions --duration=700 --position=top-right --cursor=pointer
+mise run playwright -s=pr-demo-$PR video-start "$DIR/demo.webm" --size=1440x900
+mise run playwright -s=pr-demo-$PR video-show-actions --duration=700 --position=top-right --cursor=pointer
 ```
 
 Perform the rehearsed clicks, fills, and navigation with normal CLI commands. The action overlay supplies the pointer, target highlight, and action label; do not inject a fake cursor. Let each important state remain visible long enough to read. When a longer hold is needed:
 
 ```bash
-mise run playwright -s=pr-demo run-code "async page => await page.waitForTimeout(1000)"
+mise run playwright -s=pr-demo-$PR run-code "async page => await page.waitForTimeout(1000)"
 ```
 
 For a meaningful transition, optionally add a short chapter card:
 
 ```bash
-mise run playwright -s=pr-demo video-chapter "<title>" --description="<what changes>" --duration=1200
+mise run playwright -s=pr-demo-$PR video-chapter "<title>" --description="<what changes>" --duration=1200
 ```
 
 Stop recording to flush the WebM, then close the session:
 
 ```bash
-mise run playwright -s=pr-demo video-stop
-mise run playwright -s=pr-demo close
+mise run playwright -s=pr-demo-$PR video-stop
+mise run playwright -s=pr-demo-$PR close
 ```
 
-If a take goes wrong, stop it, restore the starting state in a new session, and record again. Do not include setup, login, exploration, or unrelated page tours.
+GitHub renders `.webm` as a video player, so a recording is normally posted as-is with no conversion. If a take goes wrong, stop it, restore the starting state in a new session, and record again. Do not include setup, login, exploration, or unrelated page tours.
 
-## 3. Convert and inspect
+### GIF fallback
 
-Convert interaction footage in the scratchpad with a two-pass palette:
+Convert only when the reviewer needs the demo inline where a player will not render, notably GitHub notification emails. Two-pass palette, output beside the WebM:
 
 ```bash
-./tools/ffmpeg -ss <trim-seconds> -i .playwright-cli/pr-demos/demo.webm \
+./tools/ffmpeg -ss <trim-seconds> -i "$DIR/demo.webm" \
   -vf "fps=10,scale=1200:-1:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse" \
-  /tmp/pr-demo/demo.gif
+  "$DIR/demo.gif"
 ```
 
-Inspect the final PNG or GIF before publishing. Confirm it shows the changed behavior, contains no sensitive data, and the GIF is under roughly 10 MB. Increase the scale toward 1440 for small text, or crop to the relevant region before `fps=` instead of shrinking the whole frame.
+A GIF is hard-refused over 10 MB. Increase the scale toward 1440 for small text, or crop to the relevant region before `fps=` instead of shrinking the whole frame.
 
-## 4. Host in a secret gist
+## 3. Inspect before uploading
 
-GitHub does not expose PR attachment upload through its API. Create a secret gist from a text placeholder, then push the binary through the gist repository:
+You cannot watch a WebM. Extract frames first, then look at them:
 
 ```bash
-cd /tmp/pr-demo
-echo "demo" > placeholder.md
-gh gist create placeholder.md --desc "PR demo"
-git clone https://gist.github.com/<gist-id>.git gist
-cp demo.gif gist/
-cd gist
-git add demo.gif
-git commit -m "add demo gif"
-git -c credential.helper='!gh auth git-credential' push
+./tools/ffmpeg -i "$DIR/demo.webm" -vf "fps=1/2,scale=1200:-1" "$DIR/frame-%02d.png"
 ```
 
-For screenshots, copy the PNG from `.playwright-cli/pr-demos/` instead. Secret is the default; `gh gist create` has no `--secret` flag. Never pass a binary directly to `gh gist create`, because it silently fails. The raw URL is:
+Read every extracted frame, or the PNG or GIF for the other paths, and confirm all of the following before running any `--attach` command:
 
-```text
-https://gist.githubusercontent.com/<user>/<gist-id>/raw/<file>
-```
+1. It shows the changed behavior, and nothing before or after it.
+2. No real identity: the user menu, avatar, and account settings show no real name or email.
+3. No real organization: check the org switcher, breadcrumbs, and URL bar. `mise run seed` retargets the demo seed at **your own org**, so the rows are synthetic but the chrome around them is not.
+4. No secrets: no API keys, tokens, or environment variable values in view.
+5. Within limits: images and GIFs under 10 MB, video under 100 MB.
 
-## 5. Post the PR comment
+A recording crosses far more of these surfaces than a deliberately framed screenshot. Recapture rather than publishing a frame you are unsure about.
+
+## 4. Post the PR comment
+
+Two environment gotchas, both of which produce misleading errors:
+
+- Prefix with `env -u GH_TOKEN -u GITHUB_TOKEN`. An environment token wins over your keyring credential, and Actions' `GITHUB_TOKEN` is not allowed to upload attachments.
+- Invoke gh through `mise exec` so you get the pinned 2.100.0. A shell without mise active falls through to a system gh, and an older one fails with `unknown flag: --attach`.
+
+Write the body to a file so the same shell variable supplies the path in both the markdown and the flag. `gh` rewrites a body reference in place only when the two paths match **byte for byte**; any mismatch silently appends the image below your text instead, and still exits 0.
 
 ```bash
-gh pr comment <pr> --body "$(cat <<'EOF'
+cat > "$DIR/comment.md" <<EOF
 ### Demo
 
-![demo](https://gist.githubusercontent.com/<user>/<gist-id>/raw/demo.gif)
+![<alt text>]($DEMO)
 
 What it shows:
 1. <starting state>
 2. <interaction>
 3. <changed behavior>
 EOF
-)"
+
+env -u GH_TOKEN -u GITHUB_TOKEN mise exec -- gh pr comment "$PR" \
+  --body-file "$DIR/comment.md" --attach "$DEMO#<alt text>"
 ```
 
+Set `DEMO="$DIR/demo.png"` or `DEMO="$DIR/demo.gif"` first. The heredoc is intentionally unquoted so `$DEMO` expands; escape any literal `` ` `` or `$` in your text. A path containing `#` cannot be attached, because `#` delimits the alt text.
+
+**Video differs.** A video renders as a bare URL on its own line and cannot carry alt text, so passing `#<alt text>` is a hard error. Attach it with no alt text and let it append below your body:
+
+```bash
+env -u GH_TOKEN -u GITHUB_TOKEN mise exec -- gh pr comment "$PR" \
+  --body-file "$DIR/comment.md" --attach "$DIR/demo.webm"
+```
+
+Write that body with the numbered list above the player, and no image reference.
+
 Keep the numbered list short and aligned with the visible steps.
+
+## Common mistakes
+
+- **`HTTP 404` from `--attach`** means you lack write access, not that the PR is missing. Attachments need ADMIN, MAINTAIN, or WRITE; READ and TRIAGE both 404. Fine-grained PATs are per-repo, so one minted elsewhere fails on a repo you can otherwise push to. From a fork, fall back to hosting the file in a secret gist (`gh gist create placeholder.md`, then push the binary through the gist's git repo) and referencing its raw URL.
+- **Uploads stop at the first failure** and the body is written only if at least one file uploaded, so a partial failure posts a comment containing unresolved local paths. Attach one file at a time unless you need them in a single comment.
+- Attaching the demo to the PR body with `gh pr edit` instead of a comment. Use a comment, so the demo sits in the timeline next to the change it describes.
+
+### Verified refusals
+
+`gh` validates every attachment locally before it resolves the repository, so these all fail without uploading or posting anything:
+
+| Command                         | Error                                                                                                |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `--attach demo.webm#alt`        | `cannot set alt text on video`                                                                       |
+| `--attach missing.png`          | `missing.png: no such file or directory`                                                             |
+| `--attach empty.png`            | `empty.png is empty`                                                                                 |
+| `--attach some-dir`             | `some-dir is a directory`                                                                            |
+| `--attach notes.txt`            | `notes.txt is not a supported file type (supported: png, jpg, jpeg, gif, webp, svg, mp4, mov, webm)` |
+| `--attach a.png --attach a.png` | `a.png and a.png are the same file; attached files must be unique`                                   |
+
+Duplicate detection also catches a symlink or hard link to an already-attached file.

--- a/mise.lock
+++ b/mise.lock
@@ -185,6 +185,52 @@ checksum = "sha256:6a9869922fa6f5abdc8997a8f6eb276aa9feb5a0848d963d9eb3d50e034fc
 url = "https://github.com/superfly/flyctl/releases/download/v0.4.77/flyctl_0.4.77_Windows_x86_64.zip"
 url_api = "https://api.github.com/repos/superfly/flyctl/releases/assets/495778612"
 
+[[tools.gh]]
+version = "2.100.0"
+backend = "aqua:cli/cli"
+
+[tools.gh."platforms.linux-arm64"]
+checksum = "sha256:ea4e7a581a32ccad6cc7923cb1576ac5859ba4b9a16ab22eb8f8a96e78e2e961"
+url = "https://github.com/cli/cli/releases/download/v2.100.0/gh_2.100.0_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/cli/cli/releases/assets/542974279"
+provenance = "github-attestations"
+
+[tools.gh."platforms.linux-arm64-musl"]
+checksum = "sha256:ea4e7a581a32ccad6cc7923cb1576ac5859ba4b9a16ab22eb8f8a96e78e2e961"
+url = "https://github.com/cli/cli/releases/download/v2.100.0/gh_2.100.0_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/cli/cli/releases/assets/542974279"
+provenance = "github-attestations"
+
+[tools.gh."platforms.linux-x64"]
+checksum = "sha256:e4d4bb4498e8d007abe545b6568926793ace1b6447da598294a610018cb164be"
+url = "https://github.com/cli/cli/releases/download/v2.100.0/gh_2.100.0_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/cli/cli/releases/assets/542974264"
+provenance = "github-attestations"
+
+[tools.gh."platforms.linux-x64-musl"]
+checksum = "sha256:e4d4bb4498e8d007abe545b6568926793ace1b6447da598294a610018cb164be"
+url = "https://github.com/cli/cli/releases/download/v2.100.0/gh_2.100.0_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/cli/cli/releases/assets/542974264"
+provenance = "github-attestations"
+
+[tools.gh."platforms.macos-arm64"]
+checksum = "sha256:45f9a62da2f6e641a7fad57e2ce39656dfd7ef331372d80a2a2aed65abb01642"
+url = "https://github.com/cli/cli/releases/download/v2.100.0/gh_2.100.0_macOS_arm64.zip"
+url_api = "https://api.github.com/repos/cli/cli/releases/assets/542974295"
+provenance = "github-attestations"
+
+[tools.gh."platforms.macos-x64"]
+checksum = "sha256:fcd7799e85eb575f3c7d2b1679bfbfedaefa1269d4bc7d096b51e10939b4812b"
+url = "https://github.com/cli/cli/releases/download/v2.100.0/gh_2.100.0_macOS_amd64.zip"
+url_api = "https://api.github.com/repos/cli/cli/releases/assets/542974293"
+provenance = "github-attestations"
+
+[tools.gh."platforms.windows-x64"]
+checksum = "sha256:227e35230b25db3fa1b997bab7cf4d67df0470a3b75b99e4ee66bce1a7cd4e72"
+url = "https://github.com/cli/cli/releases/download/v2.100.0/gh_2.100.0_windows_amd64.zip"
+url_api = "https://api.github.com/repos/cli/cli/releases/assets/542974322"
+provenance = "github-attestations"
+
 [[tools."github:FiloSottile/mkcert"]]
 version = "1.4.4"
 backend = "github:FiloSottile/mkcert"

--- a/mise.toml
+++ b/mise.toml
@@ -20,6 +20,11 @@ pin = true
 "github:FiloSottile/mkcert" = "1.4.4"
 apko = "1.2.31"
 flyctl = "0.4.77"
+# 2.99.0 is the floor: it added the repeatable `--attach` flag that the
+# pr-demo-gif skill uses to upload media to PR comments. Bumping is safe,
+# downgrading past that floor is not. Nothing bumps this automatically,
+# because dependabot does not cover mise [tools].
+gh = "2.100.0"
 go = "1.27.0"
 golangci-lint = "2.13.2"
 gomigrate = "4.19.1"

--- a/mise.toml
+++ b/mise.toml
@@ -20,10 +20,6 @@ pin = true
 "github:FiloSottile/mkcert" = "1.4.4"
 apko = "1.2.31"
 flyctl = "0.4.77"
-# 2.99.0 is the floor: it added the repeatable `--attach` flag that the
-# pr-demo-gif skill uses to upload media to PR comments. Bumping is safe,
-# downgrading past that floor is not. Nothing bumps this automatically,
-# because dependabot does not cover mise [tools].
 gh = "2.100.0"
 go = "1.27.0"
 golangci-lint = "2.13.2"

--- a/tools/ffmpeg
+++ b/tools/ffmpeg
@@ -24,6 +24,14 @@ checksum = "sha256:be08b871acad2035f02eff5561d2f0c0bbfc4e12da44ed9074699a8e81e82
 url = "https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-8.1.2-gpl_h6237aff_902.conda"
 checksum = "sha256:be08b871acad2035f02eff5561d2f0c0bbfc4e12da44ed9074699a8e81e82281"
 
+[lock.platforms.macos-arm64]
+url = "https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-8.1.2-gpl_h5f9a2c2_108.conda"
+checksum = "sha256:f719c7ee889cb48cff6dca0c69a00e8b1af19936d17a74d03463b7a8d80e0022"
+
+[lock.platforms.macos-x64]
+url = "https://conda.anaconda.org/conda-forge/osx-64/ffmpeg-8.1.2-gpl_h4193ad6_108.conda"
+checksum = "sha256:4ca0c4947103aca3286295b60a7791e30edbf5853eb1e30dfe5564ca08b35e57"
+
 [lock.platforms.windows-x64]
 url = "https://conda.anaconda.org/conda-forge/win-64/ffmpeg-8.1.2-gpl_hdd6294f_902.conda"
 checksum = "sha256:136bb34782ed1dfa0cdc594c0ce61a120057c394efa3c64008c9404785d1b4da"


### PR DESCRIPTION
[AGE-3390](https://linear.app/speakeasy/issue/AGE-3390/feat-update-pr-demo-gif-to-use-github-cli-attachments)

## Summary

Replaces the secret-gist hosting step in the `pr-demo-gif` skill with `gh pr comment --attach`, and pins `gh` in `mise.toml` at `2.100.0`.

`gh` was not pinned at all before, so the resolved binary was whatever the developer happened to have installed. `2.99.0` is the floor that added `--attach`; `2.98.0` fails with `unknown flag: --attach`. The pin comment says so, because dependabot does not cover mise `[tools]` and nothing bumps this automatically.

Other changes to the skill, all prompted by the switch:

- **Interaction demos attach the Playwright WebM directly.** GitHub accepts and plays `video/webm`, so the two-pass ffmpeg GIF recipe drops to a fallback for when the demo has to render inline, notably in notification emails, where a player does not render.
- **Artifact paths and the Playwright session name are keyed on the PR number.** The old scratchpad was `/tmp/pr-demo`, which collides across worktrees, and the fixed `-s=pr-demo` session name let two concurrent sessions in one worktree drive the same browser and truncate each other's recording.
- **The pre-upload check is now a named checklist.** An attachment has no delete endpoint, and deleting the comment does not unpublish the asset, so that step is the last reversible moment in the workflow. The checklist calls out the chrome around the seeded rows, which carries the real identity and org name even though the rows themselves are synthetic.
- **The gist path survives as a fallback** for the case `--attach` cannot serve: a fork, or a token without write access, which returns a misleading `404` that reads as "no such PR".
- **Verified local refusals are recorded with their exact error text**, along with two environment traps: an env-provided `GH_TOKEN` beating the keyring credential (Actions' `GITHUB_TOKEN` is not allowed to upload), and a mise-less shell falling through to an older system `gh`.

## Motivation

`gh gist create` tripped model permission-override failures, which is what surfaced the issue. The deeper problem is that the gist workaround only existed because PR attachment upload had no CLI surface, and the skill said so in a comment that is now false. `gh 2.99.0` added the repeatable `--attach` flag across the issue and PR commands, so the workaround and roughly twenty lines of gist plumbing (create, clone, copy, commit, credential-helper push) can go.

Attaching directly is also better output: no 10fps 256-colour palette conversion on the common path, and full-motion 1440x900 instead.

The `--attach` behaviours documented in the skill were verified against the pinned binary. `gh` validates every attachment locally before it resolves the repository, so the refusal table was captured without uploading or posting anything.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
For [AGE-3390](https://linear.app/speakeasy/issue/AGE-3390/feat-update-pr-demo-gif-to-use-github-cli-attachments), updates `pr-demo-gif` to upload PNG and WebM demos with `gh pr comment --attach` instead of using secret gists. WebM recordings now render as GitHub players; uploads cannot be unpublished, and forks or read-only tokens still use the gist fallback.

- Pins `gh` to 2.100.0 in `mise.toml` and `mise.lock`; 2.99.0 is the floor that added `--attach`.
- Names artifacts and Playwright sessions by PR number to prevent concurrent sessions from colliding.
- Adds frame inspection, video trimming, credential checks, and verified attachment refusal guidance.
- Corrects paused-worktree startup and seed checks, hides the development dock, and makes the gist fallback self-contained.
- Locks ffmpeg for macOS in `tools/ffmpeg`, which previously resolved unlocked on darwin.

<sup>Written for commit 41fe6b994269d16f5575ca2ba2a9993a98282e57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

