### PR TITLE
chore: lower scan completion logs to debug

### DIFF
--- a/server/internal/scanners/customruleanalyzer/handler.go
+++ b/server/internal/scanners/customruleanalyzer/handler.go
@@ -111,7 +111,7 @@ func (h *Handler) Handle(ctx context.Context, m *riskv1.CustomRulesAnalysis, _ g
 
 	// Never log matched values — they may carry sensitive data. Counts and rule
 	// ids only.
-	h.logger.InfoContext(ctx, "custom rules scan complete", attr.SlogValueAny(map[string]any{
+	h.logger.DebugContext(ctx, "custom rules scan complete", attr.SlogValueAny(map[string]any{
 		"request_id":      m.GetRequestId(),
 		"chat_message_id": m.GetChatMessageId(),
 		"matches":         len(findings),

--- a/server/internal/scanners/gitleaks/handler.go
+++ b/server/internal/scanners/gitleaks/handler.go
@@ -72,7 +72,7 @@ func (h *Handler) Handle(ctx context.Context, m *riskv1.GitleaksAnalysis, _ gcp.
 	}
 
 	// Never log matched values — they carry the secret. Counts and rule ids only.
-	h.logger.InfoContext(ctx, "gitleaks scan complete", attr.SlogValueAny(map[string]any{
+	h.logger.DebugContext(ctx, "gitleaks scan complete", attr.SlogValueAny(map[string]any{
 		"request_id":      m.GetRequestId(),
 		"chat_message_id": m.GetChatMessageId(),
 		"detections":      len(findings),


### PR DESCRIPTION
## Summary
Change `gitleaks scan complete` and `custom rules scan complete` from info to debug level. Keep both messages and their structured attributes unchanged.

## Motivation
Routine scan completions add noise to info-level logs. Retain them for debugging without emitting them at the default info level.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowers the `gitleaks scan complete` and `custom rules scan complete` log messages from info to debug level so routine scan completions no longer clutter default info-level logs. The messages and their structured attributes are unchanged and still available when debug logging is enabled.

<sup>Written for commit 8a4cd6011b26a6cf59d1f7eda8ccb0bee8dd163c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

