### PR TITLE
chore: publish Presidio scan usage from Python

### DIFF
--- a/docs/pubsub-topology.md
+++ b/docs/pubsub-topology.md
@@ -77,34 +77,36 @@ flowchart LR
 
   p0[/"📤<br/>server/internal/authz/challenge_logger.go"/]:::go
   p0 --> t_gram_authz_v1_challenge
-  p1[/"📤<br/>server/internal/hooks/otel_tee.go"/]:::go
-  p1 --> t_gram_otel_v1_inbound_log_record
-  p2[/"📤<br/>server/internal/ping/publisher.go"/]:::go
-  p2 --> t_gram_ping_v2_message
-  p3[/"📤<br/>server/internal/background/activities/risk_analysis/scan_custom_rules.go"/]:::go
-  p3 --> t_gram_risk_v1_custom_rules_analysis
-  p4[/"📤<br/>pystreams/src/pystreams/risk/handler.py"/]:::python
-  p4 --> t_gram_risk_v1_finding
-  p5[/"📤<br/>server/internal/risk/false_positive.go"/]:::go
+  p1[/"📤<br/>pystreams/src/pystreams/risk/metering.py"/]:::python
+  p1 --> t_gram_metering_v1_meter_reading
+  p2[/"📤<br/>server/internal/hooks/otel_tee.go"/]:::go
+  p2 --> t_gram_otel_v1_inbound_log_record
+  p3[/"📤<br/>server/internal/ping/publisher.go"/]:::go
+  p3 --> t_gram_ping_v2_message
+  p4[/"📤<br/>server/internal/background/activities/risk_analysis/scan_custom_rules.go"/]:::go
+  p4 --> t_gram_risk_v1_custom_rules_analysis
+  p5[/"📤<br/>pystreams/src/pystreams/risk/handler.py"/]:::python
   p5 --> t_gram_risk_v1_finding
-  p6[/"📤<br/>server/internal/scanners/publish.go"/]:::go
+  p6[/"📤<br/>server/internal/risk/false_positive.go"/]:::go
   p6 --> t_gram_risk_v1_finding
-  p7[/"📤<br/>server/internal/background/activities/risk_analysis/scan_gitleaks.go"/]:::go
-  p7 --> t_gram_risk_v1_gitleaks_analysis
-  p8[/"📤<br/>server/internal/risk/enforcereply/dispatch.go"/]:::go
-  p8 --> t_gram_risk_v1_gitleaks_enforcement
-  p9[/"📤<br/>server/internal/background/activities/risk_analysis/scan_presidio.go"/]:::go
-  p9 --> t_gram_risk_v1_presidio_analysis
-  p10[/"📤<br/>server/internal/risk/enforcereply/dispatch.go"/]:::go
-  p10 --> t_gram_risk_v1_presidio_enforcement
-  p11[/"📤<br/>server/internal/background/activities/risk_analysis/scan_prompt_injection.go"/]:::go
-  p11 --> t_gram_risk_v1_prompt_injection_analysis
-  p12[/"📤<br/>server/internal/background/activities/risk_analysis/prompt_judge_batch.go"/]:::go
-  p12 --> t_gram_risk_v1_prompt_policy_analysis
-  p13[/"📤<br/>server/internal/telemetry/log_publisher.go"/]:::go
-  p13 --> t_gram_telemetry_v1_log_record
-  p14[/"📤<br/>server/internal/outbox/webhooks.go"/]:::go
-  p14 --> t_gram_webhooks_v1_event
+  p7[/"📤<br/>server/internal/scanners/publish.go"/]:::go
+  p7 --> t_gram_risk_v1_finding
+  p8[/"📤<br/>server/internal/background/activities/risk_analysis/scan_gitleaks.go"/]:::go
+  p8 --> t_gram_risk_v1_gitleaks_analysis
+  p9[/"📤<br/>server/internal/risk/enforcereply/dispatch.go"/]:::go
+  p9 --> t_gram_risk_v1_gitleaks_enforcement
+  p10[/"📤<br/>server/internal/background/activities/risk_analysis/scan_presidio.go"/]:::go
+  p10 --> t_gram_risk_v1_presidio_analysis
+  p11[/"📤<br/>server/internal/risk/enforcereply/dispatch.go"/]:::go
+  p11 --> t_gram_risk_v1_presidio_enforcement
+  p12[/"📤<br/>server/internal/background/activities/risk_analysis/scan_prompt_injection.go"/]:::go
+  p12 --> t_gram_risk_v1_prompt_injection_analysis
+  p13[/"📤<br/>server/internal/background/activities/risk_analysis/prompt_judge_batch.go"/]:::go
+  p13 --> t_gram_risk_v1_prompt_policy_analysis
+  p14[/"📤<br/>server/internal/telemetry/log_publisher.go"/]:::go
+  p14 --> t_gram_telemetry_v1_log_record
+  p15[/"📤<br/>server/internal/outbox/webhooks.go"/]:::go
+  p15 --> t_gram_webhooks_v1_event
   t_gram_authz_v1_challenge --> s_gram_authz_v1_challenge_ch_writer
   s_gram_authz_v1_challenge_ch_writer -. dead-letter .-> t_gram_authz_v1_challenge_ch_writer_dlq
   t_gram_metering_v1_meter_reading --> s_gram_metering_v1_meter_reading_ch_writer
@@ -145,54 +147,54 @@ flowchart LR
   t_gram_telemetry_v1_log_record --> s_gram_telemetry_v1_noop
   t_gram_webhooks_v1_event --> s_gram_webhooks_v1_svix_relay
   s_gram_webhooks_v1_svix_relay -. dead-letter .-> t_gram_webhooks_v1_svix_relay_dlq
