### PR TITLE
feat(mcp): reject unsupported protocol versions before auth

### DIFF
--- a/.changeset/reject-unsupported-mcp-protocol-versions.md
+++ b/.changeset/reject-unsupported-mcp-protocol-versions.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Reject unsupported MCP protocol versions before authentication with error code `-32022`, including the requested and supported versions so clients can retry with a compatible version.

--- a/server/internal/mcp/credential_admission_internal_test.go
+++ b/server/internal/mcp/credential_admission_internal_test.go
@@ -68,7 +68,7 @@ func TestMCPPrincipalCredentialReadmissionErrors(t *testing.T) {
 				switch caller {
 				case "hosted":
 					req := httptest.NewRequest(http.MethodPost, "/mcp/test", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`)).WithContext(ctx)
-					err = service.serveToolsetResolved(httptest.NewRecorder(), req, &toolsetsrepo.Toolset{ID: uuid.New(), ProjectID: projectID}, "test", "mcp", &hostedServing{callerGated: true}, nil, nil, nil)
+					err = service.serveToolsetResolved(httptest.NewRecorder(), req, &toolsetsrepo.Toolset{ID: uuid.New(), ProjectID: projectID}, "test", "mcp", &hostedServing{callerGated: true}, nil, nil, nil, nil)
 				case "proxy":
 					_, err = service.authorizeProxyBackendAccess(ctx, logger, projectID, &mcpserversrepo.McpServer{ID: uuid.New(), Visibility: mcpservers.VisibilityPrivate})
 				}

--- a/server/internal/mcp/hosted_killswitch_test.go
+++ b/server/internal/mcp/hosted_killswitch_test.go
@@ -59,18 +59,18 @@ func TestServePublic_HostedToolsCallKillswitch(t *testing.T) {
 
 	attachMissingRemoteSession(t, ctx, ti, *authCtx.ProjectID, authCtx.ActiveOrganizationID, issuerID)
 
-	for _, tt := range []struct {
-		name string
-		body []byte
-	}{
-		{name: "non-tools/call", body: makeToolsListBody()},
-		{name: "malformed", body: []byte(`{`)},
-	} {
-		response, err := servePublicHTTP(t, ctx, ti, endpointSlug, tt.body, userToken, sessionHeaders)
-		require.Error(t, err, tt.name)
-		require.Contains(t, err.Error(), "unauthorized", tt.name)
-		require.NotEmpty(t, response.Header().Get("WWW-Authenticate"), tt.name)
-	}
+	response, err := servePublicHTTP(t, ctx, ti, endpointSlug, makeToolsListBody(), userToken, sessionHeaders)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unauthorized")
+	require.NotEmpty(t, response.Header().Get("WWW-Authenticate"))
+
+	// Only well-formed requests can supply protocol metadata to the pre-auth
+	// version gate. Malformed input retains the endpoint's normal authentication
+	// ordering and cannot bypass credential resolution.
+	response, err = servePublicHTTP(t, ctx, ti, endpointSlug, []byte(`{`), userToken, sessionHeaders)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unauthorized")
+	require.NotEmpty(t, response.Header().Get("WWW-Authenticate"))
 
 	for _, toolName := range []string{"missing_tool", "search_tools", "describe_tools", "execute_tool"} {
 		response, err := servePublicHTTP(t, ctx, ti, endpointSlug, makeToolsCallBody(toolName), userToken, sessionHeaders)

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"mime"
 	"net/http"
@@ -55,12 +54,10 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/gateway"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/httpcache"
-	"github.com/speakeasy-api/gram/server/internal/inv"
 	"github.com/speakeasy-api/gram/server/internal/killswitches"
 	"github.com/speakeasy-api/gram/server/internal/killswitches/mcptoolexecution"
 	"github.com/speakeasy-api/gram/server/internal/mcp/httpheaders"
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
-	"github.com/speakeasy-api/gram/server/internal/mcp/mcprequests"
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
 	"github.com/speakeasy-api/gram/server/internal/mcp/sessionclientinfo"
 	"github.com/speakeasy-api/gram/server/internal/mcp/toolfilter"
@@ -884,7 +881,7 @@ func (s *Service) ServePublic(w http.ResponseWriter, r *http.Request) error {
 
 	// Legacy toolset-by-slug path has no mcp_server: hosting configuration
 	// comes entirely from the toolset columns.
-	return s.serveToolsetResolved(w, r, toolset, mcpSlug, "mcp", hostedServingFromToolset(toolset), nil, nil, nil)
+	return s.serveToolsetResolved(w, r, toolset, mcpSlug, "mcp", hostedServingFromToolset(toolset), nil, nil, nil, nil)
 }
 
 // hostedServing is the hosting configuration one toolset-backed MCP request
@@ -949,35 +946,28 @@ func hostedServingFromToolset(toolset *toolsets_repo.Toolset) *hostedServing {
 // caller-side issuer gate. Nil when the caller ran no gate or the session
 // carries no policy; the in-toolset gate below populates it for legacy-path
 // callers.
-func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, toolset *toolsets_repo.Toolset, mcpSlug, mcpRouteBase string, cfg *hostedServing, extraUpstreamTokens map[uuid.UUID]remotesessions.UpstreamToken, callerToolSelection *toolfilter.SessionSelection, pendingIssuerGate *issuerGateAuthentication) error {
+func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, toolset *toolsets_repo.Toolset, mcpSlug, mcpRouteBase string, cfg *hostedServing, extraUpstreamTokens map[uuid.UUID]remotesessions.UpstreamToken, callerToolSelection *toolfilter.SessionSelection, pendingIssuerGate *issuerGateAuthentication, prepared *preparedMCPRequest) error {
 	ctx := r.Context()
 	var err error
 
 	baseURL := s.BaseURLForRequest(r)
 
-	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
-	bodyBytes, bodyReadErr := io.ReadAll(r.Body)
-	var req rawRequest
-	var bodyDecodeErr error
-	if bodyReadErr == nil {
-		bodyDecodeErr = json.Unmarshal(bodyBytes, &req)
-		if bodyDecodeErr == nil {
-			if rpcCtx, ok := contextvalues.GetRPCContext(ctx); ok && req.ID.IsSet() {
-				rpcCtx.ID = req.ID
-			}
+	if prepared == nil {
+		var handled bool
+		prepared, handled, err = s.prepareTerminatedMCPRequest(
+			w,
+			r,
+			s.logger,
+			1<<20,
+			mcpversions.SupportedHostedToolset(),
+			mcpmetrics.SurfaceHosting,
+		)
+		if err != nil || handled {
+			return err
 		}
 	}
-
-	// Resolved the moment the declaration is readable, rather than alongside
-	// the rest of the request inputs further down, because the authorization
-	// and admission checks in between return errors of their own and each one
-	// has to be answered on the revision the client is actually speaking. The
-	// initialize handler overwrites InEffect with the negotiated answer once
-	// this reaches mcpInputs, which is the one sanctioned mutation.
-	protocolVersion := mcpversions.Resolve(mcprequests.DeclaredProtocolVersion(r.Header.Get(mcpversions.HTTPHeader), req.Params), mcpversions.SupportedHostedToolset())
-	if rpcCtx, ok := contextvalues.GetRPCContext(ctx); ok {
-		rpcCtx.ProtocolVersion = protocolVersion.InEffect
-	}
+	req := prepared.request
+	protocolVersion := prepared.protocolVersion
 
 	// Extract tokens from headers separately:
 	// - authToken: from Authorization header (for OAuth flows)
@@ -1024,7 +1014,7 @@ func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, t
 		callerToolSelection = gateToolSelection
 	}
 
-	isHostedToolsCall := bodyReadErr == nil && bodyDecodeErr == nil && req.Method == "tools/call" && cfg.mcpServerID != nil
+	isHostedToolsCall := req.Method == "tools/call" && cfg.mcpServerID != nil
 	resolvePendingIssuerGate := func() error {
 		if pendingIssuerGate == nil {
 			return nil
@@ -1144,31 +1134,13 @@ func (s *Service) serveToolsetResolved(w http.ResponseWriter, r *http.Request, t
 			}
 		}
 	}
-
-	// Decode the raw body first to check for batch requests
-	switch {
-	case errors.Is(bodyReadErr, io.EOF) || len(bodyBytes) == 0:
+	if prepared.empty() {
 		return nil
-	case bodyReadErr != nil:
-		return oops.E(oops.CodeBadRequest, bodyReadErr, "failed to read request body").LogError(ctx, s.logger)
+	}
+	if err := validateMCPRequestEnvelope(ctx, s.logger, prepared, oops.CodeBadRequest, "mcp request body exceeds 1 MiB"); err != nil {
+		return err
 	}
 
-	// Reject batch (array) requests — batch is deprecated in the MCP spec
-	if err := inv.Check("mcp request",
-		"not a batch request", len(bodyBytes) == 0 || bodyBytes[0] != '[',
-	); err != nil {
-		return oops.E(oops.CodeBadRequest, err, "batch requests are not supported").LogError(ctx, s.logger)
-	}
-
-	if bodyDecodeErr != nil {
-		// Only an unparseable body is a JSON-RPC parse error (-32700); valid
-		// JSON of the wrong shape/type stays an invalid request (-32600).
-		decodeCode := oops.CodeBadRequest
-		if !json.Valid(bodyBytes) {
-			decodeCode = oops.CodeParseError
-		}
-		return oops.E(decodeCode, bodyDecodeErr, "failed to decode request body").LogError(ctx, s.logger)
-	}
 	hostedCoverageRecorded := false
 	if isHostedToolsCall {
 		if err := s.enforceHostedToolsCall(ctx, toolset.OrganizationID, cfg.mcpServerID); err != nil {
@@ -1337,7 +1309,11 @@ func (s *Service) enforceHostedToolsCall(ctx context.Context, organizationID str
 			ID:      mcpjsonrpc.ID{Number: 0, String: ""},
 			Code:    oops.MCPCodeForbidden,
 			Message: note,
-			Data:    &oops.MCPErrorData{Code: oops.MCPErrorDataCodeToolCallsPaused},
+			Data: &oops.MCPErrorData{
+				Code:      oops.MCPErrorDataCodeToolCallsPaused,
+				Supported: nil,
+				Requested: "",
+			},
 		}
 	case killswitches.TransportDispositionInfrastructureRejection:
 		return &oops.MCPError{ID: mcpjsonrpc.ID{Number: 0, String: ""}, Code: oops.MCPCodeInternalError, Message: "", Data: nil}

--- a/server/internal/mcp/mcperror.go
+++ b/server/internal/mcp/mcperror.go
@@ -39,11 +39,16 @@ func writeMCPError(ctx context.Context, logger *slog.Logger, w http.ResponseWrit
 
 // mcpErrorHTTPStatus selects the HTTP status carrying a JSON-RPC error.
 //
-// The handshake-based revisions keep the 200 they have always been served.
-// Under them a JSON-RPC error travels in the body of a successful response,
-// and many clients on those revisions read a non-2xx as a transport failure
-// without parsing the body at all, so a status change there breaks working
-// clients to fix a problem none of them have.
+// UnsupportedProtocolVersionError is always carried by HTTP 400: the
+// unsupported declaration cannot select which revision's status rules govern
+// its own rejection, and the error exists to let the client inspect the body
+// and retry with one of the advertised versions.
+//
+// Other errors under the handshake-based revisions keep the 200 they have
+// always been served. Under them a JSON-RPC error travels in the body of a
+// successful response, and many clients on those revisions read a non-2xx as
+// a transport failure without parsing the body at all, so a status change
+// there breaks working clients to fix a problem none of them have.
 //
 // MCP 2026-07-28 instead mandates a status per condition, and the mandate is
 // load-bearing rather than cosmetic. A client that speaks both eras detects
@@ -65,6 +70,14 @@ func writeMCPError(ctx context.Context, logger *slog.Logger, w http.ResponseWrit
 // here would also put this out of step with the wrapper that answers errors
 // escaping a handler, which has no 200 to fall back to.
 func mcpErrorHTTPStatus(code oops.MCPCode, revision string) int {
+	// A protocol version outside the served set cannot govern its own error
+	// response. MCP assigns this condition HTTP 400 specifically so a client
+	// can inspect the supported set and retry with a mutually supported
+	// version, regardless of which unsupported revision it requested.
+	if code == oops.MCPCodeUnsupportedProtocolVersion {
+		return http.StatusBadRequest
+	}
+
 	if !mcpversions.AtLeast(revision, mcpversions.Version20260728) {
 		return http.StatusOK
 	}

--- a/server/internal/mcp/mcperror_internal_test.go
+++ b/server/internal/mcp/mcperror_internal_test.go
@@ -64,6 +64,22 @@ func TestMCPErrorHTTPStatus_UnresolvedRevisionKeeps200(t *testing.T) {
 	require.Equal(t, http.StatusOK, mcpErrorHTTPStatus(oops.MCPCodeMethodNotFound, "not-a-revision"))
 }
 
+func TestMCPErrorHTTPStatus_UnsupportedVersionAlwaysUsesBadRequest(t *testing.T) {
+	t.Parallel()
+
+	for _, revision := range []string{
+		"",
+		mcpversions.Version20241105,
+		mcpversions.Version20250326,
+		mcpversions.Version20250618,
+		mcpversions.Version20251125,
+		mcpversions.Version20260728,
+		"2031-01-01",
+	} {
+		require.Equal(t, http.StatusBadRequest, mcpErrorHTTPStatus(oops.MCPCodeUnsupportedProtocolVersion, revision), "revision %q", revision)
+	}
+}
+
 // TestMCPErrorHTTPStatus_UnmandatedCodesKeep200OnModernRevision guards the
 // scope of the change. The specification assigns a status to five conditions
 // and says nothing about the rest, which is most of what Gram emits; giving
@@ -123,6 +139,36 @@ func TestWriteMCPError_WritesStatusCodeAndBodyTogether(t *testing.T) {
 	require.Equal(t, "2.0", response.JSONRPC)
 	require.Equal(t, "req-1", response.ID)
 	require.Equal(t, oops.MCPCodeMethodNotFound, response.Error.Code)
+}
+
+func TestWriteMCPError_UnsupportedVersionMatchesSpecificationShape(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	supported := []string{mcpversions.Version20250326, mcpversions.Version20251125}
+	err := writeMCPError(
+		t.Context(),
+		testenv.NewLogger(t),
+		rec,
+		mcpjsonrpc.StringID("req-unsupported"),
+		mcpversions.DefaultInEffect,
+		unsupportedProtocolVersionError(mcpjsonrpc.StringID("req-unsupported"), mcpversions.Version20260728, supported),
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.JSONEq(t, `{
+		"jsonrpc":"2.0",
+		"id":"req-unsupported",
+		"error":{
+			"code":-32022,
+			"message":"Unsupported protocol version",
+			"data":{
+				"supported":["2025-03-26","2025-11-25"],
+				"requested":"2026-07-28"
+			}
+		}
+	}`, rec.Body.String())
 }
 
 // TestWriteMCPError_LegacyRevisionWritesOKWithTheSameBody is the invariant that

--- a/server/internal/mcp/mcpmetrics/metrics.go
+++ b/server/internal/mcp/mcpmetrics/metrics.go
@@ -17,6 +17,12 @@ import (
 // requests the Session OAuth authentication gate rejected before dispatch.
 const InstrumentMCPRequestRejected = "mcp.request.rejected"
 
+// InstrumentMCPProtocolVersionRejected is the OTel instrument name for the
+// counter of otherwise valid requests rejected before authentication because
+// their declared protocol revision is outside the terminating surface's
+// supported set.
+const InstrumentMCPProtocolVersionRejected = "mcp.request.protocol_version_rejected"
+
 // OAuthFlowStage is the closed set of coarse stages at which a user-facing
 // OAuth flow can terminally resolve to a non-completion outcome (failed or
 // declined). It names the handler leg where the flow ended. Kept as a bounded
@@ -74,6 +80,12 @@ type Metrics struct {
 	// resolved endpoint rather than taken from the request so an
 	// unauthenticated caller cannot mint series through the query string.
 	mcpRequestRejectedCounter metric.Int64Counter
+
+	// mcpProtocolVersionRejectedCounter partitions terminating-surface traffic
+	// with requestCensus: rejected declarations land here before authentication,
+	// while accepted declarations reach requestCensus at dispatch. Remote and
+	// tunneled proxy traffic is outside this counter by design.
+	mcpProtocolVersionRejectedCounter metric.Int64Counter
 
 	mcpToolCallCounter metric.Int64Counter
 	mcpRequestDuration metric.Float64Histogram
@@ -219,6 +231,15 @@ func NewMetrics(meter metric.Meter, logger *slog.Logger) *Metrics {
 		logger.ErrorContext(context.Background(), "failed to create metric", attr.SlogMetricName(InstrumentMCPRequestRejected), attr.SlogError(err))
 	}
 
+	mcpProtocolVersionRejectedCounter, err := meter.Int64Counter(
+		InstrumentMCPProtocolVersionRejected,
+		metric.WithDescription("MCP requests rejected before authentication because the declared protocol revision is unsupported, by revision, method, serving surface, and public/private network surface"),
+		metric.WithUnit("{request}"),
+	)
+	if err != nil {
+		logger.ErrorContext(context.Background(), "failed to create metric", attr.SlogMetricName(InstrumentMCPProtocolVersionRejected), attr.SlogError(err))
+	}
+
 	tunnelPublicRejectedCounter, err := meter.Int64Counter(
 		"mcp.tunnel_public.rejected",
 		metric.WithDescription("Anonymous public tunnel requests rejected before proxying, by MCP server and reason"),
@@ -234,6 +255,7 @@ func NewMetrics(meter metric.Meter, logger *slog.Logger) *Metrics {
 		mcpInitializeCounter:                 mcpInitializeCounter,
 		metaMemberDispatchCounter:            metaMemberDispatchCounter,
 		mcpRequestRejectedCounter:            mcpRequestRejectedCounter,
+		mcpProtocolVersionRejectedCounter:    mcpProtocolVersionRejectedCounter,
 		requestCensus:                        NewRequestCounter(meter, logger),
 		identityCoverage:                     NewIdentityCoverageCounter(meter, logger),
 		legacyFallback:                       NewLegacyFallbackCounter(meter, logger),
@@ -360,6 +382,24 @@ func (m *Metrics) RecordMCPRequest(ctx context.Context, protocolVersion, method 
 	}
 
 	m.requestCensus.Record(ctx, protocolVersion, method, surface)
+}
+
+// RecordMCPProtocolVersionRejected counts one parsed, non-initialize request
+// rejected before authentication because its declared revision is outside the
+// terminating surface's supported set. Its bounded dimensions match the
+// request census, so accepted and version-rejected traffic can be combined
+// without introducing client-controlled cardinality.
+func (m *Metrics) RecordMCPProtocolVersionRejected(ctx context.Context, protocolVersion, method string, surface Surface) {
+	if m == nil || m.mcpProtocolVersionRejectedCounter == nil {
+		return
+	}
+
+	m.mcpProtocolVersionRejectedCounter.Add(ctx, 1, metric.WithAttributes(
+		attr.MCPNegotiatedProtocolVersion(mcpversions.Clamp(mcpversions.Sanitize(protocolVersion))),
+		attr.McpMethod(mcprequests.ClampMethod(method)),
+		attr.McpSurface(string(surface)),
+		attr.NetworkSurface(NetworkSurfaceFromContext(ctx)),
+	))
 }
 
 // RecordMCPRequestRejected counts one MCP request the Session OAuth

--- a/server/internal/mcp/mcpmetrics/metrics_test.go
+++ b/server/internal/mcp/mcpmetrics/metrics_test.go
@@ -30,6 +30,7 @@ func TestNewMetrics(t *testing.T) {
 		require.NotNil(t, m)
 		require.NotNil(t, m.mcpToolCallCounter)
 		require.NotNil(t, m.mcpRequestDuration)
+		require.NotNil(t, m.mcpProtocolVersionRejectedCounter)
 		require.NotNil(t, m.identityCoverage)
 	})
 }
@@ -195,6 +196,50 @@ func TestMetricsRecordMCPRequest_ForwardsToCensus(t *testing.T) {
 
 	var nilMetrics *Metrics
 	nilMetrics.RecordMCPRequest(t.Context(), mcpversions.Version20260728, "tools/list", SurfaceHosting)
+}
+
+func TestRecordMCPProtocolVersionRejected_PinsInstrumentAndDimensions(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	meter := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)).Meter("test")
+
+	m := NewMetrics(meter, testenv.NewLogger(t))
+	m.RecordMCPProtocolVersionRejected(t.Context(), mcpversions.Version20260728, "tools/list", SurfaceMeta)
+
+	got := collectMetric(t, reader, InstrumentMCPProtocolVersionRejected)
+	metricdatatest.AssertHasAttributes(t, got,
+		attr.MCPNegotiatedProtocolVersion(mcpversions.Version20260728),
+		attr.McpMethod("tools/list"),
+		attr.McpSurface(string(SurfaceMeta)),
+		attr.NetworkSurface(NetworkSurfacePublic),
+	)
+
+	sum, ok := got.Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	require.Len(t, sum.DataPoints, 1)
+	require.Equal(t, int64(1), sum.DataPoints[0].Value)
+}
+
+func TestRecordMCPProtocolVersionRejected_ClampsAndIsNilSafe(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	meter := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)).Meter("test")
+	m := NewMetrics(meter, testenv.NewLogger(t))
+	m.RecordMCPProtocolVersionRejected(t.Context(), "2031-01-01", "extension/unbounded", SurfaceHosting)
+
+	metricdatatest.AssertHasAttributes(t, collectMetric(t, reader, InstrumentMCPProtocolVersionRejected),
+		attr.MCPNegotiatedProtocolVersion(mcpversions.Other),
+		attr.McpMethod(mcprequests.MethodOther),
+		attr.McpSurface(string(SurfaceHosting)),
+		attr.NetworkSurface(NetworkSurfacePublic),
+	)
+
+	var nilMetrics *Metrics
+	nilMetrics.RecordMCPProtocolVersionRejected(t.Context(), mcpversions.Version20260728, "tools/list", SurfaceHosting)
+	empty := &Metrics{}
+	empty.RecordMCPProtocolVersionRejected(t.Context(), mcpversions.Version20260728, "tools/list", SurfaceHosting)
 }
 
 // TestRequestCounterRecord_PinsInstrumentAndDimensions pins the census wiring

--- a/server/internal/mcp/mcpversions/mcpversions.go
+++ b/server/internal/mcp/mcpversions/mcpversions.go
@@ -23,13 +23,13 @@ const (
 )
 
 // DefaultInEffect is the revision put in effect when no usable version can be
-// taken from the request: a request that names no version at all, and a
-// per-request declaration outside the surface's supported set. The 2026-07-28
-// specification sanctions exactly this value for the first case — a server
-// supporting pre-2025-06-18 clients MAY treat a request that omits the
-// version header as 2025-03-26 — and the second case deliberately reuses it:
-// defaulting downward over-serves rather than wrongly rejecting, which is the
-// safe direction for both cohorts.
+// taken from the request: a request that names no version at all, or the
+// provisional resolution of a declaration outside the surface's supported
+// set before the serving layer rejects it. The 2026-07-28 specification
+// sanctions exactly this value for the first case — a server supporting
+// pre-2025-06-18 clients MAY treat a request that omits the version header as
+// 2025-03-26. The second case needs a stable revision only to encode the
+// UnsupportedProtocolVersionError that prevents the request from dispatching.
 const DefaultInEffect = Version20250326
 
 // The protocol revisions each Gram surface that terminates an MCP session
@@ -126,9 +126,11 @@ type Resolution struct {
 	// clamp it themselves so absent and unknown declarations stay countable.
 	Declared string
 
-	// InEffect is the revision governing the request: Declared when the
-	// surface supports it, otherwise [DefaultInEffect]. Never empty.
-	// Version-conditional behavior branches on this value and nothing else.
+	// InEffect is the revision governing an accepted request: Declared when the
+	// surface supports it, otherwise [DefaultInEffect]. In the unsupported case
+	// it provisionally selects legacy-safe error mappings while the serving
+	// layer returns -32022; the request never reaches version-conditional
+	// behavior or dispatch. Never empty.
 	//
 	// For an `initialize` request the entry-time value is provisional — a
 	// conforming handshake declares no version, so it starts at the default —
@@ -141,11 +143,10 @@ type Resolution struct {
 
 // Resolve computes the [Resolution] for a request that declared declared (raw
 // client input; bounded by [Sanitize] here) against a surface's supported
-// set. A declared revision outside the set resolves to [DefaultInEffect],
-// deliberately over-serving downward instead of rejecting; replacing that arm
-// with the spec's UnsupportedProtocolVersionError (-32022) is separate,
-// planned work, so callers must not treat the fallback as a permanent
-// contract.
+// set. A declared revision outside the set resolves provisionally to
+// [DefaultInEffect]; terminating request surfaces reject that declaration with
+// UnsupportedProtocolVersionError (-32022) before dispatch, initialize uses
+// [Negotiate], and remote proxy surfaces do not resolve it at all.
 func Resolve(declared string, supported []string) Resolution {
 	declared = Sanitize(declared)
 	inEffect := DefaultInEffect

--- a/server/internal/mcp/protocolversion_gate.go
+++ b/server/internal/mcp/protocolversion_gate.go
@@ -1,0 +1,174 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"slices"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcprequests"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
+	"github.com/speakeasy-api/gram/server/internal/mcpjsonrpc"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+// preparedMCPRequest carries the single bounded body read and JSON decode
+// across authentication and dispatch. It lets terminating surfaces validate
+// protocol metadata before authentication without consuming the body twice.
+type preparedMCPRequest struct {
+	body            []byte
+	bodyReadErr     error
+	bodyDecodeErr   error
+	request         rawRequest
+	protocolVersion mcpversions.Resolution
+}
+
+func prepareMCPRequest(w http.ResponseWriter, r *http.Request, maxBodyBytes int64, supported []string) *preparedMCPRequest {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	body, bodyReadErr := io.ReadAll(r.Body)
+
+	var req rawRequest
+	var bodyDecodeErr error
+	if bodyReadErr == nil {
+		bodyDecodeErr = json.Unmarshal(body, &req)
+		if bodyDecodeErr == nil {
+			if rpcCtx, ok := contextvalues.GetRPCContext(r.Context()); ok && req.ID.IsSet() {
+				rpcCtx.ID = req.ID
+			}
+		}
+	}
+
+	protocolVersion := mcpversions.Resolve(
+		mcprequests.DeclaredProtocolVersion(r.Header.Get(mcpversions.HTTPHeader), req.Params),
+		supported,
+	)
+	if rpcCtx, ok := contextvalues.GetRPCContext(r.Context()); ok {
+		rpcCtx.ProtocolVersion = protocolVersion.InEffect
+	}
+
+	return &preparedMCPRequest{
+		body:            body,
+		bodyReadErr:     bodyReadErr,
+		bodyDecodeErr:   bodyDecodeErr,
+		request:         req,
+		protocolVersion: protocolVersion,
+	}
+}
+
+func (p *preparedMCPRequest) empty() bool {
+	return len(p.body) == 0 && (p.bodyReadErr == nil || errors.Is(p.bodyReadErr, io.EOF))
+}
+
+// readyForProtocolVersionValidation limits the pre-authentication gate to
+// complete JSON-RPC request envelopes. Authentication retains precedence for
+// empty, unreadable, malformed, and otherwise invalid envelopes.
+func (p *preparedMCPRequest) readyForProtocolVersionValidation() bool {
+	return !p.empty() && p.bodyReadErr == nil && p.bodyDecodeErr == nil && p.request.JSONRPC == "2.0"
+}
+
+// validateMCPRequestEnvelope applies the shared transport and JSON-RPC shape
+// checks needed before a declaration can be trusted as request metadata.
+func validateMCPRequestEnvelope(ctx context.Context, logger *slog.Logger, p *preparedMCPRequest, bodyTooLargeCode oops.Code, bodyTooLargeMessage string) error {
+	var maxBytesErr *http.MaxBytesError
+	switch {
+	case errors.As(p.bodyReadErr, &maxBytesErr):
+		return oops.E(bodyTooLargeCode, p.bodyReadErr, "%s", bodyTooLargeMessage).LogError(ctx, logger)
+	case p.bodyReadErr != nil:
+		return oops.E(oops.CodeBadRequest, p.bodyReadErr, "failed to read request body").LogError(ctx, logger)
+	case p.bodyDecodeErr != nil && !json.Valid(p.body):
+		return oops.E(oops.CodeParseError, p.bodyDecodeErr, "failed to decode request body").LogError(ctx, logger)
+	case len(p.body) > 0 && p.body[0] == '[':
+		return oops.E(oops.CodeBadRequest, nil, "batch requests are not supported").LogError(ctx, logger)
+	case p.bodyDecodeErr != nil:
+		return oops.E(oops.CodeBadRequest, p.bodyDecodeErr, "failed to decode request body").LogError(ctx, logger)
+	case p.request.JSONRPC != "2.0":
+		return oops.E(oops.CodeBadRequest, errInvalidJSONRPCVersion, "unsupported JSON-RPC version").LogError(ctx, logger)
+	default:
+		return nil
+	}
+}
+
+func validateSupportedProtocolVersion(req *rawRequest, resolution mcpversions.Resolution, supported []string) error {
+	if req.Method == "initialize" || resolution.Declared == "" || slices.Contains(supported, resolution.Declared) {
+		return nil
+	}
+
+	return unsupportedProtocolVersionError(req.ID, resolution.Declared, supported)
+}
+
+func (s *Service) prepareTerminatedMCPRequest(
+	w http.ResponseWriter,
+	r *http.Request,
+	logger *slog.Logger,
+	maxBodyBytes int64,
+	supported []string,
+	surface mcpmetrics.Surface,
+) (*preparedMCPRequest, bool, error) {
+	prepared := prepareMCPRequest(w, r, maxBodyBytes, supported)
+	if !prepared.readyForProtocolVersionValidation() {
+		return prepared, false, nil
+	}
+
+	handled, err := s.handleProtocolVersionValidation(
+		r.Context(),
+		logger,
+		w,
+		&prepared.request,
+		prepared.protocolVersion,
+		surface,
+		validateSupportedProtocolVersion(&prepared.request, prepared.protocolVersion, supported),
+	)
+	if handled || err != nil {
+		return nil, handled, err
+	}
+
+	return prepared, false, nil
+}
+
+func unsupportedProtocolVersionError(id mcpjsonrpc.ID, requested string, supported []string) *oops.MCPError {
+	return &oops.MCPError{
+		ID:      id,
+		Code:    oops.MCPCodeUnsupportedProtocolVersion,
+		Message: oops.MCPCodeUnsupportedProtocolVersion.Message(),
+		Data: &oops.MCPErrorData{
+			Code:      "",
+			Supported: slices.Clone(supported),
+			Requested: requested,
+		},
+	}
+}
+
+// handleProtocolVersionValidation writes a validation failure before
+// authentication. Notifications are acknowledged without a JSON-RPC body and
+// are not dispatched. Only genuine unsupported-version failures contribute to
+// the rejection census; malformed and conflicting meta declarations retain
+// their existing invalid-request behavior.
+func (s *Service) handleProtocolVersionValidation(
+	ctx context.Context,
+	logger *slog.Logger,
+	w http.ResponseWriter,
+	req *rawRequest,
+	resolution mcpversions.Resolution,
+	surface mcpmetrics.Surface,
+	validationErr error,
+) (bool, error) {
+	if validationErr == nil {
+		return false, nil
+	}
+
+	var mcpErr *oops.MCPError
+	if errors.As(validationErr, &mcpErr) && mcpErr.Code == oops.MCPCodeUnsupportedProtocolVersion {
+		s.metrics.RecordMCPProtocolVersionRejected(ctx, resolution.Declared, req.Method, surface)
+	}
+
+	if !req.ID.IsSet() {
+		return true, respondWithNoContent(true, w)
+	}
+
+	return true, writeMCPError(ctx, logger, w, req.ID, resolution.InEffect, validationErr)
+}

--- a/server/internal/mcp/protocolversion_gate_internal_test.go
+++ b/server/internal/mcp/protocolversion_gate_internal_test.go
@@ -1,0 +1,59 @@
+package mcp
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+type failingRequestBody struct {
+	err error
+}
+
+func (b failingRequestBody) Read([]byte) (int, error) {
+	return 0, b.err
+}
+
+func (failingRequestBody) Close() error {
+	return nil
+}
+
+func TestPreparedMCPRequest_ZeroByteReadErrorIsNotEmpty(t *testing.T) {
+	t.Parallel()
+
+	readErr := errors.New("read failed")
+	req := httptest.NewRequest(http.MethodPost, "/mcp/test", nil)
+	req.Body = failingRequestBody{err: readErr}
+	prepared := prepareMCPRequest(httptest.NewRecorder(), req, 1<<20, mcpversions.SupportedHostedToolset())
+
+	require.False(t, prepared.empty())
+	err := validateMCPRequestEnvelope(t.Context(), testenv.NewLogger(t), prepared, oops.CodeBadRequest, "body too large")
+	require.Error(t, err)
+	require.ErrorIs(t, err, readErr)
+
+	var shareable *oops.ShareableError
+	require.ErrorAs(t, err, &shareable)
+	require.Equal(t, oops.CodeBadRequest, shareable.Code)
+}
+
+func TestValidateMCPRequestEnvelope_MalformedArrayIsParseError(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp/test", strings.NewReader("["))
+	prepared := prepareMCPRequest(httptest.NewRecorder(), req, 1<<20, mcpversions.SupportedHostedToolset())
+
+	err := validateMCPRequestEnvelope(t.Context(), testenv.NewLogger(t), prepared, oops.CodeBadRequest, "body too large")
+	require.Error(t, err)
+
+	var shareable *oops.ShareableError
+	require.ErrorAs(t, err, &shareable)
+	require.Equal(t, oops.CodeParseError, shareable.Code)
+}

--- a/server/internal/mcp/protocolversion_rejected_metric_test.go
+++ b/server/internal/mcp/protocolversion_rejected_metric_test.go
@@ -1,0 +1,52 @@
+package mcp_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
+	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+)
+
+func TestServePublic_UnsupportedVersionCountsRejectionWithoutDispatch(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	ctx, ti := newTestMCPServiceWithMeterProvider(t, sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsetsrepo.New(ti.conn), authCtx, "unsupported-version-metric")
+	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, toolsListBody(), "", map[string]string{
+		mcpversions.HTTPHeader: mcpversions.Version20260728,
+	})
+	require.NoError(t, err)
+	requireUnsupportedProtocolVersionResponse(t, w, mcpversions.Version20260728, mcpversions.SupportedHostedToolset())
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	var rejected, dispatched int64
+	for _, scope := range rm.ScopeMetrics {
+		for _, observed := range scope.Metrics {
+			sum, ok := observed.Data.(metricdata.Sum[int64])
+			if !ok {
+				continue
+			}
+			for _, point := range sum.DataPoints {
+				switch observed.Name {
+				case mcpmetrics.InstrumentMCPProtocolVersionRejected:
+					rejected += point.Value
+				case mcpmetrics.InstrumentMCPRequest:
+					dispatched += point.Value
+				}
+			}
+		}
+	}
+	require.Equal(t, int64(1), rejected)
+	require.Zero(t, dispatched, "a version-rejected request must not enter the dispatch census")
+}

--- a/server/internal/mcp/serve_meta.go
+++ b/server/internal/mcp/serve_meta.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"slices"
@@ -80,6 +79,47 @@ func (s *Service) serveResolvedMetaMCPEndpoint(
 	supportedMeta := mcpversions.SupportedMetaServer()
 	w.Header().Set(mcpversions.HTTPHeader, supportedMeta[len(supportedMeta)-1])
 
+	prepared := prepareMCPRequest(w, r, metamcp.MaxBodyBytes, supportedMeta)
+
+	req := prepared.request
+	resolution := prepared.protocolVersion
+	if req.Method == "initialize" {
+		// A conforming initialize declares nothing, so Resolve lands on the
+		// default; the negotiated answer is what actually governs the
+		// exchange (the write-back Resolution sanctions).
+		params, _, _ := parseInitializeParams(req.Params)
+		resolution.InEffect = mcpversions.Negotiate(params.ProtocolVersion, supportedMeta)
+	}
+	// Both halves the error wrapper needs, published together: an error
+	// escaping this handler has to echo the id the client sent and be encoded
+	// on the revision governing the request. Publishing only one leaves the
+	// wrapper answering with a modern wire code under a null id.
+	if rpcCtx, ok := contextvalues.GetRPCContext(ctx); ok {
+		rpcCtx.ProtocolVersion = resolution.InEffect
+		if req.ID.IsSet() {
+			rpcCtx.ID = req.ID
+		}
+	}
+
+	if prepared.readyForProtocolVersionValidation() {
+		validationErr := validateMetaDeclaredProtocolVersion(&req, r.Header.Get(mcpversions.HTTPHeader))
+		if validationErr != nil {
+			w.Header().Set(mcpversions.HTTPHeader, resolution.InEffect)
+		}
+		handled, err := s.handleProtocolVersionValidation(
+			ctx,
+			logger,
+			w,
+			&req,
+			resolution,
+			mcpmetrics.SurfaceMeta,
+			validationErr,
+		)
+		if err != nil || handled {
+			return err
+		}
+	}
+
 	var gateTokens map[uuid.UUID]remotesessions.UpstreamToken
 	var gateToolSelection *toolfilter.SessionSelection
 	if metaServer.UserSessionIssuerID.Valid {
@@ -96,57 +136,13 @@ func (s *Service) serveResolvedMetaMCPEndpoint(
 		gateTokens = tokens
 		gateToolSelection = toolSelection
 	}
-
-	r.Body = http.MaxBytesReader(w, r.Body, metamcp.MaxBodyBytes)
-
-	bodyBytes, err := io.ReadAll(r.Body)
-	var maxBytesErr *http.MaxBytesError
-	switch {
-	case errors.Is(err, io.EOF) || len(bodyBytes) == 0:
+	if prepared.empty() {
 		return nil
-	case errors.As(err, &maxBytesErr):
-		return oops.E(oops.CodeRequestTooLarge, err, "meta mcp request body exceeds 1 MiB").LogError(ctx, logger)
-	case err != nil:
-		return oops.E(oops.CodeBadRequest, err, "failed to read request body").LogError(ctx, logger)
 	}
-
-	if bodyBytes[0] == '[' {
-		return oops.E(oops.CodeBadRequest, nil, "batch requests are not supported").LogError(ctx, logger)
-	}
-
-	var req rawRequest
-	if err := json.Unmarshal(bodyBytes, &req); err != nil {
-		// Only an unparseable body is a JSON-RPC parse error (-32700); valid
-		// JSON of the wrong shape/type stays an invalid request (-32600).
-		code := oops.CodeBadRequest
-		if !json.Valid(bodyBytes) {
-			code = oops.CodeParseError
-		}
-		return oops.E(code, err, "failed to decode request body").LogError(ctx, logger)
-	}
-	if req.JSONRPC != "2.0" {
-		return oops.E(oops.CodeBadRequest, errInvalidJSONRPCVersion, "unsupported JSON-RPC version").LogError(ctx, logger)
-	}
-
-	resolution := mcpversions.Resolve(mcprequests.DeclaredProtocolVersion(r.Header.Get(mcpversions.HTTPHeader), req.Params), supportedMeta)
-	if req.Method == "initialize" {
-		// A conforming initialize declares nothing, so Resolve lands on the
-		// default; the negotiated answer is what actually governs the
-		// exchange (the write-back Resolution sanctions).
-		params, _, _ := parseInitializeParams(req.Params)
-		resolution.InEffect = mcpversions.Negotiate(params.ProtocolVersion, supportedMeta)
+	if err := validateMCPRequestEnvelope(ctx, logger, prepared, oops.CodeRequestTooLarge, "meta mcp request body exceeds 1 MiB"); err != nil {
+		return err
 	}
 	w.Header().Set(mcpversions.HTTPHeader, resolution.InEffect)
-	// Both halves the error wrapper needs, published together: an error
-	// escaping this handler has to echo the id the client sent and be encoded
-	// on the revision governing the request. Publishing only one leaves the
-	// wrapper answering with a modern wire code under a null id.
-	if rpcCtx, ok := contextvalues.GetRPCContext(ctx); ok {
-		rpcCtx.ProtocolVersion = resolution.InEffect
-		if req.ID.IsSet() {
-			rpcCtx.ID = req.ID
-		}
-	}
 
 	gate := &metaGateContext{
 		projectID:      mcpEndpoint.ProjectID,
@@ -224,15 +220,6 @@ func (s *Service) handleMetaMCPRequest(
 		}()
 	}
 
-	if err := validateMetaDeclaredProtocolVersion(req, protocolVersionHeader); err != nil {
-		if !req.ID.IsSet() {
-			// JSON-RPC 2.0 forbids responding to notifications, even with an
-			// error: a notification carrying a bad declaration is dropped.
-			return nil, nil
-		}
-		return nil, err
-	}
-
 	switch req.Method {
 	case "ping":
 		return handlePing(ctx, logger, req.ID, serverInfoMetaServer)
@@ -272,6 +259,10 @@ const metaProtocolVersionMetaKey = "io.modelcontextprotocol/protocolVersion"
 // unsanitizable (or not a string at all) is a malformed value, not an
 // absent one.
 func validateMetaDeclaredProtocolVersion(req *rawRequest, headerValue string) error {
+	if req.Method == "initialize" {
+		return nil
+	}
+
 	headerDeclared := strings.TrimSpace(headerValue) != ""
 	headerVersion := mcpversions.Sanitize(headerValue)
 
@@ -291,17 +282,17 @@ func validateMetaDeclaredProtocolVersion(req *rawRequest, headerValue string) er
 		if err := json.Unmarshal(raw, &metaRaw); err != nil {
 			// Present but not a string: a malformed declaration. JSON null
 			// decodes as a no-op and stays "absent".
-			return unsupportedMetaProtocolVersionError(req, unparseableVersionPlaceholder)
+			return invalidMetaProtocolVersionError(req, unparseableVersionPlaceholder)
 		}
 	}
 	metaDeclared := strings.TrimSpace(metaRaw) != ""
 	metaVersion := mcpversions.Sanitize(metaRaw)
 
 	if headerDeclared && headerVersion == "" {
-		return unsupportedMetaProtocolVersionError(req, unparseableVersionPlaceholder)
+		return invalidMetaProtocolVersionError(req, unparseableVersionPlaceholder)
 	}
 	if metaDeclared && metaVersion == "" {
-		return unsupportedMetaProtocolVersionError(req, unparseableVersionPlaceholder)
+		return invalidMetaProtocolVersionError(req, unparseableVersionPlaceholder)
 	}
 
 	if headerDeclared && metaDeclared && headerVersion != metaVersion {
@@ -315,22 +306,21 @@ func validateMetaDeclaredProtocolVersion(req *rawRequest, headerValue string) er
 
 	declared := conv.Default(headerVersion, metaVersion)
 	if declared != "" && !slices.Contains(mcpversions.SupportedMetaServer(), declared) {
-		return unsupportedMetaProtocolVersionError(req, declared)
+		return unsupportedProtocolVersionError(req.ID, declared, mcpversions.SupportedMetaServer())
 	}
 
 	return nil
 }
 
-// unsupportedMetaProtocolVersionError is the structured error for a declared
-// protocol version this surface does not serve. The named set is the served
-// set — exactly [mcpversions.SupportedMetaServer], matching what
-// server/discover advertises — not the wider set of recognized revisions.
-// declared must be sanitized (or a placeholder) — it is echoed to the client.
-func unsupportedMetaProtocolVersionError(req *rawRequest, declared string) *oops.MCPError {
+// invalidMetaProtocolVersionError preserves the meta surface's malformed
+// declaration behavior separately from a well-formed but unsupported version.
+// declared must be sanitized or the fixed placeholder; raw hostile bytes are
+// never echoed to the client.
+func invalidMetaProtocolVersionError(req *rawRequest, declared string) *oops.MCPError {
 	return &oops.MCPError{
 		ID:      req.ID,
 		Code:    oops.MCPCodeInvalidRequest,
-		Message: fmt.Sprintf("unsupported protocol version %q; supported versions: %s", declared, strings.Join(mcpversions.SupportedMetaServer(), ", ")),
+		Message: fmt.Sprintf("invalid protocol version declaration %q; supported versions: %s", declared, strings.Join(mcpversions.SupportedMetaServer(), ", ")),
 		Data:    nil,
 	}
 }

--- a/server/internal/mcp/serve_meta_test.go
+++ b/server/internal/mcp/serve_meta_test.go
@@ -343,12 +343,8 @@ func TestServePublic_MetaEndpoint_UnsupportedDeclaredVersion(t *testing.T) {
 		mcpversions.HTTPHeader: "2031-01-01",
 	})
 	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, w.Code)
 	require.Equal(t, mcpversions.DefaultInEffect, w.Header().Get(mcpversions.HTTPHeader))
-
-	envelope := decodeRPCResponse(t, w)
-	require.Contains(t, string(envelope["error"]), "unsupported protocol version")
-	require.Contains(t, string(envelope["error"]), mcpversions.Version20251125)
+	requireUnsupportedProtocolVersionResponse(t, w, "2031-01-01", mcpversions.SupportedMetaServer())
 }
 
 // TestServePublic_MetaEndpoint_OlderKnownDeclaredVersionAccepted pins the
@@ -391,16 +387,14 @@ func TestServePublic_MetaEndpoint_OlderKnownDeclaredVersionAccepted(t *testing.T
 		mcpversions.HTTPHeader: mcpversions.Version20260728,
 	})
 	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, w.Code)
-	envelope = decodeRPCResponse(t, w)
-	require.Contains(t, string(envelope["error"]), "unsupported protocol version")
+	requireUnsupportedProtocolVersionResponse(t, w, mcpversions.Version20260728, mcpversions.SupportedMetaServer())
 }
 
 // TestServePublic_MetaEndpoint_UnsanitizableDeclaredVersion pins that a
 // declared version that fails sanitization (here: an embedded control byte)
-// is treated as a malformed declaration — the structured unsupported-version
-// error — rather than silently collapsing to "absent", and that the hostile
-// raw bytes are never echoed back.
+// is treated as a malformed declaration — an invalid-request error rather
+// than UnsupportedProtocolVersionError — and that the hostile raw bytes are
+// never echoed back.
 func TestServePublic_MetaEndpoint_UnsanitizableDeclaredVersion(t *testing.T) {
 	t.Parallel()
 
@@ -420,15 +414,21 @@ func TestServePublic_MetaEndpoint_UnsanitizableDeclaredVersion(t *testing.T) {
 	require.Equal(t, mcpversions.DefaultInEffect, w.Header().Get(mcpversions.HTTPHeader))
 
 	envelope := decodeRPCResponse(t, w)
-	require.Contains(t, string(envelope["error"]), "unsupported protocol version")
+	require.Contains(t, string(envelope["error"]), "invalid protocol version declaration")
 	require.Contains(t, string(envelope["error"]), "(unparseable)")
 	require.NotContains(t, w.Body.String(), "hostile", "raw declaration bytes must not be echoed")
+	var errorBody struct {
+		Code oops.MCPCode `json:"code"`
+	}
+	require.NoError(t, json.Unmarshal(envelope["error"], &errorBody))
+	require.Equal(t, oops.MCPCodeInvalidRequest, errorBody.Code)
 }
 
 // TestServePublic_MetaEndpoint_MistypedMetaVersionDeclaration pins that a
 // `_meta` protocol-version member that is present but not a string is a
-// malformed declaration — the structured unsupported-version error — rather
-// than silently collapsing to "absent".
+// malformed declaration — an invalid-request error rather than
+// UnsupportedProtocolVersionError — instead of silently collapsing to
+// "absent".
 func TestServePublic_MetaEndpoint_MistypedMetaVersionDeclaration(t *testing.T) {
 	t.Parallel()
 
@@ -449,7 +449,7 @@ func TestServePublic_MetaEndpoint_MistypedMetaVersionDeclaration(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 
 	envelope := decodeRPCResponse(t, w)
-	require.Contains(t, string(envelope["error"]), "unsupported protocol version")
+	require.Contains(t, string(envelope["error"]), "invalid protocol version declaration")
 	require.Contains(t, string(envelope["error"]), "(unparseable)")
 }
 
@@ -502,6 +502,45 @@ func TestServePublic_MetaEndpoint_IssuerGated_NoAuth_EmitsChallenge(t *testing.T
 	// The provisional version header (the surface's newest revision) is
 	// stamped before the issuer gate can bail out.
 	require.Equal(t, mcpversions.Version20251125, w.Header().Get(mcpversions.HTTPHeader))
+}
+
+func TestServePublic_MetaEndpoint_IssuerGated_EmptyBodyRequiresAuthentication(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	slug := "meta-" + uuid.NewString()
+	issuerID := createUserSessionIssuer(t, ctx, ti.conn, *authCtx.ProjectID)
+	createMetaMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, authCtx.ActiveOrganizationID, slug, issuerID)
+
+	w, err := servePublicHTTP(t, t.Context(), ti, slug, nil, "", nil)
+	require.Error(t, err)
+	require.NotEmpty(t, w.Header().Get("WWW-Authenticate"))
+
+	var shareable *oops.ShareableError
+	require.ErrorAs(t, err, &shareable)
+	require.Equal(t, oops.CodeUnauthorized, shareable.Code)
+}
+
+func TestServePublic_MetaEndpoint_UnsupportedVersionPrecedesIssuerAuthentication(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	slug := "meta-" + uuid.NewString()
+	issuerID := createUserSessionIssuer(t, ctx, ti.conn, *authCtx.ProjectID)
+	createMetaMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, authCtx.ActiveOrganizationID, slug, issuerID)
+
+	w, err := servePublicHTTP(t, t.Context(), ti, slug, makeMetaRPCBody(t, "tools/list", map[string]any{}), "", map[string]string{
+		mcpversions.HTTPHeader: mcpversions.Version20260728,
+	})
+	require.NoError(t, err)
+	requireUnsupportedProtocolVersionResponse(t, w, mcpversions.Version20260728, mcpversions.SupportedMetaServer())
+	require.Empty(t, w.Header().Get("WWW-Authenticate"))
 }
 
 func TestServeMCPEndpoint_MetaEndpoint_NoXmcpExposure(t *testing.T) {

--- a/server/internal/mcp/serve_platform.go
+++ b/server/internal/mcp/serve_platform.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"time"
@@ -23,7 +22,6 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/gateway"
 	"github.com/speakeasy-api/gram/server/internal/mcp/httpheaders"
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
-	"github.com/speakeasy-api/gram/server/internal/mcp/mcprequests"
 	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
 	"github.com/speakeasy-api/gram/server/internal/metering"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
@@ -57,6 +55,18 @@ func (s *Service) ServePlatformToolset(w http.ResponseWriter, r *http.Request) e
 		return oops.E(oops.CodeNotFound, nil, "platform toolset not found")
 	}
 
+	prepared, handled, err := s.prepareTerminatedMCPRequest(
+		w,
+		r,
+		s.logger,
+		platformToolsetMaxBodyBytes,
+		mcpversions.SupportedPlatformToolset(),
+		mcpmetrics.SurfacePlatform,
+	)
+	if err != nil || handled {
+		return err
+	}
+
 	token := httpheaders.AuthorizationBearerToken(r)
 	if token == "" {
 		return oops.C(oops.CodeUnauthorized)
@@ -78,41 +88,15 @@ func (s *Service) ServePlatformToolset(w http.ResponseWriter, r *http.Request) e
 	if err := s.authorizePlatformToolset(ctx, slug, authCtx); err != nil {
 		return err
 	}
-
-	r.Body = http.MaxBytesReader(w, r.Body, platformToolsetMaxBodyBytes)
-
-	bodyBytes, err := io.ReadAll(r.Body)
-	var maxBytesErr *http.MaxBytesError
-	switch {
-	case errors.Is(err, io.EOF) || len(bodyBytes) == 0:
+	if prepared.empty() {
 		return nil
-	case errors.As(err, &maxBytesErr):
-		return oops.E(oops.CodeRequestTooLarge, err, "platform toolset request body exceeds 1 MiB").LogError(ctx, s.logger)
-	case err != nil:
-		return oops.E(oops.CodeBadRequest, err, "failed to read request body").LogError(ctx, s.logger)
+	}
+	if err := validateMCPRequestEnvelope(ctx, s.logger, prepared, oops.CodeRequestTooLarge, "platform toolset request body exceeds 1 MiB"); err != nil {
+		return err
 	}
 
-	if len(bodyBytes) > 0 && bodyBytes[0] == '[' {
-		return oops.E(oops.CodeBadRequest, nil, "batch requests are not supported").LogError(ctx, s.logger)
-	}
-
-	var req rawRequest
-	if err := json.Unmarshal(bodyBytes, &req); err != nil {
-		// Only an unparseable body is a JSON-RPC parse error (-32700); valid
-		// JSON of the wrong shape/type stays an invalid request (-32600).
-		code := oops.CodeBadRequest
-		if !json.Valid(bodyBytes) {
-			code = oops.CodeParseError
-		}
-		return oops.E(code, err, "failed to decode request body").LogError(ctx, s.logger)
-	}
-	if req.JSONRPC != "2.0" {
-		return oops.E(oops.CodeBadRequest, errInvalidJSONRPCVersion, "unsupported JSON-RPC version").LogError(ctx, s.logger)
-	}
-
-	// Resolved once per request; the initialize handler overwrites InEffect
-	// with the negotiated answer, which is the one sanctioned mutation.
-	protocolVersion := mcpversions.Resolve(mcprequests.DeclaredProtocolVersion(r.Header.Get(mcpversions.HTTPHeader), req.Params), mcpversions.SupportedPlatformToolset())
+	req := prepared.request
+	protocolVersion := prepared.protocolVersion
 
 	body, err := s.handlePlatformToolsetRequest(ctx, authCtx, toolset, &req, r.Header.Get("Gram-Chat-ID"), &protocolVersion)
 	switch {

--- a/server/internal/mcp/serve_platform_test.go
+++ b/server/internal/mcp/serve_platform_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
+	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/platformtools"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
@@ -104,6 +106,39 @@ func TestServePlatformToolset_NonManagedAssistantRejected(t *testing.T) {
 	_, err = servePlatformHTTP(t, ti, platformtools.ManagedAssistantPlatformToolsetSlug, toolsListBody(), token)
 	require.Error(t, err, "a non-managed assistant must be rejected at the entrypoint")
 	require.Contains(t, err.Error(), "not found")
+}
+
+func TestServePlatformToolset_UnsupportedVersionPrecedesTokenAuthentication(t *testing.T) {
+	t.Parallel()
+
+	_, ti := newTestMCPService(t)
+	slug := platformtools.ManagedAssistantPlatformToolsetSlug
+	req := httptest.NewRequest(http.MethodPost, "/platform/mcp/"+slug, bytes.NewReader(toolsListBody()))
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(mcpversions.HTTPHeader, mcpversions.Version20260728)
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("toolsetSlug", slug)
+	req = req.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	err := ti.service.ServePlatformToolset(w, req)
+	require.NoError(t, err)
+	requireUnsupportedProtocolVersionResponse(t, w, mcpversions.Version20260728, mcpversions.SupportedPlatformToolset())
+	require.Empty(t, w.Header().Get("WWW-Authenticate"))
+}
+
+func TestServePlatformToolset_EmptyBodyRequiresTokenAuthentication(t *testing.T) {
+	t.Parallel()
+
+	_, ti := newTestMCPService(t)
+	_, err := servePlatformHTTP(t, ti, platformtools.ManagedAssistantPlatformToolsetSlug, nil, "")
+	require.Error(t, err)
+
+	var shareable *oops.ShareableError
+	require.ErrorAs(t, err, &shareable)
+	require.Equal(t, oops.CodeUnauthorized, shareable.Code)
 }
 
 // The research tools are the MCP research runner's, and it holds them

--- a/server/internal/mcp/serveendpoint.go
+++ b/server/internal/mcp/serveendpoint.go
@@ -19,6 +19,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	customdomainsrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	"github.com/speakeasy-api/gram/server/internal/mcp/httpheaders"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpmetrics"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
 	"github.com/speakeasy-api/gram/server/internal/mcp/toolfilter"
 	"github.com/speakeasy-api/gram/server/internal/mcp/tunnelrouting"
 	"github.com/speakeasy-api/gram/server/internal/mcpaccess"
@@ -173,6 +175,23 @@ func (s *Service) serveResolvedMCPEndpoint(
 
 	logger = logger.With(attr.SlogMcpServerID(mcpServer.ID.String()))
 
+	var prepared *preparedMCPRequest
+	if mcpServer.ToolsetID.Valid {
+		var handled bool
+		var err error
+		prepared, handled, err = s.prepareTerminatedMCPRequest(
+			w,
+			r,
+			logger,
+			1<<20,
+			mcpversions.SupportedHostedToolset(),
+			mcpmetrics.SurfaceHosting,
+		)
+		if err != nil || handled {
+			return err
+		}
+	}
+
 	issuerGated := mcpServer.UserSessionIssuerID.Valid
 
 	// Public tunneled servers serve anonymously: no OAuth handshake, so the
@@ -263,7 +282,7 @@ func (s *Service) serveResolvedMCPEndpoint(
 			return oops.E(oops.CodeUnexpected, err, "load toolset").LogError(ctx, logger)
 		}
 
-		if err := s.serveToolsetResolved(w, r, &toolset, slug, mcpRouteBase, hostedServingFromWrapper(mcpServer, issuerGated), nil, sessionToolSelection, pendingIssuerGate); err != nil {
+		if err := s.serveToolsetResolved(w, r, &toolset, slug, mcpRouteBase, hostedServingFromWrapper(mcpServer, issuerGated), nil, sessionToolSelection, pendingIssuerGate, prepared); err != nil {
 			return fmt.Errorf("serve toolset-backed mcp: %w", err)
 		}
 		return nil

--- a/server/internal/mcp/servepublic_mcpendpoint_test.go
+++ b/server/internal/mcp/servepublic_mcpendpoint_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/customdomains"
 	customdomainsrepo "github.com/speakeasy-api/gram/server/internal/customdomains/repo"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
+	"github.com/speakeasy-api/gram/server/internal/mcp/mcpversions"
 	"github.com/speakeasy-api/gram/server/internal/mcpaccess"
 	mcpendpointsrepo "github.com/speakeasy-api/gram/server/internal/mcpendpoints/repo"
 	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
@@ -276,6 +277,27 @@ func TestServePublic_McpEndpoint_ToolsetBacked_ResolvesViaEndpoints(t *testing.T
 	require.NotEmpty(t, w.Header().Get("Mcp-Session-Id"))
 }
 
+func TestServePublic_McpEndpoint_ToolsetBacked_UnsupportedVersionPrecedesIssuerAuthentication(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolsetsRepo := toolsetsrepo.New(ti.conn)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "wrapped-unsupported-"+uuid.NewString()[:8])
+	issuerID := createUserSessionIssuer(t, ctx, ti.conn, *authCtx.ProjectID)
+	endpointSlug := "endpoint-" + uuid.NewString()
+	createToolsetMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, toolset.ID, endpointSlug, "public", uuid.NullUUID{}, issuerID)
+
+	w, err := servePublicHTTP(t, t.Context(), ti, endpointSlug, toolsListBody(), "", map[string]string{
+		mcpversions.HTTPHeader: mcpversions.Version20260728,
+	})
+	require.NoError(t, err)
+	requireUnsupportedProtocolVersionResponse(t, w, mcpversions.Version20260728, mcpversions.SupportedHostedToolset())
+	require.Empty(t, w.Header().Get("WWW-Authenticate"))
+}
+
 // TestServePublic_NoMcpEndpoint_FallsBackToLegacyToolset confirms that
 // when no mcp_endpoint matches the slug, /mcp/{slug} falls back to the
 // legacy toolsets.mcp_slug lookup so existing customers without
@@ -426,6 +448,20 @@ func TestServePublic_McpEndpoint_RemoteBacked_Proxies(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, w.Code, "body=%s", w.Body.String())
 	require.Contains(t, w.Body.String(), "upstream", "upstream initialize response must be relayed back")
+
+	// Remote and tunneled backends negotiate directly with their upstreams.
+	// Gram must relay even a declaration outside its terminating surfaces'
+	// supported sets rather than answering -32022 itself.
+	w, err = servePublicHTTP(t, ctx, ti, endpointSlug, toolsListBody(), token, map[string]string{
+		mcpversions.HTTPHeader: mcpversions.Version20260728,
+	})
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("upstream not invoked for unsupported Gram version; status=%d body=%s", w.Code, w.Body.String())
+	}
+	require.NoError(t, err)
+	require.NotContains(t, w.Body.String(), `"code":-32022`)
 }
 
 // TestServePublic_McpEndpoint_PrivateRemoteBacked_NoAuth_Returns401

--- a/server/internal/mcp/servepublic_test.go
+++ b/server/internal/mcp/servepublic_test.go
@@ -67,6 +67,31 @@ func servePublicHTTP(
 	return servePublicHTTPWithBody(t, ctx, ti, mcpSlug, io.NopCloser(bytes.NewReader(body)), int64(len(body)), authToken, extraHeaders)
 }
 
+func requireUnsupportedProtocolVersionResponse(t *testing.T, w *httptest.ResponseRecorder, requested string, supported []string) {
+	t.Helper()
+
+	require.Equal(t, http.StatusBadRequest, w.Code, "body=%s", w.Body.String())
+	var response struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Error   struct {
+			Code    oops.MCPCode `json:"code"`
+			Message string       `json:"message"`
+			Data    struct {
+				Supported []string `json:"supported"`
+				Requested string   `json:"requested"`
+			} `json:"data"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.Equal(t, "2.0", response.JSONRPC)
+	require.JSONEq(t, `1`, string(response.ID))
+	require.Equal(t, oops.MCPCodeUnsupportedProtocolVersion, response.Error.Code)
+	require.Equal(t, oops.MCPCodeUnsupportedProtocolVersion.Message(), response.Error.Message)
+	require.Equal(t, supported, response.Error.Data.Supported)
+	require.Equal(t, requested, response.Error.Data.Requested)
+}
+
 // eofOnCloseBody stands in for the request body net/http hands a handler.
 // Closing a server request body that the handler left unconsumed returns
 // io.EOF (see (*body).Close in net/http/transfer.go, which sets sawEOF without
@@ -377,6 +402,20 @@ func TestServePublic_AttachedAuthErrorReturnsMCPError(t *testing.T) {
 	require.True(t, ok, "expected JSON-RPC error: %v", response)
 	require.InDelta(t, -32001, errorBody["code"], 0)
 	require.Contains(t, errorBody["message"], "expired or invalid access token")
+}
+
+func TestServePublic_PrivateEmptyBodyRequiresAuthentication(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolset := createPrivateMCPToolset(t, ctx, ti, "private-empty-body-"+uuid.NewString()[:8])
+
+	_, err := servePublicHTTP(t, t.Context(), ti, toolset.McpSlug.String, nil, "", nil)
+	require.Error(t, err)
+
+	var shareable *oops.ShareableError
+	require.ErrorAs(t, err, &shareable)
+	require.Equal(t, oops.CodeUnauthorized, shareable.Code)
 }
 
 func TestServePublic_AttachedNotFoundReturnsMCPErrorWithNullID(t *testing.T) {
@@ -956,6 +995,85 @@ func TestServePublic_InitializeAnswersAbsentVersionWithDefault(t *testing.T) {
 	require.Equal(t, mcpversions.DefaultInEffect, answeredProtocolVersion(t, w))
 }
 
+func TestServePublic_UnsupportedRequestVersionReturnsSpecificationError(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolsetsRepo := toolsets_repo.New(ti.conn)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "unsupported-request-version")
+	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, toolsListBody(), "", map[string]string{
+		mcpversions.HTTPHeader: mcpversions.Version20260728,
+	})
+	require.NoError(t, err)
+	requireUnsupportedProtocolVersionResponse(t, w, mcpversions.Version20260728, mcpversions.SupportedHostedToolset())
+}
+
+func TestServePublic_UnsupportedBodyMetaVersionReturnsSpecificationError(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolsetsRepo := toolsets_repo.New(ti.conn)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "unsupported-body-version")
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/list",
+		"params": map[string]any{
+			"_meta": map[string]any{
+				"io.modelcontextprotocol/protocolVersion": mcpversions.Version20260728,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, body, "", nil)
+	require.NoError(t, err)
+	requireUnsupportedProtocolVersionResponse(t, w, mcpversions.Version20260728, mcpversions.SupportedHostedToolset())
+}
+
+func TestServePublic_UnsupportedVersionPrecedesPrivateAuthentication(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolset := createPrivateMCPToolset(t, ctx, ti, "unsupported-before-auth-"+uuid.NewString()[:8])
+
+	router := goahttp.NewMuxer()
+	mcp.Attach(router, ti.service, nil)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/"+toolset.McpSlug.String, bytes.NewReader(toolsListBody()))
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(mcpversions.HTTPHeader, mcpversions.Version20260728)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	requireUnsupportedProtocolVersionResponse(t, w, mcpversions.Version20260728, mcpversions.SupportedHostedToolset())
+	require.Empty(t, w.Header().Get("WWW-Authenticate"))
+}
+
+func TestServePublic_UnsupportedVersionNotificationIsDropped(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPService(t)
+	toolsetsRepo := toolsets_repo.New(ti.conn)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "unsupported-version-notification")
+	body := []byte(`{"jsonrpc":"2.0","method":"notifications/initialized"}`)
+	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, body, "", map[string]string{
+		mcpversions.HTTPHeader: mcpversions.Version20260728,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, w.Code)
+	require.Empty(t, w.Body.String())
+}
+
 // TestServePublic_InitializeBodyWinsOverNonconformingHeader pins which source
 // negotiation reads when a nonconforming client stamps MCP-Protocol-Version on
 // the initialize request itself, where the header is not defined: the body's
@@ -972,7 +1090,7 @@ func TestServePublic_InitializeBodyWinsOverNonconformingHeader(t *testing.T) {
 	toolset := createPublicMCPToolset(t, ctx, toolsetsRepo, authCtx, "negotiate-header-mcp")
 
 	w, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBodyWithVersion(mcpversions.Version20251125), "", map[string]string{
-		mcpversions.HTTPHeader: mcpversions.Version20250618,
+		mcpversions.HTTPHeader: mcpversions.Version20260728,
 	})
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, w.Code)
@@ -1023,14 +1141,12 @@ func TestServePublic_CarriesSupportedDeclarationToTheErrorWrapper(t *testing.T) 
 	require.Equal(t, mcpversions.Version20250618, carriedProtocolVersion(t, ctx, ti, toolset.McpSlug.String, mcpversions.Version20250618))
 }
 
