### PR TITLE
feat: add general-purpose PKI watchdog command

### DIFF
--- a/server/cmd/gram/pki_watchdog.go
+++ b/server/cmd/gram/pki_watchdog.go
@@ -1,0 +1,266 @@
+package gram
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/urfave/cli/v2"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+)
+
+const (
+	pkiMaxCertificates = 64
+	pkiMaxPEMBytes     = 1 << 20
+)
+
+type pkiSource struct {
+	name        string
+	location    string
+	environment bool
+}
+
+type pkiCertificate struct {
+	notBefore  time.Time
+	notAfter   time.Time
+	attributes metric.ObserveOption
+}
+
+type pkiObservation struct {
+	attributes   metric.ObserveOption
+	certificates []pkiCertificate
+	success      int64
+}
+
+type pkiWatchdog struct {
+	mu           sync.RWMutex
+	sources      []pkiSource
+	observations []pkiObservation
+}
+
+func newPKIWatchdogCommand() *cli.Command {
+	return &cli.Command{
+		Name:        "pki-watchdog",
+		Usage:       "Observe named public PEM certificate bundles over OTLP without application dependencies",
+		Description: "Each source emits observation success. Valid bundles emit age and remaining validity in seconds for every certificate, labeled by source name and zero-based PEM order (maximum 64). Reordering changes slot identity; rotation in place preserves labels. Invalid bundles emit no lifetime gauges. Files are reopened every observation; environment values are process-local and require a restart for external updates. No chain or hostname verification is performed.",
+		Flags: []cli.Flag{
+			&cli.StringSliceFlag{Name: "certificate-file", Usage: "Named PEM file: NAME=PATH (repeatable; comma-separated in env)", EnvVars: []string{"GRAM_PKI_CERTIFICATE_FILES"}},
+			&cli.StringSliceFlag{Name: "certificate-env", Usage: "Named PEM environment source: NAME=ENV_VAR (repeatable; comma-separated in env)", EnvVars: []string{"GRAM_PKI_CERTIFICATE_ENVS"}},
+			&cli.DurationFlag{Name: "observation-interval", Value: time.Minute, Usage: "Certificate reread cadence; OTLP export uses the shared 60-second cadence", EnvVars: []string{"GRAM_PKI_OBSERVATION_INTERVAL"}},
+		},
+		Action: func(c *cli.Context) (err error) {
+			sources, err := pkiSources(c.StringSlice("certificate-file"), c.StringSlice("certificate-env"))
+			if err != nil {
+				return err
+			}
+			interval := c.Duration("observation-interval")
+			if interval <= 0 {
+				return errors.New("observation-interval must be positive")
+			}
+			const serviceName = "gram-pki-watchdog"
+			logger := PullLogger(c.Context).With(attr.SlogComponent("pki_watchdog"), attr.SlogServiceName(serviceName), attr.SlogServiceVersion(shortGitSHA()))
+			ctx, stop := signal.NotifyContext(c.Context, os.Interrupt, syscall.SIGTERM)
+			defer stop()
+			shutdownOTel, err := o11y.SetupOTelSDK(ctx, logger, o11y.SetupOTelSDKOptions{
+				ServiceName: serviceName, ServiceVersion: shortGitSHA(), GitSHA: GitSHA, EnableTracing: false, EnableMetrics: true,
+			})
+			if err != nil {
+				return fmt.Errorf("setup PKI telemetry: %w", err)
+			}
+			provider := otel.GetMeterProvider()
+			var registration metric.Registration
+			// This metrics-only command shuts down the provider, which drains
+			// the reader and closes its exporter. The shared setup's cleanup
+			// closes the same exporter directly and must not run a second time.
+			defer func() {
+				shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+				defer cancel()
+				if managed, ok := provider.(interface {
+					ForceFlush(context.Context) error
+					Shutdown(context.Context) error
+				}); ok {
+					err = errors.Join(err, managed.ForceFlush(shutdownCtx), managed.Shutdown(shutdownCtx))
+				} else {
+					err = errors.Join(err, shutdownOTel(shutdownCtx))
+				}
+				if registration != nil {
+					err = errors.Join(err, registration.Unregister())
+				}
+			}()
+			watchdog := &pkiWatchdog{mu: sync.RWMutex{}, sources: sources, observations: nil}
+			watchdog.observe(ctx, logger)
+			registration, err = watchdog.register(provider)
+			if err != nil {
+				return err
+			}
+			logger.InfoContext(ctx, "PKI watchdog started")
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-ticker.C:
+					watchdog.observe(ctx, logger)
+				}
+			}
+		},
+	}
+}
+
+func pkiSources(files, envs []string) ([]pkiSource, error) {
+	sources := make([]pkiSource, 0, len(files)+len(envs))
+	names := make(map[string]bool, len(files)+len(envs))
+	for kind, entries := range [][]string{files, envs} {
+		for _, entry := range entries {
+			name, location, ok := strings.Cut(entry, "=")
+			if !ok || name == "" || location == "" || len(name) > 128 || strings.ContainsAny(name, " \t\r\n") {
+				return nil, errors.New("certificate sources must be NAME=SOURCE with a nonempty whitespace-free name of at most 128 bytes")
+			}
+			if names[name] {
+				return nil, errors.New("certificate source names must be unique")
+			}
+			names[name] = true
+			sources = append(sources, pkiSource{name: name, location: location, environment: kind == 1})
+		}
+	}
+	if len(sources) == 0 {
+		return nil, errors.New("at least one certificate-file or certificate-env is required")
+	}
+	return sources, nil
+}
+
+func readPKICertificates(source pkiSource) ([]pkiCertificate, error) {
+	var data []byte
+	if source.environment {
+		value, ok := os.LookupEnv(source.location)
+		if !ok {
+			return nil, errors.New("certificate environment variable is unset")
+		}
+		if len(value) > pkiMaxPEMBytes {
+			return nil, errors.New("certificate source exceeds 1 MiB")
+		}
+		data = []byte(value)
+	} else {
+		file, err := os.Open(source.location)
+		if err != nil {
+			return nil, errors.New("cannot open certificate file")
+		}
+		defer o11y.NoLogDefer(file.Close)
+		info, err := file.Stat()
+		if err != nil || !info.Mode().IsRegular() {
+			return nil, errors.New("certificate source must be a regular file")
+		}
+		data, err = io.ReadAll(io.LimitReader(file, pkiMaxPEMBytes+1))
+		if err != nil {
+			return nil, errors.New("cannot read certificate file")
+		}
+		if len(data) > pkiMaxPEMBytes {
+			return nil, errors.New("certificate source exceeds 1 MiB")
+		}
+	}
+	var certificates []pkiCertificate
+	for len(bytes.TrimSpace(data)) > 0 {
+		data = bytes.TrimSpace(data)
+		// pem.Decode skips malformed leading blocks. Require the next complete
+		// block to start here, so a damaged bundle cannot appear successful.
+		const begin = "-----BEGIN CERTIFICATE-----"
+		const end = "-----END CERTIFICATE-----"
+		if !bytes.HasPrefix(data, []byte(begin)) {
+			return nil, errors.New("expected certificate PEM block")
+		}
+		endIndex := bytes.Index(data, []byte(end))
+		if endIndex < 0 {
+			return nil, errors.New("unterminated certificate PEM block")
+		}
+		blockEnd := endIndex + len(end)
+		block, rest := pem.Decode(data[:blockEnd])
+		if block == nil || block.Type != "CERTIFICATE" || len(block.Headers) != 0 || len(rest) != 0 || bytes.Contains(data[len(begin):endIndex], []byte("-----BEGIN")) {
+			return nil, errors.New("invalid certificate PEM block")
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, errors.New("invalid X.509 certificate")
+		}
+		if len(certificates) == pkiMaxCertificates {
+			return nil, errors.New("certificate bundle exceeds 64 certificates")
+		}
+		certificates = append(certificates, pkiCertificate{
+			notBefore: cert.NotBefore, notAfter: cert.NotAfter,
+			attributes: metric.WithAttributes(attribute.String("pki.source.name", source.name), attribute.Int("pki.certificate.index", len(certificates))),
+		})
+		data = data[blockEnd:]
+	}
+	if len(certificates) == 0 {
+		return nil, errors.New("certificate bundle is empty")
+	}
+	return certificates, nil
+}
+
+func (w *pkiWatchdog) observe(ctx context.Context, logger *slog.Logger) {
+	observations := make([]pkiObservation, len(w.sources))
+	for i, source := range w.sources {
+		if ctx.Err() != nil {
+			return
+		}
+		certificates, err := readPKICertificates(source)
+		var success int64 = 1
+		if err != nil {
+			success = 0
+			logger.ErrorContext(ctx, "PKI source observation failed", attr.SlogError(fmt.Errorf("source %q: %w", source.name, err)))
+		}
+		observations[i] = pkiObservation{attributes: metric.WithAttributes(attribute.String("pki.source.name", source.name)), certificates: certificates, success: success}
+	}
+	w.mu.Lock()
+	w.observations = observations
+	w.mu.Unlock()
+}
+
+func (w *pkiWatchdog) register(provider metric.MeterProvider) (metric.Registration, error) {
+	meter := provider.Meter("github.com/speakeasy-api/gram/server/pki-watchdog")
+	age, err := meter.Float64ObservableGauge("pki.certificate.age", metric.WithUnit("s"), metric.WithDescription("Seconds since NotBefore; negative means not yet valid"))
+	if err != nil {
+		return nil, fmt.Errorf("create certificate age gauge: %w", err)
+	}
+	remaining, err := meter.Float64ObservableGauge("pki.certificate.remaining_validity", metric.WithUnit("s"), metric.WithDescription("Seconds until NotAfter; negative means expired"))
+	if err != nil {
+		return nil, fmt.Errorf("create certificate remaining validity gauge: %w", err)
+	}
+	success, err := meter.Int64ObservableGauge("pki.source.observation_success", metric.WithUnit("1"), metric.WithDescription("Latest source read and full bundle parse succeeded (1) or failed (0)"))
+	if err != nil {
+		return nil, fmt.Errorf("create source success gauge: %w", err)
+	}
+	registration, err := meter.RegisterCallback(func(_ context.Context, observer metric.Observer) error {
+		now := time.Now()
+		w.mu.RLock()
+		defer w.mu.RUnlock()
+		for _, observation := range w.observations {
+			observer.ObserveInt64(success, observation.success, observation.attributes)
+			for _, cert := range observation.certificates {
+				observer.ObserveFloat64(age, now.Sub(cert.notBefore).Seconds(), cert.attributes)
+				observer.ObserveFloat64(remaining, cert.notAfter.Sub(now).Seconds(), cert.attributes)
+			}
+		}
+		return nil
+	}, age, remaining, success)
+	if err != nil {
+		return nil, fmt.Errorf("register PKI observation callback: %w", err)
+	}
+	return registration, nil
+}

