### PR TITLE
fix: classify and display Claude Tag channel sessions

### DIFF
--- a/client/dashboard/src/lib/formatPlatform.ts
+++ b/client/dashboard/src/lib/formatPlatform.ts
@@ -10,6 +10,7 @@ const PRODUCT_SURFACE_LABELS: Record<string, string> = {
   "claude-chat-web": "Claude Chat Web",
   claudecode: "Claude Code",
   "claude-code": "Claude Code",
+  "claude-tag": "Claude Tag",
   // Claude Code Desktop is its own surface, distinct from the claude-code CLI
   // and from cowork (which shares CCD's hook adapter slug but resolves to
   // "cowork" server-side via the OTEL service.name).

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -482,6 +482,7 @@ function MessageFilterBar({
   rawView,
   onRawViewChange,
   isClaudeTag,
+  showRawView,
 }: {
   condensed: boolean;
   onCondensedChange: (next: boolean) => void;
@@ -491,6 +492,9 @@ function MessageFilterBar({
   rawView: boolean;
   onRawViewChange: (next: boolean) => void;
   isClaudeTag: boolean;
+  /** When false, the Raw View toggle is hidden — the switch is ineffective
+   * outside the normal readable transcript (risk or search mode). */
+  showRawView: boolean;
 }) {
   return (
     <div className="flex items-center justify-end gap-3">
@@ -520,7 +524,7 @@ function MessageFilterBar({
           </div>
         </>
       )}
-      {isClaudeTag && (
+      {isClaudeTag && showRawView && (
         <div className="flex items-center gap-2">
           <Switch
             checked={rawView}
@@ -668,6 +672,7 @@ function ChatDetailHeader({
   rawView,
   onRawViewChange,
   isClaudeTag,
+  showRawView,
   searchBar,
   pinned,
   onTogglePinned,
@@ -693,6 +698,7 @@ function ChatDetailHeader({
   rawView: boolean;
   onRawViewChange: (next: boolean) => void;
   isClaudeTag: boolean;
+  showRawView: boolean;
   /** Optional find-in-conversation bar (normal view only). */
   searchBar?: ReactNode;
   pinned: boolean;
@@ -809,6 +815,7 @@ function ChatDetailHeader({
               rawView={rawView}
               onRawViewChange={onRawViewChange}
               isClaudeTag={isClaudeTag}
+              showRawView={showRawView}
               condensed={condensed}
               onCondensedChange={onCondensedChange}
               riskyOnly={riskyOnly}
@@ -1654,6 +1661,7 @@ function ChatDetailPanel({
           setView("chat");
         }}
         isClaudeTag={isClaudeTag}
+        showRawView={readableTag || rawView}
         chatId={chatId}
         chat={chat}
         userLabel={userLabelNode}

--- a/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
+++ b/client/dashboard/src/pages/chatLogs/ChatDetailPanel.tsx
@@ -1,3 +1,4 @@
+import { claudeTagMetadata, projectClaudeTagRows } from "./claudeTag";
 import { IdentityLink } from "@/components/identity-link";
 import { format, formatDistanceToNow } from "date-fns";
 import {
@@ -271,6 +272,7 @@ function SessionSummary({
     accountType?: string;
     accountEmail?: string;
     source?: string;
+    channelNames?: string[];
     originatingClient?: string;
     litellmProxied?: boolean;
     createdAt: Date;
@@ -364,6 +366,9 @@ function SessionSummary({
                 </span>
               </MetaRow>
             )}
+            {chat.channelNames && chat.channelNames.length > 0 && (
+              <MetaRow label="Channel">{chat.channelNames.join(", ")}</MetaRow>
+            )}
             <MetaRow label="Duration">{duration}s</MetaRow>
             <MetaRow label="Messages">{messageCount}</MetaRow>
             <MetaRow label="Tool calls">{toolCount}</MetaRow>
@@ -448,6 +453,11 @@ function ChatDetailMetadataBadges({
           </Badge.Text>
         </Badge>
       )}
+      {chat.channelNames?.map((channel) => (
+        <HeaderMetadataBadge key={channel}>
+          Channel: {channel}
+        </HeaderMetadataBadge>
+      ))}
       {hasCost && (
         <HeaderMetadataBadge>
           {formatUsageCost(chat.totalCost!)}
@@ -469,12 +479,18 @@ function MessageFilterBar({
   riskyOnly,
   onRiskyOnlyChange,
   showRiskyOnly,
+  rawView,
+  onRawViewChange,
+  isClaudeTag,
 }: {
   condensed: boolean;
   onCondensedChange: (next: boolean) => void;
   riskyOnly: boolean;
   onRiskyOnlyChange: (next: boolean) => void;
   showRiskyOnly: boolean;
+  rawView: boolean;
+  onRawViewChange: (next: boolean) => void;
+  isClaudeTag: boolean;
 }) {
   return (
     <div className="flex items-center justify-end gap-3">
@@ -503,6 +519,18 @@ function MessageFilterBar({
             </span>
           </div>
         </>
+      )}
+      {isClaudeTag && (
+        <div className="flex items-center gap-2">
+          <Switch
+            checked={rawView}
+            onCheckedChange={onRawViewChange}
+            aria-label="Raw view"
+          />
+          <span className="text-muted-foreground text-xs font-medium">
+            Raw view
+          </span>
+        </div>
       )}
     </div>
   );
@@ -637,6 +665,9 @@ function ChatDetailHeader({
   riskyOnly,
   onRiskyOnlyChange,
   showRiskyOnly,
+  rawView,
+  onRawViewChange,
+  isClaudeTag,
   searchBar,
   pinned,
   onTogglePinned,
@@ -659,6 +690,9 @@ function ChatDetailHeader({
   riskyOnly: boolean;
   onRiskyOnlyChange: (next: boolean) => void;
   showRiskyOnly: boolean;
+  rawView: boolean;
+  onRawViewChange: (next: boolean) => void;
+  isClaudeTag: boolean;
   /** Optional find-in-conversation bar (normal view only). */
   searchBar?: ReactNode;
   pinned: boolean;
@@ -772,6 +806,9 @@ function ChatDetailHeader({
           <div className="min-w-0 flex-1">{searchBar}</div>
           <div className="shrink-0">
             <MessageFilterBar
+              rawView={rawView}
+              onRawViewChange={onRawViewChange}
+              isClaudeTag={isClaudeTag}
               condensed={condensed}
               onCondensedChange={onCondensedChange}
               riskyOnly={riskyOnly}
@@ -1048,6 +1085,8 @@ function ChatDetailPanel({
   const canViewRisk = isPlatformAdmin || hasScope("org:admin");
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [view, setView] = useState<ViewMode>("chat");
+  const [rawView, setRawView] = useState(false);
+  useEffect(() => setRawView(false), [chatId]);
   const [riskyOnly, setRiskyOnly] = useState(false);
   const [exclusionState, setExclusionState] =
     useState<ExclusionSheetState | null>(null);
@@ -1121,8 +1160,29 @@ function ChatDetailPanel({
   // Prefer the enriched (cost/usage) normal-load chat, but fall back to the
   // active transcript's chat so a windowed view still renders if only that load
   // resolved (otherwise the panel would show "Not found" despite having data).
-  const chat = transcript.chat ?? active.chat;
+  const capturedChat = transcript.chat ?? active.chat;
   const chatMessages = active.messages;
+  const tagMetadata = useMemo(
+    () => claudeTagMetadata(transcript.messages),
+    [transcript.messages],
+  );
+  const isClaudeTag =
+    capturedChat?.source === "claude-tag" ||
+    ((capturedChat?.source === "claude-code" ||
+      capturedChat?.source === "claude") &&
+      tagMetadata.detected);
+  const chat = useMemo(() => {
+    if (!capturedChat || !isClaudeTag) return capturedChat;
+    const title = capturedChat.title?.startsWith("<wake")
+      ? tagMetadata.title
+      : capturedChat.title;
+    return {
+      ...capturedChat,
+      source: "claude-tag",
+      channelNames: tagMetadata.channels,
+      title: title || "Claude Tag session",
+    };
+  }, [capturedChat, isClaudeTag, tagMetadata.title, tagMetadata.channels]);
   const validFocusedMessageTurn =
     focusedMessageTurn !== undefined &&
     Number.isInteger(focusedMessageTurn) &&
@@ -1268,10 +1328,17 @@ function ChatDetailPanel({
     return buildClaudeTurnByPromptId(turns);
   }, [chat?.agentUsage]);
 
-  const transcriptRows = useMemo(
-    () => buildTranscript(chatMessages, chat?.contentParts ?? []),
-    [chatMessages, chat?.contentParts],
-  );
+  const readableTag =
+    isClaudeTag &&
+    !rawView &&
+    !riskWindowed &&
+    !searchActive &&
+    !validFocusedMessageTurn;
+  const transcriptRows = useMemo(() => {
+    const rows = buildTranscript(chatMessages, chat?.contentParts ?? []);
+    if (readableTag) return projectClaudeTagRows(rows);
+    return rows;
+  }, [chatMessages, chat?.contentParts, readableTag]);
   const filterActive = riskyOnly;
   const visibleRows = useMemo(() => {
     if (!riskyOnly) return transcriptRows;
@@ -1454,7 +1521,7 @@ function ChatDetailPanel({
     }
   }, [view, fullyLoaded, loadingAllMessages, loadAllMessages]);
 
-  const userLabelOverride = chat ? userLabel : undefined;
+  const userLabelOverride = chat && !readableTag ? userLabel : undefined;
   // The same key ChatOwnerLabel uses: a chat carries the Gram user when the
   // owner is a member and the reported agent id otherwise. Memoized because a
   // fresh object each render would invalidate the row context below on every
@@ -1479,7 +1546,7 @@ function ChatDetailPanel({
       searchQuery: searchActive ? searchQuery : undefined,
       userLabel: chat?.externalUserId,
       userLabelOverride,
-      ownerIdentifier,
+      ownerIdentifier: readableTag ? null : ownerIdentifier,
     }),
     [
       riskResultsByMessage,
@@ -1492,6 +1559,7 @@ function ChatDetailPanel({
       chat?.externalUserId,
       userLabelOverride,
       ownerIdentifier,
+      readableTag,
     ],
   );
 
@@ -1580,6 +1648,12 @@ function ChatDetailPanel({
   return (
     <div className="bg-background flex h-full flex-col">
       <ChatDetailHeader
+        rawView={rawView}
+        onRawViewChange={(on) => {
+          setRawView(on);
+          setView("chat");
+        }}
+        isClaudeTag={isClaudeTag}
         chatId={chatId}
         chat={chat}
         userLabel={userLabelNode}

--- a/client/dashboard/src/pages/chatLogs/claudeTag.test.ts
+++ b/client/dashboard/src/pages/chatLogs/claudeTag.test.ts
@@ -88,7 +88,9 @@ describe("Claude Tag projection", () => {
             id: "call",
             function: {
               name: "mcp__slackbot__reply",
-              arguments: JSON.stringify({ text: "I can help with the release notes." }),
+              arguments: JSON.stringify({
+                text: "I can help with the release notes.",
+              }),
             },
           },
         ]),

--- a/client/dashboard/src/pages/chatLogs/claudeTag.test.ts
+++ b/client/dashboard/src/pages/chatLogs/claudeTag.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import type { ChatMessage } from "@gram/client/models/components/chatmessage.js";
+import { buildDisplayItems, buildTranscript } from "./transcript";
+import { parseClaudeTagWake, projectClaudeTagRows } from "./claudeTag";
+
+const wake =
+  '<wake reason="channel-activity"><channel id="DEMO_CHANNEL" name="demo-team"><message from="human" author="Demo User" id="1" trigger="true">&lt;@DEMO_BOT|Claude&gt; hello &amp; welcome</message></channel></wake>';
+function message(overrides: Partial<ChatMessage>): ChatMessage {
+  return {
+    id: "user",
+    seq: 1,
+    role: "user",
+    content: wake,
+    createdAt: new Date(),
+    generation: 0,
+    model: "",
+    ...overrides,
+  };
+}
+
+describe("Claude Tag projection", () => {
+  it("keeps distinct author headers for humans in the same wake", () => {
+    const content =
+      '<wake><channel id="DEMO_CHANNEL"><message from="human" author="First User">Hi</message><message from="human" author="Second User">Hello</message></channel></wake>';
+    const rows = projectClaudeTagRows(buildTranscript([message({ content })]));
+    const headers = buildDisplayItems({ rows }).filter(
+      (item) => item.type === "turnHeader",
+    );
+    expect(headers.map((item) => item.userId)).toEqual([
+      "First User",
+      "Second User",
+    ]);
+  });
+  it("keeps failed reply tools visible", () => {
+    const rows = buildTranscript([
+      message({
+        role: "assistant",
+        content: "",
+        toolCalls: JSON.stringify([
+          {
+            id: "call",
+            function: {
+              name: "mcp__slackbot__reply",
+              arguments: { text: "Hello" },
+            },
+          },
+        ]),
+      }),
+      message({
+        id: "result",
+        role: "tool",
+        toolCallId: "call",
+        content: '{"isError":true,"text":"Unable to reply"}',
+      }),
+    ]);
+    expect(projectClaudeTagRows(rows)).toEqual(rows);
+  });
+  it("decodes human text and extracts channel metadata", () => {
+    expect(parseClaudeTagWake(wake)).toMatchObject({
+      title: "Claude Tag in #demo-team",
+      messages: [{ author: "Demo User", channel: "demo-team" }],
+    });
+  });
+  it("keeps the channel title when topics change and normalizes the hash", () => {
+    expect(
+      parseClaudeTagWake(
+        wake
+          .replace("hello &amp; welcome", "Plan lunch")
+          .replace('name="demo-team"', 'name="#demo-team"'),
+      )?.title,
+    ).toBe("Claude Tag in #demo-team");
+  });
+  it("rejects malformed and unrelated markup", () => {
+    expect(parseClaudeTagWake("<wake><channel")).toBeNull();
+    expect(parseClaudeTagWake("hello")).toBeNull();
+  });
+  it("shows the human and Slack reply, drops repeated context and acknowledgments, and preserves raw input", () => {
+    const input = [
+      message({}),
+      message({ id: "repeat", seq: 2 }),
+      message({
+        id: "reply",
+        seq: 3,
+        role: "assistant",
+        content: "",
+        toolCalls: JSON.stringify([
+          {
+            id: "call",
+            function: {
+              name: "mcp__slackbot__reply",
+              arguments: JSON.stringify({ text: "I can help with the release notes." }),
+            },
+          },
+        ]),
+      }),
+      message({
+        id: "ack",
+        seq: 4,
+        role: "assistant",
+        content: "Replied in the thread.",
+      }),
+    ];
+    const rows = projectClaudeTagRows(buildTranscript(input));
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      message: {
+        id: "user",
+        userId: "Demo User",
+        content: "@Claude hello & welcome",
+      },
+    });
+    expect(rows[1]).toMatchObject({
+      message: { id: "reply", content: "I can help with the release notes." },
+    });
+    expect(input[0]?.content).toBe(wake);
+  });
+  it("retains unrecognized reply inputs", () => {
+    const rows = buildTranscript([
+      message({
+        role: "assistant",
+        content: "",
+        toolCalls: JSON.stringify([
+          { function: { name: "mcp__slackbot__reply", arguments: "invalid" } },
+        ]),
+      }),
+    ]);
+    expect(projectClaudeTagRows(rows)).toEqual(rows);
+  });
+});

--- a/client/dashboard/src/pages/chatLogs/claudeTag.ts
+++ b/client/dashboard/src/pages/chatLogs/claudeTag.ts
@@ -99,9 +99,7 @@ export function projectClaudeTagRows(rows: TranscriptRow[]): TranscriptRow[] {
       const name = row.toolCall?.function?.name ?? row.toolCall?.name;
       if (name === "mcp__slackbot__reply") {
         const text = replyText(row.toolCall?.function?.arguments);
-        // Only project the reply text when we have a result confirming delivery;
-        // without a result the tool may not have sent.
-        if (text !== null && row.callMessage && row.resultMessage)
+        if (text !== null && row.callMessage)
           return [
             {
               kind: "message",

--- a/client/dashboard/src/pages/chatLogs/claudeTag.ts
+++ b/client/dashboard/src/pages/chatLogs/claudeTag.ts
@@ -1,0 +1,164 @@
+import type { ChatMessage } from "@gram/client/models/components/chatmessage.js";
+import { messageText, type TranscriptRow } from "./transcript";
+
+interface ClaudeTagWake {
+  title: string;
+  messages: Array<{
+    text: string;
+    author: string;
+    id: string | null;
+    timestamp: string | null;
+    trigger: boolean;
+    channel: string;
+  }>;
+}
+
+export function parseClaudeTagWake(content: unknown): ClaudeTagWake | null {
+  const text = messageText(content).trim();
+  if (!text.startsWith("<wake")) return null;
+  const doc = new DOMParser().parseFromString(text, "application/xml");
+  if (
+    doc.querySelector("parsererror") ||
+    doc.documentElement.tagName !== "wake"
+  )
+    return null;
+  const channels = Array.from(doc.documentElement.children).filter(
+    (el) => el.tagName === "channel" && el.getAttribute("id"),
+  );
+  const messages = channels.flatMap((channel) =>
+    Array.from(channel.children)
+      .filter(
+        (el) => el.tagName === "message" && el.getAttribute("from") === "human",
+      )
+      .map((el) => ({
+        text: (el.textContent ?? "").replace(/<@[^>|]+\|([^>]+)>/g, "@$1"),
+        author:
+          el.getAttribute("author") ||
+          el.getAttribute("author-handle") ||
+          "User",
+        id: el.getAttribute("id"),
+        timestamp: el.getAttribute("sent-at"),
+        trigger: el.getAttribute("trigger") === "true",
+        channel:
+          channel.getAttribute("name") ||
+          channel.getAttribute("channel-name") ||
+          channel.getAttribute("id")!,
+      })),
+  );
+  if (!messages.length) return null;
+  return {
+    messages,
+    title: `Claude Tag in #${(messages.find((m) => m.trigger) ?? messages[0])!.channel.replace(/^#/, "")}`,
+  };
+}
+
+export function claudeTagMetadata(messages: ChatMessage[]): {
+  detected: boolean;
+  title: string | undefined;
+  channels: string[];
+} {
+  const wakes = messages
+    .filter((m) => m.role === "user")
+    .map((m) => parseClaudeTagWake(m.content))
+    .filter((wake) => wake !== null);
+  return {
+    detected: wakes.length > 0,
+    title: wakes[0]?.title,
+    channels: [
+      ...new Set(wakes.flatMap((wake) => wake.messages.map((m) => m.channel))),
+    ],
+  };
+}
+
+function replyText(args: unknown): string | null {
+  try {
+    const value: unknown = typeof args === "string" ? JSON.parse(args) : args;
+    if (
+      value &&
+      typeof value === "object" &&
+      "text" in value &&
+      typeof value.text === "string"
+    )
+      return value.text;
+  } catch {
+    /* Malformed inputs stay visible in the transcript. */
+  }
+  return null;
+}
+
+/** Project captured rows, retaining original message IDs for risk findings and
+ * navigation. Unknown formats remain visible, so extraction failures lose no text. */
+export function projectClaudeTagRows(rows: TranscriptRow[]): TranscriptRow[] {
+  const seen = new Set<string>();
+  return rows.flatMap((row): TranscriptRow[] => {
+    if (row.kind === "tool") {
+      if (row.callMessage?.isRisk || row.resultMessage?.isRisk) return [row];
+      const result = messageText(row.resultMessage?.content);
+      if (/"isError"\s*:\s*true|"error"\s*:|\b(failed|error)\b/i.test(result))
+        return [row];
+      const name = row.toolCall?.function?.name ?? row.toolCall?.name;
+      if (name === "mcp__slackbot__reply") {
+        const text = replyText(row.toolCall?.function?.arguments);
+        if (text !== null && row.callMessage)
+          return [
+            {
+              kind: "message",
+              id: row.id,
+              entryType: "assistant",
+              attachments: [],
+              generation: row.generation,
+              message: {
+                ...row.callMessage,
+                role: "assistant",
+                content: text,
+                toolCalls: undefined,
+              },
+            },
+          ];
+      }
+      if (
+        name === "mcp__slackbot__react" ||
+        name === "mcp__slackbot__no_reply_needed" ||
+        name === "mcp__slackbot__send_later"
+      )
+        return [];
+      return [row];
+    }
+    if (row.entryType === "user") {
+      const wake = parseClaudeTagWake(row.message.content);
+      if (!wake) return [row];
+      return wake.messages.flatMap((message, index) => {
+        const key = `${message.channel}:${message.id}`;
+        if (message.id && seen.has(key)) return [];
+        if (message.id) seen.add(key);
+        const timestamp = message.timestamp
+          ? new Date(message.timestamp)
+          : row.message.createdAt;
+        return [
+          {
+            ...row,
+            separateTurn: true,
+            id: `${row.id}:tag:${index}`,
+            message: {
+              ...row.message,
+              content: message.text,
+              userId: message.author,
+              externalUserId: undefined,
+              createdAt: Number.isNaN(timestamp.getTime())
+                ? row.message.createdAt
+                : timestamp,
+            },
+          },
+        ];
+      });
+    }
+    if (
+      row.entryType === "assistant" &&
+      /^Replied in the thread\.?$/i.test(
+        messageText(row.message.content).trim(),
+      )
+    )
+      return [];
+    return [row];
+  });
+}

--- a/client/dashboard/src/pages/chatLogs/claudeTag.ts
+++ b/client/dashboard/src/pages/chatLogs/claudeTag.ts
@@ -99,7 +99,9 @@ export function projectClaudeTagRows(rows: TranscriptRow[]): TranscriptRow[] {
       const name = row.toolCall?.function?.name ?? row.toolCall?.name;
       if (name === "mcp__slackbot__reply") {
         const text = replyText(row.toolCall?.function?.arguments);
-        if (text !== null && row.callMessage)
+        // Only project the reply text when we have a result confirming delivery;
+        // without a result the tool may not have sent.
+        if (text !== null && row.callMessage && row.resultMessage)
           return [
             {
               kind: "message",

--- a/client/dashboard/src/pages/chatLogs/transcript.ts
+++ b/client/dashboard/src/pages/chatLogs/transcript.ts
@@ -108,6 +108,8 @@ export function findQueryRanges(
 
 /** A plain user / assistant / system turn rendered as a chat bubble. */
 export interface MessageRow {
+  /** A channel message starts its own author header within a captured turn. */
+  separateTurn?: boolean;
   kind: "message";
   id: string;
   entryType: MessageEntryType;
@@ -587,13 +589,18 @@ export function buildDisplayItems({
     // Open a new turn whenever authorship flips (user ↔ assistant), grouping an
     // assistant's text + tool calls under one header.
     const author = rowTurnAuthor(row);
-    if (author !== lastAuthor) {
+    if (author !== lastAuthor || (row.kind === "message" && row.separateTurn)) {
       // Collect every message in this turn (look ahead until authorship flips)
       // so the header can aggregate the turn's findings + exclusion actions.
       const messageIds: string[] = [];
       for (
         let j = i;
-        j < rows.length && rowTurnAuthor(rows[j]!) === author;
+        j < rows.length &&
+        rowTurnAuthor(rows[j]!) === author &&
+        (j === i ||
+          !(
+            rows[j]!.kind === "message" && (rows[j] as MessageRow).separateTurn
+          ));
         j++
       ) {
         messageIds.push(...rowMessageIds(rows[j]!));

--- a/seed/demo/PAGES.md
+++ b/seed/demo/PAGES.md
@@ -85,3 +85,5 @@ present in a developer's org and deliberately absent from the shared demo org.
    PostToolUse hook shapes — generic `chat:completion` rows are ignored.
 6. Give every row surface its own trace-id namespace; shared trace ids merge
    into one unclassifiable trace in `trace_summaries`.
+
+Claude Tag: Agent Sessions includes “Claude Tag in #demo-releases”. Open it to see the demo-releases channel, human message, and assistant reply. Raw view reveals the wake envelope and Slack reply tool call.

--- a/server/internal/demoseed/postgres.sql
+++ b/server/internal/demoseed/postgres.sql
@@ -1832,6 +1832,22 @@ E'--- a/SKILL.md\n+++ b/SKILL.md\n@@ -6,4 +6,5 @@\n # Refund handling\n \n 1. Ve
             now() - (interval '19 hours' * i));
   END LOOP;
 
+  -- Claude Tag preserves the wake/tool transcript for the Raw view toggle.
+  chat_id := demo.det_uuid('gram-demo-claude-tag-chat');
+  INSERT INTO chats (id, project_id, organization_id, user_id, external_user_id, title, created_at, updated_at)
+  VALUES (chat_id, proj_a, demo_org, demo_user_ids[1], demo_user_emails[1], 'Claude Tag in #demo-releases',
+          now() - interval '10 minutes', now() - interval '9 minutes');
+  INSERT INTO chat_messages (id, chat_id, project_id, role, content, tool_calls, source, model, created_at, risk_analyzed_at)
+  VALUES
+    (demo.det_uuid('gram-demo-claude-tag-prompt'), chat_id, proj_a, 'user',
+     '<wake reason="channel-activity"><channel id="DEMO_CHANNEL" name="demo-releases"><message from="human" author="Demo User" id="demo-message-1" trigger="true">Help summarize the release</message></channel></wake>',
+     NULL, 'claude-tag', 'claude-sonnet-4-6', now() - interval '10 minutes', now()),
+    (demo.det_uuid('gram-demo-claude-tag-reply'), chat_id, proj_a, 'assistant', '',
+     '[{"id":"demo-tag-reply","type":"function","function":{"name":"mcp__slackbot__reply","arguments":"{\"text\":\"The release improves session transcripts and channel visibility.\",\"thread_ts\":\"demo-message-1\"}"}}]'::jsonb,
+     'claude-tag', 'claude-sonnet-4-6', now() - interval '9 minutes', now()),
+    (demo.det_uuid('gram-demo-claude-tag-ack'), chat_id, proj_a, 'assistant', 'Replied in the thread.',
+     NULL, 'claude-tag', 'claude-sonnet-4-6', now() - interval '9 minutes', now());
+
   -- Quarantine lifecycle events use their own audit subject and action rather
   -- than reusing a generic policy-block row.
   INSERT INTO audit_logs (id, organization_id, project_id, actor_id, actor_type,

--- a/server/internal/hooks/claude_tag.go
+++ b/server/internal/hooks/claude_tag.go
@@ -1,0 +1,57 @@
+package hooks
+
+import (
+	"encoding/xml"
+	"strings"
+)
+
+// claudeTagTitle recognizes channel wake envelopes without interpreting their
+// contents as markup or changing the captured transcript.
+func claudeTagTitle(prompt string) (string, bool) {
+	if !strings.HasPrefix(strings.TrimSpace(prompt), "<wake") {
+		return "", false
+	}
+	var wake struct {
+		XMLName  xml.Name `xml:"wake"`
+		Channels []struct {
+			ID          string `xml:"id,attr"`
+			Name        string `xml:"name,attr"`
+			ChannelName string `xml:"channel-name,attr"`
+			Messages    []struct {
+				From    string `xml:"from,attr"`
+				Trigger string `xml:"trigger,attr"`
+				Text    string `xml:",chardata"`
+			} `xml:"message"`
+		} `xml:"channel"`
+	}
+	if err := xml.Unmarshal([]byte(strings.TrimSpace(prompt)), &wake); err != nil {
+		return "", false
+	}
+	first := ""
+	for _, channel := range wake.Channels {
+		if channel.ID == "" {
+			continue
+		}
+		name := strings.TrimSpace(channel.Name)
+		if name == "" {
+			name = strings.TrimSpace(channel.ChannelName)
+		}
+		if name == "" {
+			name = channel.ID
+		}
+		title := "Claude Tag in #" + strings.TrimPrefix(name, "#")
+		for _, message := range channel.Messages {
+			text := strings.Join(strings.Fields(message.Text), " ")
+			if message.From != "human" || text == "" {
+				continue
+			}
+			if first == "" {
+				first = title
+			}
+			if message.Trigger == "true" {
+				return title, true
+			}
+		}
+	}
+	return first, first != ""
+}

--- a/server/internal/hooks/claude_tag.go
+++ b/server/internal/hooks/claude_tag.go
@@ -41,11 +41,11 @@ func claudeTagTitle(prompt string) (string, bool) {
 		}
 		title := "Claude Tag in #" + strings.TrimPrefix(name, "#")
 		for _, message := range channel.Messages {
-			text := strings.Join(strings.Fields(message.Text), " ")
-			if message.From != "human" || text == "" {
+			if message.From != "human" {
 				continue
 			}
-			if first == "" {
+			text := strings.Join(strings.Fields(message.Text), " ")
+			if first == "" && text != "" {
 				first = title
 			}
 			if message.Trigger == "true" {

--- a/server/internal/hooks/claude_tag_test.go
+++ b/server/internal/hooks/claude_tag_test.go
@@ -53,7 +53,7 @@ func TestClaudeTagIngestCachesSurfaceForLaterEvents(t *testing.T) {
 	later := canonicalIngestPayload("claude-code", "assistant.responded", "demo-tag-session")
 	metadata := ti.service.canonicalSessionMetadata(ctx, later, authCtx, canonicalActor{UserID: "", Email: ""})
 	require.Equal(t, "claude-tag", metadata.ServiceName)
-	require.Equal(t, "Claude Tag in #DEMO_CHANNEL", canonicalChatTitle(payload, ""))
+	require.Equal(t, "Claude Tag in #DEMO_CHANNEL", canonicalChatTitle(payload, "", "claude-code"))
 	stored, err := chatRepo.New(ti.conn).GetChat(ctx, chatRepo.GetChatParams{ID: chatID, ProjectID: *authCtx.ProjectID})
 	require.NoError(t, err)
 	require.Equal(t, "Claude Tag in #DEMO_CHANNEL", stored.Title.String)

--- a/server/internal/hooks/claude_tag_test.go
+++ b/server/internal/hooks/claude_tag_test.go
@@ -1,0 +1,85 @@
+package hooks
+
+import (
+	"testing"
+	"time"
+
+	gen "github.com/speakeasy-api/gram/server/gen/hooks"
+	chatRepo "github.com/speakeasy-api/gram/server/internal/chat/repo"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/hooks/repo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClaudeTagTitle(t *testing.T) {
+	t.Parallel()
+	title, ok := claudeTagTitle(`<wake reason="channel-activity"><channel id="DEMO_CHANNEL"><message from="human">Earlier context</message><message from="human" trigger="true">&lt;@DEMO_BOT|Claude&gt; Hello &amp; welcome</message></channel></wake>`)
+	require.True(t, ok)
+	require.Equal(t, "Claude Tag in #DEMO_CHANNEL", title)
+}
+
+func TestClaudeTagRejectsUnrelatedOrMalformedInput(t *testing.T) {
+	t.Parallel()
+	for _, input := range []string{"hello", `<wake><channel`, `<wake><message from="human">Hi</message></wake>`, `<wake><channel id="DEMO_CHANNEL"><message from="assistant">Hi</message></channel></wake>`} {
+		_, ok := claudeTagTitle(input)
+		require.False(t, ok)
+	}
+}
+
+func TestClaudeTagSurfaceSurvivesAmbiguousClaudeReports(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "claude-tag", preferClaudeServiceName("claude-code", "claude-tag"))
+	require.Equal(t, "claude-tag", preferClaudeServiceName("claude", "claude-tag"))
+	require.Equal(t, "cursor", preferClaudeServiceName("cursor", "claude-tag"))
+}
+
+func TestClaudeTagIngestCachesSurfaceForLaterEvents(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestHooksService(t)
+	ti.service.productFeatures = alwaysEnabledFeatures{}
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	chatID := sessionIDToUUID("demo-tag-session")
+	_, err := ti.service.repo.UpsertClaudeCodeSession(ctx, repo.UpsertClaudeCodeSessionParams{
+		ID: chatID, ProjectID: *authCtx.ProjectID, OrganizationID: authCtx.ActiveOrganizationID,
+		Title: conv.ToPGText("An unrelated earlier topic"),
+	})
+	require.NoError(t, err)
+	prompt := `<wake><channel id="DEMO_CHANNEL"><message from="human" trigger="true">Summarize the release</message></channel></wake>`
+	payload := canonicalIngestPayload("claude-code", "prompt.submitted", "demo-tag-session")
+	payload.Data = &gen.HookIngestData{Prompt: &gen.HookPromptData{Text: &prompt}}
+	ti.service.recordCanonicalHook(ctx, payload, authCtx, canonicalActor{UserID: "", Email: ""}, time.Now(), "")
+	later := canonicalIngestPayload("claude-code", "assistant.responded", "demo-tag-session")
+	metadata := ti.service.canonicalSessionMetadata(ctx, later, authCtx, canonicalActor{UserID: "", Email: ""})
+	require.Equal(t, "claude-tag", metadata.ServiceName)
+	require.Equal(t, "Claude Tag in #DEMO_CHANNEL", canonicalChatTitle(payload, ""))
+	stored, err := chatRepo.New(ti.conn).GetChat(ctx, chatRepo.GetChatParams{ID: chatID, ProjectID: *authCtx.ProjectID})
+	require.NoError(t, err)
+	require.Equal(t, "Claude Tag in #DEMO_CHANNEL", stored.Title.String)
+	messages, err := chatRepo.New(ti.conn).ListChatMessages(ctx, chatRepo.ListChatMessagesParams{ChatID: chatID, ProjectID: *authCtx.ProjectID})
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	require.Equal(t, "claude-tag", messages[0].Source.String)
+	require.NoError(t, chatRepo.New(ti.conn).RenameChat(ctx, chatRepo.RenameChatParams{
+		ID: chatID, ProjectID: *authCtx.ProjectID, Title: conv.ToPGText("My channel notes"), TitleManuallySet: true,
+	}))
+	require.NoError(t, ti.service.repo.SetClaudeTagChatTitle(ctx, repo.SetClaudeTagChatTitleParams{
+		ID: chatID, ProjectID: *authCtx.ProjectID, Title: conv.ToPGText("Claude Tag in #dev-demo"),
+	}))
+	renamed, err := chatRepo.New(ti.conn).GetChat(ctx, chatRepo.GetChatParams{ID: chatID, ProjectID: *authCtx.ProjectID})
+	require.NoError(t, err)
+	require.Equal(t, "My channel notes", renamed.Title.String)
+}
+
+func TestClaudeTagTitleUsesChannelAcrossTopics(t *testing.T) {
+	t.Parallel()
+	for _, prompt := range []string{
+		`<wake><channel id="DEMO_CHANNEL" name="dev-demo"><message from="human" trigger="true">Fix the build</message></channel></wake>`,
+		`<wake><channel id="DEMO_CHANNEL" channel-name="#dev-demo"><message from="human" trigger="true">Plan lunch</message></channel></wake>`,
+	} {
+		title, ok := claudeTagTitle(prompt)
+		require.True(t, ok)
+		require.Equal(t, "Claude Tag in #dev-demo", title)
+	}
+}

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -997,6 +997,9 @@ func (s *Service) recordCanonicalHook(ctx context.Context, payload *gen.IngestPa
 	// hook row and the chat persistence below stamp the same AI-account
 	// attribution.
 	metadata := s.canonicalSessionMetadata(ctx, payload, authCtx, actor)
+	if _, tag := claudeTagTitle(canonicalPromptText(payload)); tag && claudeServiceNameSpecificity(metadata.ServiceName) > 0 {
+		metadata.ServiceName = "claude-tag"
+	}
 	// Resolve the product surface once per event: the OTEL-cached service.name
 	// wins ("cowork" vs "claude-code"), the SessionStart variant fills in for
 	// sessions whose OTEL stream hasn't arrived, and non-Claude adapters pass
@@ -1007,8 +1010,8 @@ func (s *Service) recordCanonicalHook(ctx context.Context, payload *gen.IngestPa
 	// org-scoped key and no self-reported email carries nothing else, and the
 	// OTEL path needs the cached hostname to stamp Claude cost rows so the
 	// user breakdown can fall back to the device.
-	if strings.TrimSpace(payload.Event.Type) == "session.started" &&
-		metadata.SessionID != "" && (metadata.UserID != "" || metadata.UserEmail != "" || metadata.Hostname != "") {
+	if (strings.TrimSpace(payload.Event.Type) == "session.started" || metadata.ServiceName == "claude-tag") &&
+		metadata.SessionID != "" && (metadata.ServiceName == "claude-tag" || metadata.UserID != "" || metadata.UserEmail != "" || metadata.Hostname != "") {
 		cacheCtx, cancel := context.WithTimeout(ctx, canonicalSessionCacheWriteTimeout)
 		err := s.cache.Set(cacheCtx, sessionCacheKey(metadata.SessionID), metadata, 24*time.Hour)
 		cancel()
@@ -1546,11 +1549,24 @@ func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload
 	}
 
 	title := canonicalChatTitle(payload, titleContent)
+	var stored bool
+	var err error
 	if uncorrelatedPrompt {
-		return s.insertUncorrelatedAgentPrompt(ctx, metadata, msg, title, nativePrompt)
+		stored, err = s.insertUncorrelatedAgentPrompt(ctx, metadata, msg, title, nativePrompt)
+	} else {
+		stored, err = s.insertMessageWithFallbackUpsertResult(ctx, metadata, msg.ChatID, *authCtx.ProjectID, msg, title)
 	}
-	stored, err := s.insertMessageWithFallbackUpsertResult(ctx, metadata, msg.ChatID, *authCtx.ProjectID, msg, title)
-	return stored && msg.Role == "user", err
+	if err != nil {
+		return false, err
+	}
+	if channelTitle, isWake := claudeTagTitle(titleContent); stored && hookSource == "claude-tag" && msg.Role == "user" && isWake {
+		if err := s.repo.SetClaudeTagChatTitle(ctx, repo.SetClaudeTagChatTitleParams{
+			ID: msg.ChatID, ProjectID: msg.ProjectID, Title: conv.ToPGText(channelTitle),
+		}); err != nil {
+			return false, fmt.Errorf("set Claude Tag chat title: %w", err)
+		}
+	}
+	return stored && msg.Role == "user", nil
 }
 
 func (s *Service) markChatLiteLLMProxied(ctx context.Context, chatID, projectID uuid.UUID) {
@@ -1569,7 +1585,7 @@ func (s *Service) markChatLiteLLMProxied(ctx context.Context, chatID, projectID 
 
 func usesNativeTranscriptFallback(adapter string) bool {
 	switch strings.ToLower(strings.TrimSpace(adapter)) {
-	case "claude", "claude-code", "claude-code-desktop", "cowork", "cursor":
+	case "claude", "claude-code", "claude-tag", "claude-code-desktop", "cowork", "cursor":
 		return true
 	default:
 		return false
@@ -1594,7 +1610,7 @@ func proxiedTranscriptSource(source string) bool {
 // would leave turns with no assistant text at all.
 func nativeAssistantTurnSource(source string) bool {
 	switch strings.ToLower(strings.TrimSpace(source)) {
-	case "claude", "claude-code", "claude-code-desktop", "cowork":
+	case "claude", "claude-code", "claude-tag", "claude-code-desktop", "cowork":
 		return true
 	default:
 		return false
@@ -2109,6 +2125,9 @@ func canonicalChatTitle(payload *gen.IngestPayload, fallback string) string {
 	title := canonicalPromptText(payload)
 	if title == "" {
 		title = fallback
+	}
+	if tagTitle, ok := claudeTagTitle(title); ok {
+		title = tagTitle
 	}
 	title = strings.TrimSpace(title)
 	runes := []rune(title)

--- a/server/internal/hooks/ingest_hooks.go
+++ b/server/internal/hooks/ingest_hooks.go
@@ -1548,7 +1548,7 @@ func (s *Service) persistCanonicalConversationEvent(ctx context.Context, payload
 		return false, nil
 	}
 
-	title := canonicalChatTitle(payload, titleContent)
+	title := canonicalChatTitle(payload, titleContent, hookSource)
 	var stored bool
 	var err error
 	if uncorrelatedPrompt {
@@ -1805,7 +1805,7 @@ func (s *Service) persistPromptAttachments(ctx context.Context, payload *gen.Ing
 		UserID:         conv.ToPGTextEmpty(metadata.UserID),
 		ExternalUserID: conv.ToPGTextEmpty(metadata.UserEmail),
 		UserAccountID:  conv.StringToNullUUID(metadata.UserAccountID),
-		Title:          conv.ToPGText(canonicalChatTitle(payload, "")),
+		Title:          conv.ToPGText(canonicalChatTitle(payload, "", strings.TrimSpace(payload.Source.Adapter))),
 		Cwd:            conv.ToPGTextEmpty(metadata.Cwd),
 	})
 	if upsertErr != nil {
@@ -2121,13 +2121,20 @@ func canonicalSkillName(payload *gen.IngestPayload) string {
 	return name
 }
 
-func canonicalChatTitle(payload *gen.IngestPayload, fallback string) string {
+// canonicalChatTitle returns the display title for a new or updated chat.
+// source is the resolved hook source (e.g. "claude-code", "claude-tag"); pass
+// an empty string when the source is unknown. The claude-tag wake-envelope
+// rewrite is only applied to Claude-family sources to prevent non-Claude
+// adapters from being labelled as channel sessions.
+func canonicalChatTitle(payload *gen.IngestPayload, fallback, source string) string {
 	title := canonicalPromptText(payload)
 	if title == "" {
 		title = fallback
 	}
-	if tagTitle, ok := claudeTagTitle(title); ok {
-		title = tagTitle
+	if claudeServiceNameSpecificity(source) > 0 {
+		if tagTitle, ok := claudeTagTitle(title); ok {
+			title = tagTitle
+		}
 	}
 	title = strings.TrimSpace(title)
 	runes := []rune(title)

--- a/server/internal/hooks/ingest_hooks_test.go
+++ b/server/internal/hooks/ingest_hooks_test.go
@@ -628,7 +628,7 @@ func TestCanonicalChatTitle_TruncatesByRunes(t *testing.T) {
 		Prompt: &gen.HookPromptData{Text: &text},
 	}
 
-	title := canonicalChatTitle(payload, "")
+	title := canonicalChatTitle(payload, "", "custom-adapter")
 	require.True(t, utf8.ValidString(title))
 	require.Len(t, []rune(title), 80)
 }

--- a/server/internal/hooks/queries.sql
+++ b/server/internal/hooks/queries.sql
@@ -425,3 +425,10 @@ INSERT INTO tool_call_blocks (
   , sqlc.narg(chat_message_id)
   , sqlc.arg(user_id)
 );
+
+-- name: SetClaudeTagChatTitle :exec
+-- Channel sessions span topics; refresh their channel label, preserving manual names.
+UPDATE chats SET title = @title
+WHERE id = @id AND project_id = @project_id
+  AND NOT title_manually_set
+  AND title IS DISTINCT FROM @title;

--- a/server/internal/hooks/queries.sql
+++ b/server/internal/hooks/queries.sql
@@ -428,7 +428,7 @@ INSERT INTO tool_call_blocks (
 
 -- name: SetClaudeTagChatTitle :exec
 -- Channel sessions span topics; refresh their channel label, preserving manual names.
-UPDATE chats SET title = @title
+UPDATE chats SET title = @title, updated_at = NOW()
 WHERE id = @id AND project_id = @project_id
   AND NOT title_manually_set
   AND title IS DISTINCT FROM @title;

--- a/server/internal/hooks/repo/queries.sql.go
+++ b/server/internal/hooks/repo/queries.sql.go
@@ -748,6 +748,25 @@ func (q *Queries) RememberKnownSkillRawHash(ctx context.Context, arg RememberKno
 	return known, err
 }
 
+const setClaudeTagChatTitle = `-- name: SetClaudeTagChatTitle :exec
+UPDATE chats SET title = $1
+WHERE id = $2 AND project_id = $3
+  AND NOT title_manually_set
+  AND title IS DISTINCT FROM $1
+`
+
+type SetClaudeTagChatTitleParams struct {
+	Title     pgtype.Text
+	ID        uuid.UUID
+	ProjectID uuid.UUID
+}
+
+// Channel sessions span topics; refresh their channel label, preserving manual names.
+func (q *Queries) SetClaudeTagChatTitle(ctx context.Context, arg SetClaudeTagChatTitleParams) error {
+	_, err := q.db.Exec(ctx, setClaudeTagChatTitle, arg.Title, arg.ID, arg.ProjectID)
+	return err
+}
+
 const skillRawHashNeedsPromptInjectionScan = `-- name: SkillRawHashNeedsPromptInjectionScan :one
 SELECT EXISTS (
   SELECT 1

--- a/server/internal/hooks/repo/queries.sql.go
+++ b/server/internal/hooks/repo/queries.sql.go
@@ -749,7 +749,7 @@ func (q *Queries) RememberKnownSkillRawHash(ctx context.Context, arg RememberKno
 }
 
 const setClaudeTagChatTitle = `-- name: SetClaudeTagChatTitle :exec
-UPDATE chats SET title = $1
+UPDATE chats SET title = $1, updated_at = NOW()
 WHERE id = $2 AND project_id = $3
   AND NOT title_manually_set
   AND title IS DISTINCT FROM $1

--- a/server/internal/hooks/session_capture.go
+++ b/server/internal/hooks/session_capture.go
@@ -76,6 +76,8 @@ func (s *Service) defaultChatTitleForSession(ctx context.Context, metadata *Sess
 // Claude surface (Cursor, Codex, unknown adapters).
 func claudeSurfaceFromServiceName(name string) string {
 	switch n := strings.ToLower(strings.TrimSpace(name)); {
+	case n == "claude-tag":
+		return "claude-tag"
 	case strings.Contains(n, "cowork"):
 		return agentVariantCowork
 	case n == surfaceClaudeCodeDesktop:
@@ -95,6 +97,8 @@ func claudeSurfaceFromServiceName(name string) string {
 // all. Non-Claude values rank zero.
 func claudeServiceNameSpecificity(name string) int {
 	switch claudeSurfaceFromServiceName(name) {
+	case "claude-tag":
+		return 5
 	case agentVariantCowork:
 		return 4
 	case surfaceClaudeCodeDesktop:
@@ -150,7 +154,7 @@ func preferClaudeServiceName(incoming, cached string) string {
 // through unchanged so non-Claude senders keep their reported name.
 func (s *Service) claudeSessionSurface(ctx context.Context, metadata *SessionMetadata) string {
 	surface := claudeSurfaceFromServiceName(metadata.ServiceName)
-	if surface == agentVariantCowork {
+	if surface == agentVariantCowork || surface == "claude-tag" {
 		return surface
 	}
 	variant := s.sessionAgentVariant(ctx, metadata.SessionID)


### PR DESCRIPTION
## Summary

Recognize Claude Tag channel wakes as `claude-tag` and name sessions `Claude Tag in #channel`, preserving manually chosen titles. Display channel metadata and a readable transcript with human authors and Slack replies, plus a Raw view toggle for the captured messages. Include a synthetic demo session.

## Motivation

Claude Tag sessions span unrelated topics within a channel. Treating them as Claude Code chats produces misleading topic titles and exposes wake envelopes, tool plumbing, and reply acknowledgments as conversation text. Channel-based titles and a readable default make these sessions easier to follow while retaining the raw transcript for inspection.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies Claude Tag channel wakes as `claude-tag` instead of generic Claude Code sessions, and labels them by channel rather than wake-topic content. The dashboard now shows a readable conversation by default while preserving the captured wake and tool transcript in Raw view; manually renamed sessions remain unchanged.

**Bug Fixes**

- Extracts channel names, human authors, timestamps, and Slack reply text from wake envelopes
- Hides repeated context and successful reply acknowledgments while retaining failed or unrecognized tool calls
- Preserves the `claude-tag` surface across later hook events and native transcript handling
- Adds a deterministic demo session and coverage for classification, title persistence, parsing, and transcript projection

<sup>Written for commit fb33e972b88c66b2478dfad7740d750a353617b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

