### PR TITLE
fix: scope remote session operations to client tenancy

### DIFF
--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -1179,11 +1179,13 @@ WHERE link.user_session_issuer_id = @user_session_issuer_id
 ORDER BY c.id ASC;
 
 -- name: ListRemoteSessionsByProjectID :many
--- Scoped by the session's user_session_issuer project, not the client's project:
--- a remote_session belongs to the project whose user_session_issuer minted it,
--- so sessions established through an organization-level client (project_id NULL)
--- bound to this project's user_session_issuer are listed here, while another
--- project's sessions on the same shared org-level client are not.
+-- A project can reach a session only when both its provenance issuer and its
+-- remote client are in scope. An organization-tier issuer can be shared across
+-- projects, but a project-tier client remains visible only to its owning
+-- project. Organization-tier clients are visible throughout their organization.
+-- Global clients (project_id and organization_id both NULL) stay visible from
+-- every project because they form a tenantless catalog through which any project
+-- may establish a session.
 SELECT sqlc.embed(s),
   u.display_name AS subject_display_name,
   u.email AS subject_email
@@ -1192,6 +1194,7 @@ JOIN remote_session_clients AS c ON c.id = s.remote_session_client_id
 JOIN user_session_issuers AS usi ON usi.id = s.user_session_issuer_id
 LEFT JOIN users AS u ON s.subject_urn = 'user:' || u.id AND u.deleted_at IS NULL
 WHERE (usi.project_id = @project_id::uuid OR (usi.project_id IS NULL AND usi.organization_id = @organization_id::text))
+  AND (c.project_id = @project_id::uuid OR (c.project_id IS NULL AND (c.organization_id IS NULL OR c.organization_id = @organization_id::text)))
   AND s.deleted IS FALSE
   AND c.deleted IS FALSE
   AND (sqlc.narg('subject_urn')::text IS NULL OR s.subject_urn = sqlc.narg('subject_urn')::text)
@@ -1201,20 +1204,23 @@ ORDER BY s.id DESC
 LIMIT sqlc.arg('limit_value');
 
 -- name: GetRemoteSessionByID :one
--- Scoped by the session's user_session_issuer project (see
--- ListRemoteSessionsByProjectID), so an organization-level client's session is
--- reachable from the project whose user_session_issuer minted it.
+-- Both the provenance issuer and remote client must be reachable from the
+-- caller's project. This keeps project-tier client credentials confined to
+-- their owning project while preserving organization-tier and global clients.
 SELECT s.*
 FROM remote_sessions AS s
 JOIN remote_session_clients AS c ON c.id = s.remote_session_client_id
 JOIN user_session_issuers AS usi ON usi.id = s.user_session_issuer_id
-WHERE s.id = @id AND (usi.project_id = @project_id::uuid OR (usi.project_id IS NULL AND usi.organization_id = @organization_id::text)) AND s.deleted IS FALSE AND c.deleted IS FALSE;
+WHERE s.id = @id
+  AND (usi.project_id = @project_id::uuid OR (usi.project_id IS NULL AND usi.organization_id = @organization_id::text))
+  AND (c.project_id = @project_id::uuid OR (c.project_id IS NULL AND (c.organization_id IS NULL OR c.organization_id = @organization_id::text)))
+  AND s.deleted IS FALSE
+  AND c.deleted IS FALSE;
 
 -- name: RevokeRemoteSession :one
--- Scoped by the session's user_session_issuer project (see
--- ListRemoteSessionsByProjectID), so a project admin can revoke a session
--- established through an organization-level client bound to their own
--- user_session_issuer, but not another project's session on a shared one.
+-- Revocation uses the same issuer-and-client reachability boundary as reads.
+-- The global-client arm is required so every readable session can also be
+-- revoked, while project-tier client credentials stay confined to their owner.
 UPDATE remote_sessions AS s
 SET deleted_at = clock_timestamp()
 FROM remote_session_clients AS c, user_session_issuers AS usi
@@ -1222,6 +1228,7 @@ WHERE s.id = @id
   AND s.remote_session_client_id = c.id
   AND usi.id = s.user_session_issuer_id
   AND (usi.project_id = @project_id::uuid OR (usi.project_id IS NULL AND usi.organization_id = @organization_id::text))
+  AND (c.project_id = @project_id::uuid OR (c.project_id IS NULL AND (c.organization_id IS NULL OR c.organization_id = @organization_id::text)))
   AND s.deleted IS FALSE
   AND c.deleted IS FALSE
 RETURNING s.*;

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -2077,7 +2077,11 @@ SELECT s.id, s.subject_urn, s.user_session_issuer_id, s.remote_session_client_id
 FROM remote_sessions AS s
 JOIN remote_session_clients AS c ON c.id = s.remote_session_client_id
 JOIN user_session_issuers AS usi ON usi.id = s.user_session_issuer_id
