### PR TITLE
chore: tone down the icon confetti hover effect

### DIFF
--- a/client/dashboard/src/components/icon-confetti.tsx
+++ b/client/dashboard/src/components/icon-confetti.tsx
@@ -2,7 +2,7 @@ import confetti from "canvas-confetti";
 import { useCallback, useEffect, useRef } from "react";
 
 // Brand language palette. canvas-confetti parses hex only, so the tokens are
-// resolved from CSS at first use (they are hsl()) and cached.
+// resolved from CSS at first use (they are hsl()), muted, and cached.
 const CONFETTI_TOKENS = [
   "brand-ruby",
   "brand-go",
@@ -15,20 +15,34 @@ const CONFETTI_TOKENS = [
   "brand-c",
 ];
 
+// Muted against the card so the pieces read as texture rather than a party
+// popper: each brand hue is blended most of the way to the surface it lands on.
+const MUTE = 0.55;
+
 let confettiColorCache: string[] | null = null;
+
+function rgbTriplet(el: HTMLElement): [number, number, number] {
+  const rgb = getComputedStyle(el).color.match(/\d+/g);
+  if (!rgb) return [136, 136, 136];
+  return [Number(rgb[0]), Number(rgb[1]), Number(rgb[2])];
+}
 
 function brandConfettiColors(): string[] {
   if (confettiColorCache) return confettiColorCache;
   const probe = document.createElement("span");
   probe.style.display = "none";
   document.body.appendChild(probe);
+
+  // The card surface, so muting follows the theme rather than a fixed grey.
+  probe.style.color = "var(--bg-surface-primary-default)";
+  const bg = rgbTriplet(probe);
+
   const colors = CONFETTI_TOKENS.map((token) => {
     probe.style.color = `var(--color-${token})`;
-    const rgb = getComputedStyle(probe).color.match(/\d+/g);
-    if (!rgb) return "#888888";
+    const rgb = rgbTriplet(probe);
     return `#${rgb
-      .slice(0, 3)
-      .map((n) => Number(n).toString(16).padStart(2, "0"))
+      .map((n, i) => Math.round(n + (bg[i]! - n) * MUTE))
+      .map((n) => n.toString(16).padStart(2, "0"))
       .join("")}`;
   });
   probe.remove();
@@ -121,16 +135,16 @@ export function useIconConfetti(): {
 
     // The opening burst.
     void fire({
-      particleCount: 110,
+      particleCount: 34,
       spread: 360,
       // Tuned for a ~160px canvas: a slow launch with heavy drag keeps the
       // pieces inside the rail long enough to read, where the full-screen
       // defaults would shoot them off-canvas within a few frames.
-      startVelocity: 11,
-      gravity: 0.55,
-      decay: 0.93,
-      scalar: 0.6,
-      ticks: 160,
+      startVelocity: 7,
+      gravity: 0.32,
+      decay: 0.92,
+      scalar: 0.5,
+      ticks: 170,
       origin: { x: 0.5, y: 0.5 },
       colors: brandConfettiColors(),
       // The library honours the OS setting itself, so there is no separate
@@ -144,20 +158,20 @@ export function useIconConfetti(): {
     if (fallTimerRef.current) return;
     fallTimerRef.current = setInterval(() => {
       void fire({
-        particleCount: 3,
-        spread: 55,
+        particleCount: 2,
+        spread: 45,
         // Straight down, from a random point along the top edge.
         angle: 270,
-        startVelocity: 6,
-        gravity: 0.5,
-        decay: 0.94,
-        scalar: 0.55,
-        ticks: 130,
+        startVelocity: 3,
+        gravity: 0.28,
+        decay: 0.95,
+        scalar: 0.45,
+        ticks: 200,
         origin: { x: Math.random(), y: -0.1 },
         colors: brandConfettiColors(),
         disableForReducedMotion: true,
       });
-    }, 160);
+    }, 320);
   }, [getFire]);
 
   return { canvasRef, start, stop };


### PR DESCRIPTION
## Summary

Turns the card icon hover confetti down so it reads as a small flourish rather than a party popper.

- Opening burst: 110 → 34 pieces, launch velocity 11 → 7, gravity 0.55 → 0.32, scalar 0.6 → 0.5.
- Steady drift while hovering: tick 160ms → 320ms, 3 → 2 pieces per tick, velocity 6 → 3, gravity 0.5 → 0.28. Longer `ticks` on both so the slower pieces still finish their fall on-canvas rather than vanishing mid-air.
- Colors are muted: each brand hue is now blended 55% toward `--bg-surface-primary-default` before it goes to canvas-confetti, so the pieces sit against the card instead of popping off it. Reading the surface token rather than a fixed grey keeps the muting correct in both themes.

Behaviour, layering, the cross-card clear-on-hover registry and the reduced-motion guard are unchanged.

## Motivation

The effect as shipped was too loud for something that fires on every card hover — the explosion drew the eye away from the card content it was meant to decorate, and full-saturation brand colors at that particle count read as noise on a dense grid. Toning the amount, speed and contrast down keeps the moment of arrival without the effect competing with the page.

https://claude.ai/code/session_01LRbVpTuSLGJz5QwgKqAteF


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces the card icon hover confetti so it reads as a subtle flourish instead of competing with card content.

- Cuts the opening burst from 110 to 34 pieces and lowers its velocity, gravity, size, and spread.
- Slows the steady drift from every 160ms with 3 pieces to every 320ms with 2, while extending particle lifetimes.
- Blends brand colors 55% toward `--bg-surface-primary-default` so muted colors follow the active theme.
- Preserves layering, cross-card cleanup, and reduced-motion behavior.

<sup>Written for commit f156dcf251045c0c514b5e2161be22bbd40d85eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