-// TestServePublic_CarriesResolvedRevisionNotRawDeclaration pins the half that
-// is easy to get wrong. A declaration this surface does not serve resolves
-// downward, and it is the resolved answer that governs the request. Publishing
-// the raw declaration instead would encode errors on a revision Gram never
-// agreed to speak — the exact confusion the Declared/InEffect split exists to
-// prevent — and would silently begin doing so the moment a client asks for a
-// revision ahead of the supported set.
-func TestServePublic_CarriesResolvedRevisionNotRawDeclaration(t *testing.T) {
+// TestServePublic_UnsupportedDeclarationCarriesFallbackForErrorEncoding pins
+// the provisional half of unsupported-version handling. The request is
+// rejected before dispatch, but the shared error wrapper still needs a
+// supported revision for compatibility-safe encoding; publishing the raw
+// declaration would claim Gram agreed to speak a revision it rejected.
+func TestServePublic_UnsupportedDeclarationCarriesFallbackForErrorEncoding(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestMCPService(t)

--- a/server/internal/oops/mcp.go
+++ b/server/internal/oops/mcp.go
@@ -167,7 +167,16 @@ const (
 
 // MCPErrorData is the shared typed data envelope for MCP JSON-RPC errors.
 type MCPErrorData struct {
-	Code MCPErrorDataCode `json:"code"`
+	// Code identifies application-specific failures outside the MCP
+	// specification's standard error data shapes.
+	Code MCPErrorDataCode `json:"code,omitempty"`
+
+	// Supported is the protocol revision set a client may retry with after an
+	// UnsupportedProtocolVersionError.
+	Supported []string `json:"supported,omitempty"`
+
+	// Requested is the unsupported protocol revision the client declared.
+	Requested string `json:"requested,omitempty"`
 }
 
 type MCPError struct {

--- a/server/internal/oops/mcp_test.go
+++ b/server/internal/oops/mcp_test.go
@@ -91,7 +91,11 @@ func TestMCPError_MarshalJSON(t *testing.T) {
 	require.Equal(t, "tools/unknown: Method not found", errorBody["message"])
 	require.NotContains(t, errorBody, "data")
 
-	err.Data = &MCPErrorData{Code: MCPErrorDataCode("typed_code")}
+	err.Data = &MCPErrorData{
+		Code:      MCPErrorDataCode("typed_code"),
+		Supported: nil,
+		Requested: "",
+	}
 	data, marshalErr = json.Marshal(err)
 	require.NoError(t, marshalErr)
 	require.JSONEq(t, `{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"tools/unknown: Method not found","data":{"code":"typed_code"}}}`, string(data))


### PR DESCRIPTION
AIM-50

## Summary

Return MCP error -32022 with supported and requested versions for unsupported non-initialize requests on terminating MCP surfaces.

Drop invalid-version notifications without dispatch, preserve initialize negotiation, exclude proxied backends, and count rejections separately.

## Motivation

Reject unsupported protocol declarations consistently before authentication so clients can inspect the supported set and retry with a mutually supported version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects MCP protocol declarations outside each terminating surface's supported set before authentication, returning `-32022` with HTTP 400 and structured `supported` and `requested` data instead of silently serving the request under legacy semantics.

- Enforces on hosted toolset, platform toolset, and meta-MCP surfaces; remote and tunneled proxy backends still relay declarations to their upstreams.
- Drops invalid-version notifications without dispatch and preserves `initialize` protocol negotiation.
- Counts rejected declarations in the new `mcp.request.protocol_version_rejected` counter, separate from the dispatch census.
- Malformed meta declarations keep the existing invalid-request behavior; only well-formed unsupported versions receive `-32022`.

<sup>Written for commit 6ce726b0fa04fea3abd50bc1dcdcc834db3acc72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

