### PR TITLE
mig: add per-organization Shadow AI scan target tables

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1277,6 +1277,47 @@ CREATE TABLE IF NOT EXISTS device_agent_configurations (
   CONSTRAINT device_agent_configurations_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE
 );
 
+-- device_agent_ai_scan_targets holds an organization's own additions to the
+-- Shadow AI scan target catalog its device agents probe for, and its
+-- overrides of the Speakeasy defaults compiled into the server. A row whose
+-- id matches a default replaces that default for the organization, which is
+-- how a default is disabled; any other row is an extra target. The served
+-- list is the defaults overlaid with these rows. Category and signature
+-- shapes are validated in application code.
+CREATE TABLE IF NOT EXISTS device_agent_ai_scan_targets (
+  organization_id TEXT NOT NULL,
+  id TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  category TEXT NOT NULL,
+  bundle_ids TEXT[] NOT NULL DEFAULT '{}',
+  binaries TEXT[] NOT NULL DEFAULT '{}',
+  config_dirs TEXT[] NOT NULL DEFAULT '{}',
+  process_names TEXT[] NOT NULL DEFAULT '{}',
+  version_plist_key TEXT,
+  enabled boolean NOT NULL DEFAULT true,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT device_agent_ai_scan_targets_pkey PRIMARY KEY (organization_id, id),
+  CONSTRAINT device_agent_ai_scan_targets_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE
+);
+
+-- device_agent_ai_scan_catalogs counts an organization's edits to its scan
+-- target list. Added to the defaults' own version, the counter is the
+-- list_version agents receive and echo on scan receipts, so it moves whenever
+-- either side of the served list changes.
+CREATE TABLE IF NOT EXISTS device_agent_ai_scan_catalogs (
+  organization_id TEXT NOT NULL,
+  list_version integer NOT NULL DEFAULT 0,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT device_agent_ai_scan_catalogs_pkey PRIMARY KEY (organization_id),
+  CONSTRAINT device_agent_ai_scan_catalogs_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE
+);
+
 CREATE TABLE IF NOT EXISTS deployments_openapiv3_assets (
   id uuid NOT NULL DEFAULT generate_uuidv7(),
   deployment_id uuid NOT NULL,

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -647,6 +647,28 @@ type DeploymentsPackage struct {
 	VersionID    uuid.UUID
 }
 
+type DeviceAgentAiScanCatalog struct {
+	OrganizationID string
+	ListVersion    int32
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+}
+
+type DeviceAgentAiScanTarget struct {
+	OrganizationID  string
+	ID              string
+	DisplayName     string
+	Category        string
+	BundleIds       []string
+	Binaries        []string
+	ConfigDirs      []string
+	ProcessNames    []string
+	VersionPlistKey pgtype.Text
+	Enabled         bool
+	CreatedAt       pgtype.Timestamptz
+	UpdatedAt       pgtype.Timestamptz
+}
+
 type DeviceAgentConfiguration struct {
 	OrganizationID string
 	SchemaVersion  int32

--- a/server/migrations/20260909100739_device-agent-ai-scan-targets.sql
+++ b/server/migrations/20260909100739_device-agent-ai-scan-targets.sql
@@ -1,0 +1,26 @@
+-- Create "device_agent_ai_scan_catalogs" table
+CREATE TABLE "device_agent_ai_scan_catalogs" (
+  "organization_id" text NOT NULL,
+  "list_version" integer NOT NULL DEFAULT 0,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("organization_id"),
+  CONSTRAINT "device_agent_ai_scan_catalogs_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create "device_agent_ai_scan_targets" table
+CREATE TABLE "device_agent_ai_scan_targets" (
+  "organization_id" text NOT NULL,
+  "id" text NOT NULL,
+  "display_name" text NOT NULL,
+  "category" text NOT NULL,
+  "bundle_ids" text[] NOT NULL DEFAULT '{}',
+  "binaries" text[] NOT NULL DEFAULT '{}',
+  "config_dirs" text[] NOT NULL DEFAULT '{}',
+  "process_names" text[] NOT NULL DEFAULT '{}',
+  "version_plist_key" text NULL,
+  "enabled" boolean NOT NULL DEFAULT true,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("organization_id", "id"),
+  CONSTRAINT "device_agent_ai_scan_targets_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:8Vc3QRCvzD5lzbZgZOa0vJLJzv6Sdo21byub0NeY0Hg=
+h1:y7aCmxtGbadk3S1AzXjmOEOhFEfvjbEl8/3sC1svfxQ=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -391,3 +391,4 @@ h1:8Vc3QRCvzD5lzbZgZOa0vJLJzv6Sdo21byub0NeY0Hg=
 20260908172949_remote-session-issuers-enrichment-and-metadata-fetch.sql h1:W6jp3a8hZW681jjAWUM1SFgTeVAknuG3Dpc1i+vJ8bQ=
 20260908182918_project-marketplace-observability-enabled.sql h1:RkRGUCRzGzUai2ljHVG4ERSVrlJoMMO8KLPp3mUjM1w=
 20260908210453_owner_lookup_indexes.sql h1:6WOMlxikTd2AuEBGWyiY7EGtCTMs+pAfG0aIxxmAoYI=
+20260909100739_device-agent-ai-scan-targets.sql h1:Cdb8T6MSqBkzvBHuvnkSasl43c+BT3cqVOpVToJ5+0w=


### PR DESCRIPTION
DNO-1041

## Summary

- `device_agent_ai_scan_targets`: an organization's own Shadow AI scan targets and its overrides of the Speakeasy defaults compiled into the server, keyed by `(organization_id, id)` and cascading with the organization. A row under a default's id replaces that default for the organization, which is how a default is disabled.
- `device_agent_ai_scan_catalogs`: one row per organization holding the edit counter that, added to the defaults' own version, becomes the `list_version` agents receive and echo on scan receipts.

DDL only; the defaults stay in code. Split out of speakeasy-api/gram#6171.

## Motivation

Organizations manage which AI tools their device agents probe for, the same way they manage fleet configuration. These tables hold what an organization adds or changes on top of the defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
