### PR TITLE
fix: restore log target badge colors

### DIFF
--- a/client/dashboard/src/components/observe/LogsTools.tsx
+++ b/client/dashboard/src/components/observe/LogsTools.tsx
@@ -1146,7 +1146,12 @@ function LogsToolsTraceRow({
 
         <div className="flex min-w-0 flex-2 items-center gap-2">
           <div className="group/server relative flex shrink-0 items-center">
-            <span className="border-border text-muted-foreground shrink-0 truncate border px-2 py-1 font-mono text-[10px] tracking-wide uppercase">
+            <span
+              className={cn(
+                "border-border shrink-0 truncate border px-2 py-1 font-mono text-[10px] tracking-wide uppercase",
+                targetConfig.className,
+              )}
+            >
               {targetConfig.label}
             </span>
             {editDialogProps && (
@@ -1301,23 +1306,44 @@ function LogsToolsTraceRow({
   );
 }
 
-// One neutral tag treatment for every target type — the type is metadata, not
-// a signal, so it no longer carries its own color.
 function getTargetConfig(targetType: ToolUsageTraceSummary["targetType"]) {
   switch (targetType) {
     case "hosted_mcp_server":
-      return { label: "Hosted MCP" };
+      return {
+        label: "Hosted MCP",
+        className:
+          "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300",
+      };
     case "tunneled_mcp_server":
-      return { label: "Tunneled MCP" };
+      return {
+        label: "Tunneled MCP",
+        className:
+          "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300",
+      };
     case "meta_mcp_server":
-      return { label: "Gateway" };
+      return {
+        label: "Gateway",
+        className:
+          "bg-cyan-100 text-cyan-800 dark:bg-cyan-900 dark:text-cyan-300",
+      };
     case "shadow_mcp_server":
-      return { label: "Shadow MCP" };
+      return {
+        label: "Shadow MCP",
+        className:
+          "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-300",
+      };
     case "skill":
-      return { label: "Skill" };
+      return {
+        label: "Skill",
+        className:
+          "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300",
+      };
     case "local_tool":
     default:
-      return { label: "Local Tools" };
+      return {
+        label: "Local Tools",
+        className: "bg-muted/50 text-primary",
+      };
   }
 }
 


### PR DESCRIPTION
## Summary

Restore distinct color treatments for target-type badges on the logs page, including hosted and tunneled MCP servers, Shadow MCP servers, skills, and local tools.

## Motivation

A dashboard restyle made every target-type badge neutral, removing the visual distinction that helps users scan mixed tool traffic. This restores the existing per-type palette while retaining the current badge shape and typography.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores distinct colors for target-type badges on the logs page, so hosted/tunneled MCP, Shadow MCP, skills, and local tools are visually distinguishable again after a restyle made them all neutral. Badge shape and typography stay the same.

<sup>Written for commit b95fe0aa953329170981855b33120da00fe8f0f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

