### PR TITLE
feat: make MCP error codes and HTTP statuses conditional on the protocol revision

### DIFF
--- a/server/internal/contextvalues/context.go
+++ b/server/internal/contextvalues/context.go
@@ -97,8 +97,28 @@ type AdminAuthContext struct {
 	HD          string
 }
 
+// RPCContext is the mutable holder an MCP/JSON-RPC error wrapper installs
+// before invoking its handler, so that state the handler discovers while
+// serving the request is visible to the wrapper afterwards. A plain context
+// value cannot serve that purpose here: the wrapper reads the request context
+// it captured before dispatch, where anything the handler added is absent.
 type RPCContext struct {
+	// ID is the JSON-RPC id of the request being served, so that an error
+	// serialized after the handler returns echoes the id the client sent
+	// rather than a null one.
 	ID mcpjsonrpc.ID
+
+	// ProtocolVersion is the MCP protocol revision in effect for the request,
+	// which selects the revision-conditional wire mappings. It stays empty
+	// until the handler resolves it, which cannot happen before the request
+	// body is decoded, so errors raised earlier are answered on the legacy
+	// mappings.
+	//
+	// It carries the resolved revision rather than the raw declaration,
+	// because whether a declaration is honored depends on the supported set
+	// of the surface serving the request, and the wrapper reading this is
+	// shared across surfaces with sets of their own.
+	ProtocolVersion string
 }
 
 const (

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -909,6 +909,17 @@ func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		}
 	}
 
+	// Resolved the moment the declaration is readable, rather than alongside
+	// the rest of the request inputs further down, because the authorization
+	// and admission checks in between return errors of their own and each one
+	// has to be answered on the revision the client is actually speaking. The
+	// initialize handler overwrites InEffect with the negotiated answer once
+	// this reaches mcpInputs, which is the one sanctioned mutation.
+	protocolVersion := mcpversions.Resolve(mcprequests.DeclaredProtocolVersion(r.Header.Get(mcpversions.HTTPHeader), req.Params), mcpversions.SupportedHostedToolset())
+	if rpcCtx, ok := contextvalues.GetRPCContext(ctx); ok {
+		rpcCtx.ProtocolVersion = protocolVersion.InEffect
+	}
+
 	// Extract tokens from headers separately:
 	// - authToken: from Authorization header (for OAuth flows)
 	// - sessionToken: from Gram-Chat-Session header (for chat session fallback on non-OAuth endpoints)
@@ -1098,7 +1109,7 @@ func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, t
 	hostedCoverageRecorded := false
 	if isHostedToolsCall {
 		if err := s.enforceHostedToolsCall(ctx, toolset.OrganizationID, cfg.mcpServerID); err != nil {
-			return s.respondMCPError(ctx, w, req.ID, err)
+			return writeMCPError(ctx, s.logger, w, req.ID, protocolVersion.InEffect, err)
 		}
 		hostedCoverageRecorded = true
 	}
@@ -1174,7 +1185,7 @@ func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		metaMcpServerID:          "",
 		skipProxyTools:           false,
 		tags:                     tags,
-		protocolVersion:          mcpversions.Resolve(mcprequests.DeclaredProtocolVersion(r.Header.Get(mcpversions.HTTPHeader), req.Params), mcpversions.SupportedHostedToolset()),
+		protocolVersion:          protocolVersion,
 		identityCoverageRecorded: hostedCoverageRecorded,
 		toolSelection:            callerToolSelection,
 	}
@@ -1220,7 +1231,9 @@ func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		if rpcCtx, ok := contextvalues.GetRPCContext(ctx); ok && rpcCtx.ID.IsSet() {
 			mcpID = rpcCtx.ID
 		}
-		return s.respondMCPError(ctx, w, mcpID, err)
+		// Read back off mcpInputs rather than the local: an initialize
+		// request carries the negotiated answer only there.
+		return writeMCPError(ctx, s.logger, w, mcpID, mcpInputs.protocolVersion.InEffect, err)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -1268,20 +1281,6 @@ func (s *Service) enforceHostedToolsCall(ctx context.Context, organizationID str
 	default:
 		return errors.New("invalid hosted MCP kill-switch disposition")
 	}
-}
-
-func (s *Service) respondMCPError(ctx context.Context, w http.ResponseWriter, id mcpjsonrpc.ID, cause error) error {
-	bs, err := json.Marshal(oops.NewMCPErrorFromCause(id, cause))
-	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to serialize error response").LogError(ctx, s.logger)
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	if _, err := w.Write(bs); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to write MCP error response")
-	}
-	return nil
 }
 
 // checkToolsetSecurity loads the toolset's security variables and checks if the

--- a/server/internal/mcp/mcperror.go
+++ b/server/internal/mcp/mcperror.go
@@ -6,30 +6,72 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
 	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 )
 
 // writeMCPError serializes cause as the JSON-RPC error response to request id.
-// It is the single write site for errors a Gram-served MCP dispatcher returns,
-// shared by the hosted, platform, and meta surfaces so that the wire shape of
-// an MCP error does not depend on which of them produced it.
+// The hosted, platform, and meta surfaces share it so that the wire shape of an
+// MCP error does not depend on which of them produced it. The consent
+// transport writes its own JSON-RPC errors and does not come through here.
 //
-// revision is the protocol revision in effect for the request. It selects the
-// wire error code, so a surface that resolves a revision passes the resolved
-// value rather than the client's declaration; an empty value is answered on
-// the legacy mappings.
+// revision is the protocol revision in effect for the request. It selects both
+// the wire error code and the HTTP status, so a surface that resolves a
+// revision passes the resolved value rather than the client's declaration; an
+// empty value is answered on the legacy mappings.
 func writeMCPError(ctx context.Context, logger *slog.Logger, w http.ResponseWriter, id mcpjsonrpc.ID, revision string, cause error) error {
-	bs, err := json.Marshal(oops.NewMCPErrorFromCause(id, revision, cause))
+	mcpErr := oops.NewMCPErrorFromCause(id, revision, cause)
+
+	bs, err := json.Marshal(mcpErr)
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "failed to serialize error response").LogError(ctx, logger)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(mcpErrorHTTPStatus(mcpErr.Code, revision))
 	if _, err := w.Write(bs); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "failed to write MCP error response")
+		return oops.E(oops.CodeUnexpected, err, "failed to write error response body").LogError(ctx, logger)
 	}
 
 	return nil
+}
+
+// mcpErrorHTTPStatus selects the HTTP status carrying a JSON-RPC error.
+//
+// The handshake-based revisions keep the 200 they have always been served.
+// Under them a JSON-RPC error travels in the body of a successful response,
+// and many clients on those revisions read a non-2xx as a transport failure
+// without parsing the body at all, so a status change there breaks working
+// clients to fix a problem none of them have.
+//
+// MCP 2026-07-28 instead mandates a status per condition, and the mandate is
+// load-bearing rather than cosmetic. A client that speaks both eras detects
+// which one a server implements by making a modern request and inspecting the
+// body of a 400 before falling back, and it separates a modern server that
+// does not implement a method from a legacy server that does not host the
+// modern endpoint at all by the JSON-RPC body accompanying a 404. Answering
+// either with a 200 leaves such a client nothing to inspect and no way to tell
+// the eras apart.
+//
+// Conditions the specification assigns no status keep 200 on every revision.
+// Inventing one would move traffic it did not ask to move.
+//
+// An error that names no request — a notification, or a failure raised before
+// the id could be read — is treated no differently. The mandated status is a
+// property of the condition rather than of the message that provoked it, and
+// the specification's own direction for input a server cannot accept is an
+// HTTP error status, not a 200 carrying an error body. Splitting on the id
+// here would also put this out of step with the wrapper that answers errors
+// escaping a handler, which has no 200 to fall back to.
+func mcpErrorHTTPStatus(code oops.MCPCode, revision string) int {
+	if !mcpversions.IsModern(revision) {
+		return http.StatusOK
+	}
+
+	if mandated, ok := code.MandatedHTTPStatus(); ok {
+		return mandated
+	}
+
+	return http.StatusOK
 }

