### PR TITLE
fix: collapse org navigation groups on home

### DIFF
--- a/client/dashboard/src/components/org-sidebar.tsx
+++ b/client/dashboard/src/components/org-sidebar.tsx
@@ -177,11 +177,7 @@ export function OrgSidebar({
         {rbacLoading ? (
           <SidebarNavSkeleton />
         ) : (
-          <NavGroupProvider
-            activeGroup={activeGroup}
-            defaultOpenGroups={["Settings", "Data", "Secure", "Identity"]}
-            activeItem={activeItem}
-          >
+          <NavGroupProvider activeGroup={activeGroup} activeItem={activeItem}>
             <SidebarMenu className="gap-1 px-2">
               {/* Home — top-level */}
               <ScopeGatedTopLevelItem


### PR DESCRIPTION
## Summary

Start the Settings, Data, Secure, and Identity navigation groups collapsed on the organization home page. Active groups still expand when visiting a page within that section.

## Motivation

The organization home page should begin with a compact navigation state instead of expanding every grouped section by default.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Starts the organization home page with Settings, Data, Secure, and Identity navigation groups collapsed instead of expanded by default.

Active groups still expand when visiting a page within that section, so behavior only changes on the home page.

<sup>Written for commit 7f61220848abfd1c1a3522e279baa5c289ce117f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

