### PR TITLE
fix: keep the Observability group open on identity pages

### DIFF
--- a/.changeset/identity-nav-and-roster-polish.md
+++ b/.changeset/identity-nav-and-roster-polish.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Keep the Observability sidebar group open on identity pages, add a breadcrumb back to the roster from an identity, and even out cell sizes and spacing on the identity roster.

--- a/client/dashboard/src/components/page-header.test.tsx
+++ b/client/dashboard/src/components/page-header.test.tsx
@@ -17,7 +17,12 @@ vi.mock("./command-palette/CommandPaletteTrigger", () => ({
 }));
 // Stub context/hook modules imported at the top of page-header.tsx (used only
 // in PageHeaderBreadcrumbs, not PageHeaderComponent, but they execute on import)
-vi.mock("@/contexts/Sdk.tsx", () => ({ useSlugs: () => ({}) }));
+vi.mock("@/contexts/Sdk.tsx", () => ({
+  useSlugs: () => ({
+    orgSlug: "placeholder-organization",
+    projectSlug: "placeholder-project",
+  }),
+}));
 vi.mock("@/contexts/Auth.tsx", () => ({
   useOrganization: () => ({}),
   useProject: () => ({}),
@@ -93,5 +98,36 @@ describe("PageHeader", () => {
     );
 
     expect(screen.getByTestId("cap-paused-banner")).toBeTruthy();
+  });
+});
+
+// The identity detail page sits a level below the roster with no other way
+// back up, so it carries a trail — the same reason the MCP pages do.
+describe("PageHeader.Breadcrumbs", () => {
+  it("links back to the roster from an identity detail page", () => {
+    render(
+      <PageHeader>
+        <PageHeader.Breadcrumbs />
+      </PageHeader>,
+      {
+        at: "/placeholder-organization/projects/placeholder-project/identities/user%3A1/overview",
+      },
+    );
+
+    const back = screen.getByRole("link", { name: "Identities" });
+    expect(back.getAttribute("href")).toBe(
+      "/placeholder-organization/projects/placeholder-project/identities",
+    );
+  });
+
+  it("stays hidden on pages that are not nested", () => {
+    render(
+      <PageHeader>
+        <PageHeader.Breadcrumbs />
+      </PageHeader>,
+      { at: "/placeholder-organization/projects/placeholder-project/costs" },
+    );
+
+    expect(screen.queryByLabelText("Breadcrumb")).toBeNull();
   });
 });

--- a/client/dashboard/src/components/page-header.tsx
+++ b/client/dashboard/src/components/page-header.tsx
@@ -5,13 +5,13 @@ import { useSlugs } from "@/contexts/Sdk.tsx";
 import { useRBAC } from "@/hooks/useRBAC";
 import { cn, titleCaseSlug } from "@/lib/utils.ts";
 import React from "react";
-import { ChevronRight } from "lucide-react";
-import { Link, useLocation, useMatch, useParams } from "react-router";
+import { useLocation, useMatch, useParams } from "react-router";
 import { PaygCapReachedBanners } from "./billing/billing-banners.tsx";
 import { HatchRule } from "./hatch-rule.tsx";
 import { InsightsDockShortcutHint } from "./insights-dock-shortcut-hint.tsx";
 import { ReleaseStage, ReleaseStageBadge } from "./release-stage-badge.tsx";
 import { Heading } from "@/components/ui/Heading";
