### PR TITLE
mig: add observability_enabled to project marketplace settings

### DIFF
--- a/.changeset/observability-enabled-column.md
+++ b/.changeset/observability-enabled-column.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Internal: adds the nullable `project_marketplace_settings.observability_enabled` column, which will let a project opt out of publishing and installing its observability plugin. Nothing reads it in this release — `NULL` means enabled, the behavior every project has today — and the follow-up wires the setting into the publish, device-agent, and dashboard paths.

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -5571,6 +5571,10 @@ CREATE TABLE IF NOT EXISTS project_marketplace_settings (
   -- Override for the marketplace name. NULL falls back to the server-side
   -- default ("speakeasy") so the default lives in code, not data.
   marketplace_name TEXT CHECK (marketplace_name IS NULL OR (marketplace_name <> '' AND CHAR_LENGTH(marketplace_name) <= 64)),
+  -- When FALSE, the project's observability plugin is omitted from the
+  -- published marketplace and is not installed by the device agent.
+  -- NULL or TRUE means enabled (the historical default).
+  observability_enabled BOOLEAN,
 
   created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -2107,10 +2107,11 @@ type ProjectManagedAssistant struct {
 }
 
 type ProjectMarketplaceSetting struct {
-	ProjectID       uuid.UUID
-	MarketplaceName pgtype.Text
-	CreatedAt       pgtype.Timestamptz
-	UpdatedAt       pgtype.Timestamptz
+	ProjectID            uuid.UUID
+	MarketplaceName      pgtype.Text
+	ObservabilityEnabled pgtype.Bool
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
 }
 
 type ProjectToolVariation struct {

--- a/server/internal/plugins/repo/models.go
+++ b/server/internal/plugins/repo/models.go
@@ -63,8 +63,9 @@ type PluginServer struct {
 }
 
 type ProjectMarketplaceSetting struct {
-	ProjectID       uuid.UUID
-	MarketplaceName pgtype.Text
-	CreatedAt       pgtype.Timestamptz
-	UpdatedAt       pgtype.Timestamptz
+	ProjectID            uuid.UUID
+	MarketplaceName      pgtype.Text
+	ObservabilityEnabled pgtype.Bool
+	CreatedAt            pgtype.Timestamptz
+	UpdatedAt            pgtype.Timestamptz
 }

--- a/server/internal/plugins/repo/queries.sql.go
+++ b/server/internal/plugins/repo/queries.sql.go
@@ -369,7 +369,7 @@ func (q *Queries) GetGitHubConnectionOwner(ctx context.Context, arg GetGitHubCon
 }
 
 const getMarketplaceSettings = `-- name: GetMarketplaceSettings :one
-SELECT project_id, marketplace_name, created_at, updated_at
+SELECT project_id, marketplace_name, observability_enabled, created_at, updated_at
 FROM project_marketplace_settings
 WHERE project_id = $1
 `
@@ -380,6 +380,7 @@ func (q *Queries) GetMarketplaceSettings(ctx context.Context, projectID uuid.UUI
 	err := row.Scan(
 		&i.ProjectID,
 		&i.MarketplaceName,
+		&i.ObservabilityEnabled,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -2052,7 +2053,7 @@ VALUES ($1, $2)
 ON CONFLICT (project_id) DO UPDATE
   SET marketplace_name = EXCLUDED.marketplace_name,
       updated_at = clock_timestamp()
-RETURNING project_id, marketplace_name, created_at, updated_at
+RETURNING project_id, marketplace_name, observability_enabled, created_at, updated_at
 `
 
 type UpsertMarketplaceSettingsParams struct {
@@ -2068,6 +2069,7 @@ func (q *Queries) UpsertMarketplaceSettings(ctx context.Context, arg UpsertMarke
 	err := row.Scan(
 		&i.ProjectID,
 		&i.MarketplaceName,
+		&i.ObservabilityEnabled,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)

--- a/server/migrations/20260908182918_project-marketplace-observability-enabled.sql
+++ b/server/migrations/20260908182918_project-marketplace-observability-enabled.sql
@@ -1,0 +1,2 @@
+-- Modify "project_marketplace_settings" table
+ALTER TABLE "project_marketplace_settings" ADD COLUMN "observability_enabled" boolean NULL;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:DJGevIIVm7GYLDHmkkf7wqcRJeCDJhovwjHvcZ03AUw=
+h1:ACjvNeeeBLcsHtnmQuLe/D3j3M/T7a5YVMcKoEkKXPA=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -389,3 +389,4 @@ h1:DJGevIIVm7GYLDHmkkf7wqcRJeCDJhovwjHvcZ03AUw=
 20260904130247_aim-191-delegated-agent-credential-columns.sql h1:ai8nyCt3GN33WzGoe8iMil/GP1Zw9xSI5ReYhdbM2Fk=
 20260907222322_network-ingress.sql h1:T6fPhCYygyJeiWhdRzTnMqhwlv4LozzLs5Qsf0B0/YM=
 20260908172949_remote-session-issuers-enrichment-and-metadata-fetch.sql h1:W6jp3a8hZW681jjAWUM1SFgTeVAknuG3Dpc1i+vJ8bQ=
+20260908182918_project-marketplace-observability-enabled.sql h1:RkRGUCRzGzUai2ljHVG4ERSVrlJoMMO8KLPp3mUjM1w=


### PR DESCRIPTION
Migration only, per the repo rule. Split out of #6161 so the column lands ahead of the code that reads it.

## What it's for

A project will be able to turn off its observability plugin: when disabled, the plugin is omitted from the published marketplace, the device agent stops installing it, and direct ZIP / Codex install-script downloads are rejected. `project_marketplace_settings.observability_enabled` is where that setting lives.

## Why it's safe to ship alone

The column is nullable and nothing writes it in this release. `NULL` means enabled — the behavior every project has today — so applying this migration changes nothing observable. #6161 adds the reads and the dashboard toggle once this is out.

Linear Issue: [DNO-1042](https://linear.app/speakeasy/issue/DNO-1042)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UNGtUj2p8pJqjXTWhMaBL3

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a nullable `observability_enabled` column to `project_marketplace_settings` so projects can later disable their observability plugin. `NULL` means enabled, matching today's behavior, so this migration changes nothing until the follow-up PR adds the reads and dashboard toggle.

<sup>Written for commit abc86a78e34e5311b662a3fd1a5dfa628df6186b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