-WHERE s.id = $1 AND (usi.project_id = $2::uuid OR (usi.project_id IS NULL AND usi.organization_id = $3::text)) AND s.deleted IS FALSE AND c.deleted IS FALSE
+WHERE s.id = $1
+  AND (usi.project_id = $2::uuid OR (usi.project_id IS NULL AND usi.organization_id = $3::text))
+  AND (c.project_id = $2::uuid OR (c.project_id IS NULL AND (c.organization_id IS NULL OR c.organization_id = $3::text)))
+  AND s.deleted IS FALSE
+  AND c.deleted IS FALSE
 `
 
 type GetRemoteSessionByIDParams struct {
@@ -2086,9 +2090,9 @@ type GetRemoteSessionByIDParams struct {
 	OrganizationID string
 }
 
-// Scoped by the session's user_session_issuer project (see
-// ListRemoteSessionsByProjectID), so an organization-level client's session is
-// reachable from the project whose user_session_issuer minted it.
+// Both the provenance issuer and remote client must be reachable from the
+// caller's project. This keeps project-tier client credentials confined to
+// their owning project while preserving organization-tier and global clients.
 func (q *Queries) GetRemoteSessionByID(ctx context.Context, arg GetRemoteSessionByIDParams) (RemoteSession, error) {
 	row := q.db.QueryRow(ctx, getRemoteSessionByID, arg.ID, arg.ProjectID, arg.OrganizationID)
 	var i RemoteSession
@@ -4363,6 +4367,7 @@ JOIN remote_session_clients AS c ON c.id = s.remote_session_client_id
 JOIN user_session_issuers AS usi ON usi.id = s.user_session_issuer_id
 LEFT JOIN users AS u ON s.subject_urn = 'user:' || u.id AND u.deleted_at IS NULL
 WHERE (usi.project_id = $1::uuid OR (usi.project_id IS NULL AND usi.organization_id = $2::text))
+  AND (c.project_id = $1::uuid OR (c.project_id IS NULL AND (c.organization_id IS NULL OR c.organization_id = $2::text)))
   AND s.deleted IS FALSE
   AND c.deleted IS FALSE
   AND ($3::text IS NULL OR s.subject_urn = $3::text)
@@ -4387,11 +4392,13 @@ type ListRemoteSessionsByProjectIDRow struct {
 	SubjectEmail       pgtype.Text
 }
 
-// Scoped by the session's user_session_issuer project, not the client's project:
-// a remote_session belongs to the project whose user_session_issuer minted it,
-// so sessions established through an organization-level client (project_id NULL)
-// bound to this project's user_session_issuer are listed here, while another
-// project's sessions on the same shared org-level client are not.
+// A project can reach a session only when both its provenance issuer and its
+// remote client are in scope. An organization-tier issuer can be shared across
+// projects, but a project-tier client remains visible only to its owning
+// project. Organization-tier clients are visible throughout their organization.
+// Global clients (project_id and organization_id both NULL) stay visible from
+// every project because they form a tenantless catalog through which any project
+// may establish a session.
 func (q *Queries) ListRemoteSessionsByProjectID(ctx context.Context, arg ListRemoteSessionsByProjectIDParams) ([]ListRemoteSessionsByProjectIDRow, error) {
 	rows, err := q.db.Query(ctx, listRemoteSessionsByProjectID,
 		arg.ProjectID,
@@ -4864,6 +4871,7 @@ WHERE s.id = $1
   AND s.remote_session_client_id = c.id
   AND usi.id = s.user_session_issuer_id
   AND (usi.project_id = $2::uuid OR (usi.project_id IS NULL AND usi.organization_id = $3::text))
+  AND (c.project_id = $2::uuid OR (c.project_id IS NULL AND (c.organization_id IS NULL OR c.organization_id = $3::text)))
   AND s.deleted IS FALSE
   AND c.deleted IS FALSE
 RETURNING s.id, s.subject_urn, s.user_session_issuer_id, s.remote_session_client_id, s.access_token_encrypted, s.access_expires_at, s.refresh_token_encrypted, s.authorization_expires_at, s.refresh_expires_at, s.scopes, s.resource, s.auto_refresh, s.last_refresh_attempt_at, s.last_used_at, s.created_at, s.updated_at, s.deleted_at, s.deleted
@@ -4875,10 +4883,9 @@ type RevokeRemoteSessionParams struct {
 	OrganizationID string
 }
 
-// Scoped by the session's user_session_issuer project (see
-// ListRemoteSessionsByProjectID), so a project admin can revoke a session
-// established through an organization-level client bound to their own
-// user_session_issuer, but not another project's session on a shared one.
+// Revocation uses the same issuer-and-client reachability boundary as reads.
+// The global-client arm is required so every readable session can also be
+// revoked, while project-tier client credentials stay confined to their owner.
 func (q *Queries) RevokeRemoteSession(ctx context.Context, arg RevokeRemoteSessionParams) (RemoteSession, error) {
 	row := q.db.QueryRow(ctx, revokeRemoteSession, arg.ID, arg.ProjectID, arg.OrganizationID)
 	var i RemoteSession

--- a/server/internal/remotesessions/sessionhandlers_test.go
+++ b/server/internal/remotesessions/sessionhandlers_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"
 
 	gen "github.com/speakeasy-api/gram/server/gen/remote_sessions"
@@ -12,6 +13,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/audit/audittest"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -88,6 +90,149 @@ func TestListRemoteSessions_OrgLevelClientScopedByUserSessionIssuerProject(t *te
 	}
 	require.True(t, ids[mine.ID.String()], "org-level client session for this project's user_session_issuer must be listed")
 	require.False(t, ids[theirs.ID.String()], "another project's session on the shared org-level client must not be listed")
+}
+
+// An organization-tier issuer is reachable throughout its organization, but a
+// project-tier remote client bound to it remains confined to its owning project.
+func TestListRemoteSessions_OrganizationTierIssuerScopesProjectClient(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	userIssuer := seedOrganizationTierUserSessionIssuer(t, ctx, ti.conn, "rs-org-issuer-list")
+	remoteIssuer := seedOrgLevelRemoteIssuer(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "rs-org-remote-list")
+	callerClient := seedRemoteClientAtTier(t, ctx, ti.conn, conv.ToNullUUID(*authCtx.ProjectID), conv.ToPGText(authCtx.ActiveOrganizationID), remoteIssuer, "rs-org-caller-list", userIssuer)
+	otherProject := createProject(t, ctx, ti.conn, "rs-org-other-list")
+	otherClient := seedRemoteClientAtTier(t, ctx, ti.conn, conv.ToNullUUID(otherProject), conv.ToPGText(authCtx.ActiveOrganizationID), remoteIssuer, "rs-org-sibling-list", userIssuer)
+
+	mine := insertRemoteSession(t, ctx, ti.conn, urn.NewUserSubject("rs_org_list_mine"), userIssuer.String(), callerClient.String())
+	theirs := insertRemoteSession(t, ctx, ti.conn, urn.NewUserSubject("rs_org_list_theirs"), userIssuer.String(), otherClient.String())
+
+	result, err := ti.service.ListRemoteSessions(ctx, &gen.ListRemoteSessionsPayload{})
+	require.NoError(t, err)
+
+	ids := make(map[string]bool, len(result.Items))
+	for _, item := range result.Items {
+		ids[item.ID] = true
+	}
+	require.True(t, ids[mine.ID.String()], "the owning project's client session must be listed")
+	require.False(t, ids[theirs.ID.String()], "a sibling project's client session must stay hidden")
+}
+
+// Fetching a session under an organization-tier issuer still requires the
+// remote client to belong to the caller's project or a broader tier.
+func TestGetRemoteSessionByID_OrganizationTierIssuerScopesProjectClient(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	userIssuer := seedOrganizationTierUserSessionIssuer(t, ctx, ti.conn, "rs-org-issuer-get")
+	remoteIssuer := seedOrgLevelRemoteIssuer(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "rs-org-remote-get")
+	callerClient := seedRemoteClientAtTier(t, ctx, ti.conn, conv.ToNullUUID(*authCtx.ProjectID), conv.ToPGText(authCtx.ActiveOrganizationID), remoteIssuer, "rs-org-caller-get", userIssuer)
+	otherProject := createProject(t, ctx, ti.conn, "rs-org-other-get")
+	otherClient := seedRemoteClientAtTier(t, ctx, ti.conn, conv.ToNullUUID(otherProject), conv.ToPGText(authCtx.ActiveOrganizationID), remoteIssuer, "rs-org-sibling-get", userIssuer)
+
+	mine := insertRemoteSession(t, ctx, ti.conn, urn.NewUserSubject("rs_org_get_mine"), userIssuer.String(), callerClient.String())
+	theirs := insertRemoteSession(t, ctx, ti.conn, urn.NewUserSubject("rs_org_get_theirs"), userIssuer.String(), otherClient.String())
+	q := repo.New(ti.conn)
+
+	got, err := q.GetRemoteSessionByID(ctx, repo.GetRemoteSessionByIDParams{
+		ID:             mine.ID,
+		ProjectID:      *authCtx.ProjectID,
+		OrganizationID: authCtx.ActiveOrganizationID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, mine.ID, got.ID)
+
+	_, err = q.GetRemoteSessionByID(ctx, repo.GetRemoteSessionByIDParams{
+		ID:             theirs.ID,
+		ProjectID:      *authCtx.ProjectID,
+		OrganizationID: authCtx.ActiveOrganizationID,
+	})
+	require.ErrorIs(t, err, pgx.ErrNoRows, "a sibling project's client session must stay hidden")
+}
+
+// Revoking through an organization-tier issuer is allowed for the owning
+// project's client and remains a no-op for a sibling project's client.
+func TestRevokeRemoteSession_OrganizationTierIssuerScopesProjectClient(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	userIssuer := seedOrganizationTierUserSessionIssuer(t, ctx, ti.conn, "rs-org-issuer-revoke")
+	remoteIssuer := seedOrgLevelRemoteIssuer(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "rs-org-remote-revoke")
+	callerClient := seedRemoteClientAtTier(t, ctx, ti.conn, conv.ToNullUUID(*authCtx.ProjectID), conv.ToPGText(authCtx.ActiveOrganizationID), remoteIssuer, "rs-org-caller-revoke", userIssuer)
+	otherProject := createProject(t, ctx, ti.conn, "rs-org-other-revoke")
+	otherClient := seedRemoteClientAtTier(t, ctx, ti.conn, conv.ToNullUUID(otherProject), conv.ToPGText(authCtx.ActiveOrganizationID), remoteIssuer, "rs-org-sibling-revoke", userIssuer)
+
+	mineSubject := urn.NewUserSubject("rs_org_revoke_mine")
+	theirsSubject := urn.NewUserSubject("rs_org_revoke_theirs")
+	mine := insertRemoteSession(t, ctx, ti.conn, mineSubject, userIssuer.String(), callerClient.String())
+	theirs := insertRemoteSession(t, ctx, ti.conn, theirsSubject, userIssuer.String(), otherClient.String())
+
+	require.NoError(t, ti.service.RevokeRemoteSession(ctx, &gen.RevokeRemoteSessionPayload{ID: mine.ID.String()}))
+	_, err := repo.New(ti.conn).GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            mineSubject,
+		RemoteSessionClientID: callerClient,
+	})
+	require.ErrorIs(t, err, pgx.ErrNoRows, "the owning project's session must be revoked")
+
+	require.NoError(t, ti.service.RevokeRemoteSession(ctx, &gen.RevokeRemoteSessionPayload{ID: theirs.ID.String()}))
+	got, err := repo.New(ti.conn).GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            theirsSubject,
+		RemoteSessionClientID: otherClient,
+	})
+	require.NoError(t, err)
+	require.Equal(t, theirs.ID, got.ID, "a sibling project's session must remain active")
+}
+
+// A global client is a tenantless catalog entry, so a project can read and
+// revoke its sessions when the provenance issuer is in scope.
+func TestRemoteSessions_GlobalClientRemainsReadableAndRevocable(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	userIssuer := seedOrganizationTierUserSessionIssuer(t, ctx, ti.conn, "rs-global-issuer")
+	remoteIssuer := seedGlobalRemoteIssuer(t, ctx, ti.conn, "rs-global-remote")
+	client := seedRemoteClientAtTier(t, ctx, ti.conn, uuid.NullUUID{}, conv.ToPGTextEmpty(""), remoteIssuer, "rs-global-client", userIssuer)
+	subject := urn.NewUserSubject("rs_global_client")
+	session := insertRemoteSession(t, ctx, ti.conn, subject, userIssuer.String(), client.String())
+
+	result, err := ti.service.ListRemoteSessions(ctx, &gen.ListRemoteSessionsPayload{})
+	require.NoError(t, err)
+	listed := false
+	for _, item := range result.Items {
+		listed = listed || item.ID == session.ID.String()
+	}
+	require.True(t, listed, "a global-client session must be listed")
+
+	got, err := repo.New(ti.conn).GetRemoteSessionByID(ctx, repo.GetRemoteSessionByIDParams{
+		ID:             session.ID,
+		ProjectID:      *authCtx.ProjectID,
+		OrganizationID: authCtx.ActiveOrganizationID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, session.ID, got.ID)
+
+	require.NoError(t, ti.service.RevokeRemoteSession(ctx, &gen.RevokeRemoteSessionPayload{ID: session.ID.String()}))
+	_, err = repo.New(ti.conn).GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            subject,
+		RemoteSessionClientID: client,
+	})
+	require.ErrorIs(t, err, pgx.ErrNoRows, "a global-client session must be revocable")
 }
 
 // TestRevokeRemoteSession_OrgLevelClientFromOwningProject confirms a project

--- a/server/internal/remotesessions/setup_test.go
+++ b/server/internal/remotesessions/setup_test.go
@@ -252,6 +252,23 @@ func createUserSessionIssuer(t *testing.T, ctx context.Context, conn *pgxpool.Po
 	return issuer.ID
 }
 
+// seedOrganizationTierUserSessionIssuer creates an issuer shared by every
+// project in the caller's organization.
+func seedOrganizationTierUserSessionIssuer(t *testing.T, ctx context.Context, conn *pgxpool.Pool, slug string) uuid.UUID {
+	t.Helper()
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	id, err := testrepo.New(conn).InsertOrganizationTierUserSessionIssuerFixture(ctx, testrepo.InsertOrganizationTierUserSessionIssuerFixtureParams{
+		OrganizationID:     conv.ToPGText(authCtx.ActiveOrganizationID),
+		Slug:               slug,
+		AuthnChallengeMode: "interactive",
+		SessionDuration:    pgtype.Interval{Microseconds: int64(time.Hour / time.Microsecond), Valid: true},
+	})
+	require.NoError(t, err)
+	return id
+}
+
 func countRemoteSessionClientUserSessionIssuerBindings(t *testing.T, ctx context.Context, conn *pgxpool.Pool, clientID, userIssuerID uuid.UUID) int {
 	t.Helper()
 
@@ -441,6 +458,28 @@ func seedOrgLevelRemoteClient(t *testing.T, ctx context.Context, conn *pgxpool.P
 		require.NoError(t, q.AttachRemoteSessionClientToUserSessionIssuer(ctx, repo.AttachRemoteSessionClientToUserSessionIssuerParams{
 			RemoteSessionClientID: created.ID,
 			UserSessionIssuerID:   usi,
+		}))
+	}
+	return created.ID
+}
+
+// seedRemoteClientAtTier creates a remote client with explicit tenancy and
+// binds it to each supplied user-session issuer.
+func seedRemoteClientAtTier(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID uuid.NullUUID, organizationID pgtype.Text, remoteIssuerID uuid.UUID, clientID string, userSessionIssuerIDs ...uuid.UUID) uuid.UUID {
+	t.Helper()
+	q := repo.New(conn)
+	created, err := q.CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
+		ProjectID:             projectID,
+		OrganizationID:        organizationID,
+		RemoteSessionIssuerID: remoteIssuerID,
+		ClientID:              clientID,
+		ClientIDIssuedAt:      conv.ToPGTimestamptz(time.Now().UTC()),
+	})
+	require.NoError(t, err)
+	for _, userSessionIssuerID := range userSessionIssuerIDs {
+		require.NoError(t, q.AttachRemoteSessionClientToUserSessionIssuer(ctx, repo.AttachRemoteSessionClientToUserSessionIssuerParams{
+			RemoteSessionClientID: created.ID,
+			UserSessionIssuerID:   userSessionIssuerID,
 		}))
 	}
 	return created.ID


### PR DESCRIPTION
[AIM-158](https://linear.app/speakeasy/issue/AIM-158/feat-scope-remote-session-reads-to-the-clients-tenancy-under)

## Summary

- Require both the user session issuer and remote session client to be reachable from the caller's project when listing, fetching, or revoking remote sessions.
- Preserve organization-tier and global client reachability while confining project-owned client credentials to their owning project.
- Add focused coverage for organization-tier issuers with owning and sibling project clients, plus global-client reads and revocation.

## Motivation

Organization-tier user session issuers are shared across projects. Scoping remote session operations only through the issuer therefore allowed a sibling project to reach sessions backed by another project's client registration. Intersecting issuer and client tenancy restores the project boundary without making broader-tier client sessions unreadable or irrevocable.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes [AIM-158](https://linear.app/speakeasy/issue/AIM-158) by scoping remote session listing, fetching, and revocation to both the caller-reachable user session issuer and remote session client. Previously, an organization-tier issuer could expose sessions backed by another project's client; project-owned clients are now isolated, while organization-tier and global clients remain reachable as intended.

**Tests**

- Covers owning and sibling project clients under organization-tier issuers across list, fetch, and revoke operations.
- Verifies global-client sessions remain readable and revocable.

<sup>Written for commit 43a89210f520681b59550013dfceb406ff53d8ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

