### PR TITLE
fix: emit drainer liveness as a heartbeat gauge

### DIFF
--- a/server/internal/redisinbox/inbox.go
+++ b/server/internal/redisinbox/inbox.go
@@ -264,6 +264,10 @@ func New[R any](
 		drainerAliveRegistration: nil,
 		waiters:                  sync.Map{},
 	}
+	// Seed liveness before the callback can be scraped: superviseDrainer sets
+	// this true once it schedules, and an early collection would otherwise
+	// report a spurious 0 for a healthy replica.
+	inbox.drainerAlive.Store(true)
 	alive, err := meter.Int64ObservableGauge(
 		cfg.MetricPrefix+".drainer_alive",
 		metric.WithDescription("Whether the replica reply drainer is running"),

--- a/server/internal/redisinbox/inbox.go
+++ b/server/internal/redisinbox/inbox.go
@@ -27,6 +27,8 @@ import (
 )
 
 const (
+	instrumentationName = "github.com/speakeasy-api/gram/server/internal/redisinbox"
+
 	// DefaultPollInterval paces LPOP polling while waiters are registered. It
 	// bounds the added reply pickup latency; with no waiters registered the
 	// drainer does not poll at all.
@@ -169,6 +171,8 @@ type Inbox[R any] struct {
 	shutdown  chan struct{}
 	closeOnce sync.Once
 
+	drainerAliveRegistration metric.Registration
+
 	// correlation id -> *Waiter. Load/store churn is per request, not per
 	// reply, and the router only ever Loads, sync.Map's optimized case.
 	waiters sync.Map
@@ -185,7 +189,6 @@ type inboxMetrics struct {
 	roundTrip metric.Float64Histogram
 	replies   metric.Int64Counter
 	orphaned  metric.Int64Counter
-	alive     metric.Int64Gauge
 	drainErrs metric.Int64Counter
 }
 
@@ -225,39 +228,64 @@ func New[R any](
 		return nil, fmt.Errorf("ping reply inbox redis: %w", err)
 	}
 
-	metrics, err := newInboxMetrics(meterProvider, cfg.MetricPrefix)
+	meter := meterProvider.Meter(instrumentationName)
+	metrics, err := newInboxMetrics(meter, cfg.MetricPrefix)
 	if err != nil {
 		_ = client.Close()
 		return nil, err
 	}
 
-	drainCtx, cancel := context.WithCancel(ctx) //nolint:gosec // cancel is retained on the Inbox and called in Close
+	drainCtx, cancel := context.WithCancel(ctx)
 	inbox := &Inbox[R]{
-		logger:          logger.With(attr.SlogComponent(cfg.Component)),
-		tracer:          tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/redisinbox"),
-		metrics:         metrics,
-		spanName:        cfg.MetricPrefix + ".await",
-		idAttr:          cfg.MetricPrefix + ".correlation_id",
-		codec:           cfg.Codec,
-		client:          client,
-		replicaID:       cfg.ReplicaID,
-		urnNS:           cfg.URNNamespace,
-		key:             Key(cfg.Keyspace, cfg.ReplicaID),
-		poll:            cfg.PollInterval,
-		drainGate:       cfg.DrainGate,
-		activeWaiters:   atomic.Int64{},
-		wake:            make(chan struct{}, 1),
-		orphanedReplies: atomic.Uint64{},
-		drainBatches:    atomic.Uint64{},
-		drainedReplies:  atomic.Uint64{},
-		maxDrainBatch:   atomic.Uint64{},
-		drainerAlive:    atomic.Bool{},
-		drainerErrors:   atomic.Uint64{},
-		cancel:          cancel,
-		done:            make(chan struct{}),
-		shutdown:        make(chan struct{}),
-		closeOnce:       sync.Once{},
-		waiters:         sync.Map{},
+		logger:                   logger.With(attr.SlogComponent(cfg.Component)),
+		tracer:                   tracerProvider.Tracer("github.com/speakeasy-api/gram/server/internal/redisinbox"),
+		metrics:                  metrics,
+		spanName:                 cfg.MetricPrefix + ".await",
+		idAttr:                   cfg.MetricPrefix + ".correlation_id",
+		codec:                    cfg.Codec,
+		client:                   client,
+		replicaID:                cfg.ReplicaID,
+		urnNS:                    cfg.URNNamespace,
+		key:                      Key(cfg.Keyspace, cfg.ReplicaID),
+		poll:                     cfg.PollInterval,
+		drainGate:                cfg.DrainGate,
+		activeWaiters:            atomic.Int64{},
+		wake:                     make(chan struct{}, 1),
+		orphanedReplies:          atomic.Uint64{},
+		drainBatches:             atomic.Uint64{},
+		drainedReplies:           atomic.Uint64{},
+		maxDrainBatch:            atomic.Uint64{},
+		drainerAlive:             atomic.Bool{},
+		drainerErrors:            atomic.Uint64{},
+		cancel:                   cancel,
+		done:                     make(chan struct{}),
+		shutdown:                 make(chan struct{}),
+		closeOnce:                sync.Once{},
+		drainerAliveRegistration: nil,
+		waiters:                  sync.Map{},
+	}
+	alive, err := meter.Int64ObservableGauge(
+		cfg.MetricPrefix+".drainer_alive",
+		metric.WithDescription("Whether the replica reply drainer is running"),
+		metric.WithUnit("1"),
+	)
+	if err != nil {
+		cancel()
+		_ = client.Close()
+		return nil, fmt.Errorf("create %s.drainer_alive metric: %w", cfg.MetricPrefix, err)
+	}
+	inbox.drainerAliveRegistration, err = meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
+		value := int64(0)
+		if inbox.drainerAlive.Load() {
+			value = 1
+		}
+		o.ObserveInt64(alive, value)
+		return nil
+	}, alive)
+	if err != nil {
+		cancel()
+		_ = client.Close()
+		return nil, fmt.Errorf("register %s.drainer_alive callback: %w", cfg.MetricPrefix, err)
 	}
 	drainFunc := inbox.drain
 	if cfg.drainFunc != nil {
@@ -289,8 +317,7 @@ func (i *Inbox[R]) Snapshot() Stats {
 	}
 }
 
-func newInboxMetrics(meterProvider metric.MeterProvider, prefix string) (inboxMetrics, error) {
-	meter := meterProvider.Meter("github.com/speakeasy-api/gram/server/internal/redisinbox")
+func newInboxMetrics(meter metric.Meter, prefix string) (inboxMetrics, error) {
 	roundTrip, err := meter.Float64Histogram(
 		prefix+".round_trip_duration",
 		metric.WithDescription("End-to-end request-reply duration in seconds"),
@@ -316,14 +343,6 @@ func newInboxMetrics(meterProvider metric.MeterProvider, prefix string) (inboxMe
 	if err != nil {
 		return inboxMetrics{}, fmt.Errorf("create %s.orphaned_replies metric: %w", prefix, err)
 	}
-	alive, err := meter.Int64Gauge(
-		prefix+".drainer_alive",
-		metric.WithDescription("Whether the replica reply drainer is running"),
-		metric.WithUnit("1"),
-	)
-	if err != nil {
-		return inboxMetrics{}, fmt.Errorf("create %s.drainer_alive metric: %w", prefix, err)
-	}
 	drainErrs, err := meter.Int64Counter(
 		prefix+".drainer_errors",
 		metric.WithDescription("Unexpected reply drainer exits that triggered a restart"),
@@ -336,7 +355,6 @@ func newInboxMetrics(meterProvider metric.MeterProvider, prefix string) (inboxMe
 		roundTrip: roundTrip,
 		replies:   replies,
 		orphaned:  orphaned,
-		alive:     alive,
 		drainErrs: drainErrs,
 	}, nil
 }
@@ -425,10 +443,8 @@ func (i *Inbox[R]) superviseDrainer(ctx context.Context, run func(context.Contex
 	metricCtx := context.WithoutCancel(ctx)
 	for ctx.Err() == nil {
 		i.drainerAlive.Store(true)
-		i.metrics.alive.Record(metricCtx, 1)
 		panicked, recovered, stack := invokeDrainer(ctx, run)
 		i.drainerAlive.Store(false)
-		i.metrics.alive.Record(metricCtx, 0)
 		if ctx.Err() != nil {
 			return
 		}
@@ -578,8 +594,12 @@ func (i *Inbox[R]) Close() error {
 	i.closeOnce.Do(func() { close(i.shutdown) })
 	i.cancel()
 	<-i.done
-	if err := i.client.Close(); err != nil {
-		return fmt.Errorf("close reply inbox redis: %w", err)
+	var closeErrs []error
+	if err := i.drainerAliveRegistration.Unregister(); err != nil {
+		closeErrs = append(closeErrs, fmt.Errorf("unregister drainer liveness callback: %w", err))
 	}
-	return nil
+	if err := i.client.Close(); err != nil {
+		closeErrs = append(closeErrs, fmt.Errorf("close reply inbox redis: %w", err))
+	}
+	return errors.Join(closeErrs...)
 }

--- a/server/internal/redisinbox/inbox_test.go
+++ b/server/internal/redisinbox/inbox_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -13,7 +14,9 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 // toyReply exercises the generic inbox with a payload unrelated to risk
@@ -49,6 +52,24 @@ type toyEnv struct {
 	client *redis.Client
 	inbox  *Inbox[toyReply]
 	writer *Writer[toyReply]
+	reader *sdkmetric.ManualReader
+}
+
+type blockingRegistration struct {
+	metric.Registration
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+	err     error
+}
+
+func (r *blockingRegistration) Unregister() error {
+	r.once.Do(func() {
+		close(r.started)
+		<-r.release
+		r.err = r.Registration.Unregister()
+	})
+	return r.err
 }
 
 func setupToyInbox(t *testing.T, replicaID string, drainFunc func(context.Context)) *toyEnv {
@@ -80,7 +101,26 @@ func setupToyInbox(t *testing.T, replicaID string, drainFunc func(context.Contex
 		Encode:        toyCodec().Encode,
 		CorrelationID: toyCodec().CorrelationID,
 	})
-	return &toyEnv{redis: mr, client: client, inbox: inbox, writer: writer}
+	return &toyEnv{redis: mr, client: client, inbox: inbox, writer: writer, reader: reader}
+}
+
+func collectInt64Gauge(t *testing.T, reader *sdkmetric.ManualReader, name string) (int64, bool) {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			gauge, ok := m.Data.(metricdata.Gauge[int64])
+			require.True(t, ok)
+			require.Len(t, gauge.DataPoints, 1)
+			return gauge.DataPoints[0].Value, true
+		}
+	}
+	return 0, false
 }
 
 func TestToyInstantiationRoundTrip(t *testing.T) {
@@ -161,6 +201,45 @@ func TestDrainerSupervisorRestartsAfterPanic(t *testing.T) {
 		stats := te.inbox.Snapshot()
 		return attempts.Load() >= 2 && stats.DrainerAlive && stats.DrainerErrors == 1
 	}, 2*time.Second, 5*time.Millisecond)
+}
+
+func TestDrainerAliveMetricIsAHeartbeat(t *testing.T) {
+	t.Parallel()
+
+	te := setupToyInbox(t, "toy-heartbeat", nil)
+	require.Eventually(t, te.inbox.drainerAlive.Load, time.Second, 5*time.Millisecond)
+
+	value, ok := collectInt64Gauge(t, te.reader, "toy.requests.drainer_alive")
+	require.True(t, ok)
+	require.Equal(t, int64(1), value)
+	value, ok = collectInt64Gauge(t, te.reader, "toy.requests.drainer_alive")
+	require.True(t, ok)
+	require.Equal(t, int64(1), value)
+
+	// Hold unregistration open so Close's final false state can be collected.
+	registration := &blockingRegistration{
+		Registration: te.inbox.drainerAliveRegistration,
+		started:      make(chan struct{}),
+		release:      make(chan struct{}),
+		once:         sync.Once{},
+		err:          nil,
+	}
+	te.inbox.drainerAliveRegistration = registration
+	var releaseOnce sync.Once
+	releaseRegistration := func() { releaseOnce.Do(func() { close(registration.release) }) }
+	defer releaseRegistration()
+	closeResult := make(chan error, 1)
+	go func() { closeResult <- te.inbox.Close() }()
+	<-registration.started
+
+	value, ok = collectInt64Gauge(t, te.reader, "toy.requests.drainer_alive")
+	require.True(t, ok)
+	require.Equal(t, int64(0), value)
+	releaseRegistration()
+	require.NoError(t, <-closeResult)
+
+	_, ok = collectInt64Gauge(t, te.reader, "toy.requests.drainer_alive")
+	require.False(t, ok)
 }
 
 func TestMissingCodecOrNamespaceIsRejected(t *testing.T) {


### PR DESCRIPTION
AIS-402

## Summary

Emit the drainer liveness gauge on every metrics collection so healthy idle replicas continue producing fresh heartbeat points.

- Read liveness from the existing atomic drainer state.
- Unregister the observable callback during inbox shutdown.
- Cover repeated observations and shutdown behavior with a manual reader.

## Motivation

The synchronous gauge only emitted on state transitions, so quiet healthy replicas became no-data and triggered false alerts.

https://claude.ai/code/session_011zaiS6VU4N6NBoc5jbUL5b

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes the drainer liveness gauge from a synchronous record on state transitions to an observable gauge collected on every metrics cycle, so healthy idle replicas keep emitting fresh heartbeat points instead of dropping to no-data and triggering false alerts. Seeds liveness to true before callback registration so the first collection can't report a spurious 0, and unregisters the callback during inbox shutdown so the metric stops being collected after close.

<sup>Written for commit 92c1d57800813c9d5a614fc16222c0e44b2c101f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