--- a/server/cmd/gram/pki_watchdog.go
+++ b/server/cmd/gram/pki_watchdog.go
@@ -8,50 +8,27 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"os"
 	"os/signal"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
 	"github.com/urfave/cli/v2"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
+	"github.com/speakeasy-api/gram/server/internal/pki"
 )
 
 const (
-	pkiMaxCertificates = 64
-	pkiMaxPEMBytes     = 1 << 20
+	pkiMaxPEMBytes = 1 << 20
 )
 
 type pkiSource struct {
-	name        string
 	location    string
 	environment bool
-}
-
-type pkiCertificate struct {
-	notBefore  time.Time
-	notAfter   time.Time
-	attributes metric.ObserveOption
-}
-
-type pkiObservation struct {
-	attributes   metric.ObserveOption
-	certificates []pkiCertificate
-	success      int64
-}
-
-type pkiWatchdog struct {
-	mu           sync.RWMutex
-	sources      []pkiSource
-	observations []pkiObservation
 }
 
 func newPKIWatchdogCommand() *cli.Command {
@@ -84,69 +61,59 @@ func newPKIWatchdogCommand() *cli.Command {
 				return fmt.Errorf("setup PKI telemetry: %w", err)
 			}
 			provider := otel.GetMeterProvider()
-			var registration metric.Registration
+			var watchdog *pki.WatchDog
 			// This metrics-only command shuts down the provider, which drains
 			// the reader and closes its exporter. The shared setup's cleanup
 			// closes the same exporter directly and must not run a second time.
 			defer func() {
 				shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 				defer cancel()
+				if watchdog != nil {
+					err = errors.Join(err, watchdog.Shutdown(shutdownCtx))
+				}
 				if managed, ok := provider.(interface {
-					ForceFlush(context.Context) error
 					Shutdown(context.Context) error
 				}); ok {
-					err = errors.Join(err, managed.ForceFlush(shutdownCtx), managed.Shutdown(shutdownCtx))
+					err = errors.Join(err, managed.Shutdown(shutdownCtx))
 				} else {
 					err = errors.Join(err, shutdownOTel(shutdownCtx))
 				}
-				if registration != nil {
-					err = errors.Join(err, registration.Unregister())
-				}
 			}()
-			watchdog := &pkiWatchdog{mu: sync.RWMutex{}, sources: sources, observations: nil}
-			watchdog.observe(ctx, logger)
-			registration, err = watchdog.register(provider)
+			watchdog, err = pki.NewWatchDog(logger, provider, append(sources, pki.WithObservationInterval(interval))...)
 			if err != nil {
-				return err
+				return fmt.Errorf("configure PKI watchdog: %w", err)
+			}
+			if err := watchdog.Start(ctx); err != nil {
+				return fmt.Errorf("start PKI watchdog: %w", err)
 			}
 			logger.InfoContext(ctx, "PKI watchdog started")
-			ticker := time.NewTicker(interval)
-			defer ticker.Stop()
-			for {
-				select {
-				case <-ctx.Done():
-					return nil
-				case <-ticker.C:
-					watchdog.observe(ctx, logger)
-				}
-			}
+			<-ctx.Done()
+			return nil
 		},
 	}
 }
 
