### PR TITLE
chore: use one private ingress proxy for MVP

### DIFF
--- a/server/internal/k8s/tailscale_network_ingress_provisioner.go
+++ b/server/internal/k8s/tailscale_network_ingress_provisioner.go
@@ -719,7 +719,7 @@ func tailnetObject(desired NetworkIngressDesired) *unstructured.Unstructured {
 }
 
 func proxyGroupObject(desired NetworkIngressDesired, proxyTag string) *unstructured.Unstructured {
-	return &unstructured.Unstructured{Object: map[string]any{"apiVersion": tailscaleAPIGroup + "/" + tailscaleAPIVersion, "kind": "ProxyGroup", "metadata": map[string]any{"name": desired.Resources.ProxyGroup, "labels": unstructuredIngressLabels(desired)}, "spec": map[string]any{"type": "ingress", "replicas": int64(2), "tailnet": desired.Resources.Tailnet, "tags": []any{proxyTag}}}}
+	return &unstructured.Unstructured{Object: map[string]any{"apiVersion": tailscaleAPIGroup + "/" + tailscaleAPIVersion, "kind": "ProxyGroup", "metadata": map[string]any{"name": desired.Resources.ProxyGroup, "labels": unstructuredIngressLabels(desired)}, "spec": map[string]any{"type": "ingress", "replicas": int64(1), "tailnet": desired.Resources.Tailnet, "tags": []any{proxyTag}}}}
 }
 
 func proxyGroupPolicyObject(desired NetworkIngressDesired) *unstructured.Unstructured {

--- a/server/internal/k8s/tailscale_network_ingress_provisioner_test.go
+++ b/server/internal/k8s/tailscale_network_ingress_provisioner_test.go
@@ -47,6 +47,10 @@ func TestTailscaleNetworkIngressProvisionerApplyObserveAndDelete(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, found)
 	require.Equal(t, desired.Resources.Tailnet, tailnetName)
+	replicas, found, err := unstructured.NestedInt64(proxyGroup.Object, "spec", "replicas")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, int64(1), replicas)
 	policy, err := dynamicClient.Resource(proxyGroupPolicyGVR).Namespace(desired.Resources.Namespace).Get(t.Context(), desired.Resources.ProxyGroupPolicy, metav1.GetOptions{})
 	require.NoError(t, err)
 	allowedGroups, found, err := unstructured.NestedSlice(policy.Object, "spec", "ingress")
@@ -56,6 +60,7 @@ func TestTailscaleNetworkIngressProvisionerApplyObserveAndDelete(t *testing.T) {
 
 	deployment, err := typed.AppsV1().Deployments(desired.Resources.Namespace).Get(t.Context(), desired.Resources.AttestorDeployment, metav1.GetOptions{})
 	require.NoError(t, err)
+	require.Equal(t, int32(1), *deployment.Spec.Replicas)
 	require.False(t, *deployment.Spec.Template.Spec.AutomountServiceAccountToken)
 	require.Equal(t, networkIngressTokenAudience, deployment.Spec.Template.Spec.Volumes[0].Projected.Sources[0].ServiceAccountToken.Audience)
 	require.Equal(t, int64(600), *deployment.Spec.Template.Spec.Volumes[0].Projected.Sources[0].ServiceAccountToken.ExpirationSeconds)


### PR DESCRIPTION
## Summary

Use one Tailscale proxy replica per private ingress, retaining the single attestor replica. Add assertions for both replica counts.

Stacked on #5970. The rollout gates were backported into #5922 and #5970 so they are present when those features first land, rather than relying on this top PR.

## Motivation

Match the agreed internal-test MVP topology and avoid provisioning an extra proxy before capacity and HA requirements are established. This is not end-to-end HA: losing the sole proxy or attestor can interrupt private access. No infrastructure is deployed or live flags changed by this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces the private ingress proxy replica count from 2 to 1 so the deployed topology matches the agreed internal-test MVP, avoiding provisioning an extra proxy before capacity and HA requirements are established. Adds test assertions that pin both the proxy group and attestor deployment to a single replica; this is not end-to-end HA, so losing the sole proxy or attestor can interrupt private access.

<sup>Written for commit 2baf3236d111e67936e1583100d733f68a14a3fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

