### PR TITLE
ci: delay mise upgrades by one day across workflows

### DIFF
--- a/.github/workflows/hygiene.yaml
+++ b/.github/workflows/hygiene.yaml
@@ -197,8 +197,9 @@ jobs:
 
       - name: Setup Mise
         if: ${{ steps.check.outputs.lint == 'true' }}
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1

--- a/.github/workflows/litellm-e2e.yml
+++ b/.github/workflows/litellm-e2e.yml
@@ -15,8 +15,9 @@ jobs:
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -260,10 +260,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
-          # Pin mise to avoid intermittent latest-version download failures.
-          version: "2026.9.2"
+          minimum_release_age: 1d
           install: true
           # The retag action only needs yq; skip the rest of the toolset and
           # keep this job's cache separate from the full-install caches.
@@ -302,8 +301,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1
@@ -475,8 +475,9 @@ jobs:
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1
@@ -621,8 +622,9 @@ jobs:
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1
@@ -778,8 +780,9 @@ jobs:
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1
@@ -819,8 +822,9 @@ jobs:
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1
@@ -882,8 +886,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1
@@ -993,8 +998,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           install_args: aqua:ariga/atlas
           cache: true
@@ -1047,8 +1053,9 @@ jobs:
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1
@@ -1110,8 +1117,9 @@ jobs:
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1
@@ -1210,8 +1218,9 @@ jobs:
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1
@@ -1279,8 +1288,9 @@ jobs:
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1
@@ -1335,8 +1345,9 @@ jobs:
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1
@@ -1392,8 +1403,9 @@ jobs:
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1
@@ -1436,8 +1448,9 @@ jobs:
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1
@@ -1477,8 +1490,9 @@ jobs:
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1
@@ -1544,8 +1558,9 @@ jobs:
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1
@@ -1605,8 +1620,9 @@ jobs:
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1
@@ -1647,8 +1663,9 @@ jobs:
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1
@@ -1831,8 +1848,9 @@ jobs:
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1
@@ -1897,8 +1915,9 @@ jobs:
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1
@@ -1944,8 +1963,9 @@ jobs:
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1
@@ -2002,8 +2022,9 @@ jobs:
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1
@@ -2105,8 +2126,9 @@ jobs:
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1
@@ -2283,8 +2305,9 @@ jobs:
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1
@@ -2344,8 +2367,9 @@ jobs:
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           # This job only needs npx; avoid restoring the full ~606 MiB toolchain

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -262,6 +262,8 @@ jobs:
       - name: Setup Mise
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
+          # Pin mise to avoid intermittent latest-version download failures.
+          version: "2026.9.2"
           install: true
           # The retag action only needs yq; skip the rest of the toolset and
           # keep this job's cache separate from the full-install caches.

--- a/.github/workflows/release-hooks.yaml
+++ b/.github/workflows/release-hooks.yaml
@@ -48,8 +48,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,8 +33,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-github-v1

--- a/.github/workflows/wake-stack-e2e.yml
+++ b/.github/workflows/wake-stack-e2e.yml
@@ -54,8 +54,9 @@ jobs:
         uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
 
       - name: Setup Mise
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          minimum_release_age: 1d
           install: true
           cache: true
           cache_key_prefix: mise-blacksmith-v1


### PR DESCRIPTION
## Summary
Upgrade all 31 mise setup steps across six workflows to the commit-pinned mise-action v4.3.0 and set `minimum_release_age: 1d`. Replace the preview-retag job's exact version pin with the same policy so CI receives mise updates after a 24-hour delay.

## Motivation
Mise setup intermittently returned HTTP 404 while downloading a newly released version in [#6147's run](https://github.com/speakeasy-api/gram/actions/runs/34226993264/job/102063526238) and [#6148's run](https://github.com/speakeasy-api/gram/actions/runs/34231047587/job/102077066603). Deferring new releases mitigates release-publication timing issues without maintaining a fixed mise version.
