### PR TITLE
fix: serve the installation page for MCP gateway endpoints

### DIFF
--- a/.changeset/gateway-install-page.md
+++ b/.changeset/gateway-install-page.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Serve the installation page for MCP gateway endpoints instead of a not-found page.

--- a/server/internal/mcpmetadata/impl.go
+++ b/server/internal/mcpmetadata/impl.go
@@ -53,6 +53,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mcpmetadata/templatefuncs"
 	"github.com/speakeasy-api/gram/server/internal/mcpservers"
 	mcpservers_repo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
+	metamcp_repo "github.com/speakeasy-api/gram/server/internal/metamcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
@@ -919,6 +920,7 @@ func appendTagsQuery(mcpURL, tag string) string {
 type installContext struct {
 	toolset      *toolsets_repo.Toolset
 	mcpServer    *mcpservers_repo.McpServer
+	metaServer   *metamcp_repo.MetaMcpServer
 	mcpEndpoint  *mcpendpoints_repo.McpEndpoint
 	organization organizations_repo.OrganizationMetadatum
 }
@@ -927,7 +929,8 @@ type installContext struct {
 // When resolution went through an mcp_servers row — any backend, hosted
 // (toolset-backed) included — that row's visibility is authoritative; the
 // toolset's McpIsPublic flag only decides for pure legacy toolset routing
-// where no wrapper exists.
+// where no wrapper exists. Gateways (meta_mcp_servers) have no public
+// visibility, so their install page is always session-gated.
 func (ic *installContext) isPublic() bool {
 	if ic.mcpServer != nil {
 		return ic.mcpServer.Visibility == mcpservers.VisibilityPublic
@@ -1021,10 +1024,14 @@ func (s *Service) ServeInstallPage(w http.ResponseWriter, r *http.Request) error
 		}
 	}
 
-	if ic.toolset != nil {
+	switch {
+	case ic.toolset != nil:
 		return s.renderToolsetInstallPage(ctx, w, ic, mcpSlug, metadataRecord)
+	case ic.metaServer != nil:
+		return s.renderMetaMcpInstallPage(ctx, w, ic)
+	default:
+		return s.renderRemoteMcpInstallPage(ctx, w, ic, metadataRecord)
 	}
-	return s.renderRemoteMcpInstallPage(ctx, w, ic, metadataRecord)
 }
 
 // resolveInstallContext tries the mcp_endpoints → mcp_server resolution path
@@ -1041,8 +1048,19 @@ func (s *Service) resolveInstallContext(ctx context.Context, mcpSlug string) (*i
 	case err != nil:
 		return nil, fmt.Errorf("resolve mcp endpoint: %w", err)
 	case metaServer != nil:
-		// Meta-backed endpoints have no install page yet (AGE-3299).
-		return nil, fmt.Errorf("%w: meta-backed endpoint has no install page", errToolsetNotFound)
+		// Disabled gateways never resolve (policy denial above), so a
+		// resolved gateway is private and session-gated by the caller.
+		org, err := s.orgsRepo.GetOrganizationMetadata(ctx, metaServer.OrganizationID)
+		if err != nil {
+			return nil, fmt.Errorf("load organization: %w", err)
+		}
+		return &installContext{
+			toolset:      nil,
+			mcpServer:    nil,
+			metaServer:   metaServer,
+			mcpEndpoint:  endpoint,
+			organization: org,
+		}, nil
 	default:
 		var bridgeToolset *toolsets_repo.Toolset
 		if server.ToolsetID.Valid {
@@ -1066,6 +1084,7 @@ func (s *Service) resolveInstallContext(ctx context.Context, mcpSlug string) (*i
 		return &installContext{
 			toolset:      bridgeToolset,
 			mcpServer:    server,
+			metaServer:   nil,
 			mcpEndpoint:  endpoint,
 			organization: org,
 		}, nil
@@ -1083,6 +1102,7 @@ func (s *Service) resolveInstallContext(ctx context.Context, mcpSlug string) (*i
 	return &installContext{
 		toolset:      toolset,
 		mcpServer:    nil,
+		metaServer:   nil,
 		mcpEndpoint:  nil,
 		organization: org,
 	}, nil
@@ -1366,6 +1386,40 @@ func (s *Service) renderRemoteMcpInstallPage(ctx context.Context, w http.Respons
 		IsOAuth:        mcpServer.UserSessionIssuerID.Valid && !tunneledPublic,
 		OrgName:        ic.organization.Name,
 		// Remote-MCP-backed installs have no tool list, so no filter scopes.
+		FilteringEnabled: false,
+		Scopes:           nil,
+	})
+}
+
+// renderMetaMcpInstallPage renders the install page for a gateway
+// (meta_mcp_servers) endpoint. Gateways carry no branding metadata and expose
+// no Gram-side env vars or tool list, so the page is the URL plus defaults.
+func (s *Service) renderMetaMcpInstallPage(ctx context.Context, w http.ResponseWriter, ic *installContext) error {
+	metaServer := ic.metaServer
+	endpoint := ic.mcpEndpoint
+	if metaServer == nil || endpoint == nil {
+		return oops.E(oops.CodeUnexpected, nil, "meta mcp install context missing backend or endpoint").LogError(ctx, s.logger)
+	}
+
+	mcpURL, err := s.resolveMcpEndpointURL(ctx, endpoint)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "resolve mcp endpoint url").LogError(ctx, s.logger, attr.SlogMetaMcpServerID(metaServer.ID.String()))
+	}
+
+	return s.writeInstallPage(ctx, w, hostedPageRenderInputs{
+		MCPName:          metaServer.Name,
+		MCPSlug:          endpoint.Slug,
+		MCPDescription:   "",
+		MCPURL:           mcpURL,
+		SecurityInputs:   []securityInput{},
+		Tools:            []toolInfo{},
+		LogoAssetURL:     s.siteURL.String() + "/external/sticker-logo.png",
+		DocsURL:          "",
+		DocsText:         "",
+		Instructions:     "",
+		IsPublic:         false,
+		IsOAuth:          metaServer.UserSessionIssuerID.Valid,
+		OrgName:          ic.organization.Name,
 		FilteringEnabled: false,
 		Scopes:           nil,
 	})

--- a/server/internal/mcpmetadata/serve_install_page_test.go
+++ b/server/internal/mcpmetadata/serve_install_page_test.go
@@ -1985,31 +1985,37 @@ func TestServeInstallPage_PrivateOnlyEndpointDoesNotFallBack(t *testing.T) {
 	require.NotContains(t, rr.Body.String(), "Legacy Install Fallback")
 }
 
-// TestServeInstallPage_MetaBackedEndpoint_ReturnsNotFound verifies that a
-// meta-MCP-backed endpoint's install page is an authoritative 404 (AGE-3299
-// will add a real page): the response is the rendered not-found page rather
-// than a 500, and the slug must not fall through to an unrelated legacy
-// toolset sharing the same mcp_slug.
-func TestServeInstallPage_MetaBackedEndpoint_ReturnsNotFound(t *testing.T) {
-	t.Parallel()
-	ctx, testInstance := newTestMCPMetadataService(t)
+// metaEndpointFixtureOptions configures seedMetaBackedEndpoint. Zero values
+// mean a private gateway with no user session issuer.
+type metaEndpointFixtureOptions struct {
+	visibility          string
+	userSessionIssuerID uuid.NullUUID
+}
+
+// seedMetaBackedEndpoint creates a gateway (meta_mcp_servers) with a
+// platform-domain endpoint at mcpSlug, plus a public legacy toolset sharing
+// the same mcp_slug that must never shadow the gateway.
+func seedMetaBackedEndpoint(t *testing.T, ctx context.Context, ti *testInstance, mcpSlug string, opts metaEndpointFixtureOptions) metamcp_repo.MetaMcpServer {
+	t.Helper()
 
 	authCtx, ok := contextvalues.GetAuthContext(ctx)
 	require.True(t, ok)
 	require.NotNil(t, authCtx.ProjectID)
 
-	mcpSlug := "meta-install-" + uuid.New().String()[:8]
-
-	meta, err := metamcp_repo.New(testInstance.conn).CreateMetaMCPServer(ctx, metamcp_repo.CreateMetaMCPServerParams{
+	vis := opts.visibility
+	if vis == "" {
+		vis = visibility.Private
+	}
+	meta, err := metamcp_repo.New(ti.conn).CreateMetaMCPServer(ctx, metamcp_repo.CreateMetaMCPServerParams{
 		OrganizationID:      authCtx.ActiveOrganizationID,
 		ProjectID:           *authCtx.ProjectID,
-		Name:                "install page gateway",
-		UserSessionIssuerID: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
-		Visibility:          visibility.Private,
+		Name:                "Install Page Gateway",
+		UserSessionIssuerID: opts.userSessionIssuerID,
+		Visibility:          vis,
 	})
 	require.NoError(t, err)
 
-	_, err = mcpendpoints_repo.New(testInstance.conn).CreateMCPEndpoint(ctx, mcpendpoints_repo.CreateMCPEndpointParams{
+	_, err = mcpendpoints_repo.New(ti.conn).CreateMCPEndpoint(ctx, mcpendpoints_repo.CreateMCPEndpointParams{
 		ProjectID:       *authCtx.ProjectID,
 		CustomDomainID:  uuid.NullUUID{UUID: uuid.Nil, Valid: false},
 		McpServerID:     uuid.NullUUID{UUID: uuid.Nil, Valid: false},
@@ -2018,9 +2024,7 @@ func TestServeInstallPage_MetaBackedEndpoint_ReturnsNotFound(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// A public legacy toolset sharing the mcp_slug must not be rendered: the
-	// meta-backed endpoint owns the slug.
-	toolset, err := testInstance.toolsetRepo.CreateToolset(ctx, toolsets_repo.CreateToolsetParams{
+	toolset, err := ti.toolsetRepo.CreateToolset(ctx, toolsets_repo.CreateToolsetParams{
 		OrganizationID:         authCtx.ActiveOrganizationID,
 		ProjectID:              *authCtx.ProjectID,
 		Name:                   "Legacy Same-Slug Toolset",
@@ -2031,21 +2035,145 @@ func TestServeInstallPage_MetaBackedEndpoint_ReturnsNotFound(t *testing.T) {
 		McpEnabled:             true,
 	})
 	require.NoError(t, err)
-	require.NoError(t, toolsets_repo.New(testInstance.conn).SetToolsetMCPPublicByID(ctx, toolsets_repo.SetToolsetMCPPublicByIDParams{
+	require.NoError(t, toolsets_repo.New(ti.conn).SetToolsetMCPPublicByID(ctx, toolsets_repo.SetToolsetMCPPublicByIDParams{
 		McpIsPublic: true,
 		ID:          toolset.ID,
 		ProjectID:   toolset.ProjectID,
 	}))
 
+	return meta
+}
+
+// serveMetaInstallPage issues GET /mcp/<slug>/install with reqCtx as the
+// request context and returns the recorded response.
+func serveMetaInstallPage(t *testing.T, reqCtx context.Context, ti *testInstance, mcpSlug string) *httptest.ResponseRecorder {
+	t.Helper()
+
 	req := httptest.NewRequest("GET", "/mcp/"+mcpSlug+"/install", nil)
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("mcpSlug", mcpSlug)
-	req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
+	req = req.WithContext(context.WithValue(reqCtx, chi.RouteCtxKey, rctx))
 
 	rr := httptest.NewRecorder()
-	require.NoError(t, testInstance.service.ServeInstallPage(rr, req))
-	assert.Equal(t, http.StatusNotFound, rr.Code)
+	require.NoError(t, ti.service.ServeInstallPage(rr, req))
+	return rr
+}
+
+// TestServeInstallPage_MetaBackedEndpoint_RendersGateway verifies that a
+// gateway (meta_mcp_servers) endpoint renders its install page for a
+// session in the owning org, and that the slug does not fall through to an
+// unrelated legacy toolset sharing the same mcp_slug.
+func TestServeInstallPage_MetaBackedEndpoint_RendersGateway(t *testing.T) {
+	t.Parallel()
+	ctx, testInstance := newTestMCPMetadataService(t)
+
+	mcpSlug := "meta-install-" + uuid.New().String()[:8]
+	seedMetaBackedEndpoint(t, ctx, testInstance, mcpSlug, metaEndpointFixtureOptions{
+		visibility:          "",
+		userSessionIssuerID: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+	})
+
+	rr := serveMetaInstallPage(t, ctx, testInstance, mcpSlug)
+	require.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+	assert.Contains(t, body, "Install Page Gateway")
+	assert.Contains(t, body, testInstance.serverURL.String()+"/mcp/"+mcpSlug)
+	assert.Contains(t, body, "private-badge", "gateways are never public")
+	assert.NotContains(t, body, "codex mcp login", "no issuer means no OAuth steps")
+	assert.NotContains(t, body, "Server Not Found")
+	assert.NotContains(t, body, "Legacy Same-Slug Toolset")
+}
+
+// TestServeInstallPage_MetaBackedEndpoint_IssuerGatedShowsOAuthSteps verifies
+// that a gateway with a user session issuer renders the OAuth instructions.
+func TestServeInstallPage_MetaBackedEndpoint_IssuerGatedShowsOAuthSteps(t *testing.T) {
+	t.Parallel()
+	ctx, testInstance := newTestMCPMetadataService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	issuer := createUserSessionIssuer(t, ctx, testInstance, *authCtx.ProjectID)
+
+	mcpSlug := "meta-install-oauth-" + uuid.New().String()[:8]
+	seedMetaBackedEndpoint(t, ctx, testInstance, mcpSlug, metaEndpointFixtureOptions{
+		visibility:          "",
+		userSessionIssuerID: uuid.NullUUID{UUID: issuer.ID, Valid: true},
+	})
+
+	rr := serveMetaInstallPage(t, ctx, testInstance, mcpSlug)
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "codex mcp login")
+}
+
+// TestServeInstallPage_MetaBackedEndpoint_DisabledReturnsNotFound verifies
+// that a disabled gateway is an authoritative 404 and never falls through to
+// the legacy toolset sharing its slug.
+func TestServeInstallPage_MetaBackedEndpoint_DisabledReturnsNotFound(t *testing.T) {
+	t.Parallel()
+	ctx, testInstance := newTestMCPMetadataService(t)
+
+	mcpSlug := "meta-install-disabled-" + uuid.New().String()[:8]
+	seedMetaBackedEndpoint(t, ctx, testInstance, mcpSlug, metaEndpointFixtureOptions{
+		visibility:          visibility.Disabled,
+		userSessionIssuerID: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+	})
+
+	rr := serveMetaInstallPage(t, ctx, testInstance, mcpSlug)
+	require.Equal(t, http.StatusNotFound, rr.Code)
 	assert.Contains(t, rr.Body.String(), "Server Not Found")
+	assert.NotContains(t, rr.Body.String(), "Install Page Gateway")
+	assert.NotContains(t, rr.Body.String(), "Legacy Same-Slug Toolset")
+}
+
+// TestServeInstallPage_MetaBackedEndpoint_RedirectsAnonymousToLogin verifies
+// that a gateway install page is session-gated: gateways have no public
+// visibility, so an unauthenticated request is sent to /login.
+func TestServeInstallPage_MetaBackedEndpoint_RedirectsAnonymousToLogin(t *testing.T) {
+	t.Parallel()
+	ctx, testInstance := newTestMCPMetadataService(t)
+
+	mcpSlug := "meta-install-anon-" + uuid.New().String()[:8]
+	seedMetaBackedEndpoint(t, ctx, testInstance, mcpSlug, metaEndpointFixtureOptions{
+		visibility:          "",
+		userSessionIssuerID: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+	})
+
+	rr := serveMetaInstallPage(t, context.Background(), testInstance, mcpSlug)
+	require.Equal(t, http.StatusFound, rr.Code)
+	assert.Contains(t, rr.Header().Get("Location"), "/login")
+}
+
+// TestServeInstallPage_MetaBackedEndpoint_WrongOrgReturnsNotFound verifies
+// that a session from another organization gets the not-found page for a
+// gateway install page, and never the gateway's name or URL.
+func TestServeInstallPage_MetaBackedEndpoint_WrongOrgReturnsNotFound(t *testing.T) {
+	t.Parallel()
+	ctx, testInstance := newTestMCPMetadataService(t)
+
+	mcpSlug := "meta-install-wrong-org-" + uuid.New().String()[:8]
+	seedMetaBackedEndpoint(t, ctx, testInstance, mcpSlug, metaEndpointFixtureOptions{
+		visibility:          "",
+		userSessionIssuerID: uuid.NullUUID{UUID: uuid.Nil, Valid: false},
+	})
+
+	wrongAuthCtx := &contextvalues.AuthContext{
+		ActiveOrganizationID: "different-org-id",
+		UserID:               "test-user-456",
+		SessionID:            new("test-session-456"),
+		ProjectID:            nil,
+		OrganizationSlug:     "",
+		Email:                nil,
+		AccountType:          "",
+		ProjectSlug:          nil,
+		APIKeyScopes:         nil,
+	}
+	reqCtx := contextvalues.SetAuthContext(context.Background(), wrongAuthCtx)
+
+	rr := serveMetaInstallPage(t, reqCtx, testInstance, mcpSlug)
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Server Not Found")
+	assert.NotContains(t, rr.Body.String(), "Install Page Gateway")
 	assert.NotContains(t, rr.Body.String(), "Legacy Same-Slug Toolset")
 }
 


### PR DESCRIPTION
## Summary

- `ServeInstallPage` now renders an install page for gateway (`meta_mcp_servers`) endpoints instead of the not-found page. The install context carries the resolved gateway row, and a new `renderMetaMcpInstallPage` writes the standard page with the gateway's name, endpoint URL, and OAuth flag (from `user_session_issuer_id`).
- Gateways have no public visibility, so the page reuses the existing private gate: anonymous callers are redirected to `/login`, and sessions from another organization get the not-found page. Disabled gateways and network-surface denials still 404 through endpoint resolution, and the slug never falls through to a legacy toolset sharing the same `mcp_slug`.
- Replaces the test that pinned the old 404 with tests for the rendered page, the anonymous redirect, and the wrong-organization not-found path.

## Motivation

The gateway detail page in the dashboard already links to `/mcp/<slug>/install`, but the server returned a not-found page for gateway-backed slugs, left as a placeholder when gateways shipped. Clicking "Installation page" on any gateway therefore landed on a broken page. Gateways carry no branding metadata yet, so the page renders with the default logo and no instructions; adding gateway-keyed metadata is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEg3GXMsMAGGSc1nriWHRx


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders the installation page for MCP gateway endpoints instead of the not-found page, so the gateway detail page's Installation link no longer lands on a broken page.

- The page shows the gateway's name, endpoint URL, and OAuth state, using the default logo and no instructions since gateways carry no branding metadata.
- Gateways have no public visibility, so the page is session-gated: anonymous callers get redirected to `/login`, and other-org sessions get the not-found page; disabled gateways and network denials still 404.
- Replaces the old 404-pinning test with coverage for the rendered page, anonymous redirect, wrong-org 404, disabled 404, and OAuth-instruction rendering.

<sup>Written for commit d83271e774b2a445841b4e809de25d019d191cdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

