### PR TITLE
fix(platform-mcp): allow catalogue registration with legacy servers

### DIFF
--- a/.changeset/platform-mcp-legacy-catalog-registration.md
+++ b/.changeset/platform-mcp-legacy-catalog-registration.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Allow reviewed catalogue MCP servers to be registered in projects that also contain legacy toolset-backed MCP servers.

--- a/server/internal/platformmcp/queries.sql
+++ b/server/internal/platformmcp/queries.sql
@@ -590,25 +590,16 @@ WHERE organization_id = @organization_id
   AND deleted IS FALSE;
 
 -- name: IsPlatformMCPCatalogRegistrationTargetEligible :one
--- Registration is safe for a new organization: the selected project may be
--- empty. It remains unavailable for a project that already owns an active
--- toolset-backed MCP, because that legacy model must not be mixed with the
--- Platform registration lifecycle. Package admission retains its independent
--- organization-level cohort check.
+-- Registration may add a separately managed MCP server to any live project in
+-- the active organization. Existing toolset-backed servers can coexist because
+-- registration identity, component ownership, and active caps are enforced on
+-- the Platform registration and its own component rows.
 SELECT EXISTS (
     SELECT 1
     FROM projects AS target
     WHERE target.id = @project_id
       AND target.organization_id = @organization_id
       AND target.deleted IS FALSE
-      AND NOT EXISTS (
-          SELECT 1
-          FROM mcp_servers AS legacy_server
-          WHERE legacy_server.project_id = target.id
-            AND legacy_server.deleted IS FALSE
-            AND legacy_server.visibility <> 'disabled'
-            AND legacy_server.toolset_id IS NOT NULL
-      )
 );
 
 -- name: LockPlatformMCPOperationReceipt :exec

--- a/server/internal/platformmcp/registration_integration_test.go
+++ b/server/internal/platformmcp/registration_integration_test.go
@@ -32,6 +32,7 @@ import (
 	remotemcprepo "github.com/speakeasy-api/gram/server/internal/remotemcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
 	usersessionsrepo "github.com/speakeasy-api/gram/server/internal/usersessions/repo"
 )
 