-func pkiSources(files, envs []string) ([]pkiSource, error) {
-	sources := make([]pkiSource, 0, len(files)+len(envs))
-	names := make(map[string]bool, len(files)+len(envs))
+func pkiSources(files, envs []string) ([]pki.Option, error) {
+	options := make([]pki.Option, 0, len(files)+len(envs))
 	for kind, entries := range [][]string{files, envs} {
 		for _, entry := range entries {
 			name, location, ok := strings.Cut(entry, "=")
-			if !ok || name == "" || location == "" || len(name) > 128 || strings.ContainsAny(name, " \t\r\n") {
-				return nil, errors.New("certificate sources must be NAME=SOURCE with a nonempty whitespace-free name of at most 128 bytes")
+			if !ok || location == "" {
+				return nil, errors.New("certificate sources must be NAME=SOURCE with a nonempty source")
 			}
-			if names[name] {
-				return nil, errors.New("certificate source names must be unique")
-			}
-			names[name] = true
-			sources = append(sources, pkiSource{name: name, location: location, environment: kind == 1})
+			source := pkiSource{location: location, environment: kind == 1}
+			options = append(options, pki.WithSource(name, func(ctx context.Context) ([]*x509.Certificate, error) {
+				return readPKICertificates(ctx, source)
+			}))
 		}
 	}
-	if len(sources) == 0 {
-		return nil, errors.New("at least one certificate-file or certificate-env is required")
-	}
-	return sources, nil
+	return options, nil
 }
 
-func readPKICertificates(source pkiSource) ([]pkiCertificate, error) {
+func readPKICertificates(ctx context.Context, source pkiSource) ([]*x509.Certificate, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("read PKI source: %w", err)
+	}
 	var data []byte
 	if source.environment {
 		value, ok := os.LookupEnv(source.location)
@@ -175,7 +142,7 @@ func readPKICertificates(source pkiSource) ([]pkiCertificate, error) {
 			return nil, errors.New("certificate source exceeds 1 MiB")
 		}
 	}
-	var certificates []pkiCertificate
+	var certificates []*x509.Certificate
 	for len(bytes.TrimSpace(data)) > 0 {
 		data = bytes.TrimSpace(data)
 		// pem.Decode skips malformed leading blocks. Require the next complete
@@ -198,69 +165,14 @@ func readPKICertificates(source pkiSource) ([]pkiCertificate, error) {
 		if err != nil {
 			return nil, errors.New("invalid X.509 certificate")
 		}
-		if len(certificates) == pkiMaxCertificates {
+		if len(certificates) == pki.MaxCertificates {
 			return nil, errors.New("certificate bundle exceeds 64 certificates")
 		}
-		certificates = append(certificates, pkiCertificate{
-			notBefore: cert.NotBefore, notAfter: cert.NotAfter,
-			attributes: metric.WithAttributes(attribute.String("pki.source.name", source.name), attribute.Int("pki.certificate.index", len(certificates))),
-		})
+		certificates = append(certificates, cert)
 		data = data[blockEnd:]
 	}
 	if len(certificates) == 0 {
 		return nil, errors.New("certificate bundle is empty")
 	}
 	return certificates, nil
-}
-
-func (w *pkiWatchdog) observe(ctx context.Context, logger *slog.Logger) {
-	observations := make([]pkiObservation, len(w.sources))
-	for i, source := range w.sources {
-		if ctx.Err() != nil {
-			return
-		}
-		certificates, err := readPKICertificates(source)
-		var success int64 = 1
-		if err != nil {
-			success = 0
-			logger.ErrorContext(ctx, "PKI source observation failed", attr.SlogError(fmt.Errorf("source %q: %w", source.name, err)))
-		}
-		observations[i] = pkiObservation{attributes: metric.WithAttributes(attribute.String("pki.source.name", source.name)), certificates: certificates, success: success}
-	}
-	w.mu.Lock()
-	w.observations = observations
-	w.mu.Unlock()
-}
-
-func (w *pkiWatchdog) register(provider metric.MeterProvider) (metric.Registration, error) {
-	meter := provider.Meter("github.com/speakeasy-api/gram/server/pki-watchdog")
-	age, err := meter.Float64ObservableGauge("pki.certificate.age", metric.WithUnit("s"), metric.WithDescription("Seconds since NotBefore; negative means not yet valid"))
-	if err != nil {
-		return nil, fmt.Errorf("create certificate age gauge: %w", err)
-	}
-	remaining, err := meter.Float64ObservableGauge("pki.certificate.remaining_validity", metric.WithUnit("s"), metric.WithDescription("Seconds until NotAfter; negative means expired"))
-	if err != nil {
-		return nil, fmt.Errorf("create certificate remaining validity gauge: %w", err)
-	}
-	success, err := meter.Int64ObservableGauge("pki.source.observation_success", metric.WithUnit("1"), metric.WithDescription("Latest source read and full bundle parse succeeded (1) or failed (0)"))
-	if err != nil {
-		return nil, fmt.Errorf("create source success gauge: %w", err)
-	}
-	registration, err := meter.RegisterCallback(func(_ context.Context, observer metric.Observer) error {
-		now := time.Now()
-		w.mu.RLock()
-		defer w.mu.RUnlock()
-		for _, observation := range w.observations {
-			observer.ObserveInt64(success, observation.success, observation.attributes)
-			for _, cert := range observation.certificates {
-				observer.ObserveFloat64(age, now.Sub(cert.notBefore).Seconds(), cert.attributes)
-				observer.ObserveFloat64(remaining, cert.notAfter.Sub(now).Seconds(), cert.attributes)
-			}
-		}
-		return nil
-	}, age, remaining, success)
-	if err != nil {
-		return nil, fmt.Errorf("register PKI observation callback: %w", err)
-	}
-	return registration, nil
 }

--- a/server/cmd/gram/pki_watchdog_test.go
+++ b/server/cmd/gram/pki_watchdog_test.go
@@ -1,0 +1,107 @@
+package gram
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func pkiTestPEM(t *testing.T, before, after time.Time) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	template := &x509.Certificate{SerialNumber: big.NewInt(1), NotBefore: before, NotAfter: after}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Headers: nil, Bytes: der})
+}
+
+func TestPKIObservationFailureAndRotation(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	expired := pkiTestPEM(t, now.Add(-2*time.Hour), now.Add(-time.Hour))
+	future := pkiTestPEM(t, now.Add(time.Hour), now.Add(2*time.Hour))
+	path := filepath.Join(t.TempDir(), "bundle.pem")
+	require.NoError(t, os.WriteFile(path, append(expired, future...), 0600))
+	t.Setenv("PKI_TEST_CERT", string(future))
+	sources, err := pkiSources([]string{"bundle=" + path, "missing=" + path + ".missing"}, []string{"env=PKI_TEST_CERT"})
+	require.NoError(t, err)
+	watchdog := &pkiWatchdog{mu: sync.RWMutex{}, sources: sources, observations: nil}
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	defer o11y.NoLogDefer(func() error { return provider.Shutdown(t.Context()) })
+	registration, err := watchdog.register(provider)
+	require.NoError(t, err)
+	defer o11y.NoLogDefer(registration.Unregister)
+	collect := func() map[string]map[string]float64 {
+		watchdog.observe(t.Context(), testenv.NewLogger(t))
+		var data metricdata.ResourceMetrics
+		require.NoError(t, reader.Collect(t.Context(), &data))
+		values := make(map[string]map[string]float64)
+		for _, scope := range data.ScopeMetrics {
+			for _, m := range scope.Metrics {
+				values[m.Name] = make(map[string]float64)
+				switch gauge := m.Data.(type) {
+				case metricdata.Gauge[float64]:
+					for _, point := range gauge.DataPoints {
+						name, _ := point.Attributes.Value(attribute.Key("pki.source.name"))
+						index, _ := point.Attributes.Value(attribute.Key("pki.certificate.index"))
+						values[m.Name][name.AsString()+"/"+index.Emit()] = point.Value
+					}
+				case metricdata.Gauge[int64]:
+					for _, point := range gauge.DataPoints {
+						name, _ := point.Attributes.Value(attribute.Key("pki.source.name"))
+						values[m.Name][name.AsString()] = float64(point.Value)
+					}
+				}
+			}
+		}
+		return values
+	}
+	values := collect()
+	require.Negative(t, values["pki.certificate.remaining_validity"]["bundle/0"])
+	require.Negative(t, values["pki.certificate.age"]["bundle/1"])
+	require.Equal(t, map[string]float64{"bundle": 1, "missing": 0, "env": 1}, values["pki.source.observation_success"])
+	require.NoError(t, os.WriteFile(path, append(future, []byte("malformed")...), 0600))
+	values = collect()
+	require.Equal(t, map[string]float64{"bundle": 0, "missing": 0, "env": 1}, values["pki.source.observation_success"])
+	require.NotContains(t, values["pki.certificate.age"], "bundle/0")
+	require.Positive(t, values["pki.certificate.remaining_validity"]["env/0"])
+	replacement := path + ".new"
+	require.NoError(t, os.WriteFile(replacement, future, 0600))
+	require.NoError(t, os.Rename(replacement, path))
+	values = collect()
+	require.Equal(t, map[string]float64{"bundle": 1, "missing": 0, "env": 1}, values["pki.source.observation_success"])
+	require.Positive(t, values["pki.certificate.remaining_validity"]["bundle/0"])
+	require.NotContains(t, values["pki.certificate.age"], "bundle/1")
+}
+
+func TestPKIBundleRejectsSkippedMalformedBlockAndOverflow(t *testing.T) {
+	now := time.Now()
+	valid := string(pkiTestPEM(t, now, now.Add(time.Hour)))
+	source := pkiSource{name: "bundle", location: "PKI_TEST_BUNDLE", environment: true}
+	t.Setenv(source.location, "-----BEGIN CERTIFICATE-----\ninvalid\n"+valid)
+	certs, err := readPKICertificates(source)
+	require.Error(t, err)
+	require.Nil(t, certs)
+	t.Setenv(source.location, strings.Repeat(valid, pkiMaxCertificates+1))
+	certs, err = readPKICertificates(source)
+	require.Error(t, err)
+	require.Nil(t, certs)
+}

--- a/server/cmd/gram/pki_watchdog_test.go
+++ b/server/cmd/gram/pki_watchdog_test.go
@@ -9,8 +9,8 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/speakeasy-api/gram/server/internal/o11y"
+	"github.com/speakeasy-api/gram/server/internal/pki"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
@@ -42,15 +43,14 @@ func TestPKIObservationFailureAndRotation(t *testing.T) {
 	t.Setenv("PKI_TEST_CERT", string(future))
 	sources, err := pkiSources([]string{"bundle=" + path, "missing=" + path + ".missing"}, []string{"env=PKI_TEST_CERT"})
 	require.NoError(t, err)
-	watchdog := &pkiWatchdog{mu: sync.RWMutex{}, sources: sources, observations: nil}
 	reader := sdkmetric.NewManualReader()
 	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 	defer o11y.NoLogDefer(func() error { return provider.Shutdown(t.Context()) })
-	registration, err := watchdog.register(provider)
+	watchdog, err := pki.NewWatchDog(testenv.NewLogger(t), provider, append(sources, pki.WithObservationInterval(10*time.Millisecond))...)
 	require.NoError(t, err)
-	defer o11y.NoLogDefer(registration.Unregister)
+	require.NoError(t, watchdog.Start(t.Context()))
+	defer o11y.NoLogDefer(func() error { return watchdog.Shutdown(t.Context()) })
 	collect := func() map[string]map[string]float64 {
-		watchdog.observe(t.Context(), testenv.NewLogger(t))
 		var data metricdata.ResourceMetrics
 		require.NoError(t, reader.Collect(t.Context(), &data))
 		values := make(map[string]map[string]float64)
@@ -74,20 +74,25 @@ func TestPKIObservationFailureAndRotation(t *testing.T) {
 		}
 		return values
 	}
-	values := collect()
+	var values map[string]map[string]float64
+	awaitSuccess := func(expected map[string]float64) {
+		t.Helper()
+		require.Eventually(t, func() bool {
+			values = collect()
+			return reflect.DeepEqual(expected, values["pki.source.observation_success"])
+		}, time.Second, time.Millisecond)
+	}
+	awaitSuccess(map[string]float64{"bundle": 1, "missing": 0, "env": 1})
 	require.Negative(t, values["pki.certificate.remaining_validity"]["bundle/0"])
 	require.Negative(t, values["pki.certificate.age"]["bundle/1"])
-	require.Equal(t, map[string]float64{"bundle": 1, "missing": 0, "env": 1}, values["pki.source.observation_success"])
 	require.NoError(t, os.WriteFile(path, append(future, []byte("malformed")...), 0600))
-	values = collect()
-	require.Equal(t, map[string]float64{"bundle": 0, "missing": 0, "env": 1}, values["pki.source.observation_success"])
+	awaitSuccess(map[string]float64{"bundle": 0, "missing": 0, "env": 1})
 	require.NotContains(t, values["pki.certificate.age"], "bundle/0")
 	require.Positive(t, values["pki.certificate.remaining_validity"]["env/0"])
 	replacement := path + ".new"
 	require.NoError(t, os.WriteFile(replacement, future, 0600))
 	require.NoError(t, os.Rename(replacement, path))
-	values = collect()
-	require.Equal(t, map[string]float64{"bundle": 1, "missing": 0, "env": 1}, values["pki.source.observation_success"])
+	awaitSuccess(map[string]float64{"bundle": 1, "missing": 0, "env": 1})
 	require.Positive(t, values["pki.certificate.remaining_validity"]["bundle/0"])
 	require.NotContains(t, values["pki.certificate.age"], "bundle/1")
 }
@@ -95,13 +100,13 @@ func TestPKIObservationFailureAndRotation(t *testing.T) {
 func TestPKIBundleRejectsSkippedMalformedBlockAndOverflow(t *testing.T) {
 	now := time.Now()
 	valid := string(pkiTestPEM(t, now, now.Add(time.Hour)))
-	source := pkiSource{name: "bundle", location: "PKI_TEST_BUNDLE", environment: true}
+	source := pkiSource{location: "PKI_TEST_BUNDLE", environment: true}
 	t.Setenv(source.location, "-----BEGIN CERTIFICATE-----\ninvalid\n"+valid)
-	certs, err := readPKICertificates(source)
+	certs, err := readPKICertificates(t.Context(), source)
 	require.Error(t, err)
 	require.Nil(t, certs)
-	t.Setenv(source.location, strings.Repeat(valid, pkiMaxCertificates+1))
-	certs, err = readPKICertificates(source)
+	t.Setenv(source.location, strings.Repeat(valid, pki.MaxCertificates+1))
+	certs, err = readPKICertificates(t.Context(), source)
 	require.Error(t, err)
 	require.Nil(t, certs)
 }

--- a/server/cmd/gram/root.go
+++ b/server/cmd/gram/root.go
@@ -41,6 +41,7 @@ func newApp() *cli.App {
 			newStartCommand(),
 			newNetingressAttestorCommand(),
 			newWorkerCommand(),
+			newPKIWatchdogCommand(),
 			newAdminCommand(),
 			newGenWebhookSpecCommand(),
 			newRenderPlatformMCPCommand(),

--- a/server/internal/pki/watchdog.go
+++ b/server/internal/pki/watchdog.go
@@ -1,0 +1,246 @@
+package pki
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+)
+
+// MaxCertificates bounds the number of stable certificate slots per source.
+const MaxCertificates = 64
+
+// Source loads a complete, ordered bundle of parsed certificates. It is called
+// only at the observation cadence, never during metric collection. Implementations
+// must honor cancellation and return errors safe to log, without PEM or key data.
+type Source func(context.Context) ([]*x509.Certificate, error)
+
+// Option configures a WatchDog before it starts.
+type Option func(*WatchDog)
+
+// WithSource adds a uniquely named source. Certificate labels use this name and
+// zero-based bundle position: rotation preserves labels; reordering changes slots.
+func WithSource(name string, source Source) Option {
+	return func(w *WatchDog) {
+		w.sources = append(w.sources, namedSource{name: name, load: source})
+	}
+}
+
+// WithObservationInterval overrides the default one-minute source loading cadence.
+func WithObservationInterval(interval time.Duration) Option {
+	return func(w *WatchDog) { w.interval = interval }
+}
+
+type namedSource struct {
+	name string
+	load Source
+}
+
+type certificate struct {
+	notBefore  time.Time
+	notAfter   time.Time
+	attributes metric.ObserveOption
+}
+
+type observation struct {
+	attributes   metric.ObserveOption
+	certificates []certificate
+	success      int64
+}
+
+// WatchDog observes certificate validity independently of certificate consumers.
+// It borrows its meter provider; the caller retains responsibility for shutting
+// down the provider after Shutdown returns. A WatchDog can only be started once.
+type WatchDog struct {
+	logger   *slog.Logger
+	provider metric.MeterProvider
+	sources  []namedSource
+	interval time.Duration
+
+	mu           sync.Mutex
+	started      bool
+	stopped      bool
+	cancel       context.CancelFunc
+	done         chan struct{}
+	registration metric.Registration
+
+	snapshotMu   sync.RWMutex
+	observations []observation
+}
+
+// NewWatchDog constructs a watchdog with parsed-certificate sources.
+func NewWatchDog(logger *slog.Logger, provider metric.MeterProvider, options ...Option) (*WatchDog, error) {
+	w := &WatchDog{
+		logger: logger, provider: provider, sources: nil, interval: time.Minute,
+		mu: sync.Mutex{}, started: false, stopped: false, cancel: nil,
+		done: make(chan struct{}), registration: nil,
+		snapshotMu: sync.RWMutex{}, observations: nil,
+	}
+	for _, option := range options {
+		option(w)
+	}
+	if w.interval <= 0 {
+		return nil, errors.New("PKI observation interval must be positive")
+	}
+	if len(w.sources) == 0 {
+		return nil, errors.New("at least one PKI source is required")
+	}
+	names := make(map[string]bool, len(w.sources))
+	for _, source := range w.sources {
+		if source.name == "" || len(source.name) > 128 || strings.ContainsAny(source.name, " \t\r\n") || source.load == nil {
+			return nil, errors.New("PKI sources require a loader and a whitespace-free name of 1 to 128 bytes")
+		}
+		if names[source.name] {
+			return nil, errors.New("PKI source names must be unique")
+		}
+		names[source.name] = true
+	}
+	return w, nil
+}
+
+// Start registers metrics and launches an immediate observation followed by
+// periodic observations. It returns without waiting for source I/O.
+func (w *WatchDog) Start(ctx context.Context) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.started || w.stopped {
+		return errors.New("PKI watchdog cannot be started more than once or after shutdown")
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("start PKI watchdog: %w", err)
+	}
+	registration, err := w.register()
+	if err != nil {
+		return err
+	}
+	w.registration = registration
+	ctx, w.cancel = context.WithCancel(ctx)
+	w.started = true
+	go func() {
+		defer close(w.done)
+		w.observe(ctx)
+		ticker := time.NewTicker(w.interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				w.observe(ctx)
+			}
+		}
+	}()
+	return nil
+}
+
+// Shutdown cancels source loading, waits for observation to stop, flushes the
+// provider when supported, and unregisters the metric callback. It does not shut
+// down the borrowed provider. If waiting times out, a subsequent call can finish
+// cleanup. Repeated calls after cleanup are harmless.
+func (w *WatchDog) Shutdown(ctx context.Context) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.stopped = true
+	if !w.started || w.registration == nil {
+		return nil
+	}
+	w.cancel()
+	select {
+	case <-w.done:
+	case <-ctx.Done():
+		return fmt.Errorf("stop PKI observation: %w", ctx.Err())
+	}
+	var err error
+	if provider, ok := w.provider.(interface{ ForceFlush(context.Context) error }); ok {
+		if flushErr := provider.ForceFlush(ctx); flushErr != nil {
+			err = fmt.Errorf("flush PKI metrics: %w", flushErr)
+		}
+	}
+	if unregisterErr := w.registration.Unregister(); unregisterErr != nil {
+		err = errors.Join(err, fmt.Errorf("unregister PKI metrics: %w", unregisterErr))
+	}
+	w.registration = nil
+	return err
+}
+
+func (w *WatchDog) observe(ctx context.Context) {
+	observations := make([]observation, len(w.sources))
+	for i, source := range w.sources {
+		if ctx.Err() != nil {
+			return
+		}
+		certs, err := source.load(ctx)
+		if ctx.Err() != nil {
+			return
+		}
+		if err == nil && (len(certs) == 0 || len(certs) > MaxCertificates) {
+			err = errors.New("certificate source must contain 1 to 64 certificates")
+		}
+		var certificates []certificate
+		if err == nil {
+			certificates = make([]certificate, len(certs))
+			for index, cert := range certs {
+				if cert == nil {
+					err = errors.New("certificate source contains a nil certificate")
+					break
+				}
+				certificates[index] = certificate{
+					notBefore: cert.NotBefore, notAfter: cert.NotAfter,
+					attributes: metric.WithAttributes(attribute.String("pki.source.name", source.name), attribute.Int("pki.certificate.index", index)),
+				}
+			}
+		}
+		var success int64 = 1
+		if err != nil {
+			success = 0
+			certificates = nil
+			w.logger.ErrorContext(ctx, "PKI source observation failed", attr.SlogError(fmt.Errorf("source %q: %w", source.name, err)))
+		}
+		observations[i] = observation{attributes: metric.WithAttributes(attribute.String("pki.source.name", source.name)), certificates: certificates, success: success}
+	}
+	w.snapshotMu.Lock()
+	w.observations = observations
+	w.snapshotMu.Unlock()
+}
+
+func (w *WatchDog) register() (metric.Registration, error) {
+	meter := w.provider.Meter("github.com/speakeasy-api/gram/server/pki-watchdog")
+	age, err := meter.Float64ObservableGauge("pki.certificate.age", metric.WithUnit("s"), metric.WithDescription("Seconds since NotBefore; negative means not yet valid"))
+	if err != nil {
+		return nil, fmt.Errorf("create certificate age gauge: %w", err)
+	}
+	remaining, err := meter.Float64ObservableGauge("pki.certificate.remaining_validity", metric.WithUnit("s"), metric.WithDescription("Seconds until NotAfter; negative means expired"))
+	if err != nil {
+		return nil, fmt.Errorf("create certificate remaining validity gauge: %w", err)
+	}
+	success, err := meter.Int64ObservableGauge("pki.source.observation_success", metric.WithUnit("1"), metric.WithDescription("Latest source read and full bundle parse succeeded (1) or failed (0)"))
+	if err != nil {
+		return nil, fmt.Errorf("create source success gauge: %w", err)
+	}
+	registration, err := meter.RegisterCallback(func(_ context.Context, observer metric.Observer) error {
+		now := time.Now()
+		w.snapshotMu.RLock()
+		defer w.snapshotMu.RUnlock()
+		for _, observation := range w.observations {
+			observer.ObserveInt64(success, observation.success, observation.attributes)
+			for _, cert := range observation.certificates {
+				observer.ObserveFloat64(age, now.Sub(cert.notBefore).Seconds(), cert.attributes)
+				observer.ObserveFloat64(remaining, cert.notAfter.Sub(now).Seconds(), cert.attributes)
+			}
+		}
+		return nil
+	}, age, remaining, success)
+	if err != nil {
+		return nil, fmt.Errorf("register PKI observation callback: %w", err)
+	}
+	return registration, nil
+}