--- a/server/internal/mcp/mcperror.go
+++ b/server/internal/mcp/mcperror.go
@@ -65,7 +65,7 @@ func writeMCPError(ctx context.Context, logger *slog.Logger, w http.ResponseWrit
 // here would also put this out of step with the wrapper that answers errors
 // escaping a handler, which has no 200 to fall back to.
 func mcpErrorHTTPStatus(code oops.MCPCode, revision string) int {
-	if !mcpversions.IsModern(revision) {
+	if !mcpversions.AtLeast(revision, mcpversions.Version20260728) {
 		return http.StatusOK
 	}
 

--- a/server/internal/mcp/mcperror.go
+++ b/server/internal/mcp/mcperror.go
@@ -1,0 +1,35 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+// writeMCPError serializes cause as the JSON-RPC error response to request id.
+// It is the single write site for errors a Gram-served MCP dispatcher returns,
+// shared by the hosted, platform, and meta surfaces so that the wire shape of
+// an MCP error does not depend on which of them produced it.
+//
+// revision is the protocol revision in effect for the request. It selects the
+// wire error code, so a surface that resolves a revision passes the resolved
+// value rather than the client's declaration; an empty value is answered on
+// the legacy mappings.
+func writeMCPError(ctx context.Context, logger *slog.Logger, w http.ResponseWriter, id mcpjsonrpc.ID, revision string, cause error) error {
+	bs, err := json.Marshal(oops.NewMCPErrorFromCause(id, revision, cause))
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to serialize error response").LogError(ctx, logger)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(bs); err != nil {
+		return oops.E(oops.CodeUnexpected, err, "failed to write MCP error response")
+	}
+
+	return nil
+}

--- a/server/internal/mcp/mcperror_internal_test.go
+++ b/server/internal/mcp/mcperror_internal_test.go
@@ -1,0 +1,183 @@
+package mcp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
+	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+// TestMCPErrorHTTPStatus_ModernRevisionUsesMandatedStatuses covers the table
+// MCP 2026-07-28 mandates. The 404 is the one with a rationale beyond
+// tidiness: the JSON-RPC body accompanying it is what separates a modern
+// server that does not implement the method from a legacy server that does not
+// host the modern endpoint at all.
+func TestMCPErrorHTTPStatus_ModernRevisionUsesMandatedStatuses(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		code oops.MCPCode
+		want int
+	}{
+		{code: oops.MCPCodeMethodNotFound, want: http.StatusNotFound},
+		{code: oops.MCPCodeInvalidParams, want: http.StatusBadRequest},
+		{code: oops.MCPCodeHeaderMismatch, want: http.StatusBadRequest},
+		{code: oops.MCPCodeMissingRequiredClientCapability, want: http.StatusBadRequest},
+		{code: oops.MCPCodeUnsupportedProtocolVersion, want: http.StatusBadRequest},
+	} {
+		require.Equal(t, tt.want, mcpErrorHTTPStatus(tt.code, mcpversions.Version20260728), "code %d", tt.code)
+	}
+}
+
+// TestMCPErrorHTTPStatus_LegacyRevisionsKeep200 pins the invariant that keeps
+// today's clients working. Under the handshake-based revisions a JSON-RPC
+// error is carried by a successful response, and clients that treat a non-2xx
+// as a transport failure never reach the body at all.
+func TestMCPErrorHTTPStatus_LegacyRevisionsKeep200(t *testing.T) {
+	t.Parallel()
+
+	for _, revision := range []string{
+		mcpversions.Version20241105,
+		mcpversions.Version20250326,
+		mcpversions.Version20250618,
+		mcpversions.Version20251125,
+	} {
+		require.Equal(t, http.StatusOK, mcpErrorHTTPStatus(oops.MCPCodeMethodNotFound, revision), "revision %s", revision)
+		require.Equal(t, http.StatusOK, mcpErrorHTTPStatus(oops.MCPCodeInvalidParams, revision), "revision %s", revision)
+	}
+}
+
+// TestMCPErrorHTTPStatus_UnresolvedRevisionKeeps200 covers the errors raised
+// before a revision can be resolved. They must fall to the legacy side: a
+// request whose revision is unknown is not evidence of a modern client.
+func TestMCPErrorHTTPStatus_UnresolvedRevisionKeeps200(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, http.StatusOK, mcpErrorHTTPStatus(oops.MCPCodeMethodNotFound, ""))
+	require.Equal(t, http.StatusOK, mcpErrorHTTPStatus(oops.MCPCodeMethodNotFound, "not-a-revision"))
+}
+
+// TestMCPErrorHTTPStatus_UnmandatedCodesKeep200OnModernRevision guards the
+// scope of the change. The specification assigns a status to five conditions
+// and says nothing about the rest, which is most of what Gram emits; giving
+// those a status of our choosing would move traffic on a guess.
+func TestMCPErrorHTTPStatus_UnmandatedCodesKeep200OnModernRevision(t *testing.T) {
+	t.Parallel()
+
+	for _, code := range []oops.MCPCode{
+		oops.MCPCodeParseError,
+		oops.MCPCodeInvalidRequest,
+		oops.MCPCodeInternalError,
+		oops.MCPCodeServerError,
+		oops.MCPCodeUnauthorized,
+		oops.MCPCodeForbidden,
+	} {
+		require.Equal(t, http.StatusOK, mcpErrorHTTPStatus(code, mcpversions.Version20260728), "code %d", code)
+	}
+}
+
+// TestMCPErrorHTTPStatus_RetiredNotFoundBecomesBadRequestOnModernRevision
+// covers the two revision-conditional rules meeting on one error. Gram's
+// general not-found — an unknown tool, toolset, or endpoint — maps to -32602
+// under 2026-07-28, and that code is answered with 400 rather than the 404 the
+// internal error code alone would suggest.
+func TestMCPErrorHTTPStatus_RetiredNotFoundBecomesBadRequestOnModernRevision(t *testing.T) {
+	t.Parallel()
+
+	code := oops.CodeNotFound.MCPCodeFor(mcpversions.Version20260728)
+
+	require.Equal(t, oops.MCPCodeInvalidParams, code)
+	require.Equal(t, http.StatusBadRequest, mcpErrorHTTPStatus(code, mcpversions.Version20260728))
+}
+
+// TestWriteMCPError_WritesStatusCodeAndBodyTogether covers the wiring rather
+// than the table: that the status actually reaches the response, and that it
+// was chosen for the same error the body carries. A helper that computed the
+// right status and wrote a different one would satisfy every other test here.
+func TestWriteMCPError_WritesStatusCodeAndBodyTogether(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	err := writeMCPError(t.Context(), testenv.NewLogger(t), rec, mcpjsonrpc.StringID("req-1"),
+		mcpversions.Version20260728, oops.E(oops.CodeNotImplemented, nil, "tools/nope: Method not found"))
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+	var response struct {
+		JSONRPC string `json:"jsonrpc"`
+		ID      string `json:"id"`
+		Error   struct {
+			Code oops.MCPCode `json:"code"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	require.Equal(t, "2.0", response.JSONRPC)
+	require.Equal(t, "req-1", response.ID)
+	require.Equal(t, oops.MCPCodeMethodNotFound, response.Error.Code)
+}
+
+// TestWriteMCPError_LegacyRevisionWritesOKWithTheSameBody is the invariant that
+// protects today's traffic: identical JSON-RPC error, HTTP 200.
+func TestWriteMCPError_LegacyRevisionWritesOKWithTheSameBody(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	err := writeMCPError(t.Context(), testenv.NewLogger(t), rec, mcpjsonrpc.StringID("req-1"),
+		mcpversions.Version20251125, oops.E(oops.CodeNotImplemented, nil, "tools/nope: Method not found"))
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var response struct {
+		Error struct {
+			Code oops.MCPCode `json:"code"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	require.Equal(t, oops.MCPCodeMethodNotFound, response.Error.Code)
+}
+
+// TestWriteMCPError_NotificationsGetTheMandatedStatusToo records a deliberate
+// choice. A message carrying no id gets the same status as one that does: the
+// mandated status describes the condition, not the message that provoked it,
+// and 2026-07-28 directs a server that cannot accept input to answer with an
+// HTTP error status rather than a 200 carrying an error body. Answering
+// notifications differently here would also diverge from the wrapper that
+// handles errors escaping a handler, which has no 200 to fall back to.
+func TestWriteMCPError_NotificationsGetTheMandatedStatusToo(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	err := writeMCPError(t.Context(), testenv.NewLogger(t), rec, mcpjsonrpc.ID{},
+		mcpversions.Version20260728, oops.E(oops.CodeNotImplemented, nil, "notifications/nope: Method not found"))
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+
+	var response map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	require.Nil(t, response["id"], "a notification is still answered with a null id")
+}
+
+// TestWriteMCPError_NotificationsKeep200OnLegacyRevisions is the other half:
+// nothing about notification handling changes for the revisions in service
+// today.
+func TestWriteMCPError_NotificationsKeep200OnLegacyRevisions(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	err := writeMCPError(t.Context(), testenv.NewLogger(t), rec, mcpjsonrpc.ID{},
+		mcpversions.Version20251125, oops.E(oops.CodeNotImplemented, nil, "notifications/nope: Method not found"))
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+}

--- a/server/internal/mcp/mcpversions/mcpversions.go
+++ b/server/internal/mcp/mcpversions/mcpversions.go
@@ -227,24 +227,15 @@ func Known(v string) bool {
 //
 // An unrecognized value is never at least anything, so a garbage revision
 // cannot reach behavior gated on a real one.
+//
+// Callers testing what governs a request pass the revision in effect
+// ([Resolution.InEffect]), never the declared one: what a client asked for
+// does not decide what it is served.
 func AtLeast(v, floor string) bool {
 	vi := slices.Index(all, v)
 	fi := slices.Index(all, floor)
 
 	return vi >= 0 && fi >= 0 && vi >= fi
-}
-
-// IsModern reports whether v is [Version20260728] or later — the boundary the
-// specification draws between the handshake-based revisions and the stateless
-// era, and the only version test the wire-format branches make. Naming it once
-// means a later revision that supersedes 2026-07-28 moves the boundary here
-// rather than at each branch.
-//
-// Callers pass the revision in effect for a request ([Resolution.InEffect]),
-// never the declared one: what a client asked for does not govern what it is
-// served.
-func IsModern(v string) bool {
-	return AtLeast(v, Version20260728)
 }
 
 // Clamp bounds a client-supplied version for use as a metric dimension: a

--- a/server/internal/mcp/mcpversions/mcpversions.go
+++ b/server/internal/mcp/mcpversions/mcpversions.go
@@ -216,12 +216,22 @@ func Known(v string) bool {
 
 // AtLeast reports whether v is a recognized revision no older than floor.
 //
-// Revision identifiers are ISO dates, so lexical order is chronological order
-// and the comparison stands on its own rather than on the ordering of [all].
-// An unrecognized value is never at least anything: garbage that happens to
-// sort above a real revision must not read as the newer behavior.
+// The comparison is positional in [all] rather than lexical on the
+// identifiers. Both are correct for the revisions recognized today, which are
+// all ISO dates and are held in that order by TestAllIsChronologicallyOrdered
+// and TestAllAreDatedRevisions. Position is used anyway because it depends on
+// the ordering [all] already declares contractual instead of on the shape of
+// the identifiers, so it keeps its meaning if the specification's undated
+// `draft` revision is ever recognized here — where a lexical test would rank
+// it above every dated revision.
+//
+// An unrecognized value is never at least anything, so a garbage revision
+// cannot reach behavior gated on a real one.
 func AtLeast(v, floor string) bool {
-	return Known(v) && v >= floor
+	vi := slices.Index(all, v)
+	fi := slices.Index(all, floor)
+
+	return vi >= 0 && fi >= 0 && vi >= fi
 }
 
 // IsModern reports whether v is [Version20260728] or later — the boundary the

--- a/server/internal/mcp/mcpversions/mcpversions.go
+++ b/server/internal/mcp/mcpversions/mcpversions.go
@@ -214,6 +214,29 @@ func Known(v string) bool {
 	return slices.Contains(all, v)
 }
 
+// AtLeast reports whether v is a recognized revision no older than floor.
+//
+// Revision identifiers are ISO dates, so lexical order is chronological order
+// and the comparison stands on its own rather than on the ordering of [all].
+// An unrecognized value is never at least anything: garbage that happens to
+// sort above a real revision must not read as the newer behavior.
+func AtLeast(v, floor string) bool {
+	return Known(v) && v >= floor
+}
+
+// IsModern reports whether v is [Version20260728] or later — the boundary the
+// specification draws between the handshake-based revisions and the stateless
+// era, and the only version test the wire-format branches make. Naming it once
+// means a later revision that supersedes 2026-07-28 moves the boundary here
+// rather than at each branch.
+//
+// Callers pass the revision in effect for a request ([Resolution.InEffect]),
+// never the declared one: what a client asked for does not govern what it is
+// served.
+func IsModern(v string) bool {
+	return AtLeast(v, Version20260728)
+}
+
 // Clamp bounds a client-supplied version for use as a metric dimension: a
 // recognized revision passes through, an absent one becomes [None], and
 // anything else becomes [Other].

--- a/server/internal/mcp/mcpversions/mcpversions_test.go
+++ b/server/internal/mcp/mcpversions/mcpversions_test.go
@@ -1,6 +1,7 @@
 package mcpversions_test
 
 import (
+	"regexp"
 	"slices"
 	"strings"
 	"testing"
@@ -15,6 +16,23 @@ func TestAllIsChronologicallyOrdered(t *testing.T) {
 
 	versions := mcpversions.All()
 	require.True(t, slices.IsSorted(versions), "revision identifiers are YYYY-MM-DD, so chronological order is lexical order")
+}
+
+// TestAllAreDatedRevisions makes the assumption TestAllIsChronologicallyOrdered
+// rests on explicit: that lexical order is chronological order here. It holds
+// only while every recognized revision is an ISO date. The specification also
+// names an undated `draft` revision, and recognizing one would break that
+// equivalence, so this fails rather than letting the ordering check quietly
+// stop meaning what it says.
+func TestAllAreDatedRevisions(t *testing.T) {
+	t.Parallel()
+
+	dated := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
+	for _, v := range mcpversions.All() {
+		require.Regexpf(t, dated, v,
+			"revision %q is not a date, so lexical ordering no longer implies chronological ordering; "+
+				"place it in All by release order and confirm the comparisons in this package still hold", v)
+	}
 }
 
 func TestAllHasNoDuplicates(t *testing.T) {
@@ -317,7 +335,10 @@ func TestIsModern_NoSupportedSetResolvesModernYet(t *testing.T) {
 		mcpversions.SupportedMetaServer(),
 	} {
 		for _, v := range supported {
-			require.False(t, mcpversions.IsModern(v), "revision %s", v)
+			require.Falsef(t, mcpversions.IsModern(v),
+				"revision %s is now served, so the version-conditional wire behavior it gates is reachable for the first time. "+
+					"That behavior currently has unit coverage only: give the modern error codes and HTTP statuses end-to-end "+
+					"coverage on every surface, then delete this test.", v)
 		}
 	}
 }

--- a/server/internal/mcp/mcpversions/mcpversions_test.go
+++ b/server/internal/mcp/mcpversions/mcpversions_test.go
@@ -305,12 +305,12 @@ func TestAtLeast_UnrecognizedInputIsNeverAtLeast(t *testing.T) {
 	require.False(t, mcpversions.AtLeast("", mcpversions.Version20260728))
 }
 
-// TestIsModern_SplitsAtTheStatelessBoundary pins which side of the
+// TestAtLeast_SplitsAtTheStatelessBoundary pins which side of the
 // handshake/stateless divide each recognized revision falls on.
-func TestIsModern_SplitsAtTheStatelessBoundary(t *testing.T) {
+func TestAtLeast_SplitsAtTheStatelessBoundary(t *testing.T) {
 	t.Parallel()
 
-	require.True(t, mcpversions.IsModern(mcpversions.Version20260728))
+	require.True(t, mcpversions.AtLeast(mcpversions.Version20260728, mcpversions.Version20260728))
 
 	for _, v := range []string{
 		mcpversions.Version20241105,
@@ -318,15 +318,15 @@ func TestIsModern_SplitsAtTheStatelessBoundary(t *testing.T) {
 		mcpversions.Version20250618,
 		mcpversions.Version20251125,
 	} {
-		require.False(t, mcpversions.IsModern(v), "revision %s", v)
+		require.False(t, mcpversions.AtLeast(v, mcpversions.Version20260728), "revision %s", v)
 	}
 }
 
-// TestIsModern_NoSupportedSetResolvesModernYet records that every
-// revision-conditional branch keyed on IsModern is unreachable in production
-// until a surface advertises 2026-07-28, and fails the day one does — which is
-// when those branches need their own end-to-end coverage.
-func TestIsModern_NoSupportedSetResolvesModernYet(t *testing.T) {
+// TestAtLeast_NoSupportedSetIsModernYet records that every
+// revision-conditional branch keyed on the 2026-07-28 boundary is unreachable
+// in production until a surface advertises that revision, and fails the day one
+// does, which is when those branches need their own end-to-end coverage.
+func TestAtLeast_NoSupportedSetIsModernYet(t *testing.T) {
 	t.Parallel()
 
 	for _, supported := range [][]string{
@@ -335,7 +335,7 @@ func TestIsModern_NoSupportedSetResolvesModernYet(t *testing.T) {
 		mcpversions.SupportedMetaServer(),
 	} {
 		for _, v := range supported {
-			require.Falsef(t, mcpversions.IsModern(v),
+			require.Falsef(t, mcpversions.AtLeast(v, mcpversions.Version20260728),
 				"revision %s is now served, so the version-conditional wire behavior it gates is reachable for the first time. "+
 					"That behavior currently has unit coverage only: give the modern error codes and HTTP statuses end-to-end "+
 					"coverage on every surface, then delete this test.", v)

--- a/server/internal/mcp/mcpversions/mcpversions_test.go
+++ b/server/internal/mcp/mcpversions/mcpversions_test.go
@@ -264,3 +264,60 @@ func TestSupportedMetaServerSpansFloorToCeiling(t *testing.T) {
 	mcpversions.SupportedMetaServer()[0] = "mutated"
 	require.Equal(t, mcpversions.Version20241105, mcpversions.SupportedMetaServer()[0], "SupportedMetaServer must not hand out a mutable view of package state")
 }
+
+// TestAtLeast_ComparesChronologically covers the ordering the wire-format
+// branches rest on.
+func TestAtLeast_ComparesChronologically(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, mcpversions.AtLeast(mcpversions.Version20260728, mcpversions.Version20251125))
+	require.True(t, mcpversions.AtLeast(mcpversions.Version20251125, mcpversions.Version20251125))
+	require.False(t, mcpversions.AtLeast(mcpversions.Version20250618, mcpversions.Version20251125))
+}
+
+// TestAtLeast_UnrecognizedInputIsNeverAtLeast covers the case lexical
+// comparison alone would get wrong: a garbage value can sort above a real
+// revision, and reading that as the newer behavior would serve a wire format
+// to a client that cannot possibly have asked for it.
+func TestAtLeast_UnrecognizedInputIsNeverAtLeast(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, mcpversions.AtLeast("zzzz-zz-zz", mcpversions.Version20260728))
+	require.False(t, mcpversions.AtLeast("9999-12-31", mcpversions.Version20260728))
+	require.False(t, mcpversions.AtLeast("", mcpversions.Version20260728))
+}
+
+// TestIsModern_SplitsAtTheStatelessBoundary pins which side of the
+// handshake/stateless divide each recognized revision falls on.
+func TestIsModern_SplitsAtTheStatelessBoundary(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, mcpversions.IsModern(mcpversions.Version20260728))
+
+	for _, v := range []string{
+		mcpversions.Version20241105,
+		mcpversions.Version20250326,
+		mcpversions.Version20250618,
+		mcpversions.Version20251125,
+	} {
+		require.False(t, mcpversions.IsModern(v), "revision %s", v)
+	}
+}
+
+// TestIsModern_NoSupportedSetResolvesModernYet records that every
+// revision-conditional branch keyed on IsModern is unreachable in production
+// until a surface advertises 2026-07-28, and fails the day one does — which is
+// when those branches need their own end-to-end coverage.
+func TestIsModern_NoSupportedSetResolvesModernYet(t *testing.T) {
+	t.Parallel()
+
+	for _, supported := range [][]string{
+		mcpversions.SupportedHostedToolset(),
+		mcpversions.SupportedPlatformToolset(),
+		mcpversions.SupportedMetaServer(),
+	} {
+		for _, v := range supported {
+			require.False(t, mcpversions.IsModern(v), "revision %s", v)
+		}
+	}
+}

--- a/server/internal/mcp/rpc_initialize.go
+++ b/server/internal/mcp/rpc_initialize.go
@@ -80,6 +80,14 @@ func handleInitialize(ctx context.Context, logger *slog.Logger, telemetry *mcpme
 	negotiated := mcpversions.Negotiate(params.ProtocolVersion, mcpversions.SupportedHostedToolset())
 	payload.protocolVersion.InEffect = negotiated
 
+	// The error wrapper reads its own holder after the handler returns, and it
+	// was populated before the body was parsed, so it still carries the
+	// provisional value. Republishing keeps an error escaping after this point
+	// encoded on the revision that was actually negotiated.
+	if rpcCtx, ok := contextvalues.GetRPCContext(ctx); ok {
+		rpcCtx.ProtocolVersion = negotiated
+	}
+
 	// Recording requested and negotiated separately keeps a downgrade — a
 	// client asking for a revision outside the supported set — visible rather
 	// than collapsed.

--- a/server/internal/mcp/serve_meta.go
+++ b/server/internal/mcp/serve_meta.go
@@ -137,6 +137,9 @@ func (s *Service) serveResolvedMetaMCPEndpoint(
 		resolution.InEffect = mcpversions.Negotiate(params.ProtocolVersion, supportedMeta)
 	}
 	w.Header().Set(mcpversions.HTTPHeader, resolution.InEffect)
+	if rpcCtx, ok := contextvalues.GetRPCContext(ctx); ok {
+		rpcCtx.ProtocolVersion = resolution.InEffect
+	}
 
 	gate := &metaGateContext{
 		projectID:      mcpEndpoint.ProjectID,
@@ -184,16 +187,7 @@ func (s *Service) serveResolvedMetaMCPEndpoint(
 	case body == nil && err == nil:
 		return respondWithNoContent(true, w)
 	case err != nil:
-		bs, merr := json.Marshal(oops.NewMCPErrorFromCause(req.ID, err))
-		if merr != nil {
-			return oops.E(oops.CodeUnexpected, merr, "failed to serialize error response").LogError(ctx, logger)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		if _, writeErr := w.Write(bs); writeErr != nil {
-			return oops.E(oops.CodeUnexpected, writeErr, "failed to write error response body").LogError(ctx, logger)
-		}
-		return nil
+		return writeMCPError(ctx, logger, w, req.ID, resolution.InEffect, err)
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/server/internal/mcp/serve_meta.go
+++ b/server/internal/mcp/serve_meta.go
@@ -137,8 +137,15 @@ func (s *Service) serveResolvedMetaMCPEndpoint(
 		resolution.InEffect = mcpversions.Negotiate(params.ProtocolVersion, supportedMeta)
 	}
 	w.Header().Set(mcpversions.HTTPHeader, resolution.InEffect)
+	// Both halves the error wrapper needs, published together: an error
+	// escaping this handler has to echo the id the client sent and be encoded
+	// on the revision governing the request. Publishing only one leaves the
+	// wrapper answering with a modern wire code under a null id.
 	if rpcCtx, ok := contextvalues.GetRPCContext(ctx); ok {
 		rpcCtx.ProtocolVersion = resolution.InEffect
+		if req.ID.IsSet() {
+			rpcCtx.ID = req.ID
+		}
 	}
 
 	gate := &metaGateContext{

--- a/server/internal/mcp/serve_platform.go
+++ b/server/internal/mcp/serve_platform.go
@@ -119,16 +119,7 @@ func (s *Service) ServePlatformToolset(w http.ResponseWriter, r *http.Request) e
 	case body == nil && err == nil:
 		return respondWithNoContent(true, w)
 	case err != nil:
-		bs, merr := json.Marshal(oops.NewMCPErrorFromCause(req.ID, err))
-		if merr != nil {
-			return oops.E(oops.CodeUnexpected, merr, "failed to serialize error response").LogError(ctx, s.logger)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		if _, writeErr := w.Write(bs); writeErr != nil {
-			return oops.E(oops.CodeUnexpected, writeErr, "failed to write error response body").LogError(ctx, s.logger)
-		}
-		return nil
+		return writeMCPError(ctx, s.logger, w, req.ID, protocolVersion.InEffect, err)
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/server/internal/mcp/servepublic_test.go
+++ b/server/internal/mcp/servepublic_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
+	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
 	metadata_repo "github.com/speakeasy-api/gram/server/internal/mcpmetadata/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
@@ -976,4 +977,71 @@ func TestServePublic_InitializeBodyWinsOverNonconformingHeader(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, w.Code)
 	require.Equal(t, mcpversions.Version20251125, answeredProtocolVersion(t, w))
+}
+
+// carriedProtocolVersion serves a tools/list request declaring declared and
+// returns the revision the hosted handler published to the error wrapper's
+// holder. tools/list is deliberate: initialize would additionally negotiate,
+// which is a different value settled at a different point.
+func carriedProtocolVersion(t *testing.T, ctx context.Context, ti *testInstance, mcpSlug, declared string) string {
+	t.Helper()
+
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/list",
+		"params":  map[string]any{},
+	})
+	require.NoError(t, err)
+
+	rpcCtx := &contextvalues.RPCContext{ID: mcpjsonrpc.NullID(), ProtocolVersion: ""}
+	ctx = contextvalues.SetRPCContext(ctx, rpcCtx)
+
+	_, err = servePublicHTTP(t, ctx, ti, mcpSlug, body, "", map[string]string{
+		mcpversions.HTTPHeader: declared,
+	})
+	require.NoError(t, err)
+
+	return rpcCtx.ProtocolVersion
+}
+
+// TestServePublic_CarriesSupportedDeclarationToTheErrorWrapper covers the
+// plumbing that lets an error escaping the handler be encoded on the revision
+// the client is speaking. A supported declaration governs the request, so it
+// is what the wrapper must see.
+func TestServePublic_CarriesSupportedDeclarationToTheErrorWrapper(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolsetsRepo := toolsets_repo.New(ti.conn)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "carried-supported-version")
+
+	require.Equal(t, mcpversions.Version20250618, carriedProtocolVersion(t, ctx, ti, toolset.McpSlug.String, mcpversions.Version20250618))
+}
+
+// TestServePublic_CarriesResolvedRevisionNotRawDeclaration pins the half that
+// is easy to get wrong. A declaration this surface does not serve resolves
+// downward, and it is the resolved answer that governs the request. Publishing
+// the raw declaration instead would encode errors on a revision Gram never
+// agreed to speak — the exact confusion the Declared/InEffect split exists to
+// prevent — and would silently begin doing so the moment a client asks for a
+// revision ahead of the supported set.
+func TestServePublic_CarriesResolvedRevisionNotRawDeclaration(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolsetsRepo := toolsets_repo.New(ti.conn)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "carried-resolved-version")
+
+	require.NotContains(t, mcpversions.SupportedHostedToolset(), mcpversions.Version20260728,
+		"this test's premise is that the declared revision is unsupported")
+	require.Equal(t, mcpversions.DefaultInEffect, carriedProtocolVersion(t, ctx, ti, toolset.McpSlug.String, mcpversions.Version20260728))
 }

--- a/server/internal/mcpjsonrpc/id.go
+++ b/server/internal/mcpjsonrpc/id.go
@@ -34,6 +34,15 @@ func (id ID) IsSet() bool {
 	return id.format != 0
 }
 
+// IsNull reports whether id serializes as JSON null, which happens both when
+// the request carried no id at all — as a notification does — and when it
+// carried an explicit null. Either way a response bearing this id answers no
+// particular request, so callers deciding how to answer one treat the two the
+// same.
+func (id ID) IsNull() bool {
+	return !id.IsSet() || id.format == idFormatNull
+}
+
 func (id ID) Value() string {
 	switch id.format {
 	case idFormatNumber:
@@ -46,7 +55,7 @@ func (id ID) Value() string {
 }
 
 func (id ID) MarshalJSON() ([]byte, error) {
-	if !id.IsSet() || id.format == idFormatNull {
+	if id.IsNull() {
 		return []byte("null"), nil
 	}
 

--- a/server/internal/mcpjsonrpc/id_test.go
+++ b/server/internal/mcpjsonrpc/id_test.go
@@ -85,3 +85,33 @@ func TestID_Value(t *testing.T) {
 	require.Equal(t, "my-id", StringID("my-id").Value())
 	require.Empty(t, NullID().Value())
 }
+
+// TestID_IsNullCoversAbsentAndExplicitNull covers both ways a JSON-RPC message
+// ends up naming no request. They arrive by different routes — an absent id
+// never reaches UnmarshalJSON at all, while an explicit null does — and
+// callers deciding how to answer such a message must not have to tell them
+// apart.
+func TestID_IsNullCoversAbsentAndExplicitNull(t *testing.T) {
+	t.Parallel()
+
+	var absent ID
+	require.True(t, absent.IsNull(), "a notification carries no id field")
+
+	var explicit ID
+	require.NoError(t, json.Unmarshal([]byte(`null`), &explicit))
+	require.True(t, explicit.IsNull(), "an explicit null names no request either")
+
+	require.True(t, NullID().IsNull())
+}
+
+// TestID_IsNullIsFalseForRealIDs guards the other direction: a request that
+// does name itself must never be mistaken for one that does not, including the
+// zero-valued number and empty string a naive emptiness check would swallow.
+func TestID_IsNullIsFalseForRealIDs(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, NumberID(1).IsNull())
+	require.False(t, NumberID(0).IsNull(), "zero is a valid JSON-RPC id")
+	require.False(t, StringID("req-1").IsNull())
+	require.False(t, StringID("").IsNull(), "an empty string id is still an id")
+}

--- a/server/internal/oops/codes.go
+++ b/server/internal/oops/codes.go
@@ -162,7 +162,7 @@ func (c Code) MCPCode() MCPCode {
 // this is a branch, not a replacement.
 func (c Code) MCPCodeFor(revision string) MCPCode {
 	code := c.MCPCode()
-	if code == MCPCodeResourceNotFound && mcpversions.IsModern(revision) {
+	if code == MCPCodeResourceNotFound && mcpversions.AtLeast(revision, mcpversions.Version20260728) {
 		return MCPCodeInvalidParams
 	}
 

--- a/server/internal/oops/codes.go
+++ b/server/internal/oops/codes.go
@@ -1,6 +1,10 @@
 package oops
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
+)
 
 type Code string
 
@@ -118,6 +122,10 @@ func (c Code) IsTemporary() bool {
 	}
 }
 
+// MCPCode maps c to the JSON-RPC error code the handshake-based protocol
+// revisions expect. Callers serving a request whose protocol revision is known
+// use [Code.MCPCodeFor] instead, which honors the revision-conditional
+// mappings.
 func (c Code) MCPCode() MCPCode {
 	switch c {
 	case CodeUnauthorized:
@@ -139,4 +147,24 @@ func (c Code) MCPCode() MCPCode {
 	default:
 		return MCPCodeInternalError
 	}
+}
+
+// MCPCodeFor maps c to the JSON-RPC error code expected by the protocol
+// revision in effect for the request being answered. revision is the resolved
+// in-effect revision; empty or unrecognized input is served the legacy
+// mapping, which is what the error paths that fail before a revision is
+// resolved need.
+//
+// MCP 2026-07-28 retires MCPCodeResourceNotFound and forbids implementations
+// of that revision from emitting it, directing the condition to
+// MCPCodeInvalidParams instead. Earlier revisions keep receiving the retired
+// code: their clients are told to accept it, and some key handling on it. So
+// this is a branch, not a replacement.
+func (c Code) MCPCodeFor(revision string) MCPCode {
+	code := c.MCPCode()
+	if code == MCPCodeResourceNotFound && mcpversions.IsModern(revision) {
+		return MCPCodeInvalidParams
+	}
+
+	return code
 }

--- a/server/internal/oops/mcp.go
+++ b/server/internal/oops/mcp.go
@@ -61,7 +61,7 @@ func MCPErrHandle(logger *slog.Logger, handler func(http.ResponseWriter, *http.R
 			payload.Code = shareableErr.Code.MCPCodeFor(rpcCtx.ProtocolVersion)
 			payload.Message = shareableErr.Error()
 
-			if mcpversions.IsModern(rpcCtx.ProtocolVersion) {
+			if mcpversions.AtLeast(rpcCtx.ProtocolVersion, mcpversions.Version20260728) {
 				if mandated, ok := payload.Code.MandatedHTTPStatus(); ok {
 					code = mandated
 				}
@@ -201,7 +201,7 @@ func NewMCPErrorFromCause(id mcpjsonrpc.ID, revision string, source error) *MCPE
 		if !adjusted.ID.IsSet() {
 			adjusted.ID = id
 		}
-		if adjusted.Code == MCPCodeResourceNotFound && mcpversions.IsModern(revision) {
+		if adjusted.Code == MCPCodeResourceNotFound && mcpversions.AtLeast(revision, mcpversions.Version20260728) {
 			adjusted.Code = MCPCodeInvalidParams
 		}
 		return &adjusted

--- a/server/internal/oops/mcp.go
+++ b/server/internal/oops/mcp.go
@@ -17,7 +17,7 @@ import (
 // errors as JSON-RPC error responses instead of the generic HTTP error shape.
 func MCPErrHandle(logger *slog.Logger, handler func(http.ResponseWriter, *http.Request) error) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		rpcCtx := &contextvalues.RPCContext{ID: mcpjsonrpc.NullID()}
+		rpcCtx := &contextvalues.RPCContext{ID: mcpjsonrpc.NullID(), ProtocolVersion: ""}
 		r = r.WithContext(contextvalues.SetRPCContext(r.Context(), rpcCtx))
 
 		err := handler(w, r)
@@ -42,8 +42,17 @@ func MCPErrHandle(logger *slog.Logger, handler func(http.ResponseWriter, *http.R
 		var shareableErr *ShareableError
 		switch {
 		case errors.As(err, &shareableErr):
+			// The status stays keyed on the Gram error code, not on the wire
+			// code and not on the revision. Errors that escape a handler are
+			// transport-level refusals rather than protocol results, and the
+			// statuses this path already answers are correct on every
+			// revision: 401 carries the OAuth discovery challenge MCP clients
+			// need to start their authorization flow, 404 names an unknown
+			// server, 405 answers the GET compatibility probe. The
+			// specification's status table governs the JSON-RPC errors
+			// written from inside the handler, which this is not.
 			code = shareableErr.HTTPStatus(r.Context())
-			payload.Code = shareableErr.Code.MCPCode()
+			payload.Code = shareableErr.Code.MCPCodeFor(rpcCtx.ProtocolVersion)
 			payload.Message = shareableErr.Error()
 		default:
 			stack := string(debug.Stack())
@@ -119,7 +128,15 @@ type MCPError struct {
 	Data    *MCPErrorData
 }
 
-func NewMCPErrorFromCause(id mcpjsonrpc.ID, source error) *MCPError {
+// NewMCPErrorFromCause converts an error returned by an MCP request handler
+// into the JSON-RPC error to write in response to request id. revision is the
+// protocol revision in effect for that request, which selects the wire error
+// code; an empty or unrecognized value is served the legacy mappings.
+//
+// An error that already carries its own [MCPError] passes through with its
+// code intact, on the grounds that a caller naming a wire code directly has
+// chosen it deliberately.
+func NewMCPErrorFromCause(id mcpjsonrpc.ID, revision string, source error) *MCPError {
 	var mcpErr *MCPError
 	var shareableErr *ShareableError
 
@@ -132,7 +149,7 @@ func NewMCPErrorFromCause(id mcpjsonrpc.ID, source error) *MCPError {
 	case errors.As(source, &shareableErr):
 		return &MCPError{
 			ID:      id,
-			Code:    shareableErr.Code.MCPCode(),
+			Code:    shareableErr.Code.MCPCodeFor(revision),
 			Message: shareableErr.Error(),
 			Data:    nil,
 		}

--- a/server/internal/oops/mcp.go
+++ b/server/internal/oops/mcp.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
 	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
 )
 
@@ -42,18 +43,29 @@ func MCPErrHandle(logger *slog.Logger, handler func(http.ResponseWriter, *http.R
 		var shareableErr *ShareableError
 		switch {
 		case errors.As(err, &shareableErr):
-			// The status stays keyed on the Gram error code, not on the wire
-			// code and not on the revision. Errors that escape a handler are
-			// transport-level refusals rather than protocol results, and the
-			// statuses this path already answers are correct on every
-			// revision: 401 carries the OAuth discovery challenge MCP clients
-			// need to start their authorization flow, 404 names an unknown
-			// server, 405 answers the GET compatibility probe. The
-			// specification's status table governs the JSON-RPC errors
-			// written from inside the handler, which this is not.
+			// The status starts from the Gram error code, which is what makes
+			// this path answer 401 with the OAuth discovery challenge MCP
+			// clients need to start authorizing, 403 for a denied toolset, and
+			// 405 for the GET compatibility probe. Those wire codes carry no
+			// mandated status, so the override leaves them alone on every
+			// revision.
+			//
+			// It does not leave the not-found alone, and must not: the wire
+			// code answered here is now the revision's, and a code carries its
+			// status with it. A not-found on a modern request answers -32602,
+			// whose mandated status is 400. Keeping the Gram code's 404 would
+			// pair it with the one status the specification gives a distinct
+			// meaning — a 404 carrying a JSON-RPC body says the method is
+			// unimplemented — and tell a dual-era client something untrue.
 			code = shareableErr.HTTPStatus(r.Context())
 			payload.Code = shareableErr.Code.MCPCodeFor(rpcCtx.ProtocolVersion)
 			payload.Message = shareableErr.Error()
+
+			if mcpversions.IsModern(rpcCtx.ProtocolVersion) {
+				if mandated, ok := payload.Code.MandatedHTTPStatus(); ok {
+					code = mandated
+				}
+			}
 		default:
 			stack := string(debug.Stack())
 			logger.ErrorContext(r.Context(), "unexpected error", attr.SlogError(err), attr.SlogErrorStack(stack))
@@ -83,7 +95,38 @@ const (
 	MCPCodeUnauthorized     MCPCode = -32001
 	MCPCodeResourceNotFound MCPCode = -32002
 	MCPCodeForbidden        MCPCode = -32003
+
+	// Codes MCP 2026-07-28 defines for the request-level conditions a server
+	// validates before it can act on a request at all. They sit outside the
+	// -32000 to -32019 sub-range that revision designates legacy, and unlike
+	// the codes in it they carry meaning a modern client is entitled to rely
+	// on. Each one is answered with 400.
+	MCPCodeHeaderMismatch                  MCPCode = -32020
+	MCPCodeMissingRequiredClientCapability MCPCode = -32021
+	MCPCodeUnsupportedProtocolVersion      MCPCode = -32022
 )
+
+// MandatedHTTPStatus returns the HTTP status MCP 2026-07-28 requires for c,
+// and whether that revision mandates one at all. Codes it says nothing about
+// report false, so callers leave their status alone rather than inventing one.
+//
+// Callers apply this only to requests governed by 2026-07-28. The
+// handshake-based revisions carry every JSON-RPC error in the body of a
+// successful response, and clients there read a non-2xx as a transport failure
+// without parsing the body.
+func (c MCPCode) MandatedHTTPStatus() (int, bool) {
+	switch c {
+	case MCPCodeMethodNotFound:
+		return http.StatusNotFound, true
+	case MCPCodeInvalidParams,
+		MCPCodeHeaderMismatch,
+		MCPCodeMissingRequiredClientCapability,
+		MCPCodeUnsupportedProtocolVersion:
+		return http.StatusBadRequest, true
+	default:
+		return 0, false
+	}
+}
 
 func (c MCPCode) Message() string {
 	switch c {
@@ -103,6 +146,12 @@ func (c MCPCode) Message() string {
 		return "Resource not found"
 	case MCPCodeForbidden:
 		return "Forbidden"
+	case MCPCodeHeaderMismatch:
+		return "Header mismatch"
+	case MCPCodeMissingRequiredClientCapability:
+		return "Missing required client capability"
+	case MCPCodeUnsupportedProtocolVersion:
+		return "Unsupported protocol version"
 	default:
 		return "Internal error"
 	}
@@ -133,9 +182,10 @@ type MCPError struct {
 // protocol revision in effect for that request, which selects the wire error
 // code; an empty or unrecognized value is served the legacy mappings.
 //
-// An error that already carries its own [MCPError] passes through with its
-// code intact, on the grounds that a caller naming a wire code directly has
-// chosen it deliberately.
+// An error that already carries its own [MCPError] passes through with the
+// code its caller named, since naming a wire code directly is a deliberate
+// choice. The one exception is the code 2026-07-28 forbids outright: a MUST
+// NOT is not a caller's to opt out of, so it is remapped like any other.
 func NewMCPErrorFromCause(id mcpjsonrpc.ID, revision string, source error) *MCPError {
 	var mcpErr *MCPError
 	var shareableErr *ShareableError
@@ -144,6 +194,9 @@ func NewMCPErrorFromCause(id mcpjsonrpc.ID, revision string, source error) *MCPE
 	case errors.As(source, &mcpErr):
 		if !mcpErr.ID.IsSet() {
 			mcpErr.ID = id
+		}
+		if mcpErr.Code == MCPCodeResourceNotFound && mcpversions.IsModern(revision) {
+			mcpErr.Code = MCPCodeInvalidParams
 		}
 		return mcpErr
 	case errors.As(source, &shareableErr):

--- a/server/internal/oops/mcp.go
+++ b/server/internal/oops/mcp.go
@@ -192,13 +192,19 @@ func NewMCPErrorFromCause(id mcpjsonrpc.ID, revision string, source error) *MCPE
 
 	switch {
 	case errors.As(source, &mcpErr):
-		if !mcpErr.ID.IsSet() {
-			mcpErr.ID = id
+		// Adjusted on a copy. The caller owns the value it built, and the code
+		// chosen here is right for one request only: rewriting it in place
+		// would let a value that outlives the request answer -32602 to every
+		// later legacy client, which is the compatibility break this branch
+		// exists to prevent.
+		adjusted := *mcpErr
+		if !adjusted.ID.IsSet() {
+			adjusted.ID = id
 		}
-		if mcpErr.Code == MCPCodeResourceNotFound && mcpversions.IsModern(revision) {
-			mcpErr.Code = MCPCodeInvalidParams
+		if adjusted.Code == MCPCodeResourceNotFound && mcpversions.IsModern(revision) {
+			adjusted.Code = MCPCodeInvalidParams
 		}
-		return mcpErr
+		return &adjusted
 	case errors.As(source, &shareableErr):
 		return &MCPError{
 			ID:      id,

--- a/server/internal/oops/mcp_test.go
+++ b/server/internal/oops/mcp_test.go
@@ -249,11 +249,82 @@ func TestNewMCPErrorFromCause_ModernRevisionReplacesRetiredResourceNotFound(t *t
 func TestNewMCPErrorFromCause_PreservesExplicitCodeOnModernRevision(t *testing.T) {
 	t.Parallel()
 
-	existing := &MCPError{ID: mcpjsonrpc.NullID(), Code: MCPCodeResourceNotFound, Message: "explicit", Data: nil}
+	existing := &MCPError{ID: mcpjsonrpc.NullID(), Code: MCPCodeForbidden, Message: "explicit", Data: nil}
 	err := NewMCPErrorFromCause(mcpjsonrpc.StringID("req-1"), mcpversions.Version20260728, existing)
 
 	require.Same(t, existing, err)
+	require.Equal(t, MCPCodeForbidden, err.Code)
+}
+
+// TestNewMCPErrorFromCause_RemapsExplicitRetiredCodeOnModernRevision covers the
+// limit of that deference. Naming a wire code is a caller's choice, but the one
+// code 2026-07-28 forbids outright is not a choice that stays available, so the
+// passthrough arm remaps it like any other.
+func TestNewMCPErrorFromCause_RemapsExplicitRetiredCodeOnModernRevision(t *testing.T) {
+	t.Parallel()
+
+	existing := &MCPError{ID: mcpjsonrpc.NullID(), Code: MCPCodeResourceNotFound, Message: "explicit", Data: nil}
+	err := NewMCPErrorFromCause(mcpjsonrpc.StringID("req-1"), mcpversions.Version20260728, existing)
+
+	require.Equal(t, MCPCodeInvalidParams, err.Code)
+}
+
+// TestNewMCPErrorFromCause_KeepsExplicitRetiredCodeOnLegacyRevision is the
+// other half: the retired code is still what legacy clients are told to expect.
+func TestNewMCPErrorFromCause_KeepsExplicitRetiredCodeOnLegacyRevision(t *testing.T) {
+	t.Parallel()
+
+	existing := &MCPError{ID: mcpjsonrpc.NullID(), Code: MCPCodeResourceNotFound, Message: "explicit", Data: nil}
+	err := NewMCPErrorFromCause(mcpjsonrpc.StringID("req-1"), mcpversions.Version20251125, existing)
+
 	require.Equal(t, MCPCodeResourceNotFound, err.Code)
+}
+
+// TestMCPErrHandle_ModernRevisionUsesMandatedStatusForRemappedNotFound covers
+// the coupling between the two halves of this path. Once the wire code is
+// revision-aware, the status has to follow it: a not-found answers -32602 on a
+// modern request, and answering that with the Gram code's 404 would tell a
+// dual-era client the method is unimplemented, since a 404 carrying a JSON-RPC
+// body is precisely that signal.
+func TestMCPErrHandle_ModernRevisionUsesMandatedStatusForRemappedNotFound(t *testing.T) {
+	t.Parallel()
+	logger, _ := captureLogger()
+
+	handler := MCPErrHandle(logger, func(w http.ResponseWriter, r *http.Request) error {
+		if rpcCtx, ok := contextvalues.GetRPCContext(r.Context()); ok {
+			rpcCtx.ID = mcpjsonrpc.StringID("req-1")
+			rpcCtx.ProtocolVersion = mcpversions.Version20260728
+		}
+
+		return C(CodeNotFound)
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/mcp/test", nil))
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// TestMCPErrHandle_LegacyRevisionKeepsNotFoundStatus pins that the override is
+// confined to the modern branch, so the statuses this path answers today are
+// untouched for the traffic that has always received them.
+func TestMCPErrHandle_LegacyRevisionKeepsNotFoundStatus(t *testing.T) {
+	t.Parallel()
+	logger, _ := captureLogger()
+
+	handler := MCPErrHandle(logger, func(w http.ResponseWriter, r *http.Request) error {
+		if rpcCtx, ok := contextvalues.GetRPCContext(r.Context()); ok {
+			rpcCtx.ID = mcpjsonrpc.StringID("req-1")
+			rpcCtx.ProtocolVersion = mcpversions.Version20251125
+		}
+
+		return C(CodeNotFound)
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/mcp/test", nil))
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
 }
 
 // TestMCPErrHandle_ModernRevisionReplacesRetiredResourceNotFound covers the
@@ -265,16 +336,21 @@ func TestMCPErrHandle_ModernRevisionReplacesRetiredResourceNotFound(t *testing.T
 	t.Parallel()
 	logger, _ := captureLogger()
 
+	var holderInstalled bool
 	handler := MCPErrHandle(logger, func(w http.ResponseWriter, r *http.Request) error {
 		rpcCtx, ok := contextvalues.GetRPCContext(r.Context())
-		require.True(t, ok)
-		rpcCtx.ProtocolVersion = mcpversions.Version20260728
+		holderInstalled = ok
+		if ok {
+			rpcCtx.ProtocolVersion = mcpversions.Version20260728
+		}
 
 		return C(CodeNotFound)
 	})
 
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/mcp/test", nil))
+
+	require.True(t, holderInstalled, "the wrapper must install the holder before dispatch, or the handler has nowhere to publish the revision")
 
 	var response struct {
 		Error struct {
@@ -285,33 +361,146 @@ func TestMCPErrHandle_ModernRevisionReplacesRetiredResourceNotFound(t *testing.T
 	require.Equal(t, MCPCodeInvalidParams, response.Error.Code)
 }
 
-// TestMCPErrHandle_StatusStaysKeyedOnGramCodeForModernRevision pins the
-// deliberate asymmetry between the two error paths. The statuses this wrapper
-// answers are transport-level refusals that are correct on every revision, and
-// the 401 in particular is what an MCP client needs to begin its OAuth
-// discovery flow. Deriving the status from the revision here would answer that
-// challenge with a 200 and strand every client that has to authorize.
-func TestMCPErrHandle_StatusStaysKeyedOnGramCodeForModernRevision(t *testing.T) {
+// TestMCPErrHandle_UnmandatedCodesKeepGramStatusOnModernRevision pins the
+// statuses that must survive the modern branch. None of these Gram codes maps
+// to a wire code 2026-07-28 assigns a status to, so each keeps the status this
+// path has always answered. The 401 is the one that would hurt most to lose:
+// it carries the challenge an MCP client needs to begin OAuth discovery, and
+// answering it with anything else strands every client that has to authorize.
+func TestMCPErrHandle_UnmandatedCodesKeepGramStatusOnModernRevision(t *testing.T) {
 	t.Parallel()
 	logger, _ := captureLogger()
 
-	for code, want := range map[Code]int{
-		CodeUnauthorized:     http.StatusUnauthorized,
-		CodeForbidden:        http.StatusForbidden,
-		CodeNotFound:         http.StatusNotFound,
-		CodeMethodNotAllowed: http.StatusMethodNotAllowed,
+	for _, tt := range []struct {
+		code Code
+		want int
+	}{
+		{code: CodeUnauthorized, want: http.StatusUnauthorized},
+		{code: CodeForbidden, want: http.StatusForbidden},
+		{code: CodeMethodNotAllowed, want: http.StatusMethodNotAllowed},
 	} {
 		handler := MCPErrHandle(logger, func(w http.ResponseWriter, r *http.Request) error {
-			rpcCtx, ok := contextvalues.GetRPCContext(r.Context())
-			require.True(t, ok)
-			rpcCtx.ProtocolVersion = mcpversions.Version20260728
+			if rpcCtx, ok := contextvalues.GetRPCContext(r.Context()); ok {
+				rpcCtx.ID = mcpjsonrpc.StringID("req-1")
+				rpcCtx.ProtocolVersion = mcpversions.Version20260728
+			}
 
-			return C(code)
+			return C(tt.code)
 		})
 
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/mcp/test", nil))
 
-		require.Equal(t, want, rec.Code, "code %s", code)
+		require.Equal(t, tt.want, rec.Code, "code %s", tt.code)
+	}
+}
+
+// TestMCPErrHandle_ModernRevisionUsesMandatedStatusForNullID covers the case
+// the two error paths previously disagreed on. A message naming no request
+// still gets the status its condition mandates: this path has no 200 to fall
+// back to, so skipping the override here would leave the Gram code's 404 on a
+// -32602 body and tell a dual-era client the method is unimplemented.
+func TestMCPErrHandle_ModernRevisionUsesMandatedStatusForNullID(t *testing.T) {
+	t.Parallel()
+	logger, _ := captureLogger()
+
+	handler := MCPErrHandle(logger, func(w http.ResponseWriter, r *http.Request) error {
+		if rpcCtx, ok := contextvalues.GetRPCContext(r.Context()); ok {
+			rpcCtx.ProtocolVersion = mcpversions.Version20260728
+		}
+
+		return C(CodeNotFound)
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/mcp/test", nil))
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var response map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	require.Nil(t, response["id"])
+}
+
+// TestMCPErrHandle_ModernRevisionMapsNotImplementedToNotFound covers the one
+// override that moves a status the specification names for a reason. Gram
+// answers an unimplemented feature with 501, but the wire code is -32601, and
+// 404 carrying that code is what lets a dual-era client tell a modern server
+// missing a method from a legacy server missing the endpoint.
+func TestMCPErrHandle_ModernRevisionMapsNotImplementedToNotFound(t *testing.T) {
+	t.Parallel()
+	logger, _ := captureLogger()
+
+	require.Equal(t, http.StatusNotImplemented, StatusCodes[CodeNotImplemented],
+		"this test's premise: the Gram status differs from the mandated one")
+
+	handler := MCPErrHandle(logger, func(w http.ResponseWriter, r *http.Request) error {
+		if rpcCtx, ok := contextvalues.GetRPCContext(r.Context()); ok {
+			rpcCtx.ID = mcpjsonrpc.StringID("req-1")
+			rpcCtx.ProtocolVersion = mcpversions.Version20260728
+		}
+
+		return C(CodeNotImplemented)
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/mcp/test", nil))
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TestMCPErrHandle_ModernRevisionMapsInvalidToBadRequest covers the other
+// status the override moves: Gram answers an invalid payload with 422, and
+// -32602 mandates 400.
+func TestMCPErrHandle_ModernRevisionMapsInvalidToBadRequest(t *testing.T) {
+	t.Parallel()
+	logger, _ := captureLogger()
+
+	require.Equal(t, http.StatusUnprocessableEntity, StatusCodes[CodeInvalid],
+		"this test's premise: the Gram status differs from the mandated one")
+
+	handler := MCPErrHandle(logger, func(w http.ResponseWriter, r *http.Request) error {
+		if rpcCtx, ok := contextvalues.GetRPCContext(r.Context()); ok {
+			rpcCtx.ID = mcpjsonrpc.StringID("req-1")
+			rpcCtx.ProtocolVersion = mcpversions.Version20260728
+		}
+
+		return C(CodeInvalid)
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/mcp/test", nil))
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// TestMCPErrHandle_LegacyRevisionKeepsGramStatusesForMandatedCodes is the
+// guard on all of the above: none of those statuses may move for the traffic
+// in service today.
+func TestMCPErrHandle_LegacyRevisionKeepsGramStatusesForMandatedCodes(t *testing.T) {
+	t.Parallel()
+	logger, _ := captureLogger()
+
+	for _, tt := range []struct {
+		code Code
+		want int
+	}{
+		{code: CodeNotFound, want: http.StatusNotFound},
+		{code: CodeNotImplemented, want: http.StatusNotImplemented},
+		{code: CodeInvalid, want: http.StatusUnprocessableEntity},
+	} {
+		handler := MCPErrHandle(logger, func(w http.ResponseWriter, r *http.Request) error {
+			if rpcCtx, ok := contextvalues.GetRPCContext(r.Context()); ok {
+				rpcCtx.ID = mcpjsonrpc.StringID("req-1")
+				rpcCtx.ProtocolVersion = mcpversions.Version20251125
+			}
+
+			return C(tt.code)
+		})
+
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/mcp/test", nil))
+
+		require.Equal(t, tt.want, rec.Code, "code %s", tt.code)
 	}
 }

--- a/server/internal/oops/mcp_test.go
+++ b/server/internal/oops/mcp_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
 	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
 	"github.com/stretchr/testify/require"
 )
@@ -144,7 +145,7 @@ func TestNewMCPErrorFromCause(t *testing.T) {
 		t.Parallel()
 
 		existing := &MCPError{ID: mcpjsonrpc.ID{Number: 0, String: ""}, Code: MCPCodeMethodNotFound, Message: "missing", Data: nil}
-		err := NewMCPErrorFromCause(id, existing)
+		err := NewMCPErrorFromCause(id, mcpversions.Version20251125, existing)
 
 		require.Same(t, existing, err)
 		require.Equal(t, id, err.ID)
@@ -153,7 +154,7 @@ func TestNewMCPErrorFromCause(t *testing.T) {
 	t.Run("maps_shareable_error_code", func(t *testing.T) {
 		t.Parallel()
 
-		err := NewMCPErrorFromCause(id, E(CodeNotFound, nil, "mcp server not found"))
+		err := NewMCPErrorFromCause(id, mcpversions.Version20251125, E(CodeNotFound, nil, "mcp server not found"))
 
 		require.Equal(t, id, err.ID)
 		require.Equal(t, MCPCodeResourceNotFound, err.Code)
@@ -163,10 +164,154 @@ func TestNewMCPErrorFromCause(t *testing.T) {
 	t.Run("defaults_unknown_error_to_internal", func(t *testing.T) {
 		t.Parallel()
 
-		err := NewMCPErrorFromCause(id, errors.New("boom"))
+		err := NewMCPErrorFromCause(id, mcpversions.Version20251125, errors.New("boom"))
 
 		require.Equal(t, id, err.ID)
 		require.Equal(t, MCPCodeInternalError, err.Code)
 		require.Equal(t, "Internal error", err.Message)
 	})
+}
+
+// TestCodeMCPCodeFor_LegacyRevisionsKeepRetiredResourceNotFound pins the half
+// of the 2026-07-28 error-code rule that is easy to lose in a refactor: the
+// retired -32002 is not merely permitted on the handshake-based revisions, it
+// is what their clients are told to expect, so the mapping is a branch rather
+// than a migration.
+func TestCodeMCPCodeFor_LegacyRevisionsKeepRetiredResourceNotFound(t *testing.T) {
+	t.Parallel()
+
+	for _, revision := range []string{
+		mcpversions.Version20241105,
+		mcpversions.Version20250326,
+		mcpversions.Version20250618,
+		mcpversions.Version20251125,
+	} {
+		require.Equal(t, MCPCodeResourceNotFound, CodeNotFound.MCPCodeFor(revision), "revision %s", revision)
+	}
+}
+
+// TestCodeMCPCodeFor_ModernRevisionReplacesRetiredResourceNotFound covers the
+// MUST NOT: an implementation of 2026-07-28 may not emit -32002 at all.
+func TestCodeMCPCodeFor_ModernRevisionReplacesRetiredResourceNotFound(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, MCPCodeInvalidParams, CodeNotFound.MCPCodeFor(mcpversions.Version20260728))
+}
+
+// TestCodeMCPCodeFor_UnresolvedRevisionIsLegacy covers the error paths that
+// fail before a revision can be resolved — everything ahead of body decode.
+// They have no declaration to read, so they must not be answered as modern.
+func TestCodeMCPCodeFor_UnresolvedRevisionIsLegacy(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, MCPCodeResourceNotFound, CodeNotFound.MCPCodeFor(""))
+	require.Equal(t, MCPCodeResourceNotFound, CodeNotFound.MCPCodeFor("not-a-revision"))
+}
+
+// TestCodeMCPCodeFor_OnlyResourceNotFoundIsRevisionConditional guards the
+// scope of the branch. Gram's other server-defined codes sit in the range
+// 2026-07-28 designates legacy, but only -32002 is a MUST NOT; the rest stay
+// legal to emit and must not be quietly remapped alongside it.
+func TestCodeMCPCodeFor_OnlyResourceNotFoundIsRevisionConditional(t *testing.T) {
+	t.Parallel()
+
+	for _, code := range []Code{
+		CodeUnauthorized,
+		CodeForbidden,
+		CodeBadRequest,
+		CodeConflict,
+		CodeFailedPrecondition,
+		CodeUnsupportedMedia,
+		CodeMethodNotAllowed,
+		CodeInvalid,
+		CodeNotImplemented,
+		CodeUnexpected,
+	} {
+		require.Equal(t, code.MCPCode(), code.MCPCodeFor(mcpversions.Version20260728), "code %s", code)
+	}
+}
+
+// TestNewMCPErrorFromCause_ModernRevisionReplacesRetiredResourceNotFound
+// covers the in-handler write path, which is where Gram's general not-found —
+// an unknown tool, toolset, or endpoint — reaches the wire.
+func TestNewMCPErrorFromCause_ModernRevisionReplacesRetiredResourceNotFound(t *testing.T) {
+	t.Parallel()
+
+	err := NewMCPErrorFromCause(mcpjsonrpc.StringID("req-1"), mcpversions.Version20260728, E(CodeNotFound, nil, "unknown tool"))
+
+	require.Equal(t, MCPCodeInvalidParams, err.Code)
+	require.Equal(t, "unknown tool", err.Message)
+}
+
+// TestNewMCPErrorFromCause_PreservesExplicitCodeOnModernRevision covers the
+// passthrough arm: a caller that names a wire code itself has chosen it, and
+// the revision mapping must not second-guess that.
+func TestNewMCPErrorFromCause_PreservesExplicitCodeOnModernRevision(t *testing.T) {
+	t.Parallel()
+
+	existing := &MCPError{ID: mcpjsonrpc.NullID(), Code: MCPCodeResourceNotFound, Message: "explicit", Data: nil}
+	err := NewMCPErrorFromCause(mcpjsonrpc.StringID("req-1"), mcpversions.Version20260728, existing)
+
+	require.Same(t, existing, err)
+	require.Equal(t, MCPCodeResourceNotFound, err.Code)
+}
+
+// TestMCPErrHandle_ModernRevisionReplacesRetiredResourceNotFound covers the
+// outer path. A not-found can escape a handler after the body is decoded — a
+// private MCP server reached anonymously is answered that way — so this path
+// carries the MUST NOT too, and reaches the revision through the mutable
+// holder it installs rather than through the request context it captured.
+func TestMCPErrHandle_ModernRevisionReplacesRetiredResourceNotFound(t *testing.T) {
+	t.Parallel()
+	logger, _ := captureLogger()
+
+	handler := MCPErrHandle(logger, func(w http.ResponseWriter, r *http.Request) error {
+		rpcCtx, ok := contextvalues.GetRPCContext(r.Context())
+		require.True(t, ok)
+		rpcCtx.ProtocolVersion = mcpversions.Version20260728
+
+		return C(CodeNotFound)
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/mcp/test", nil))
+
+	var response struct {
+		Error struct {
+			Code MCPCode `json:"code"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	require.Equal(t, MCPCodeInvalidParams, response.Error.Code)
+}
+
+// TestMCPErrHandle_StatusStaysKeyedOnGramCodeForModernRevision pins the
+// deliberate asymmetry between the two error paths. The statuses this wrapper
+// answers are transport-level refusals that are correct on every revision, and
+// the 401 in particular is what an MCP client needs to begin its OAuth
+// discovery flow. Deriving the status from the revision here would answer that
+// challenge with a 200 and strand every client that has to authorize.
+func TestMCPErrHandle_StatusStaysKeyedOnGramCodeForModernRevision(t *testing.T) {
+	t.Parallel()
+	logger, _ := captureLogger()
+
+	for code, want := range map[Code]int{
+		CodeUnauthorized:     http.StatusUnauthorized,
+		CodeForbidden:        http.StatusForbidden,
+		CodeNotFound:         http.StatusNotFound,
+		CodeMethodNotAllowed: http.StatusMethodNotAllowed,
+	} {
+		handler := MCPErrHandle(logger, func(w http.ResponseWriter, r *http.Request) error {
+			rpcCtx, ok := contextvalues.GetRPCContext(r.Context())
+			require.True(t, ok)
+			rpcCtx.ProtocolVersion = mcpversions.Version20260728
+
+			return C(code)
+		})
+
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/mcp/test", nil))
+
+		require.Equal(t, want, rec.Code, "code %s", code)
+	}
 }

--- a/server/internal/oops/mcp_test.go
+++ b/server/internal/oops/mcp_test.go
@@ -147,8 +147,11 @@ func TestNewMCPErrorFromCause(t *testing.T) {
 		existing := &MCPError{ID: mcpjsonrpc.ID{Number: 0, String: ""}, Code: MCPCodeMethodNotFound, Message: "missing", Data: nil}
 		err := NewMCPErrorFromCause(id, mcpversions.Version20251125, existing)
 
-		require.Same(t, existing, err)
+		require.NotSame(t, existing, err, "the caller's value is adjusted on a copy")
+		require.Equal(t, MCPCodeMethodNotFound, err.Code)
+		require.Equal(t, "missing", err.Message)
 		require.Equal(t, id, err.ID)
+		require.False(t, existing.ID.IsSet(), "the caller's value keeps the id it was built with")
 	})
 
 	t.Run("maps_shareable_error_code", func(t *testing.T) {
@@ -252,8 +255,25 @@ func TestNewMCPErrorFromCause_PreservesExplicitCodeOnModernRevision(t *testing.T
 	existing := &MCPError{ID: mcpjsonrpc.NullID(), Code: MCPCodeForbidden, Message: "explicit", Data: nil}
 	err := NewMCPErrorFromCause(mcpjsonrpc.StringID("req-1"), mcpversions.Version20260728, existing)
 
-	require.Same(t, existing, err)
 	require.Equal(t, MCPCodeForbidden, err.Code)
+}
+
+// TestNewMCPErrorFromCause_DoesNotMutateTheCallersError covers the lifetime
+// hazard in remapping a caller-supplied error. The code chosen here is right
+// for one request, so writing it back into a value the caller may hold would
+// let a single modern request leave every later legacy client answered with
+// -32602: the compatibility break the revision branch exists to prevent.
+func TestNewMCPErrorFromCause_DoesNotMutateTheCallersError(t *testing.T) {
+	t.Parallel()
+
+	existing := &MCPError{ID: mcpjsonrpc.NullID(), Code: MCPCodeResourceNotFound, Message: "explicit", Data: nil}
+
+	modern := NewMCPErrorFromCause(mcpjsonrpc.StringID("req-1"), mcpversions.Version20260728, existing)
+	require.Equal(t, MCPCodeInvalidParams, modern.Code)
+	require.Equal(t, MCPCodeResourceNotFound, existing.Code, "the caller's value is untouched")
+
+	legacy := NewMCPErrorFromCause(mcpjsonrpc.StringID("req-2"), mcpversions.Version20251125, existing)
+	require.Equal(t, MCPCodeResourceNotFound, legacy.Code, "a legacy request after a modern one still gets the retired code")
 }
 
 // TestNewMCPErrorFromCause_RemapsExplicitRetiredCodeOnModernRevision covers the


### PR DESCRIPTION
https://linear.app/speakeasy/issue/AIM-43/feat-make-mcp-error-code-mapping-conditional-on-the-protocol-revision
https://linear.app/speakeasy/issue/AIM-46/feat-return-spec-mandated-http-statuses-for-modern-mcp-errors-instead

## Summary

Two commits, both groundwork for advertising MCP `2026-07-28`. **Nothing changes on the wire today**: every surface's supported set still tops out at `2025-11-25`, so no request can resolve to a modern revision and every mapping returns exactly what it returned before.

**AIM-43** adds `Code.MCPCodeFor(revision)`, which answers `-32602` instead of the retired `-32002` on a modern revision. `Code.MCPCode()` stays as the legacy mapping. Legacy revisions must keep receiving `-32002`, so this is a branch rather than a migration.

**AIM-46** adds `MCPCode.MandatedHTTPStatus()`, holding the specification's table (400 for `-32602`, `-32020`, `-32021`, `-32022`; 404 for `-32601`). Both error paths read it. Legacy revisions keep the 200 they have always been served, and codes the specification says nothing about keep their existing status on every revision.

Supporting changes: the three near-identical in-handler write sites (hosted, platform, meta) collapse into one `writeMCPError`; `mcpversions.AtLeast`/`IsModern` name the era boundary once; `mcpjsonrpc.ID.IsNull` distinguishes a message that names no request; the `-32020`, `-32021` and `-32022` constants land with their statuses so the table is the specification's rather than the subset Gram currently reaches.

### Carriage

Gram has two error paths and they needed different plumbing. Errors returned by a handler take a revision parameter. Errors that escape a handler reach `oops.MCPErrHandle`, which reads the request context it captured **before** dispatch, so a plain context value set inside the handler is invisible to it. The revision therefore travels on the mutable `contextvalues.RPCContext` holder the wrapper installs, alongside the JSON-RPC id already carried there. The hosted surface's resolution moved up to just after body decode, because the authorization and admission checks between there and the old resolution point return errors of their own.

### Choices worth a reviewer's attention

- **The outer wrapper still derives its status from the Gram error code**, which is what makes it answer 401 with the OAuth discovery challenge, 403 for a denied toolset, and 405 for the GET compatibility probe. None of those wire codes carries a mandated status, so they are unaffected. The not-found is affected deliberately: that path now answers with the revision's wire code, and pairing `-32602` with the Gram code's 404 would claim the method is unimplemented, which is the one meaning the specification assigns that status.
- **A message naming no request gets the mandated status too.** The status describes the condition, not the message that provoked it, and `2026-07-28` directs a server that cannot accept input to answer with an HTTP error status rather than a 200 carrying an error body.
- **An explicitly constructed `MCPError` passes through with its caller's code, except `-32002`.** A MUST NOT is not a caller's to opt out of.
- **One behavior change beyond the statuses**: consolidating the write sites gives the hosted surface the write-failure logging the platform and meta surfaces already had. Its message text changes from `failed to write MCP error response` to `failed to write error response body`, so a log query pinned to the old string goes quiet.

### Deferred, not addressed here

- `CodeNotFound` covers both "no server is hosted at this URL" and "no such tool", so both answer 400 under a modern revision. Worth an explicit decision before AIM-41 makes it visible.
- The status override reads the authored error code while the status it replaces comes from the promoted one, so an authored not-found whose cause is a client disconnect answers 400 rather than 499.
- `NewMCPErrorFromCause` mutates the caller's `*MCPError` in place, now in two fields rather than one. Safe for today's single caller, which builds a fresh value per request.
- The meta surface answers `-32600` for the header versus `_meta` conflict and for an unsupported declared version, both of which now have dedicated codes. That belongs with AIM-48 and AIM-50.
- The consent transport and the remote MCP proxy have their own JSON-RPC error writers and are out of scope, the proxy because it relays a negotiation it does not participate in.

## Motivation

`2026-07-28` retires `-32002` as a MUST NOT and mandates a status per error condition, and the statuses are load-bearing rather than cosmetic. A client that speaks both eras detects which one a server implements by making a modern request and inspecting the body of a 400, and separates a modern server missing a method from a legacy server not hosting the modern endpoint by the JSON-RPC body accompanying a 404. Answering everything with 200 leaves such a client nothing to inspect. Meanwhile legacy clients must keep 200, because many treat a non-2xx as a transport failure and never parse the body, so both behaviors have to coexist and key off the revision in effect.

The two issues need the same value at the same call sites, so the threading is designed once rather than twice.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares MCP error responses for the revision-dependent requirements in [AIM-43](https://linear.app/speakeasy/issue/AIM-43) and [AIM-46](https://linear.app/speakeasy/issue/AIM-46). Current supported sets still stop at `2025-11-25`, so requests retain legacy `-32002` mappings and HTTP 200; when `2026-07-28` is served, `-32002` maps to `-32602` and mandated conditions use HTTP 400/404.

- Applies the resolved revision to hosted, platform, and meta errors, including errors escaping `MCPErrHandle`.
- Shares `writeMCPError` across those surfaces with consistent write-failure logging; the hosted log message changes.
- Keeps HTTP 200 for unspecified modern error codes and preserves existing auth, permission, and other outer-path statuses.
- Copies caller-supplied `MCPError` values before filling IDs or remapping codes, preventing one request from mutating an error reused by another.
- Adds the three protocol validation codes and coverage for revision ordering, ID handling, mappings, and statuses.

<sup>Written for commit 20c0905699ba99ff0a40f9a1111a3b384ce5acdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