@@ -268,6 +269,66 @@ func TestRegistrationStoreAllowsFreshOrganizationTarget(t *testing.T) {
 	eligible, err := store.EligibleCatalogRegistrationTarget(ctx, principal.OrganizationID, project)
 	require.NoError(t, err)
 	require.True(t, eligible)
+}
+
+func TestRegistrationStoreRejectsProjectOutsideOrganization(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_registration_wrong_organization")
+	require.NoError(t, err)
+
+	_, project := seedRegistrationLifecycle(t, ctx, conn)
+	store, err := NewRegistrationStore(conn, RegistrationStoreConfig{ActiveRegistrationCap: 1})
+	require.NoError(t, err)
+
+	eligible, err := store.EligibleCatalogRegistrationTarget(ctx, "org_"+uuid.NewString(), project)
+	require.NoError(t, err)
+	require.False(t, eligible)
+}
+
+func TestRegistrationStoreAllowsLegacyToolsetBackedServer(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	conn, err := platformMCPInfra.CloneTestDatabase(t, "platform_mcp_registration_legacy_toolset")
+	require.NoError(t, err)
+
+	principal, project := seedRegistrationLifecycle(t, ctx, conn)
+	toolset, err := toolsetsrepo.New(conn).CreateToolset(ctx, toolsetsrepo.CreateToolsetParams{
+		OrganizationID: principal.OrganizationID,
+		ProjectID:      project.ID,
+		Name:           "Legacy hosted server",
+		Slug:           "legacy-" + uuid.NewString()[:8],
+		McpSlug:        conv.ToPGText("legacy-mcp-" + uuid.NewString()[:8]),
+		McpEnabled:     true,
+	})
+	require.NoError(t, err)
+	_, err = mcpserversrepo.New(conn).CreateMCPServer(ctx, mcpserversrepo.CreateMCPServerParams{
+		ID:         uuid.New(),
+		ProjectID:  project.ID,
+		Name:       conv.ToPGText("Legacy hosted server"),
+		Slug:       conv.ToPGText("legacy-server-" + uuid.NewString()[:8]),
+		ToolsetID:  uuid.NullUUID{UUID: toolset.ID, Valid: true},
+		Visibility: "private",
+	})
+	require.NoError(t, err)
+
+	store, err := NewRegistrationStore(conn, RegistrationStoreConfig{ActiveRegistrationCap: 1})
+	require.NoError(t, err)
+	eligible, err := store.EligibleCatalogRegistrationTarget(ctx, principal.OrganizationID, project)
+	require.NoError(t, err)
+	require.True(t, eligible)
+
+	request := registrationRequest(project, "reviewed", "legacy-coexistence-key")
+	receipt, err := store.BeginReceipt(ctx, principal, project, request, time.Now().UTC())
+	require.NoError(t, err)
+	receipt, err = store.ConvergeRegistration(ctx, principal, project, request, receipt)
+	require.NoError(t, err)
+	completed, err := store.CompleteRegistrationWithRemoteURL(ctx, principal, project, request, receipt, "https://reviewed.example.test/mcp")
+	require.NoError(t, err)
+	require.Equal(t, receiptStatusSucceeded, completed.Status)
+	require.Equal(t, receiptResultRegistered, completed.ResultCode)
 }
 
 func TestRegistrationStoreEnforcesActiveRegistrationCap(t *testing.T) {

--- a/server/internal/platformmcp/repo/queries.sql.go
+++ b/server/internal/platformmcp/repo/queries.sql.go
@@ -3845,14 +3845,6 @@ SELECT EXISTS (
     WHERE target.id = $1
       AND target.organization_id = $2
       AND target.deleted IS FALSE
-      AND NOT EXISTS (
-          SELECT 1
-          FROM mcp_servers AS legacy_server
-          WHERE legacy_server.project_id = target.id
-            AND legacy_server.deleted IS FALSE
-            AND legacy_server.visibility <> 'disabled'
-            AND legacy_server.toolset_id IS NOT NULL
-      )
 )
 `
 
@@ -3861,11 +3853,10 @@ type IsPlatformMCPCatalogRegistrationTargetEligibleParams struct {
 	OrganizationID string
 }
 
-// Registration is safe for a new organization: the selected project may be
-// empty. It remains unavailable for a project that already owns an active
-// toolset-backed MCP, because that legacy model must not be mixed with the
-// Platform registration lifecycle. Package admission retains its independent
-// organization-level cohort check.
+// Registration may add a separately managed MCP server to any live project in
+// the active organization. Existing toolset-backed servers can coexist because
+// registration identity, component ownership, and active caps are enforced on
+// the Platform registration and its own component rows.
 func (q *Queries) IsPlatformMCPCatalogRegistrationTargetEligible(ctx context.Context, arg IsPlatformMCPCatalogRegistrationTargetEligibleParams) (bool, error) {
 	row := q.db.QueryRow(ctx, isPlatformMCPCatalogRegistrationTargetEligible, arg.ProjectID, arg.OrganizationID)
 	var exists bool

--- a/server/internal/platformmcp/tools.go
+++ b/server/internal/platformmcp/tools.go
@@ -450,7 +450,7 @@ func operationBudgetToolResult(err error) (*mcp.CallToolResult, bool) {
 	case errors.Is(err, ErrRegistrationConflict):
 		result = operationBudgetResult{Code: "conflict", Message: "That MCP server conflicts with something already set up in this project."}
 	case errors.Is(err, ErrTargetIneligible):
-		result = operationBudgetResult{Code: "ineligible_project", Message: "This project already has an older-style MCP server set up, so it cannot use this flow. Pick a different project."}
+		result = operationBudgetResult{Code: "ineligible_project", Message: "That project is not available for MCP setup. Check the project slug and try again."}
 	default:
 		return nil, false
 	}

--- a/server/internal/platformmcp/tools_test.go
+++ b/server/internal/platformmcp/tools_test.go
@@ -30,6 +30,16 @@ func TestOperationBudgetToolResultAddsOnlyTypedSetupDiagnostics(t *testing.T) {
 	require.JSONEq(t, `{"code":"feature_unavailable","reason":"remote_inspection_unavailable","message":"That MCP server could not be checked safely right now. Try again shortly."}`, legacyText.Text)
 }
 
+func TestOperationBudgetToolResultMapsIneligibleProject(t *testing.T) {
+	t.Parallel()
+
+	result, ok := operationBudgetToolResult(ErrTargetIneligible)
+	require.True(t, ok)
+	text, ok := result.Content[0].(*mcp.TextContent)
+	require.True(t, ok)
+	require.JSONEq(t, `{"code":"ineligible_project","message":"That project is not available for MCP setup. Check the project slug and try again."}`, text.Text)
+}
+
 func TestOperationBudgetToolResultMapsRegistrationInputErrors(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Why

Catalogue MCP registration rejected an entire project when it contained any legacy toolset-backed MCP server. This prevented established projects from adding reviewed catalogue servers even though the new registration owns separate components and enforces its own identity and capacity checks.

Fixes GRW-72

## What changed

- Allow catalogue registration for any live project in the active organisation, including projects with legacy toolset-backed servers.
- Keep project tenancy and lifecycle checks in place, and update the unavailable-project message so it no longer blames legacy servers.
- Add regression coverage for mixed legacy and catalogue servers, cross-organisation rejection, and the updated tool response.
- Add a server patch changeset.

## Review notes

- The main behavior change is the eligibility predicate in `server/internal/platformmcp/queries.sql`.
- Legacy servers do not count toward the Platform MCP active registration cap. Candidate identity, component ownership, and Platform registration caps remain unchanged.

## Testing

- `mise run test:server ./internal/platformmcp -count=1` (678 tests)
- `mise lint:server`
- `mise run gen:sqlc-server`
- `git diff --check`
- Independent code review completed and findings addressed.

## Rollout / deployment notes

No migration, feature flag, or configuration change is required.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes catalogue MCP registration being rejected for any project containing legacy toolset-backed servers, so established projects can now add reviewed catalogue servers alongside them.

- Removes the project-wide eligibility gate that blocked registration when legacy servers were present; identity, ownership, and registration cap checks on the catalogue candidate remain unchanged.
- Updates the ineligible-project error message to stop blaming legacy servers.
- Adds regression tests for mixed legacy and catalogue servers and cross-organisation rejection.
- No migration, feature flag, or configuration change is required.

<sup>Written for commit 176b5b191b9f5827033b43effaaa96ccb4ec36bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