-  c15[\"📥<br/>server/cmd/gram/streams.go<br/>authz.NewChallengeCHWriter<br/>(batch)"\]:::go
-  s_gram_authz_v1_challenge_ch_writer --> c15
-  c16[\"📥<br/>server/cmd/gram/streams.go<br/>metering.NewMeterReadingCHWriter<br/>(batch)"\]:::go
-  s_gram_metering_v1_meter_reading_ch_writer --> c16
-  c17[\"📥<br/>server/cmd/gram/streams.go<br/>metering.NewMeterReadingStripeExporter"\]:::go
-  s_gram_metering_v1_meter_reading_stripe_exporter --> c17
-  c18[\"📥<br/>server/cmd/gram/streams.go<br/>otelsvc.NewLogTransformHandler"\]:::go
-  s_gram_otel_v1_inbound_log_record_transformer --> c18
-  c19[\"📥<br/>server/cmd/gram/streams.go<br/>otelsvc.NewMetricTransformHandler"\]:::go
-  s_gram_otel_v1_inbound_metric_transformer --> c19
-  c20[\"📥<br/>server/cmd/gram/streams.go<br/>otelsvc.NewSpanTransformHandler"\]:::go
-  s_gram_otel_v1_inbound_span_transformer --> c20
-  c21[\"📥<br/>server/cmd/gram/streams.go<br/>otelsvc.NewLogEventCHWriter<br/>(batch)"\]:::go
-  s_gram_otel_v1_log_event_ch_writer --> c21
-  c22[\"📥<br/>server/cmd/gram/streams.go<br/>logRelayHandler<br/>(batch)"\]:::go
-  s_gram_otel_v1_log_relay --> c22
-  c23[\"📥<br/>server/cmd/gram/streams.go<br/>metricRelayHandler<br/>(batch)"\]:::go
-  s_gram_otel_v1_metric_relay --> c23
-  c24[\"📥<br/>server/cmd/gram/streams.go<br/>otelsvc.NewSpanEventCHWriter<br/>(batch)"\]:::go
-  s_gram_otel_v1_span_event_ch_writer --> c24
-  c25[\"📥<br/>server/cmd/gram/streams.go<br/>spanRelayHandler<br/>(batch)"\]:::go
-  s_gram_otel_v1_span_relay --> c25
-  c26[\"📥<br/>server/cmd/gram/streams.go<br/>ping.NewHandler"\]:::go
-  s_gram_ping_v2_processor --> c26
-  c27[\"📥<br/>pystreams/src/pystreams/cmd/multi.py<br/>PingHandler.handle"\]:::python
-  s_gram_ping_v2_py_processor --> c27
-  c28[\"📥<br/>server/cmd/gram/streams.go<br/>customRulesHandler"\]:::go
-  s_gram_risk_v1_custom_rules_analyzer --> c28
-  c29[\"📥<br/>server/cmd/gram/streams.go<br/>risk.NewFindingCHWriter<br/>(batch)"\]:::go
-  s_gram_risk_v1_finding_ch_writer --> c29
-  c30[\"📥<br/>server/cmd/gram/streams.go<br/>riskFindingRelayHandler<br/>(batch)"\]:::go
-  s_gram_risk_v1_finding_otel_relay --> c30
-  c31[\"📥<br/>server/cmd/gram/streams.go<br/>gitleaksHandler"\]:::go
-  s_gram_risk_v1_gitleaks_analyzer --> c31
-  c32[\"📥<br/>server/cmd/gram/streams.go<br/>gitleaksEnforceHandler"\]:::go
-  s_gram_risk_v1_gitleaks_enforcer --> c32
-  c33[\"📥<br/>pystreams/src/pystreams/cmd/multi.py<br/>presidio_handler.handle"\]:::python
-  s_gram_risk_v1_presidio_analyzer --> c33
-  c34[\"📥<br/>pystreams/src/pystreams/cmd/multi.py<br/>enforce_handler.handle"\]:::python
-  s_gram_risk_v1_presidio_enforcer --> c34
-  c35[\"📥<br/>server/cmd/gram/streams.go<br/>promptInjectionHandler"\]:::go
-  s_gram_risk_v1_prompt_injection_analyzer --> c35
-  c36[\"📥<br/>server/cmd/gram/streams.go<br/>promptPolicyHandler"\]:::go
-  s_gram_risk_v1_prompt_policy_analyzer --> c36
-  c37[\"📥<br/>server/cmd/gram/streams.go<br/>new"\]:::go
-  s_gram_telemetry_v1_noop --> c37
-  c38[\"📥<br/>server/cmd/gram/streams.go<br/>webhookEventHandler"\]:::go
-  s_gram_webhooks_v1_svix_relay --> c38
+  c16[\"📥<br/>server/cmd/gram/streams.go<br/>authz.NewChallengeCHWriter<br/>(batch)"\]:::go
+  s_gram_authz_v1_challenge_ch_writer --> c16
+  c17[\"📥<br/>server/cmd/gram/streams.go<br/>metering.NewMeterReadingCHWriter<br/>(batch)"\]:::go
+  s_gram_metering_v1_meter_reading_ch_writer --> c17
+  c18[\"📥<br/>server/cmd/gram/streams.go<br/>metering.NewMeterReadingStripeExporter"\]:::go
+  s_gram_metering_v1_meter_reading_stripe_exporter --> c18
+  c19[\"📥<br/>server/cmd/gram/streams.go<br/>otelsvc.NewLogTransformHandler"\]:::go
+  s_gram_otel_v1_inbound_log_record_transformer --> c19
+  c20[\"📥<br/>server/cmd/gram/streams.go<br/>otelsvc.NewMetricTransformHandler"\]:::go
+  s_gram_otel_v1_inbound_metric_transformer --> c20
+  c21[\"📥<br/>server/cmd/gram/streams.go<br/>otelsvc.NewSpanTransformHandler"\]:::go
+  s_gram_otel_v1_inbound_span_transformer --> c21
+  c22[\"📥<br/>server/cmd/gram/streams.go<br/>otelsvc.NewLogEventCHWriter<br/>(batch)"\]:::go
+  s_gram_otel_v1_log_event_ch_writer --> c22
+  c23[\"📥<br/>server/cmd/gram/streams.go<br/>logRelayHandler<br/>(batch)"\]:::go
+  s_gram_otel_v1_log_relay --> c23
+  c24[\"📥<br/>server/cmd/gram/streams.go<br/>metricRelayHandler<br/>(batch)"\]:::go
+  s_gram_otel_v1_metric_relay --> c24
+  c25[\"📥<br/>server/cmd/gram/streams.go<br/>otelsvc.NewSpanEventCHWriter<br/>(batch)"\]:::go
+  s_gram_otel_v1_span_event_ch_writer --> c25
+  c26[\"📥<br/>server/cmd/gram/streams.go<br/>spanRelayHandler<br/>(batch)"\]:::go
+  s_gram_otel_v1_span_relay --> c26
+  c27[\"📥<br/>server/cmd/gram/streams.go<br/>ping.NewHandler"\]:::go
+  s_gram_ping_v2_processor --> c27
+  c28[\"📥<br/>pystreams/src/pystreams/cmd/multi.py<br/>PingHandler.handle"\]:::python
+  s_gram_ping_v2_py_processor --> c28
+  c29[\"📥<br/>server/cmd/gram/streams.go<br/>customRulesHandler"\]:::go
+  s_gram_risk_v1_custom_rules_analyzer --> c29
+  c30[\"📥<br/>server/cmd/gram/streams.go<br/>risk.NewFindingCHWriter<br/>(batch)"\]:::go
+  s_gram_risk_v1_finding_ch_writer --> c30
+  c31[\"📥<br/>server/cmd/gram/streams.go<br/>riskFindingRelayHandler<br/>(batch)"\]:::go
+  s_gram_risk_v1_finding_otel_relay --> c31
+  c32[\"📥<br/>server/cmd/gram/streams.go<br/>gitleaksHandler"\]:::go
+  s_gram_risk_v1_gitleaks_analyzer --> c32
+  c33[\"📥<br/>server/cmd/gram/streams.go<br/>gitleaksEnforceHandler"\]:::go
+  s_gram_risk_v1_gitleaks_enforcer --> c33
+  c34[\"📥<br/>pystreams/src/pystreams/cmd/multi.py<br/>presidio_handler.handle"\]:::python
+  s_gram_risk_v1_presidio_analyzer --> c34
+  c35[\"📥<br/>pystreams/src/pystreams/cmd/multi.py<br/>enforce_handler.handle"\]:::python
+  s_gram_risk_v1_presidio_enforcer --> c35
+  c36[\"📥<br/>server/cmd/gram/streams.go<br/>promptInjectionHandler"\]:::go
+  s_gram_risk_v1_prompt_injection_analyzer --> c36
+  c37[\"📥<br/>server/cmd/gram/streams.go<br/>promptPolicyHandler"\]:::go
+  s_gram_risk_v1_prompt_policy_analyzer --> c37
+  c38[\"📥<br/>server/cmd/gram/streams.go<br/>new"\]:::go
+  s_gram_telemetry_v1_noop --> c38
+  c39[\"📥<br/>server/cmd/gram/streams.go<br/>webhookEventHandler"\]:::go
+  s_gram_webhooks_v1_svix_relay --> c39
 ```
 
 ## Topics
@@ -201,7 +203,7 @@ flowchart LR
 | --- | --- | --- | --- |
 | [`gram-authz-v1-challenge`](../infra/proto/gram/authz/v1/challenge.proto) | topic | 7d | [`server/internal/authz/challenge_logger.go`](../server/internal/authz/challenge_logger.go) |
 | [`gram-authz-v1-challenge-ch-writer-dlq`](../infra/proto/gram/authz/v1/challenge_ch_writer.proto) | DLQ | 7d | — |
-| [`gram-metering-v1-meter-reading`](../infra/proto/gram/metering/v1/meter_reading.proto) | topic | 31d | — |
+| [`gram-metering-v1-meter-reading`](../infra/proto/gram/metering/v1/meter_reading.proto) | topic | 31d | [`pystreams/src/pystreams/risk/metering.py`](../pystreams/src/pystreams/risk/metering.py) |
 | [`gram-metering-v1-meter-reading-ch-writer-dlq`](../infra/proto/gram/metering/v1/meter_reading_ch_writer.proto) | DLQ | 31d | — |
 | [`gram-otel-v1-inbound-log-record`](../infra/proto/gram/otel/v1/inbound_log_record.proto) | topic | — | [`server/internal/hooks/otel_tee.go`](../server/internal/hooks/otel_tee.go) |
 | [`gram-otel-v1-inbound-log-record-transformer-dlq`](../infra/proto/gram/otel/v1/inbound_log_record_transformer.proto) | DLQ | 7d | — |
@@ -266,7 +268,6 @@ flowchart LR
 
 ## Notes
 
-- Topic `gram-metering-v1-meter-reading` has no publisher in `server/` or `pystreams/`.
 - Topic `gram-otel-v1-inbound-metric` has no publisher in `server/` or `pystreams/`.
 - Topic `gram-otel-v1-inbound-span` has no publisher in `server/` or `pystreams/`.
 - Topic `gram-otel-v1-log-record` has no publisher in `server/` or `pystreams/`.

--- a/pystreams/src/pystreams/cmd/multi.py
+++ b/pystreams/src/pystreams/cmd/multi.py
@@ -8,6 +8,7 @@ import anyio
 import click
 import structlog
 from google.cloud.pubsub_v1 import PublisherClient, SubscriberClient
+from gram.metering.v1 import meter_reading_pb2
 from gram.ping.v2 import ping_pb2, processor_pb2
 from gram.risk.v1 import (
     finding_pb2,
@@ -131,6 +132,9 @@ async def multi(
             findings_publisher = await pubsub_publisher_for_message_async(
                 broker, finding_pb2.Finding
             )
+            meter_publisher = await pubsub_publisher_for_message_async(
+                broker, meter_reading_pb2.MeterReading
+            )
 
             # The enforcement lane registers only when both Redis and the
             # pepper keyring are configured; validated before the scan pool
@@ -190,7 +194,7 @@ async def multi(
                 activate_blocking_detection(logger=logger)
 
             presidio_handler = PresidioHandler(
-                logger, findings_publisher, presidio_scanner
+                logger, findings_publisher, meter_publisher, presidio_scanner
             )
 
             enforce_handler = None
@@ -198,6 +202,7 @@ async def multi(
                 enforce_handler = PresidioEnforceHandler(
                     logger,
                     ReplyWriter(enforce_redis),
+                    meter_publisher,
                     presidio_scanner,
                     enforce_fingerprinter,
                 )

--- a/pystreams/src/pystreams/risk/enforce_handler.py
+++ b/pystreams/src/pystreams/risk/enforce_handler.py
@@ -259,7 +259,12 @@ class PresidioEnforceHandler:
             # starts only after Redis was attempted. Its failure still escapes
             # to nack and retry the stable reading identity.
             await publish_meter_reading(
-                self._meter_publisher, message.meter_reading, scan_started_at
+                self._meter_publisher,
+                message.meter_reading,
+                scan_started_at,
+                request_id=message.request_id,
+                reply_urn=reply_urn,
+                delivery_attempt=meta.delivery_attempt,
             )
 
         if reply_written:

--- a/pystreams/src/pystreams/risk/enforce_handler.py
+++ b/pystreams/src/pystreams/risk/enforce_handler.py
@@ -29,6 +29,7 @@ from opentelemetry import metrics
 
 from pystreams.risk import maskdisplay
 from pystreams.risk.fingerprint import Fingerprinter, encode_fingerprint
+from pystreams.risk.metering import MeterReadingPublisher, publish_meter_reading
 from pystreams.risk.replywriter import ReplyWriter, parse_reply_urn
 from pystreams.risk.scanner import (
     DEFAULT_SCORE_THRESHOLD,
@@ -124,12 +125,14 @@ class PresidioEnforceHandler:
         self,
         logger: structlog.stdlib.BoundLogger,
         writer: ReplyWriter,
+        meter_publisher: MeterReadingPublisher,
         scanner: Scanner,
         fingerprinter: Fingerprinter,
         max_request_age_seconds: float = DEFAULT_MAX_REQUEST_AGE_SECONDS,
     ) -> None:
         self._logger = logger
         self._writer = writer
+        self._meter_publisher = meter_publisher
         self._scanner = scanner
         self._fingerprinter = fingerprinter
         # abs(age) > NaN/inf is always false, defeating the freshness window.
@@ -175,6 +178,8 @@ class PresidioEnforceHandler:
         detections: list[Detection] = []
         status = enforcement_reply_pb2.ENFORCEMENT_STATUS_OK
         reason = ""
+        scan_started_at: datetime | None = None
+        scan_completed = False
         if len(message.content.encode()) > MAX_CONTENT_BYTES:
             status = enforcement_reply_pb2.ENFORCEMENT_STATUS_ERROR
             reason = "enforcement content exceeds the maximum byte budget"
@@ -194,6 +199,7 @@ class PresidioEnforceHandler:
             else:
                 score_threshold = DEFAULT_SCORE_THRESHOLD
             try:
+                scan_started_at = datetime.now(UTC)
                 detections = await self._scanner.scan(
                     message.content, requested, score_threshold
                 )
@@ -221,6 +227,8 @@ class PresidioEnforceHandler:
                     request_id=message.request_id,
                     error_type=type(exc).__name__,
                 )
+            else:
+                scan_completed = True
 
         reply = enforcement_reply_pb2.EnforcementReply(
             correlation_id=scan_id,
@@ -234,8 +242,11 @@ class PresidioEnforceHandler:
                 delivery_attempt=meta.delivery_attempt or 0,
             ),
         )
+
+        reply_written = False
         try:
             await self._writer.write(reply_urn, reply)
+            reply_written = True
         except Exception as exc:
             _reply_write_errors.add(1)
             self._logger.error(
@@ -243,14 +254,21 @@ class PresidioEnforceHandler:
                 request_id=message.request_id,
                 error_type=type(exc).__name__,
             )
-            return
+        if scan_completed and scan_started_at is not None and message.meter_reading:
+            # Reply delivery owns the enforcement deadline, so usage transport
+            # starts only after Redis was attempted. Its failure still escapes
+            # to nack and retry the stable reading identity.
+            await publish_meter_reading(
+                self._meter_publisher, message.meter_reading, scan_started_at
+            )
 
-        await self._logger.adebug(
-            "presidio enforcement scan complete",
-            request_id=message.request_id,
-            detections=len(detections),
-            status=enforcement_reply_pb2.EnforcementStatus.Name(status),
-        )
+        if reply_written:
+            await self._logger.adebug(
+                "presidio enforcement scan complete",
+                request_id=message.request_id,
+                detections=len(detections),
+                status=enforcement_reply_pb2.EnforcementStatus.Name(status),
+            )
 
     def _build_findings(
         self, organization_id: str, detections: list[Detection]

--- a/pystreams/src/pystreams/risk/handler.py
+++ b/pystreams/src/pystreams/risk/handler.py
@@ -139,7 +139,7 @@ class PresidioHandler:
                 return
 
             if not detections:
-                await self._publish_meter_reading(message, scan_started_at)
+                await self._publish_meter_reading(message, scan_started_at, meta)
                 outcome = metrics.OUTCOME_CLEAN
                 return
 
@@ -159,7 +159,7 @@ class PresidioHandler:
             # Finding delivery is best effort and independent from usage. The
             # scan is meterable once every result was constructed, even if one
             # or more finding commits failed.
-            await self._publish_meter_reading(message, scan_started_at)
+            await self._publish_meter_reading(message, scan_started_at, meta)
             outcome = metrics.OUTCOME_DETECTED if published else metrics.OUTCOME_ERROR
 
             # Log entity *types* and counts only — never the matched values or the
@@ -199,6 +199,7 @@ class PresidioHandler:
         self,
         message: presidio_analysis_pb2.PresidioAnalysis,
         scan_started_at: datetime,
+        meta: MessageMetadata,
     ) -> None:
         if not message.meter_reading:
             return
@@ -206,7 +207,12 @@ class PresidioHandler:
         # failure must escape so the subscription nacks and redelivers the
         # stable reading identity.
         await publish_meter_reading(
-            self._meter_publisher, message.meter_reading, scan_started_at
+            self._meter_publisher,
+            message.meter_reading,
+            scan_started_at,
+            request_id=message.request_id,
+            reply_urn=message.reply_urn,
+            delivery_attempt=meta.delivery_attempt,
         )
 
     def _build_and_dispatch(

--- a/pystreams/src/pystreams/risk/handler.py
+++ b/pystreams/src/pystreams/risk/handler.py
@@ -267,9 +267,9 @@ class PresidioHandler:
                 tags=["pii"],
                 source=SOURCE_PRESIDIO,
                 confidence=d.confidence,
-                # Presidio scans the request's verbatim content, so the span
-                # offsets index the anchored message/part text.
-                surface="content",
+                # Offsets index the producer's submitted surface, which can
+                # include composed tool arguments rather than the stored body.
+                surface=message.finding_surface or "content",
             )
             try:
                 result = self.publisher.publish(finding)

--- a/pystreams/src/pystreams/risk/handler.py
+++ b/pystreams/src/pystreams/risk/handler.py
@@ -14,6 +14,7 @@ from opentelemetry import trace
 
 from pystreams import attr
 from pystreams.risk import metrics
+from pystreams.risk.metering import MeterReadingPublisher, publish_meter_reading
 from pystreams.risk.scanner import (
     DEFAULT_SCORE_THRESHOLD,
     Detection,
@@ -53,10 +54,12 @@ class PresidioHandler:
         self,
         logger: structlog.stdlib.BoundLogger,
         publisher: FindingPublisher,
+        meter_publisher: MeterReadingPublisher,
         scanner: Scanner,
     ):
         self.logger = logger
         self.publisher = publisher
+        self._meter_publisher = meter_publisher
         self._scanner = scanner
 
     async def handle(
@@ -94,6 +97,7 @@ class PresidioHandler:
             # which under load (not the scan itself) can dominate per-message ACK
             # latency.
             try:
+                scan_started_at = datetime.now(UTC)
                 scan_started = time.perf_counter()
                 detections = await self._scanner.scan(
                     message.content, requested, score_threshold
@@ -135,6 +139,7 @@ class PresidioHandler:
                 return
 
             if not detections:
+                await self._publish_meter_reading(message, scan_started_at)
                 outcome = metrics.OUTCOME_CLEAN
                 return
 
@@ -151,10 +156,10 @@ class PresidioHandler:
             )
             published = await self._collect(message, pending)
             publish_ms = (time.perf_counter() - publish_started) * 1000
-            # "detected" means at least one finding actually landed. If every
-            # publish failed (all swallowed by ``_collect``), the work is an error
-            # outcome, not a success — keeping those out of the detected bucket so
-            # it stays a clean read of healthy detection latency.
+            # Finding delivery is best effort and independent from usage. The
+            # scan is meterable once every result was constructed, even if one
+            # or more finding commits failed.
+            await self._publish_meter_reading(message, scan_started_at)
             outcome = metrics.OUTCOME_DETECTED if published else metrics.OUTCOME_ERROR
 
             # Log entity *types* and counts only — never the matched values or the
@@ -189,6 +194,20 @@ class PresidioHandler:
             metrics.record_process_duration(
                 time.perf_counter() - process_started, outcome, size_bucket
             )
+
+    async def _publish_meter_reading(
+        self,
+        message: presidio_analysis_pb2.PresidioAnalysis,
+        scan_started_at: datetime,
+    ) -> None:
+        if not message.meter_reading:
+            return
+        # Deliberately outside the scanner-error catch: a usage transport
+        # failure must escape so the subscription nacks and redelivers the
+        # stable reading identity.
+        await publish_meter_reading(
+            self._meter_publisher, message.meter_reading, scan_started_at
+        )
 
     def _build_and_dispatch(
         self,

--- a/pystreams/src/pystreams/risk/metering.py
+++ b/pystreams/src/pystreams/risk/metering.py
@@ -1,0 +1,30 @@
+from datetime import UTC, datetime
+from typing import Protocol
+
+from gram.metering.v1 import meter_reading_pb2
+from gram_infra.pubsub import PublishResult
+
+
+class MeterReadingPublisher(Protocol):
+    """Publisher surface shared by the Presidio handlers."""
+
+    def publish(self, message: meter_reading_pb2.MeterReading) -> PublishResult: ...
+
+
+async def publish_meter_reading(
+    publisher: MeterReadingPublisher,
+    serialized_template: bytes,
+    scan_started_at: datetime,
+) -> None:
+    """Publish without changing the reading's stable identity or provenance."""
+    reading = meter_reading_pb2.MeterReading()
+    reading.ParseFromString(serialized_template)
+    reading.occurred_at = _utc_timestamp(scan_started_at)
+    reading.produced_at = _utc_timestamp(datetime.now(UTC))
+    await publisher.publish(reading).get()
+
+
+def _utc_timestamp(value: datetime) -> str:
+    return (
+        value.astimezone(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
+    )

--- a/pystreams/src/pystreams/risk/metering.py
+++ b/pystreams/src/pystreams/risk/metering.py
@@ -1,8 +1,12 @@
 from datetime import UTC, datetime
 from typing import Protocol
 
+import structlog
+from google.protobuf.message import DecodeError
 from gram.metering.v1 import meter_reading_pb2
 from gram_infra.pubsub import PublishResult
+
+_logger = structlog.get_logger()
 
 
 class MeterReadingPublisher(Protocol):
@@ -18,7 +22,14 @@ async def publish_meter_reading(
 ) -> None:
     """Publish without changing the reading's stable identity or provenance."""
     reading = meter_reading_pb2.MeterReading()
-    reading.ParseFromString(serialized_template)
+    try:
+        reading.ParseFromString(serialized_template)
+    except DecodeError as exc:
+        _logger.warning(
+            "discard malformed presidio meter reading",
+            error_type=type(exc).__name__,
+        )
+        return
     reading.occurred_at = _utc_timestamp(scan_started_at)
     reading.produced_at = _utc_timestamp(datetime.now(UTC))
     await publisher.publish(reading).get()

--- a/pystreams/src/pystreams/risk/metering.py
+++ b/pystreams/src/pystreams/risk/metering.py
@@ -19,6 +19,10 @@ async def publish_meter_reading(
     publisher: MeterReadingPublisher,
     serialized_template: bytes,
     scan_started_at: datetime,
+    *,
+    request_id: str,
+    reply_urn: str,
+    delivery_attempt: int | None,
 ) -> None:
     """Publish without changing the reading's stable identity or provenance."""
     reading = meter_reading_pb2.MeterReading()
@@ -27,6 +31,9 @@ async def publish_meter_reading(
     except DecodeError as exc:
         _logger.warning(
             "discard malformed presidio meter reading",
+            request_id=request_id,
+            reply_urn=reply_urn,
+            delivery_attempt=delivery_attempt,
             error_type=type(exc).__name__,
         )
         return

--- a/pystreams/tests/test_risk_enforce.py
+++ b/pystreams/tests/test_risk_enforce.py
@@ -10,9 +10,11 @@ import structlog
 from gram.metering.v1 import meter_reading_pb2
 from gram.risk.v1 import enforcement_reply_pb2, presidio_enforcement_pb2
 from gram_infra.pubsub.subscriber import MessageMetadata
+from structlog.testing import capture_logs
 
 import pystreams.risk.enforce_handler as enforce_handler_mod
 from pystreams.risk import maskdisplay
+from pystreams.risk import metering as metering_mod
 from pystreams.risk.enforce_handler import (
     MAX_CONTENT_BYTES,
     MalformedEnforcementRequest,
@@ -40,6 +42,22 @@ _KEYRING = json.dumps(
 
 _REPLY_URN = "urn:gram:risk:enforce:replica-1:0198f1f4-0000-7000-8000-000000000000"
 _SCAN_ID = "0198f1f4-0000-7000-8000-000000000000"
+_SCAN_STARTED_AT = datetime(2025, 1, 2, 3, 4, 5, 123456, tzinfo=UTC)
+_METER_PRODUCED_AT = datetime(2025, 1, 2, 3, 4, 6, 654321, tzinfo=UTC)
+
+
+class _FrozenScanDateTime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        assert tz is UTC
+        return _SCAN_STARTED_AT
+
+
+class _FrozenMeterDateTime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        assert tz is UTC
+        return _METER_PRODUCED_AT
 
 
 class FakeScanner:
@@ -233,10 +251,14 @@ async def test_handler_writes_ok_reply_with_safe_findings():
     assert finding.fingerprint == "OtttmK1tiaZmS8oK2PAT-n3vNa4iic0SQh6RpOY5_yo"
 
 
-async def test_clean_enforcement_scan_publishes_canonical_meter_reading():
+async def test_clean_enforcement_scan_publishes_canonical_meter_reading(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(enforce_handler_mod, "datetime", _FrozenScanDateTime)
+    monkeypatch.setattr(metering_mod, "datetime", _FrozenMeterDateTime)
     client = fakeredis.aioredis.FakeRedis()
     meter_publisher = FakeMeterPublisher()
-    message = _metered_message()
+    message = _metered_message(created_at=_SCAN_STARTED_AT.isoformat())
 
     await _handler(FakeScanner(), client, meter_publisher).handle(message, _meta())
 
@@ -246,8 +268,44 @@ async def test_clean_enforcement_scan_publishes_canonical_meter_reading():
     assert reading.operation_id == template.operation_id
     assert reading.value == template.value == 11
     assert reading.attributes == template.attributes
-    assert reading.occurred_at != template.occurred_at
-    assert reading.produced_at != template.produced_at
+    assert reading.occurred_at == "2025-01-02T03:04:05.123456Z"
+    assert reading.produced_at == "2025-01-02T03:04:06.654321Z"
+    assert datetime.fromisoformat(reading.occurred_at) < datetime.fromisoformat(
+        reading.produced_at
+    )
+
+
+async def test_malformed_enforcement_meter_preserves_successful_reply():
+    client = fakeredis.aioredis.FakeRedis()
+    meter_publisher = FakeMeterPublisher()
+    scanner = FakeScanner(
+        detections=[
+            Detection(
+                entity_type="EMAIL_ADDRESS",
+                match="jane.doe@example.com",
+                start_pos=6,
+                end_pos=26,
+                confidence=0.9,
+            )
+        ]
+    )
+    message = _message()
+    message.meter_reading = b"\x0a\xffprivate-envelope"
+
+    with capture_logs() as logs:
+        await _handler(scanner, client, meter_publisher).handle(message, _meta())
+
+    reply = await _read_reply(client)
+    assert reply.status == enforcement_reply_pb2.ENFORCEMENT_STATUS_OK
+    assert [finding.rule_id for finding in reply.findings] == ["pii.email_address"]
+    assert meter_publisher.published == []
+    (entry,) = [
+        item
+        for item in logs
+        if item["event"] == "discard malformed presidio meter reading"
+    ]
+    assert entry["error_type"] == "DecodeError"
+    assert "private-envelope" not in repr(entry)
 
 
 async def test_enforcement_meter_identity_is_stable_on_redelivery():
@@ -332,7 +390,7 @@ def test_classify_covers_every_category_set():
     assert enforce_handler_mod._classify("pii.email_address") == "pii"
 
 
-async def test_handler_replies_error_when_fingerprinting_fails():
+async def test_handler_replies_error_when_fingerprinting_fails_without_metering():
     class FailingFingerprinter:
         def tenanted_hs256(self, tenant_id: str, message: bytes) -> tuple[bytes, str]:
             raise RuntimeError("hkdf failure")
@@ -349,18 +407,20 @@ async def test_handler_replies_error_when_fingerprinting_fails():
             )
         ]
     )
+    meter_publisher = FakeMeterPublisher()
     handler = PresidioEnforceHandler(
         structlog.get_logger(),
         ReplyWriter(client),
-        FakeMeterPublisher(),
+        meter_publisher,
         scanner,
         cast(Fingerprinter, FailingFingerprinter()),
     )
-    await handler.handle(_message(), _meta())
+    await handler.handle(_metered_message(), _meta())
     reply = await _read_reply(client)
     assert reply.status == enforcement_reply_pb2.ENFORCEMENT_STATUS_ERROR
     assert reply.reason == "fingerprint enforcement finding"
     assert len(reply.findings) == 0
+    assert meter_publisher.published == []
 
 
 async def test_handler_honors_explicit_zero_score_threshold():

--- a/pystreams/tests/test_risk_enforce.py
+++ b/pystreams/tests/test_risk_enforce.py
@@ -1,8 +1,8 @@
 """Tests for the Presidio enforcement scanning domain."""
 
 import json
-from datetime import UTC, datetime, timedelta
-from typing import cast
+from datetime import UTC, datetime, timedelta, tzinfo
+from typing import Self, cast
 
 import fakeredis.aioredis
 import pytest
@@ -48,16 +48,14 @@ _METER_PRODUCED_AT = datetime(2025, 1, 2, 3, 4, 6, 654321, tzinfo=UTC)
 
 class _FrozenScanDateTime(datetime):
     @classmethod
-    def now(cls, tz=None):
-        assert tz is UTC
-        return _SCAN_STARTED_AT
+    def now(cls, tz: tzinfo | None = None) -> Self:
+        return cls.fromtimestamp(_SCAN_STARTED_AT.timestamp(), tz)
 
 
 class _FrozenMeterDateTime(datetime):
     @classmethod
-    def now(cls, tz=None):
-        assert tz is UTC
-        return _METER_PRODUCED_AT
+    def now(cls, tz: tzinfo | None = None) -> Self:
+        return cls.fromtimestamp(_METER_PRODUCED_AT.timestamp(), tz)
 
 
 class FakeScanner:

--- a/pystreams/tests/test_risk_enforce.py
+++ b/pystreams/tests/test_risk_enforce.py
@@ -303,6 +303,9 @@ async def test_malformed_enforcement_meter_preserves_successful_reply():
         if item["event"] == "discard malformed presidio meter reading"
     ]
     assert entry["error_type"] == "DecodeError"
+    assert entry["request_id"] == message.request_id
+    assert entry["reply_urn"] == _REPLY_URN
+    assert entry["delivery_attempt"] == 1
     assert "private-envelope" not in repr(entry)
 
 

--- a/pystreams/tests/test_risk_enforce.py
+++ b/pystreams/tests/test_risk_enforce.py
@@ -7,6 +7,7 @@ from typing import cast
 import fakeredis.aioredis
 import pytest
 import structlog
+from gram.metering.v1 import meter_reading_pb2
 from gram.risk.v1 import enforcement_reply_pb2, presidio_enforcement_pb2
 from gram_infra.pubsub.subscriber import MessageMetadata
 
@@ -74,6 +75,22 @@ class FakeScanner:
         return None
 
 
+class _FakeResult:
+    async def get(self) -> str:
+        return "meter-message"
+
+
+class FakeMeterPublisher:
+    def __init__(self) -> None:
+        self.published: list[meter_reading_pb2.MeterReading] = []
+
+    def publish(self, message: meter_reading_pb2.MeterReading) -> _FakeResult:
+        reading = meter_reading_pb2.MeterReading()
+        reading.CopyFrom(message)
+        self.published.append(reading)
+        return _FakeResult()
+
+
 def _message(
     *,
     content: str = "email jane.doe@example.com",
@@ -91,6 +108,36 @@ def _message(
     )
 
 
+def _meter_reading() -> meter_reading_pb2.MeterReading:
+    return meter_reading_pb2.MeterReading(
+        id="reading-1",
+        organization_id="org-123",
+        project_id="proj-1",
+        meter_id="risk.presidio",
+        operation_id="operation-1",
+        unit="stokens",
+        value=11,
+        occurred_at="2000-01-01T00:00:00Z",
+        produced_at="2000-01-01T00:00:00Z",
+        attributes={
+            "risk_policy_id": "policy-1",
+            "risk_policy_version": "2",
+            "execution_path": "realtime_streams",
+            "message_link_reason": "realtime_not_persisted",
+        },
+        meter_version=1,
+        kind=meter_reading_pb2.MeterReading.KIND_USAGE,
+        measurement_method="scanner_stokens_v1",
+        source="risk",
+    )
+
+
+def _metered_message(**kwargs) -> presidio_enforcement_pb2.PresidioEnforcement:
+    message = _message(**kwargs)
+    message.meter_reading = _meter_reading().SerializeToString()
+    return message
+
+
 def _meta(reply_urn: str = _REPLY_URN) -> MessageMetadata:
     return MessageMetadata(
         id="m1",
@@ -100,11 +147,14 @@ def _meta(reply_urn: str = _REPLY_URN) -> MessageMetadata:
 
 
 def _handler(
-    scanner: FakeScanner, client: fakeredis.aioredis.FakeRedis
+    scanner: FakeScanner,
+    client: fakeredis.aioredis.FakeRedis,
+    meter_publisher: FakeMeterPublisher | None = None,
 ) -> PresidioEnforceHandler:
     return PresidioEnforceHandler(
         structlog.get_logger(),
         ReplyWriter(client),
+        meter_publisher or FakeMeterPublisher(),
         scanner,
         parse_pepper_keyring(_KEYRING),
     )
@@ -183,6 +233,73 @@ async def test_handler_writes_ok_reply_with_safe_findings():
     assert finding.fingerprint == "OtttmK1tiaZmS8oK2PAT-n3vNa4iic0SQh6RpOY5_yo"
 
 
+async def test_clean_enforcement_scan_publishes_canonical_meter_reading():
+    client = fakeredis.aioredis.FakeRedis()
+    meter_publisher = FakeMeterPublisher()
+    message = _metered_message()
+
+    await _handler(FakeScanner(), client, meter_publisher).handle(message, _meta())
+
+    (reading,) = meter_publisher.published
+    template = _meter_reading()
+    assert reading.id == template.id == "reading-1"
+    assert reading.operation_id == template.operation_id
+    assert reading.value == template.value == 11
+    assert reading.attributes == template.attributes
+    assert reading.occurred_at != template.occurred_at
+    assert reading.produced_at != template.produced_at
+
+
+async def test_enforcement_meter_identity_is_stable_on_redelivery():
+    client = fakeredis.aioredis.FakeRedis()
+    meter_publisher = FakeMeterPublisher()
+    message = _metered_message()
+    handler = _handler(FakeScanner(), client, meter_publisher)
+
+    await handler.handle(message, _meta())
+    await handler.handle(message, _meta())
+
+    first, second = meter_publisher.published
+    assert first.id == second.id == "reading-1"
+    assert first.operation_id == second.operation_id == "operation-1"
+    assert first.attributes == second.attributes == _meter_reading().attributes
+
+
+class _FailingMeterResult:
+    def __init__(self, client: fakeredis.aioredis.FakeRedis) -> None:
+        self._client = client
+
+    async def get(self) -> str:
+        # The inline reply must be committed before usage transport is awaited.
+        assert await self._client.llen(inbox_key("replica-1")) == 1
+        raise RuntimeError("meter unavailable")
+
+
+class _FailingMeterPublisher:
+    def __init__(self, client: fakeredis.aioredis.FakeRedis) -> None:
+        self._client = client
+
+    def publish(self, message: meter_reading_pb2.MeterReading) -> _FailingMeterResult:
+        return _FailingMeterResult(self._client)
+
+
+async def test_meter_failure_nacks_after_writing_enforcement_reply():
+    client = fakeredis.aioredis.FakeRedis()
+    handler = PresidioEnforceHandler(
+        structlog.get_logger(),
+        ReplyWriter(client),
+        _FailingMeterPublisher(client),
+        FakeScanner(),
+        parse_pepper_keyring(_KEYRING),
+    )
+
+    with pytest.raises(RuntimeError, match="meter unavailable"):
+        await handler.handle(_metered_message(), _meta())
+
+    reply = await _read_reply(client)
+    assert reply.status == enforcement_reply_pb2.ENFORCEMENT_STATUS_OK
+
+
 class FailingWriter:
     def __init__(self) -> None:
         self.called = False
@@ -193,17 +310,18 @@ class FailingWriter:
 
 
 async def test_handler_acks_request_when_reply_write_fails():
-    # A nack would send raw content to the DLQ; the handler must ack and the
-    # waiter's deadline covers the lost reply.
     writer = FailingWriter()
+    meter_publisher = FakeMeterPublisher()
     handler = PresidioEnforceHandler(
         structlog.get_logger(),
         cast(ReplyWriter, writer),
+        meter_publisher,
         FakeScanner(),
         parse_pepper_keyring(_KEYRING),
     )
-    await handler.handle(_message(), _meta())
+    await handler.handle(_metered_message(), _meta())
     assert writer.called
+    assert len(meter_publisher.published) == 1
 
 
 def test_classify_covers_every_category_set():
@@ -234,6 +352,7 @@ async def test_handler_replies_error_when_fingerprinting_fails():
     handler = PresidioEnforceHandler(
         structlog.get_logger(),
         ReplyWriter(client),
+        FakeMeterPublisher(),
         scanner,
         cast(Fingerprinter, FailingFingerprinter()),
     )
@@ -262,6 +381,7 @@ def test_handler_rejects_non_finite_max_request_age():
         handler = PresidioEnforceHandler(
             structlog.get_logger(),
             ReplyWriter(fakeredis.aioredis.FakeRedis()),
+            FakeMeterPublisher(),
             FakeScanner(),
             parse_pepper_keyring(_KEYRING),
             max_request_age_seconds=bad,
@@ -280,12 +400,16 @@ def test_parse_pepper_keyring_accepts_line_wrapped_base64():
     assert encode_fingerprint(sum1) == "OtttmK1tiaZmS8oK2PAT-n3vNa4iic0SQh6RpOY5_yo"
 
 
-async def test_handler_drops_stale_request_without_reply():
+async def test_handler_drops_stale_request_without_reply_or_meter():
     client = fakeredis.aioredis.FakeRedis()
     scanner = FakeScanner()
+    meter_publisher = FakeMeterPublisher()
     stale = (datetime.now(UTC) - timedelta(seconds=45)).isoformat()
-    await _handler(scanner, client).handle(_message(created_at=stale), _meta())
+    await _handler(scanner, client, meter_publisher).handle(
+        _metered_message(created_at=stale), _meta()
+    )
     assert scanner.calls == []
+    assert meter_publisher.published == []
     assert await client.lpop(inbox_key("replica-1")) is None
 
 
@@ -330,6 +454,17 @@ async def test_handler_replies_error_on_scan_failure_without_content():
     assert reply.status == enforcement_reply_pb2.ENFORCEMENT_STATUS_ERROR
     assert "jane.doe" not in reply.reason
     assert "RuntimeError" in reply.reason
+
+
+async def test_scan_failure_does_not_publish_enforcement_meter():
+    client = fakeredis.aioredis.FakeRedis()
+    meter_publisher = FakeMeterPublisher()
+
+    await _handler(
+        FakeScanner(error=RuntimeError("scan failed")), client, meter_publisher
+    ).handle(_metered_message(), _meta())
+
+    assert meter_publisher.published == []
 
 
 async def test_handler_replies_error_on_scan_slot_timeout():
@@ -386,3 +521,14 @@ async def test_handler_rejects_oversized_content_without_scanning():
     assert scanner.calls == []
     reply = await _read_reply(client)
     assert reply.status == enforcement_reply_pb2.ENFORCEMENT_STATUS_ERROR
+
+
+async def test_oversized_request_does_not_publish_enforcement_meter():
+    client = fakeredis.aioredis.FakeRedis()
+    meter_publisher = FakeMeterPublisher()
+
+    await _handler(FakeScanner(), client, meter_publisher).handle(
+        _metered_message(content="a" * (MAX_CONTENT_BYTES + 1)), _meta()
+    )
+
+    assert meter_publisher.published == []

--- a/pystreams/tests/test_risk_handler.py
+++ b/pystreams/tests/test_risk_handler.py
@@ -238,6 +238,27 @@ async def test_publishes_content_part_anchor():
     assert finding.content_part_id == "part-1"
 
 
+async def test_composed_tool_arguments_keep_reveal_surface():
+    content = 'send_email\n{"recipient":"person@example.com"}'
+    match = "person@example.com"
+    start = content.index(match)
+    scanner = FakeScanner(
+        [
+            _detection(
+                "EMAIL_ADDRESS", match, start_pos=start, end_pos=start + len(match)
+            )
+        ]
+    )
+    publisher = FakePublisher()
+    await _handler(scanner, publisher).handle(
+        _message(content, finding_surface="scan_surface"), _meta()
+    )
+
+    (finding,) = publisher.published
+    assert finding.surface == "scan_surface"
+    assert content[finding.start_pos : finding.end_pos] == match
+
+
 async def test_finding_ids_are_deterministic_across_deliveries():
     """A redelivered message republishes every finding under the same id."""
     detections = [
@@ -383,6 +404,61 @@ async def test_clean_scan_publishes_canonical_meter_reading():
     assert started <= occurred_at <= produced_at <= datetime.now(UTC)
     # The request envelope remains reusable under the same stable identity.
     assert message.meter_reading == template.SerializeToString()
+
+
+@pytest.mark.parametrize(
+    ("detections", "expected_rules"),
+    [
+        pytest.param([], [], id="clean"),
+        pytest.param(
+            [_detection("EMAIL_ADDRESS", "a@b.com", start_pos=0, end_pos=7)],
+            ["pii.email_address"],
+            id="detected",
+        ),
+    ],
+)
+async def test_legacy_message_without_meter_reading_stays_unmetered(
+    detections: list[Detection],
+    expected_rules: list[str],
+):
+    publisher = FakePublisher()
+    meter_publisher = FakeMeterPublisher()
+
+    await _handler(FakeScanner(detections), publisher, meter_publisher).handle(
+        _message("a@b.com", request_id="req-1"), _meta()
+    )
+
+    assert [finding.rule_id for finding in publisher.published] == expected_rules
+    assert meter_publisher.published == []
+
+
+async def test_malformed_meter_reading_preserves_successful_findings():
+    publisher = FakePublisher()
+    meter_publisher = FakeMeterPublisher()
+    message = _message(
+        "a@b.com",
+        request_id="req-1",
+        meter_reading=b"\x0a\xffprivate-envelope",
+    )
+
+    with capture_logs() as logs:
+        await _handler(
+            FakeScanner(
+                [_detection("EMAIL_ADDRESS", "a@b.com", start_pos=0, end_pos=7)]
+            ),
+            publisher,
+            meter_publisher,
+        ).handle(message, _meta())
+
+    assert [finding.rule_id for finding in publisher.published] == ["pii.email_address"]
+    assert meter_publisher.published == []
+    (entry,) = [
+        item
+        for item in logs
+        if item["event"] == "discard malformed presidio meter reading"
+    ]
+    assert entry["error_type"] == "DecodeError"
+    assert "private-envelope" not in repr(entry)
 
 
 async def test_meter_identity_and_provenance_are_stable_on_redelivery():

--- a/pystreams/tests/test_risk_handler.py
+++ b/pystreams/tests/test_risk_handler.py
@@ -448,7 +448,7 @@ async def test_malformed_meter_reading_preserves_successful_findings():
             ),
             publisher,
             meter_publisher,
-        ).handle(message, _meta())
+        ).handle(message, _meta(delivery_attempt=2))
 
     assert [finding.rule_id for finding in publisher.published] == ["pii.email_address"]
     assert meter_publisher.published == []
@@ -458,6 +458,9 @@ async def test_malformed_meter_reading_preserves_successful_findings():
         if item["event"] == "discard malformed presidio meter reading"
     ]
     assert entry["error_type"] == "DecodeError"
+    assert entry["request_id"] == message.request_id
+    assert entry["reply_urn"] == message.reply_urn
+    assert entry["delivery_attempt"] == 2
     assert "private-envelope" not in repr(entry)
 
 

--- a/pystreams/tests/test_risk_handler.py
+++ b/pystreams/tests/test_risk_handler.py
@@ -1,8 +1,10 @@
 import re
 import uuid
+from datetime import UTC, datetime
 
 import pytest
 import structlog
+from gram.metering.v1 import meter_reading_pb2
 from gram.risk.v1 import finding_pb2, presidio_analysis_pb2
 from gram_infra.pubsub.subscriber import MessageMetadata
 from structlog.testing import capture_logs
@@ -91,22 +93,60 @@ class FakePublisher:
         return _FakeResult(f"id-{len(self.published)}")
 
 
+class FakeMeterPublisher:
+    def __init__(self):
+        self.published: list[meter_reading_pb2.MeterReading] = []
+
+    def publish(self, message: meter_reading_pb2.MeterReading) -> _FakeResult:
+        reading = meter_reading_pb2.MeterReading()
+        reading.CopyFrom(message)
+        self.published.append(reading)
+        return _FakeResult(f"meter-{len(self.published)}")
+
+
 def _meta(delivery_attempt: int = 1) -> MessageMetadata:
     return MessageMetadata(id="m-1", attributes={}, delivery_attempt=delivery_attempt)
 
 
 def _handler(
-    scanner: FakeScanner, publisher: FakePublisher | None = None
+    scanner: FakeScanner,
+    publisher: FakePublisher | None = None,
+    meter_publisher: FakeMeterPublisher | None = None,
 ) -> PresidioHandler:
     return PresidioHandler(
         structlog.get_logger(),
         publisher or FakePublisher(),
+        meter_publisher or FakeMeterPublisher(),
         scanner,
     )
 
 
 def _message(content: str, **kwargs) -> presidio_analysis_pb2.PresidioAnalysis:
     return presidio_analysis_pb2.PresidioAnalysis(content=content, **kwargs)
+
+
+def _meter_reading() -> meter_reading_pb2.MeterReading:
+    return meter_reading_pb2.MeterReading(
+        id="reading-1",
+        organization_id="org-1",
+        project_id="project-1",
+        meter_id="risk.presidio",
+        operation_id="operation-1",
+        unit="stokens",
+        value=7,
+        occurred_at="2000-01-01T00:00:00Z",
+        produced_at="2000-01-01T00:00:00Z",
+        attributes={
+            "risk_policy_id": "policy-1",
+            "risk_policy_version": "3",
+            "execution_path": "shadow_streams",
+            "chat_message_id": "message-1",
+        },
+        meter_version=1,
+        kind=meter_reading_pb2.MeterReading.KIND_USAGE,
+        measurement_method="scanner_stokens_v1",
+        source="risk",
+    )
 
 
 async def test_publishes_a_finding_per_detection():
@@ -318,6 +358,98 @@ async def test_no_log_or_publish_when_nothing_detected():
     assert publisher.published == []
 
 
+async def test_clean_scan_publishes_canonical_meter_reading():
+    meter_publisher = FakeMeterPublisher()
+    template = _meter_reading()
+    message = _message(
+        "nothing sensitive here",
+        request_id="req-1",
+        meter_reading=template.SerializeToString(),
+    )
+
+    started = datetime.now(UTC)
+    await _handler(FakeScanner([]), meter_publisher=meter_publisher).handle(
+        message, _meta()
+    )
+
+    (reading,) = meter_publisher.published
+    assert reading.id == template.id
+    assert reading.operation_id == template.operation_id
+    assert reading.value == template.value
+    assert reading.attributes == template.attributes
+    occurred_at = datetime.fromisoformat(reading.occurred_at)
+    produced_at = datetime.fromisoformat(reading.produced_at)
+    assert occurred_at.utcoffset() == produced_at.utcoffset() == UTC.utcoffset(None)
+    assert started <= occurred_at <= produced_at <= datetime.now(UTC)
+    # The request envelope remains reusable under the same stable identity.
+    assert message.meter_reading == template.SerializeToString()
+
+
+async def test_meter_identity_and_provenance_are_stable_on_redelivery():
+    meter_publisher = FakeMeterPublisher()
+    message = _message(
+        "email a@b.com",
+        request_id="req-1",
+        meter_reading=_meter_reading().SerializeToString(),
+    )
+    handler = _handler(
+        FakeScanner([_detection("EMAIL_ADDRESS", "a@b.com")]),
+        meter_publisher=meter_publisher,
+    )
+
+    await handler.handle(message, _meta(delivery_attempt=1))
+    await handler.handle(message, _meta(delivery_attempt=2))
+
+    first, second = meter_publisher.published
+    assert first.id == second.id == "reading-1"
+    assert first.operation_id == second.operation_id == "operation-1"
+    assert first.value == second.value == 7
+    assert first.attributes == second.attributes == _meter_reading().attributes
+
+
+class _FailingMeterResult:
+    async def get(self) -> str:
+        raise RuntimeError("meter unavailable")
+
+
+class _FailingMeterPublisher:
+    def publish(self, message: meter_reading_pb2.MeterReading) -> _FailingMeterResult:
+        return _FailingMeterResult()
+
+
+async def test_meter_publish_failure_nacks_without_scanner_error_swallow():
+    handler = PresidioHandler(
+        structlog.get_logger(),
+        FakePublisher(),
+        _FailingMeterPublisher(),
+        FakeScanner([]),
+    )
+    message = _message(
+        "nothing sensitive here",
+        request_id="req-1",
+        meter_reading=_meter_reading().SerializeToString(),
+    )
+
+    with capture_logs() as logs, pytest.raises(RuntimeError, match="meter unavailable"):
+        await handler.handle(message, _meta())
+
+    assert not [entry for entry in logs if entry["event"] == "presidio scan failed"]
+
+
+async def test_scan_failure_does_not_publish_meter_reading():
+    meter_publisher = FakeMeterPublisher()
+    handler = _handler(
+        FakeScanner(error=RuntimeError("scan failed")),
+        meter_publisher=meter_publisher,
+    )
+
+    await handler.handle(
+        _message("secret", meter_reading=_meter_reading().SerializeToString()), _meta()
+    )
+
+    assert meter_publisher.published == []
+
+
 async def test_requested_entities_forwarded_to_scanner():
     scanner = FakeScanner([_detection("EMAIL_ADDRESS", "a@b.com")])
     handler = _handler(scanner)
@@ -399,8 +531,13 @@ async def test_scan_failure_is_swallowed_and_logged():
 async def test_slot_timeout_is_reraised_for_redelivery():
     scanner = FakeScanner(error=ScanSlotTimeout("scan queued for 60s"))
     publisher = FakePublisher()
-    handler = _handler(scanner, publisher)
-    msg = _message("my ssn is 123-45-6789", request_id="req-1")
+    meter_publisher = FakeMeterPublisher()
+    handler = _handler(scanner, publisher, meter_publisher)
+    msg = _message(
+        "my ssn is 123-45-6789",
+        request_id="req-1",
+        meter_reading=_meter_reading().SerializeToString(),
+    )
 
     # A slot timeout means the content was never scanned: unlike other scan
     # failures it must propagate, so the message nacks and Pub/Sub redelivers
@@ -412,6 +549,7 @@ async def test_slot_timeout_is_reraised_for_redelivery():
     # Nothing was scanned, so nothing is published — redelivery duplicates no
     # findings.
     assert publisher.published == []
+    assert meter_publisher.published == []
     # Deliberately silent: requeues fire in bursts under backlog, and the
     # ``requeued`` outcome on process_duration already carries the signal, so
     # the handler emits no per-message log line (it must not be mislabeled as
@@ -451,12 +589,22 @@ class _BoomPublisher:
 async def test_publish_failure_is_swallowed_and_logged():
     secret = "a@b.com"
     scanner = FakeScanner([_detection("EMAIL_ADDRESS", secret)])
-    handler = PresidioHandler(structlog.get_logger(), _BoomPublisher(), scanner)
+    meter_publisher = FakeMeterPublisher()
+    handler = PresidioHandler(
+        structlog.get_logger(), _BoomPublisher(), meter_publisher, scanner
+    )
 
     # A publish failure must not propagate either: nacking would redeliver and
     # re-publish any findings that already landed, duplicating them.
     with capture_logs() as logs:
-        await handler.handle(_message(secret, request_id="req-1"), _meta())
+        await handler.handle(
+            _message(
+                secret,
+                request_id="req-1",
+                meter_reading=_meter_reading().SerializeToString(),
+            ),
+            _meta(),
+        )
 
     publish_errors = [e for e in logs if e["event"] == "failed to publish risk finding"]
     (err,) = publish_errors
@@ -468,6 +616,8 @@ async def test_publish_failure_is_swallowed_and_logged():
     # The summary line still reports zero published.
     summary = next(e for e in logs if e["event"] == "presidio scan detected entities")
     assert summary["published_count"] == 0
+    # Finding transport is best effort and does not suppress successful usage.
+    assert len(meter_publisher.published) == 1
 
 
 class _SyncBoomPublisher:
@@ -481,7 +631,9 @@ class _SyncBoomPublisher:
 async def test_sync_publish_failure_is_swallowed_and_logged():
     secret = "a@b.com"
     scanner = FakeScanner([_detection("EMAIL_ADDRESS", secret)])
-    handler = PresidioHandler(structlog.get_logger(), _SyncBoomPublisher(), scanner)
+    handler = PresidioHandler(
+        structlog.get_logger(), _SyncBoomPublisher(), FakeMeterPublisher(), scanner
+    )
 
     # A synchronous publish failure must be treated like an async one: logged as a
     # publish failure and skipped, never escaping to nack/redeliver the message
@@ -555,7 +707,9 @@ async def test_records_error_outcome_when_all_publishes_fail(recorded_durations)
     # Detections found, but every publish fails: nothing landed, so this must not
     # inflate the "detected" bucket — it is recorded as an error outcome.
     scanner = FakeScanner([_detection("EMAIL_ADDRESS", "a@b.com")])
-    handler = PresidioHandler(structlog.get_logger(), _BoomPublisher(), scanner)
+    handler = PresidioHandler(
+        structlog.get_logger(), _BoomPublisher(), FakeMeterPublisher(), scanner
+    )
 
     await handler.handle(_message("a@b.com", request_id="req-1"), _meta())
 

--- a/pystreams/tests/test_tracing.py
+++ b/pystreams/tests/test_tracing.py
@@ -131,6 +131,11 @@ class _UnusedPublisher:
         raise AssertionError("no findings expected on the clean path")
 
 
+class _UnusedMeterPublisher:
+    def publish(self, message: object) -> PublishResult:
+        raise AssertionError("no meter reading expected without an envelope")
+
+
 async def test_presidio_handler_stamps_content_size_on_delivery_span(
     exporter: InMemorySpanExporter,
 ):
@@ -138,7 +143,10 @@ async def test_presidio_handler_stamps_content_size_on_delivery_span(
     # so its content-size attribute must land on that delivery span — the exact
     # per-message value trace analytics correlates against duration.
     handler = PresidioHandler(
-        structlog.get_logger(), _UnusedPublisher(), _CleanScanner()
+        structlog.get_logger(),
+        _UnusedPublisher(),
+        _UnusedMeterPublisher(),
+        _CleanScanner(),
     )
     wrapped = tracing.traced(
         handler.handle,

--- a/server/internal/platformmcp/risk_reads_test.go
+++ b/server/internal/platformmcp/risk_reads_test.go
@@ -205,9 +205,13 @@ func TestRiskReadProjectionsOmitSensitivePolicyFields(t *testing.T) {
 
 	encoded, err := json.Marshal(output)
 	require.NoError(t, err)
+	var document map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(encoded, &document))
+	var policyDocument map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(document["policy"], &policyDocument))
+	require.NotContains(t, policyDocument, "model_config")
 	text := string(encoded)
 	require.NotContains(t, text, "temperature")
-	require.NotContains(t, text, "0.42")
 	require.NotContains(t, text, "user:<USER_ID>")
 	require.NotContains(t, text, scope)
 	require.NotContains(t, text, "custom.rule")


### PR DESCRIPTION
Closes AIS-680

## Summary
- Decode the Go-prepared metering envelope and publish it only after successful Presidio result construction.
- Wire the meter publisher into asynchronous and enforcement consumers.
- Preserve retry identity and leave older messages without envelopes unmetered.

## Motivation
Python owns Presidio execution completion, while Go owns canonical meter identity and attribution. Publishing at the consumer avoids charging for failed work or recomputing a different input count.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Presidio scans in Python were not previously metered; the standard and enforcement handlers now publish the Go-prepared usage envelope after successful scans. They preserve the reading's identity and attribution, stamp scan-start and publish timestamps, and nack when meter delivery fails so redelivery reuses the same reading. Closes AIS-680.

- Legacy or malformed envelopes, scan failures, timeouts, and rejected requests remain unmetered; malformed inputs log request and delivery context.
- Finding and enforcement reply delivery remain best-effort, and findings use `finding_surface` when provided.

<sup>Written for commit bef38645fc67ed26b8d238a9f01b2a9d5157a93a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