--- a/server/internal/pki/watchdog_test.go
+++ b/server/internal/pki/watchdog_test.go
@@ -1,0 +1,100 @@
+package pki_test
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/speakeasy-api/gram/server/internal/o11y"
+	"github.com/speakeasy-api/gram/server/internal/pki"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+func TestWatchDogCadenceAndPartialFailure(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reader := sdkmetric.NewManualReader()
+		provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+		defer o11y.NoLogDefer(func() error { return provider.Shutdown(t.Context()) })
+		cert := &x509.Certificate{NotBefore: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(time.Hour)}
+		calls := 0
+		watchdog, err := pki.NewWatchDog(testenv.NewLogger(t), provider,
+			pki.WithSource("bundle", func(context.Context) ([]*x509.Certificate, error) {
+				calls++
+				if calls > 1 {
+					return []*x509.Certificate{cert}, errors.New("partial bundle")
+				}
+				return []*x509.Certificate{cert}, nil
+			}),
+		)
+		require.NoError(t, err)
+		require.NoError(t, watchdog.Start(t.Context()))
+		defer o11y.NoLogDefer(func() error { return watchdog.Shutdown(t.Context()) })
+		synctest.Wait()
+		collect := func() map[string]float64 {
+			var data metricdata.ResourceMetrics
+			require.NoError(t, reader.Collect(t.Context(), &data))
+			values := make(map[string]float64)
+			for _, scope := range data.ScopeMetrics {
+				for _, m := range scope.Metrics {
+					switch gauge := m.Data.(type) {
+					case metricdata.Gauge[float64]:
+						for _, point := range gauge.DataPoints {
+							values[m.Name] = point.Value
+						}
+					case metricdata.Gauge[int64]:
+						for _, point := range gauge.DataPoints {
+							values[m.Name] = float64(point.Value)
+						}
+					}
+				}
+			}
+			return values
+		}
+		want := map[string]float64{"pki.certificate.age": 3600, "pki.certificate.remaining_validity": 3600, "pki.source.observation_success": 1}
+		require.Equal(t, want, collect())
+		// Repeated collections must not call the loader again.
+		require.Equal(t, want, collect())
+		time.Sleep(time.Minute) //nolint:forbidigo // GG013: advances only the synctest fake clock to the next observation.
+		synctest.Wait()
+		require.Equal(t, map[string]float64{"pki.source.observation_success": 0}, collect())
+		require.NoError(t, watchdog.Shutdown(t.Context()))
+		require.Empty(t, collect(), "shutdown must unregister the watchdog without closing the shared provider")
+		require.NoError(t, watchdog.Shutdown(t.Context()))
+		require.Error(t, watchdog.Start(t.Context()), "a stopped watchdog cannot restart")
+	})
+}
+
+func TestWatchDogShutdownCancelsLoading(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		loading := make(chan struct{})
+		stopped := make(chan struct{})
+		watchdog, err := pki.NewWatchDog(testenv.NewLogger(t), testenv.NewMeterProvider(t),
+			pki.WithSource("blocking", func(ctx context.Context) ([]*x509.Certificate, error) {
+				close(loading)
+				<-ctx.Done()
+				close(stopped)
+				return nil, ctx.Err()
+			}),
+		)
+		require.NoError(t, err)
+		require.NoError(t, watchdog.Start(t.Context()))
+		<-loading
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		defer cancel()
+		require.NoError(t, watchdog.Shutdown(ctx))
+		select {
+		case <-stopped:
+		default:
+			t.Fatal("Shutdown returned before the source stopped")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Add `gram pki-watchdog` as a standalone command, with no application dependency startup. Configure named public PEM bundles through repeatable file or environment-source flags and their environment equivalents.
- Export certificate age and remaining validity in seconds, plus per-source observation success, through the existing OTel/OTLP pipeline. One shared meter uses stable source names and zero-based bundle positions, bounded to 64 certificates per source.
- Reopen mounted files at the observation cadence to detect rotation. Failed reads or complete-bundle parsing publish failure and omit lifetime gauges without interrupting other sources. Negative values expose expired and not-yet-valid certificates.
- Keep collection callbacks free of I/O, flush metrics on graceful shutdown, and cover malformed bundles, failure/recovery, and file replacement with regression tests.

## Motivation

Certificate renewal can depend on an external reconciliation run, so renewal configuration alone does not provide timely expiry visibility. A general-purpose watchdog observes the deployed public certificates independently of the services that consume them and reuses the existing telemetry export path.

This change does not deploy a workload or provision alerts. Follow-up infrastructure should alert at 30 days remaining, escalate at 7 days, and cover expiry, observation failures, and no data.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `gram pki-watchdog`, backed by a reusable `internal/pki` watchdog, to observe public PEM bundles independently of application startup and export certificate validity through the existing OTLP pipeline. Failed sources report failure without interrupting monitoring of other sources.

**New Features**

- Configure named file or environment sources with repeatable flags and environment equivalents.
- Reopen files on each observation to detect atomic certificate replacement; environment sources require a process restart to update.
- Export per-source success plus zero-based certificate age and remaining-validity gauges, with negative values for not-yet-valid or expired certificates.
- Reject malformed bundles, bundles over 64 certificates, and sources over 1 MiB; invalid bundles retain failure status but emit no lifetime gauges.
- Keep source I/O outside metric collection callbacks, cancel loading on shutdown, flush metrics, and unregister callbacks cleanly.

<sup>Written for commit c18f81d912f0619a685b9deee54cc1a6599988a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