+import { Breadcrumb, type BreadcrumbItem } from "@/components/ui/Breadcrumb";
 import { WorkspaceSwitcher } from "./workspace-switcher.tsx";
 
 function PageHeaderComponent({
@@ -124,47 +124,6 @@ const breadcrumbUrlSubstitutions: Record<string, string> = {
   "/shadow-mcp/requests": "/shadow-mcp",
 };
 
-// One rendered crumb. Pending crumbs (substitution key present, value not yet
-// resolved) show a placeholder so the raw id/slug never flashes before its
-// human label arrives.
-function BreadcrumbCrumb({
-  elem,
-}: {
-  elem: {
-    url: string;
-    display: string;
-    isCurrentPage: boolean;
-    disableLink?: boolean;
-    pending?: boolean;
-  };
-}) {
-  if (elem.pending) {
-    return (
-      <span
-        aria-hidden="true"
-        className="bg-muted inline-block h-3.5 w-20 animate-pulse align-middle"
-      />
-    );
-  }
-  if (elem.isCurrentPage || elem.disableLink) {
-    return (
-      <span
-        className={elem.isCurrentPage ? undefined : "text-muted-foreground"}
-      >
-        {elem.display}
-      </span>
-    );
-  }
-  return (
-    <Link
-      to={elem.url}
-      className="text-muted-foreground hover:text-foreground trans hover:underline underline-offset-4"
-    >
-      {elem.display}
-    </Link>
-  );
-}
-
 type PageHeaderBreadcrumbsProps = {
   fullWidth?: boolean;
   className?: string;
@@ -187,7 +146,7 @@ type PageHeaderBreadcrumbsTrailProps = PageHeaderBreadcrumbsProps & {
 // those pages sit two and three levels deep with no way back up but browser
 // back. Listed by first path segment; every caller still mounts
 // <PageHeader.Breadcrumbs>, so adding a surface here is all it takes.
-const BREADCRUMB_PAGE_SLUGS = new Set(["mcp"]);
+const BREADCRUMB_PAGE_SLUGS = new Set(["mcp", "identities"]);
 
 // Whether the current page shows a breadcrumb trail. Shared by the header (to
 // give the trail its own bar) and by the breadcrumbs themselves (to render
@@ -296,13 +255,7 @@ function PageHeaderBreadcrumbsTrail({
 
   // Build full breadcrumb list: {org} > [project >] page segments
   const canAccessOrg = hasAnyScope(["org:read", "org:admin"]);
-  const visibleElements: {
-    url: string;
-    display: string;
-    isCurrentPage: boolean;
-    disableLink?: boolean;
-    pending?: boolean;
-  }[] = [];
+  const visibleElements: BreadcrumbItem[] = [];
 
   if (rootCrumbs) {
     // 1. Org name (always first; only clickable if user has org access)
@@ -338,20 +291,9 @@ function PageHeaderBreadcrumbsTrail({
       <PageHeader.Title
         className={cn(fullWidth ? "max-w-full" : "", className)}
       >
-        <div className="flex items-center gap-2 normal-case">
-          {visibleElements.map((elem, index) => (
-            <React.Fragment key={`${elem.url}-${index}`}>
-              <BreadcrumbCrumb elem={elem} />
-              {index < visibleElements.length - 1 && (
-                <ChevronRight
-                  aria-hidden="true"
-                  className="text-muted-foreground/60 size-3.5 shrink-0"
-                />
-              )}
-            </React.Fragment>
-          ))}
+        <Breadcrumb items={visibleElements}>
           {stage && <ReleaseStageBadge stage={stage} />}
-        </div>
+        </Breadcrumb>
       </PageHeader.Title>
     </div>
   );

--- a/client/dashboard/src/components/page-header.tsx
+++ b/client/dashboard/src/components/page-header.tsx
@@ -141,10 +141,11 @@ type PageHeaderBreadcrumbsTrailProps = PageHeaderBreadcrumbsProps & {
 // The renderer below is kept intact (and every caller keeps mounting
 // <PageHeader.Breadcrumbs>) so flipping this back on is a one-line change.
 // Widened to boolean so the renderer below doesn't type as unreachable.
-// MCP is the exception to the app-wide hiding above. S-853 made it the
-// inventory and nested the add flow, the catalog, and sources underneath it, so
-// those pages sit two and three levels deep with no way back up but browser
-// back. Listed by first path segment; every caller still mounts
+// The exceptions to the app-wide hiding above are the surfaces that nest: MCP
+// (S-853 made it the inventory and put the add flow, the catalog and sources
+// underneath it) and Identities (each person has their own page below the
+// roster). Those pages sit two and three levels deep with no way back up but
+// browser back. Listed by first path segment; every caller still mounts
 // <PageHeader.Breadcrumbs>, so adding a surface here is all it takes.
 const BREADCRUMB_PAGE_SLUGS = new Set(["mcp", "identities"]);
 

--- a/client/dashboard/src/components/ui/Breadcrumb/index.stories.tsx
+++ b/client/dashboard/src/components/ui/Breadcrumb/index.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MemoryRouter } from "react-router";
+import { Breadcrumb } from "./";
+
+const meta: Meta<typeof Breadcrumb> = {
+  title: "Design System/Breadcrumb",
+  component: Breadcrumb,
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Breadcrumb>;
+
+export const Default: Story = {
+  args: {
+    items: [
+      { url: "/identities", display: "Identities" },
+      {
+        url: "/identities/user",
+        display: "Dániel Kovács",
+        isCurrentPage: true,
+      },
+    ],
+  },
+};
+
+export const Pending: Story = {
+  args: {
+    items: [
+      { url: "/identities", display: "Identities" },
+      { url: "/identities/user", display: "", pending: true },
+    ],
+  },
+};
+
+export const WithoutLink: Story = {
+  args: {
+    items: [
+      { url: "/acme", display: "Acme", disableLink: true },
+      { url: "/acme/mcp", display: "MCP", isCurrentPage: true },
+    ],
+  },
+};

--- a/client/dashboard/src/components/ui/Breadcrumb/index.tsx
+++ b/client/dashboard/src/components/ui/Breadcrumb/index.tsx
@@ -1,0 +1,83 @@
+import { ChevronRight } from "lucide-react";
+import React from "react";
+import { Link } from "react-router";
+
+import { cn } from "@/lib/utils";
+
+/** One crumb in a trail. */
+export interface BreadcrumbItem {
+  /** Where the crumb links. Ignored when `isCurrentPage` or `disableLink`. */
+  url: string;
+  display: string;
+  /** The page being viewed — rendered as plain text, not a link. */
+  isCurrentPage?: boolean;
+  /** A real page the reader may not open (no scope), or no page at all. */
+  disableLink?: boolean;
+  /** Label still loading: show a placeholder rather than flash a raw id. */
+  pending?: boolean;
+}
+
+function Crumb({ item }: { item: BreadcrumbItem }): React.JSX.Element {
+  if (item.pending) {
+    return (
+      <span
+        aria-hidden="true"
+        className="bg-muted inline-block h-3.5 w-20 animate-pulse align-middle"
+      />
+    );
+  }
+  if (item.isCurrentPage || item.disableLink) {
+    return (
+      <span
+        className={item.isCurrentPage ? undefined : "text-muted-foreground"}
+      >
+        {item.display}
+      </span>
+    );
+  }
+  return (
+    <Link
+      to={item.url}
+      className="text-muted-foreground hover:text-foreground trans underline-offset-4 hover:underline"
+    >
+      {item.display}
+    </Link>
+  );
+}
+
+export interface BreadcrumbProps {
+  items: BreadcrumbItem[];
+  className?: string;
+  /** Rendered after the last crumb — e.g. a release-stage badge. */
+  children?: React.ReactNode;
+}
+
+/**
+ * A crumb trail: how the reader got to this page, and the way back up. The
+ * caller owns which segments become crumbs; this only draws them.
+ */
+export function Breadcrumb({
+  items,
+  className,
+  children,
+}: BreadcrumbProps): React.JSX.Element {
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className={cn("flex items-center gap-2 normal-case", className)}
+    >
+      {items.map((item, index) => (
+        <React.Fragment key={`${item.url}-${index}`}>
+          <Crumb item={item} />
+          {index < items.length - 1 && (
+            <ChevronRight
+              aria-hidden="true"
+              className="text-muted-foreground/60 size-3.5 shrink-0"
+            />
+          )}
+        </React.Fragment>
+      ))}
+      {children}
+    </nav>
+  );
+}

--- a/client/dashboard/src/components/ui/Breadcrumb/index.tsx
+++ b/client/dashboard/src/components/ui/Breadcrumb/index.tsx
@@ -29,6 +29,7 @@ function Crumb({ item }: { item: BreadcrumbItem }): React.JSX.Element {
   if (item.isCurrentPage || item.disableLink) {
     return (
       <span
+        aria-current={item.isCurrentPage ? "page" : undefined}
         className={item.isCurrentPage ? undefined : "text-muted-foreground"}
       >
         {item.display}

--- a/client/dashboard/src/hooks/useNavArea.test.ts
+++ b/client/dashboard/src/hooks/useNavArea.test.ts
@@ -1,0 +1,29 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const pathname = vi.hoisted(() => ({ current: "/" }));
+vi.mock("react-router", () => ({
+  useLocation: () => ({ pathname: pathname.current }),
+}));
+
+import { useNavArea } from "./useNavArea";
+
+function areaAt(path: string) {
+  pathname.current = path;
+  return renderHook(() => useNavArea()).result.current;
+}
+
+describe("useNavArea", () => {
+  // The detail page's own segment sits below the page slug, so the group the
+  // reader came from has to stay open while they are on it.
+  it.each([
+    "/org/projects/proj/identities",
+    "/org/projects/proj/identities/user%3A1/overview",
+  ])("puts %s in Observability", (path) => {
+    expect(areaAt(path)).toBe("Observability");
+  });
+
+  it("leaves ungrouped project pages without an area", () => {
+    expect(areaAt("/org/projects/proj")).toBeUndefined();
+  });
+});

--- a/client/dashboard/src/hooks/useNavArea.ts
+++ b/client/dashboard/src/hooks/useNavArea.ts
@@ -17,7 +17,7 @@ const AREA_BY_PAGE_SLUG: Record<string, NavArea> = {
   "agent-sessions": "Observability",
   "org-memory": "Observability",
   logs: "Observability",
-  employees: "Observability",
+  identities: "Observability",
   // Security and Policy
   watchdog: "Security and Policy",
   "risk-overview": "Security and Policy",

--- a/client/dashboard/src/pages/identities/IdentitiesIndex.tsx
+++ b/client/dashboard/src/pages/identities/IdentitiesIndex.tsx
@@ -12,7 +12,6 @@ import {
   PopoverTrigger,
 } from "@/components/ui/Popover";
 import { SimpleTooltip } from "@/components/ui/Tooltip";
-import { cn } from "@/lib/utils";
 import { Info } from "lucide-react";
 import {
   StatTile,
@@ -627,119 +626,125 @@ function IdentitiesIndexContent(): JSX.Element {
           : `${rows.length} of ${identities.length} — every person and agent the platform knows about, account here or not.`}
       </Page.Section.Description>
       <Page.Section.Body>
-        <StatTileGroup className="overflow-x-auto [&>*]:min-w-[11.5rem]">
-          {rosterLoading ? (
-            <>
-              <StatTileSkeleton />
-              <StatTileSkeleton />
-              <StatTileSkeleton />
-              <StatTileSkeleton />
-            </>
-          ) : (
-            <>
-              <StatTile
-                title="Identities"
-                value={identities.length}
-                displayValue={rosterUnavailable}
-                tooltip={rosterTooltip}
-                format="compact"
-                tone="neutral"
-                icon="users"
-              />
-              <StatTile
-                title="Enrolled"
-                value={counts.enrolled}
-                displayValue={rosterUnavailable}
-                tooltip={rosterTooltip}
-                format="compact"
-                tone="success"
-                icon="circle-check"
-              />
-              <StatTile
-                title="No linked account"
-                value={counts.noAccount}
-                displayValue={rosterUnavailable}
-                tooltip={rosterTooltip}
-                format="compact"
-                tone={
-                  counts.noAccount > 0 && !rosterFailed ? "warning" : "neutral"
-                }
-                icon="circle-help"
-              />
-              <StatTile
-                title="Agents"
-                value={counts.agent}
-                displayValue={rosterUnavailable}
-                tooltip={rosterTooltip}
-                format="compact"
-                tone="information"
-                icon="bot"
-              />
-            </>
-          )}
-        </StatTileGroup>
-        <Page.Toolbar>
-          <Page.Toolbar.Search
-            value={search}
-            onChange={setSearch}
-            placeholder="Search identities…"
-            debounceMs={200}
-          />
-          <Page.Toolbar.Filters
-            schema={filterSchema}
-            values={values}
-            optionsById={{
-              kind: KIND_OPTIONS,
-              enrollment: ENROLLMENT_OPTIONS,
-              activity: ACTIVITY_OPTIONS,
-              device_status: deviceStatusOptions,
-              role: roleOptions,
-              department: departmentOptions,
-              team: teamOptions,
-              account_type: ACCOUNT_TYPE_OPTIONS,
-              personal_account: PERSONAL_ACCOUNT_OPTIONS,
-            }}
-            onChange={setValue as (id: string, value: unknown) => void}
-            onClear={clearValue as (id: string) => void}
-            onClearAll={clearAll}
-          />
-        </Page.Toolbar>
-        <Table
-          columns={IDENTITY_COLUMNS}
-          data={sortedRows.slice(0, visibleCount)}
-          sort={sort}
-          onSortChange={setSort}
-          hasMore={visibleCount < sortedRows.length}
-          onLoadMore={async () => {
-            setVisibleCount((count) => count + PAGE_SIZE);
-          }}
-          rowKey={(row) => row.id}
-          onRowClick={(row) =>
-            void navigate(
-              routes.identities.detail.overview.href(
-                encodeIdentityUrn(identityUrnForEmployee(row)),
-              ),
-            )
-          }
-          noResultsMessage={
-            rosterLoading ? (
-              "Loading identities…"
-            ) : rosterFailed ? (
-              <span>
-                The identity roster could not be loaded.{" "}
-                <button
-                  type="button"
-                  onClick={retryRoster}
-                  className="underline underline-offset-2"
-                >
-                  Try again
-                </button>
-              </span>
+        {/* The section stacks its body children at 8px, which reads as one
+            block: the tiles, the controls and the table are three things. */}
+        <div className="flex flex-col gap-4">
+          <StatTileGroup className="overflow-x-auto [&>*]:min-w-[11.5rem]">
+            {rosterLoading ? (
+              <>
+                <StatTileSkeleton />
+                <StatTileSkeleton />
+                <StatTileSkeleton />
+                <StatTileSkeleton />
+              </>
             ) : (
-              "No identities match these filters"
-            )
-          }
-        />
+              <>
+                <StatTile
+                  title="Identities"
+                  value={identities.length}
+                  displayValue={rosterUnavailable}
+                  tooltip={rosterTooltip}
+                  format="compact"
+                  tone="neutral"
+                  icon="users"
+                />
+                <StatTile
+                  title="Enrolled"
+                  value={counts.enrolled}
+                  displayValue={rosterUnavailable}
+                  tooltip={rosterTooltip}
+                  format="compact"
+                  tone="success"
+                  icon="circle-check"
+                />
+                <StatTile
+                  title="No linked account"
+                  value={counts.noAccount}
+                  displayValue={rosterUnavailable}
+                  tooltip={rosterTooltip}
+                  format="compact"
+                  tone={
+                    counts.noAccount > 0 && !rosterFailed
+                      ? "warning"
+                      : "neutral"
+                  }
+                  icon="circle-help"
+                />
+                <StatTile
+                  title="Agents"
+                  value={counts.agent}
+                  displayValue={rosterUnavailable}
+                  tooltip={rosterTooltip}
+                  format="compact"
+                  tone="information"
+                  icon="bot"
+                />
+              </>
+            )}
+          </StatTileGroup>
+          <Page.Toolbar>
+            <Page.Toolbar.Search
+              value={search}
+              onChange={setSearch}
+              placeholder="Search identities…"
+              debounceMs={200}
+            />
+            <Page.Toolbar.Filters
+              schema={filterSchema}
+              values={values}
+              optionsById={{
+                kind: KIND_OPTIONS,
+                enrollment: ENROLLMENT_OPTIONS,
+                activity: ACTIVITY_OPTIONS,
+                device_status: deviceStatusOptions,
+                role: roleOptions,
+                department: departmentOptions,
+                team: teamOptions,
+                account_type: ACCOUNT_TYPE_OPTIONS,
+                personal_account: PERSONAL_ACCOUNT_OPTIONS,
+              }}
+              onChange={setValue as (id: string, value: unknown) => void}
+              onClear={clearValue as (id: string) => void}
+              onClearAll={clearAll}
+            />
+          </Page.Toolbar>
+          <Table
+            columns={IDENTITY_COLUMNS}
+            data={sortedRows.slice(0, visibleCount)}
+            sort={sort}
+            onSortChange={setSort}
+            hasMore={visibleCount < sortedRows.length}
+            onLoadMore={async () => {
+              setVisibleCount((count) => count + PAGE_SIZE);
+            }}
+            rowKey={(row) => row.id}
+            onRowClick={(row) =>
+              void navigate(
+                routes.identities.detail.overview.href(
+                  encodeIdentityUrn(identityUrnForEmployee(row)),
+                ),
+              )
+            }
+            noResultsMessage={
+              rosterLoading ? (
+                "Loading identities…"
+              ) : rosterFailed ? (
+                <span>
+                  The identity roster could not be loaded.{" "}
+                  <button
+                    type="button"
+                    onClick={retryRoster}
+                    className="underline underline-offset-2"
+                  >
+                    Try again
+                  </button>
+                </span>
+              ) : (
+                "No identities match these filters"
+              )
+            }
+          />
+        </div>
       </Page.Section.Body>
     </Page.Section>
   );
@@ -762,7 +767,6 @@ function LastActivityCell({ identity }: { identity: Employee }): JSX.Element {
   return (
     <AccountsPopover
       label={identity.lastActivity}
-      labelClassName="text-xs"
       title="Most recent account"
       accounts={[identity.mostRecentAccount]}
     />
@@ -783,7 +787,6 @@ function AccountsCell({ identity }: { identity: Employee }): JSX.Element {
   return (
     <AccountsPopover
       label={`${accounts.length} account${accounts.length === 1 ? "" : "s"}`}
-      labelClassName="text-xs"
       title="Linked accounts"
       accounts={accounts}
     />
@@ -796,12 +799,10 @@ function AccountsCell({ identity }: { identity: Employee }): JSX.Element {
  */
 function AccountsPopover({
   label,
-  labelClassName,
   title,
   accounts,
 }: {
   label: string;
-  labelClassName?: string;
   title: string;
   accounts: EmployeeAccount[];
 }): JSX.Element {
@@ -814,9 +815,8 @@ function AccountsPopover({
           onClick={(event) => event.stopPropagation()}
           className="hover:bg-muted/60 -mx-1.5 flex items-center gap-1.5 px-1.5 py-1 transition-colors"
         >
-          <span className={cn("text-muted-foreground", labelClassName)}>
-            {label}
-          </span>
+          {/* text-sm: the same size the cells that do not open a popover use. */}
+          <span className="text-muted-foreground text-sm">{label}</span>
           <Icon
             name="chevron-down"
             className="text-muted-foreground/60 size-3"


### PR DESCRIPTION
## Summary

- `useNavArea` mapped a stale `employees` page slug to Observability; the roster and its detail pages live at `identities`. Renamed the key, so the sidebar group opens and highlights on both.
- Added `identities` to `BREADCRUMB_PAGE_SLUGS`, turning on the trail the identity detail page already mounts. Detail pages sit a level below the roster with no other way back up — the same reason MCP has crumbs.
- Extracted the crumb rendering out of `page-header.tsx` into `components/ui/Breadcrumb` (crumb list, separators, link/current/disabled/pending states) with a story. `PageHeader.Breadcrumbs` keeps its segment-and-substitution logic and renders through it, so MCP's trail is unchanged.
- Roster table: the Accounts and Last activity cells that open a popover rendered at `text-xs` while the plain cells in the same columns rendered at `text-sm`, so the column changed size row to row. Both now use `text-sm`.
- Roster body: the tiles, the toolbar and the table stacked at the section's 8px, reading as one block. Wrapped them at 16px so the three read as three.

## Motivation

On an identity detail page the sidebar showed no active group at all: the group highlight is driven by the first path segment, and the slug map still named a page that no longer exists. The same segment gap also kept the breadcrumb trail hidden, leaving browser back as the only route to the roster.

The trail markup was private to `page-header.tsx`; moving it to `components/ui` lets other detail surfaces reuse it without importing the page header's routing logic.
