### PR TITLE
fix: speed up chat.load transcript opens

### DIFF
--- a/.changeset/chat-load-clickhouse-enrichment.md
+++ b/.changeset/chat-load-clickhouse-enrichment.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Speed up chat.load on Agent Sessions by reading token/cost metrics from chat_session_summaries, skipping Claude OTEL scans for non-Claude chats, and running remaining ClickHouse enrichment in parallel.

--- a/server/internal/chat/enrich_internal_test.go
+++ b/server/internal/chat/enrich_internal_test.go
@@ -2,7 +2,10 @@ package chat
 
 import (
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,4 +24,26 @@ func TestNeedsClaudeTurnUsage(t *testing.T) {
 	require.True(t, needsClaudeTurnUsage(nil, nil))
 	require.True(t, needsClaudeTurnUsage(ptr("new-agent-surface"), nil))
 	require.True(t, needsClaudeTurnUsage(nil, ptr("unknown-client")))
+}
+
+func TestWorkUnitsTrendMetricsFrom(t *testing.T) {
+	t.Parallel()
+
+	from := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	created := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+
+	require.Equal(t, from.Add(-chatMetricsLookback), workUnitsTrendMetricsFrom(pgtype.Timestamptz{}, from))
+	require.Equal(t, created.Add(-chatMetricsLookback), workUnitsTrendMetricsFrom(pgtype.Timestamptz{
+		Time:             created,
+		InfinityModifier: pgtype.Finite,
+		Valid:            true,
+	}, from))
+}
+
+func TestParseChatIDs(t *testing.T) {
+	t.Parallel()
+
+	id := uuid.New()
+	require.Equal(t, []uuid.UUID{id}, parseChatIDs([]string{"not-a-uuid", id.String()}))
+	require.Empty(t, parseChatIDs(nil))
 }

--- a/server/internal/chat/enrich_internal_test.go
+++ b/server/internal/chat/enrich_internal_test.go
@@ -19,4 +19,6 @@ func TestNeedsClaudeTurnUsage(t *testing.T) {
 	require.False(t, needsClaudeTurnUsage(ptr("litellm"), ptr("codex")))
 	require.True(t, needsClaudeTurnUsage(ptr("litellm"), nil))
 	require.True(t, needsClaudeTurnUsage(nil, nil))
+	require.True(t, needsClaudeTurnUsage(ptr("new-agent-surface"), nil))
+	require.True(t, needsClaudeTurnUsage(nil, ptr("unknown-client")))
 }

--- a/server/internal/chat/enrich_internal_test.go
+++ b/server/internal/chat/enrich_internal_test.go
@@ -1,0 +1,22 @@
+package chat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNeedsClaudeTurnUsage(t *testing.T) {
+	t.Parallel()
+
+	ptr := func(s string) *string { return &s }
+
+	require.False(t, needsClaudeTurnUsage(ptr("cursor"), nil))
+	require.False(t, needsClaudeTurnUsage(ptr("codex"), nil))
+	require.False(t, needsClaudeTurnUsage(nil, ptr("codex")))
+	require.True(t, needsClaudeTurnUsage(ptr("claude-code"), nil))
+	require.True(t, needsClaudeTurnUsage(ptr("litellm"), ptr("claude-code")))
+	require.False(t, needsClaudeTurnUsage(ptr("litellm"), ptr("codex")))
+	require.True(t, needsClaudeTurnUsage(ptr("litellm"), nil))
+	require.True(t, needsClaudeTurnUsage(nil, nil))
+}

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -621,7 +621,7 @@ func (s *Service) GetWorkUnitsTrend(ctx context.Context, payload *gen.GetWorkUni
 		chatIDs[i] = verdict.ChatID
 	}
 	for batch := range slices.Chunk(chatIDs, workUnitsTrendMetricsBatch) {
-		metrics, err := s.telemetryService.GetChatMetricsByIDs(ctx, projectID, batch, from)
+		metrics, err := s.telemetryService.GetChatMetricsByIDs(ctx, projectID, batch, time.Time{})
 		if err != nil {
 			s.logger.WarnContext(ctx, "failed to load chat metrics for work units trend", attr.SlogError(err))
 			break
@@ -3255,12 +3255,20 @@ func oldestChatCreatedAt(rows []repo.ListChatsRow) time.Time {
 }
 
 // needsClaudeTurnUsage reports whether chat.load should query raw Claude Code
-// OTEL rows. Known non-Claude surfaces never emit those events; unknown or
-// LiteLLM-without-client stays on the current fetch path so a missing source
-// stamp on the first page cannot drop usage.
+// OTEL rows. Known non-Claude surfaces never emit those events. Unknown
+// sources stay on the fetch path so a new or unstamped surface cannot drop
+// AgentUsage.
 func needsClaudeTurnUsage(source, originatingClient *string) bool {
 	if originatingClient != nil && *originatingClient != "" {
-		return CanonicalSource(*originatingClient) == "claude-code"
+		switch CanonicalSource(*originatingClient) {
+		case "claude-code":
+			return true
+		case "cursor", "codex", "codex-web", "chatgpt", "opencode", "openclaw",
+			"claude", "claude-chat-web", "assistants", "playground":
+			return false
+		default:
+			return true
+		}
 	}
 	if source == nil || *source == "" {
 		return true
@@ -3268,8 +3276,11 @@ func needsClaudeTurnUsage(source, originatingClient *string) bool {
 	switch CanonicalSource(*source) {
 	case "claude-code", "claude-code-desktop", "cowork", "litellm":
 		return true
-	default:
+	case "cursor", "codex", "codex-web", "chatgpt", "opencode", "openclaw",
+		"claude", "claude-chat-web", "assistants", "playground":
 		return false
+	default:
+		return true
 	}
 }
 

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -620,8 +620,25 @@ func (s *Service) GetWorkUnitsTrend(ctx context.Context, payload *gen.GetWorkUni
 	for i, verdict := range verdicts {
 		chatIDs[i] = verdict.ChatID
 	}
+	// Bound raw telemetry_logs by the oldest chat's created_at, not the score
+	// window: a session that started earlier still contributes its full tokens
+	// and cost, while ClickHouse can prune partitions. If Postgres has no
+	// matching rows, fall back to the window start minus lookback so the scan
+	// stays bounded.
+	eventTimeFrom := workUnitsTrendMetricsFrom(pgtype.Timestamptz{}, from)
+	if ids := parseChatIDs(chatIDs); len(ids) > 0 {
+		oldest, err := s.repo.GetOldestChatCreatedAt(ctx, repo.GetOldestChatCreatedAtParams{
+			ProjectID: *authCtx.ProjectID,
+			Ids:       ids,
+		})
+		if err != nil {
+			s.logger.WarnContext(ctx, "failed to load oldest chat created_at for work units trend metrics", attr.SlogError(err))
+		} else {
+			eventTimeFrom = workUnitsTrendMetricsFrom(oldest, from)
+		}
+	}
 	for batch := range slices.Chunk(chatIDs, workUnitsTrendMetricsBatch) {
-		metrics, err := s.telemetryService.GetChatMetricsByIDs(ctx, projectID, batch, time.Time{})
+		metrics, err := s.telemetryService.GetChatMetricsByIDs(ctx, projectID, batch, eventTimeFrom)
 		if err != nil {
 			s.logger.WarnContext(ctx, "failed to load chat metrics for work units trend", attr.SlogError(err))
 			break
@@ -3177,7 +3194,7 @@ func (s *Service) enrichChatWithClaudeTurnUsage(ctx context.Context, projectID s
 		return nil
 	})
 	if err := usageGroup.Wait(); err != nil {
-		return err
+		return fmt.Errorf("wait for Claude usage enrichment: %w", err)
 	}
 
 	turns := usageMap[chat.ID]
@@ -3252,6 +3269,29 @@ func oldestChatCreatedAt(rows []repo.ListChatsRow) time.Time {
 		return time.Time{}
 	}
 	return oldest.Add(-chatMetricsLookback)
+}
+
+func parseChatIDs(ids []string) []uuid.UUID {
+	parsed := make([]uuid.UUID, 0, len(ids))
+	for _, id := range ids {
+		chatID, err := uuid.Parse(id)
+		if err != nil {
+			continue
+		}
+		parsed = append(parsed, chatID)
+	}
+	return parsed
+}
+
+// workUnitsTrendMetricsFrom is the ClickHouse EventTimeFrom for work-units
+// trend metrics. Prefer the oldest chat created_at so a scored session that
+// began before the window keeps its earlier tokens; otherwise use the window
+// start so a raw telemetry_logs fallback stays partition-prunable.
+func workUnitsTrendMetricsFrom(oldestCreatedAt pgtype.Timestamptz, from time.Time) time.Time {
+	if bound := chatMetricsEventTimeFrom(oldestCreatedAt); !bound.IsZero() {
+		return bound
+	}
+	return from.Add(-chatMetricsLookback)
 }
 
 // needsClaudeTurnUsage reports whether chat.load should query raw Claude Code

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -625,7 +625,7 @@ func (s *Service) GetWorkUnitsTrend(ctx context.Context, payload *gen.GetWorkUni
 	// and cost, while ClickHouse can prune partitions. If Postgres has no
 	// matching rows, fall back to the window start minus lookback so the scan
 	// stays bounded.
-	eventTimeFrom := workUnitsTrendMetricsFrom(pgtype.Timestamptz{}, from)
+	eventTimeFrom := from.Add(-chatMetricsLookback)
 	if ids := parseChatIDs(chatIDs); len(ids) > 0 {
 		oldest, err := s.repo.GetOldestChatCreatedAt(ctx, repo.GetOldestChatCreatedAtParams{
 			ProjectID: *authCtx.ProjectID,

--- a/server/internal/chat/impl.go
+++ b/server/internal/chat/impl.go
@@ -400,7 +400,7 @@ func (s *Service) ListChats(ctx context.Context, payload *gen.ListChatsPayload) 
 		})
 	}
 
-	if err := s.enrichChatsWithMetrics(ctx, authCtx.ProjectID.String(), result); err != nil {
+	if err := s.enrichChatsWithMetrics(ctx, authCtx.ProjectID.String(), result, oldestChatCreatedAt(rows)); err != nil {
 		s.logger.WarnContext(ctx, "failed to enrich chats with metrics", attr.SlogError(err))
 	}
 	if err := s.enrichChatsWithWorkUnits(ctx, authCtx.ActiveOrganizationID, authCtx.ProjectID.String(), result); err != nil {
@@ -621,7 +621,7 @@ func (s *Service) GetWorkUnitsTrend(ctx context.Context, payload *gen.GetWorkUni
 		chatIDs[i] = verdict.ChatID
 	}
 	for batch := range slices.Chunk(chatIDs, workUnitsTrendMetricsBatch) {
-		metrics, err := s.telemetryService.GetChatMetricsByIDs(ctx, projectID, batch)
+		metrics, err := s.telemetryService.GetChatMetricsByIDs(ctx, projectID, batch, from)
 		if err != nil {
 			s.logger.WarnContext(ctx, "failed to load chat metrics for work units trend", attr.SlogError(err))
 			break
@@ -1376,15 +1376,30 @@ func (s *Service) LoadChat(ctx context.Context, payload *gen.LoadChatPayload) (*
 	}
 
 	if isInitialLatest {
-		if err := s.enrichChatWithMetrics(ctx, authCtx.ProjectID.String(), result); err != nil {
-			s.logger.WarnContext(ctx, "failed to enrich chat with metrics", attr.SlogError(err))
-		}
-		if err := s.enrichChatWithClaudeTurnUsage(ctx, authCtx.ProjectID.String(), result); err != nil {
-			s.logger.WarnContext(ctx, "failed to enrich chat with Claude turn usage", attr.SlogError(err))
-		}
-		if err := s.enrichChatWithWorkUnits(ctx, authCtx.ActiveOrganizationID, authCtx.ProjectID.String(), result); err != nil {
-			s.logger.WarnContext(ctx, "failed to enrich chat with work units", attr.SlogError(err))
-		}
+		eventTimeFrom := chatMetricsEventTimeFrom(chat.CreatedAt)
+		var enrichGroup errgroup.Group
+		enrichGroup.Go(func() error {
+			if err := s.enrichChatWithMetrics(ctx, authCtx.ProjectID.String(), result, eventTimeFrom); err != nil {
+				s.logger.WarnContext(ctx, "failed to enrich chat with metrics", attr.SlogError(err))
+			}
+			return nil
+		})
+		enrichGroup.Go(func() error {
+			if !needsClaudeTurnUsage(source, originatingClient) {
+				return nil
+			}
+			if err := s.enrichChatWithClaudeTurnUsage(ctx, authCtx.ProjectID.String(), result, eventTimeFrom); err != nil {
+				s.logger.WarnContext(ctx, "failed to enrich chat with Claude turn usage", attr.SlogError(err))
+			}
+			return nil
+		})
+		enrichGroup.Go(func() error {
+			if err := s.enrichChatWithWorkUnits(ctx, authCtx.ActiveOrganizationID, authCtx.ProjectID.String(), result); err != nil {
+				s.logger.WarnContext(ctx, "failed to enrich chat with work units", attr.SlogError(err))
+			}
+			return nil
+		})
+		_ = enrichGroup.Wait()
 	}
 
 	return result, nil
@@ -3022,7 +3037,7 @@ func prepareMessages(ctx context.Context, logger *slog.Logger, assetStorage asse
 
 // enrichChatsWithMetrics fetches token and cost metrics from ClickHouse and adds them to chat overviews.
 // This is a best-effort operation - if metrics can't be fetched, chats are returned with zero values.
-func (s *Service) enrichChatsWithMetrics(ctx context.Context, projectID string, chats []*gen.ChatOverview) error {
+func (s *Service) enrichChatsWithMetrics(ctx context.Context, projectID string, chats []*gen.ChatOverview, eventTimeFrom time.Time) error {
 	if len(chats) == 0 {
 		return nil
 	}
@@ -3039,7 +3054,7 @@ func (s *Service) enrichChatsWithMetrics(ctx context.Context, projectID string, 
 	}
 
 	// Fetch metrics from ClickHouse
-	metricsMap, err := s.telemetryService.GetChatMetricsByIDs(ctx, projectID, chatIDs)
+	metricsMap, err := s.telemetryService.GetChatMetricsByIDs(ctx, projectID, chatIDs, eventTimeFrom)
 	if err != nil {
 		return fmt.Errorf("get chat metrics from ClickHouse: %w", err)
 	}
@@ -3059,14 +3074,14 @@ func (s *Service) enrichChatsWithMetrics(ctx context.Context, projectID string, 
 
 // enrichChatWithMetrics fetches token and cost metrics from ClickHouse and adds them to a single chat.
 // This is a best-effort operation - if metrics can't be fetched, the chat is returned with zero values.
-func (s *Service) enrichChatWithMetrics(ctx context.Context, projectID string, chat *gen.Chat) error {
+func (s *Service) enrichChatWithMetrics(ctx context.Context, projectID string, chat *gen.Chat, eventTimeFrom time.Time) error {
 	// Check if telemetry service is available
 	if s.telemetryService == nil {
 		return nil
 	}
 
 	// Fetch metrics from ClickHouse
-	metricsMap, err := s.telemetryService.GetChatMetricsByIDs(ctx, projectID, []string{chat.ID})
+	metricsMap, err := s.telemetryService.GetChatMetricsByIDs(ctx, projectID, []string{chat.ID}, eventTimeFrom)
 	if err != nil {
 		return fmt.Errorf("get chat metrics from ClickHouse: %w", err)
 	}
@@ -3134,19 +3149,35 @@ func (s *Service) enrichChatWithWorkUnits(ctx context.Context, organizationID st
 // enrichChatWithClaudeTurnUsage fetches per-turn Claude Code usage from ClickHouse
 // and attaches it to chat.load. This is best-effort: missing ClickHouse data
 // simply leaves the optional agent usage payload empty.
-func (s *Service) enrichChatWithClaudeTurnUsage(ctx context.Context, projectID string, chat *gen.Chat) error {
+func (s *Service) enrichChatWithClaudeTurnUsage(ctx context.Context, projectID string, chat *gen.Chat, eventTimeFrom time.Time) error {
 	if s.telemetryService == nil {
 		return nil
 	}
 
-	usageMap, err := s.telemetryService.GetClaudeTurnUsageByChatIDs(ctx, projectID, []string{chat.ID})
-	if err != nil {
-		return fmt.Errorf("get Claude turn usage from ClickHouse: %w", err)
-	}
-	toolUsageMap, err := s.telemetryService.GetClaudeToolUsageByChatIDs(ctx, projectID, []string{chat.ID})
-	if err != nil {
-		s.logger.WarnContext(ctx, "failed to enrich chat with Claude tool usage", attr.SlogError(err))
-		toolUsageMap = nil
+	var (
+		usageMap     map[string][]telemetryrepo.ClaudeTurnUsageRow
+		toolUsageMap map[string][]telemetryrepo.ClaudeToolUsageRow
+	)
+	var usageGroup errgroup.Group
+	usageGroup.Go(func() error {
+		var err error
+		usageMap, err = s.telemetryService.GetClaudeTurnUsageByChatIDs(ctx, projectID, []string{chat.ID}, eventTimeFrom)
+		if err != nil {
+			return fmt.Errorf("get Claude turn usage from ClickHouse: %w", err)
+		}
+		return nil
+	})
+	usageGroup.Go(func() error {
+		var err error
+		toolUsageMap, err = s.telemetryService.GetClaudeToolUsageByChatIDs(ctx, projectID, []string{chat.ID}, eventTimeFrom)
+		if err != nil {
+			s.logger.WarnContext(ctx, "failed to enrich chat with Claude tool usage", attr.SlogError(err))
+			toolUsageMap = nil
+		}
+		return nil
+	})
+	if err := usageGroup.Wait(); err != nil {
+		return err
 	}
 
 	turns := usageMap[chat.ID]
@@ -3193,6 +3224,53 @@ func (s *Service) enrichChatWithClaudeTurnUsage(ctx context.Context, projectID s
 	}
 
 	return nil
+}
+
+// chatMetricsLookback extends below chats.created_at so spool-replayed hook
+// events that occurred before the chat row was inserted still contribute to
+// ClickHouse reads.
+const chatMetricsLookback = 24 * time.Hour
+
+func chatMetricsEventTimeFrom(createdAt pgtype.Timestamptz) time.Time {
+	if !createdAt.Valid {
+		return time.Time{}
+	}
+	return createdAt.Time.Add(-chatMetricsLookback)
+}
+
+func oldestChatCreatedAt(rows []repo.ListChatsRow) time.Time {
+	var oldest time.Time
+	for _, row := range rows {
+		if !row.CreatedAt.Valid {
+			continue
+		}
+		if oldest.IsZero() || row.CreatedAt.Time.Before(oldest) {
+			oldest = row.CreatedAt.Time
+		}
+	}
+	if oldest.IsZero() {
+		return time.Time{}
+	}
+	return oldest.Add(-chatMetricsLookback)
+}
+
+// needsClaudeTurnUsage reports whether chat.load should query raw Claude Code
+// OTEL rows. Known non-Claude surfaces never emit those events; unknown or
+// LiteLLM-without-client stays on the current fetch path so a missing source
+// stamp on the first page cannot drop usage.
+func needsClaudeTurnUsage(source, originatingClient *string) bool {
+	if originatingClient != nil && *originatingClient != "" {
+		return CanonicalSource(*originatingClient) == "claude-code"
+	}
+	if source == nil || *source == "" {
+		return true
+	}
+	switch CanonicalSource(*source) {
+	case "claude-code", "claude-code-desktop", "cowork", "litellm":
+		return true
+	default:
+		return false
+	}
 }
 
 func clampUint64ToInt64(value uint64) int64 {

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -998,6 +998,16 @@ WHERE id = ANY(@ids::uuid[])
   AND project_id = ANY(@project_ids::uuid[])
   AND deleted IS FALSE;
 
+-- name: GetOldestChatCreatedAt :one
+-- Lowest chats.created_at for these ids in this project. ClickHouse metric
+-- reads use it as a partition lower bound so sessions that started before a
+-- score window still contribute their full tokens and cost.
+SELECT MIN(created_at)::timestamptz AS created_at
+FROM chats
+WHERE project_id = @project_id
+  AND id = ANY(@ids::uuid[])
+  AND deleted IS FALSE;
+
 -- name: SumMessageTokenStatsByDay :many
 -- Daily message-level token stats for the billing details table
 -- (telemetry.queryTumDetails): tokens in messages carrying at least one

--- a/server/internal/chat/queries.sql
+++ b/server/internal/chat/queries.sql
@@ -999,14 +999,15 @@ WHERE id = ANY(@ids::uuid[])
   AND deleted IS FALSE;
 
 -- name: GetOldestChatCreatedAt :one
--- Lowest chats.created_at for these ids in this project. ClickHouse metric
--- reads use it as a partition lower bound so sessions that started before a
--- score window still contribute their full tokens and cost.
+-- Lowest chats.created_at for these ids in this project, including
+-- soft-deleted rows. Work-units verdicts outlive chat deletion, and
+-- GetChatMetricsByIDs still reads those ids, so dropping deleted created_at
+-- values would shift the ClickHouse bound later and omit earlier tokens.
+-- Tenancy only: project_id plus the caller-supplied id list.
 SELECT MIN(created_at)::timestamptz AS created_at
 FROM chats
 WHERE project_id = @project_id
-  AND id = ANY(@ids::uuid[])
-  AND deleted IS FALSE;
+  AND id = ANY(@ids::uuid[]);
 
 -- name: SumMessageTokenStatsByDay :many
 -- Daily message-level token stats for the billing details table

--- a/server/internal/chat/queries_scoping_test.go
+++ b/server/internal/chat/queries_scoping_test.go
@@ -2,6 +2,7 @@ package chat_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -28,6 +29,37 @@ func TestQueries_GetChat_IsProjectScoped(t *testing.T) {
 	got, err := r.GetChat(t.Context(), repo.GetChatParams{ID: chatID, ProjectID: otherProject})
 	require.NoError(t, err)
 	require.Equal(t, chatID, got.ID)
+}
+
+func TestQueries_GetOldestChatCreatedAt_IsProjectScoped(t *testing.T) {
+	t.Parallel()
+	ti := newTestChatService(t)
+	r := repo.New(ti.conn)
+	ctx := initSessionCtx(t, ti)
+
+	otherProject := createProjectInSameOrg(t, ti)
+	older := time.Now().UTC().Add(-48 * time.Hour).Truncate(time.Second)
+	newer := time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Second)
+
+	foreignID, err := r.SeedChatAtTime(ctx, repo.SeedChatAtTimeParams{
+		ID:             uuid.New(),
+		ProjectID:      otherProject,
+		OrganizationID: ti.orgID,
+		UserID:         pgtype.Text{},
+		ExternalUserID: pgtype.Text{},
+		Title:          pgtype.Text{},
+		CreatedAt:      pgtype.Timestamptz{Time: older, InfinityModifier: pgtype.Finite, Valid: true},
+	})
+	require.NoError(t, err)
+	ownID := seedChatAtTime(t, ctx, ti, "own-user", newer)
+
+	got, err := r.GetOldestChatCreatedAt(ctx, repo.GetOldestChatCreatedAtParams{
+		ProjectID: ti.projectID,
+		Ids:       []uuid.UUID{foreignID, ownID},
+	})
+	require.NoError(t, err)
+	require.True(t, got.Valid)
+	require.WithinDuration(t, newer, got.Time, time.Second)
 }
 
 // UpsertChat conflicts on the bare primary key, so without the project fence a

--- a/server/internal/chat/queries_scoping_test.go
+++ b/server/internal/chat/queries_scoping_test.go
@@ -53,13 +53,19 @@ func TestQueries_GetOldestChatCreatedAt_IsProjectScoped(t *testing.T) {
 	require.NoError(t, err)
 	ownID := seedChatAtTime(t, ctx, ti, "own-user", newer)
 
+	deletedAt := time.Now().UTC().Add(-72 * time.Hour).Truncate(time.Second)
+	deletedID := seedChatAtTime(t, ctx, ti, "deleted-user", deletedAt)
+	deleted, err := r.SoftDeleteChat(ctx, repo.SoftDeleteChatParams{ID: deletedID, ProjectID: ti.projectID})
+	require.NoError(t, err)
+	require.True(t, deleted.Deleted)
+
 	got, err := r.GetOldestChatCreatedAt(ctx, repo.GetOldestChatCreatedAtParams{
 		ProjectID: ti.projectID,
-		Ids:       []uuid.UUID{foreignID, ownID},
+		Ids:       []uuid.UUID{foreignID, ownID, deletedID},
 	})
 	require.NoError(t, err)
 	require.True(t, got.Valid)
-	require.WithinDuration(t, newer, got.Time, time.Second)
+	require.WithinDuration(t, deletedAt, got.Time, time.Second)
 }
 
 // UpsertChat conflicts on the bare primary key, so without the project fence a

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -1165,6 +1165,29 @@ func (q *Queries) GetMaxGenerationForChat(ctx context.Context, arg GetMaxGenerat
 	return generation, err
 }
 
+const getOldestChatCreatedAt = `-- name: GetOldestChatCreatedAt :one
+SELECT MIN(created_at)::timestamptz AS created_at
+FROM chats
+WHERE project_id = $1
+  AND id = ANY($2::uuid[])
+  AND deleted IS FALSE
+`
+
+type GetOldestChatCreatedAtParams struct {
+	ProjectID uuid.UUID
+	Ids       []uuid.UUID
+}
+
+// Lowest chats.created_at for these ids in this project. ClickHouse metric
+// reads use it as a partition lower bound so sessions that started before a
+// score window still contribute their full tokens and cost.
+func (q *Queries) GetOldestChatCreatedAt(ctx context.Context, arg GetOldestChatCreatedAtParams) (pgtype.Timestamptz, error) {
+	row := q.db.QueryRow(ctx, getOldestChatCreatedAt, arg.ProjectID, arg.Ids)
+	var created_at pgtype.Timestamptz
+	err := row.Scan(&created_at)
+	return created_at, err
+}
+
 const getProjectOrganizationID = `-- name: GetProjectOrganizationID :one
 SELECT organization_id
 FROM projects

--- a/server/internal/chat/repo/queries.sql.go
+++ b/server/internal/chat/repo/queries.sql.go
@@ -1170,7 +1170,6 @@ SELECT MIN(created_at)::timestamptz AS created_at
 FROM chats
 WHERE project_id = $1
   AND id = ANY($2::uuid[])
-  AND deleted IS FALSE
 `
 
 type GetOldestChatCreatedAtParams struct {
@@ -1178,9 +1177,11 @@ type GetOldestChatCreatedAtParams struct {
 	Ids       []uuid.UUID
 }
 
-// Lowest chats.created_at for these ids in this project. ClickHouse metric
-// reads use it as a partition lower bound so sessions that started before a
-// score window still contribute their full tokens and cost.
+// Lowest chats.created_at for these ids in this project, including
+// soft-deleted rows. Work-units verdicts outlive chat deletion, and
+// GetChatMetricsByIDs still reads those ids, so dropping deleted created_at
+// values would shift the ClickHouse bound later and omit earlier tokens.
+// Tenancy only: project_id plus the caller-supplied id list.
 func (q *Queries) GetOldestChatCreatedAt(ctx context.Context, arg GetOldestChatCreatedAtParams) (pgtype.Timestamptz, error) {
 	row := q.db.QueryRow(ctx, getOldestChatCreatedAt, arg.ProjectID, arg.Ids)
 	var created_at pgtype.Timestamptz

--- a/server/internal/telemetry/chat_metrics_test.go
+++ b/server/internal/telemetry/chat_metrics_test.go
@@ -31,6 +31,7 @@ func TestGetChatMetricsByIDs_UsesMaterializedChatID(t *testing.T) {
 		got, err := ti.chClient.GetChatMetricsByIDs(ctx, repo.GetChatMetricsByIDsParams{
 			GramProjectID: projectID,
 			ChatIDs:       []string{chatID},
+			EventTimeFrom: time.Time{},
 		})
 		require.NoError(c, err)
 		row, ok := got[chatID]
@@ -39,6 +40,35 @@ func TestGetChatMetricsByIDs_UsesMaterializedChatID(t *testing.T) {
 		require.Equal(c, int64(8), row.TotalOutputTokens)
 		require.Equal(c, int64(20), row.TotalTokens)
 		require.Less(c, math.Abs(row.TotalCost-0.42), 1e-9)
+	}, 10*time.Second, 200*time.Millisecond)
+}
+
+func TestGetChatMetricsByIDs_UsesSessionSummaries(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	projectID := authCtx.ProjectID.String()
+	chatID := uuid.NewString()
+	now := time.Now().UTC()
+
+	insertClaudeSessionUsageLog(t, ctx, projectID, chatID, now, 40, 15, 0.21)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		got, err := ti.chClient.GetChatMetricsByIDs(ctx, repo.GetChatMetricsByIDsParams{
+			GramProjectID: projectID,
+			ChatIDs:       []string{chatID},
+			EventTimeFrom: time.Time{},
+		})
+		require.NoError(c, err)
+		row, ok := got[chatID]
+		require.True(c, ok)
+		require.Equal(c, int64(40), row.TotalInputTokens)
+		require.Equal(c, int64(15), row.TotalOutputTokens)
+		require.Equal(c, int64(55), row.TotalTokens)
+		require.Less(c, math.Abs(row.TotalCost-0.21), 1e-9)
 	}, 10*time.Second, 200*time.Millisecond)
 }
 
@@ -100,5 +130,38 @@ func insertChatCompletionMetricLog(t *testing.T, ctx context.Context, projectID,
 	`, id.String(), timestamp.UnixNano(), timestamp.UnixNano(), "INFO", "chat completion",
 		nil, nil, string(attrsJSON), "{}",
 		projectID, "assistants:chat:completion", "gram-server")
+	require.NoError(t, err)
+}
+
+func insertClaudeSessionUsageLog(t *testing.T, ctx context.Context, projectID, chatID string, timestamp time.Time, inputTokens, outputTokens int, cost float64) {
+	t.Helper()
+
+	conn, err := infra.NewClickhouseClient(t)
+	require.NoError(t, err)
+
+	id, err := uuid.NewV7()
+	require.NoError(t, err)
+
+	attributes := map[string]any{
+		"gen_ai.conversation.id": chatID,
+		"prompt.id":              uuid.NewString(),
+		"event.name":             "api_request",
+		"input_tokens":           inputTokens,
+		"output_tokens":          outputTokens,
+		"cost_usd":               cost,
+		"model":                  "claude-sonnet-4-6",
+	}
+	attrsJSON, err := json.Marshal(attributes)
+	require.NoError(t, err)
+
+	err = conn.Exec(ctx, `
+		INSERT INTO telemetry_logs (
+			id, time_unix_nano, observed_time_unix_nano, severity_text, body,
+			trace_id, span_id, attributes, resource_attributes,
+			gram_project_id, gram_urn, service_name, gram_chat_id
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, id.String(), timestamp.UnixNano(), timestamp.UnixNano(), "INFO", "claude_code.api_request",
+		nil, nil, string(attrsJSON), "{}",
+		projectID, "claude-code:otel:logs", "claude-code", chatID)
 	require.NoError(t, err)
 }

--- a/server/internal/telemetry/claude_turn_usage_test.go
+++ b/server/internal/telemetry/claude_turn_usage_test.go
@@ -46,6 +46,7 @@ func TestGetClaudeTurnUsageByChatIDs_MultipleTurns(t *testing.T) {
 	got := requireClaudeTurnUsageEventually(ctx, t, ti, repo.GetClaudeTurnUsageByChatIDsParams{
 		GramProjectID: projectID,
 		ChatIDs:       []string{chatID},
+		EventTimeFrom: time.Time{},
 	}, chatID, 2)
 	require.Equal(t, "prompt-1", got[chatID][0].PromptID)
 	require.Equal(t, int64(20), got[chatID][0].TotalTokens)
@@ -83,6 +84,7 @@ func TestGetClaudeTurnUsageByChatIDs_MultipleAPIRequestsInTurn(t *testing.T) {
 	got := requireClaudeTurnUsageEventually(ctx, t, ti, repo.GetClaudeTurnUsageByChatIDsParams{
 		GramProjectID: projectID,
 		ChatIDs:       []string{chatID},
+		EventTimeFrom: time.Time{},
 	}, chatID, 1)
 
 	turn := got[chatID][0]
@@ -115,6 +117,7 @@ func TestGetClaudeTurnUsageByChatIDs_NoCostBearingRequest(t *testing.T) {
 	got := requireClaudeTurnUsageEventually(ctx, t, ti, repo.GetClaudeTurnUsageByChatIDsParams{
 		GramProjectID: projectID,
 		ChatIDs:       []string{chatID},
+		EventTimeFrom: time.Time{},
 	}, chatID, 1)
 
 	turn := got[chatID][0]
@@ -137,10 +140,41 @@ func TestGetClaudeTurnUsageByChatIDs_NoOTELData(t *testing.T) {
 	got, err := ti.chClient.GetClaudeTurnUsageByChatIDs(ctx, repo.GetClaudeTurnUsageByChatIDsParams{
 		GramProjectID: projectID,
 		ChatIDs:       []string{chatID},
+		EventTimeFrom: time.Time{},
 	})
 	require.NoError(t, err)
 	require.Contains(t, got, chatID)
 	require.Empty(t, got[chatID])
+}
+
+func TestGetClaudeTurnUsageByChatIDs_EventTimeFrom(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestLogsService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	projectID := authCtx.ProjectID.String()
+	deploymentID := uuid.New().String()
+	chatID := uuid.New().String()
+	now := time.Now().UTC()
+
+	insertClaudeOTELLog(t, ctx, claudeOTELLogParams{
+		projectID: projectID, deploymentID: deploymentID, chatID: chatID,
+		timestamp: now.Add(-48 * time.Hour), promptID: "old-prompt", eventName: "api_request",
+		inputTokens: 10, outputTokens: 5,
+	})
+	insertClaudeOTELLog(t, ctx, claudeOTELLogParams{
+		projectID: projectID, deploymentID: deploymentID, chatID: chatID,
+		timestamp: now, promptID: "new-prompt", eventName: "api_request",
+		inputTokens: 20, outputTokens: 8,
+	})
+
+	got := requireClaudeTurnUsageEventually(ctx, t, ti, repo.GetClaudeTurnUsageByChatIDsParams{
+		GramProjectID: projectID,
+		ChatIDs:       []string{chatID},
+		EventTimeFrom: now.Add(-time.Hour),
+	}, chatID, 1)
+	require.Equal(t, "new-prompt", got[chatID][0].PromptID)
+	require.Equal(t, int64(20), got[chatID][0].InputTokens)
 }
 
 func TestGetClaudeToolUsageByChatIDs(t *testing.T) {
@@ -167,6 +201,7 @@ func TestGetClaudeToolUsageByChatIDs(t *testing.T) {
 	got := requireClaudeToolUsageEventually(ctx, t, ti, repo.GetClaudeTurnUsageByChatIDsParams{
 		GramProjectID: projectID,
 		ChatIDs:       []string{chatID},
+		EventTimeFrom: time.Time{},
 	}, chatID, 2)
 
 	require.Equal(t, "toolu_1", got[chatID][0].ToolUseID)

--- a/server/internal/telemetry/impl.go
+++ b/server/internal/telemetry/impl.go
@@ -4257,7 +4257,7 @@ func (s *Service) ListHooksTraces(ctx context.Context, payload *telem_gen.ListHo
 
 // GetChatMetricsByIDs retrieves token and cost metrics for specific chat IDs.
 // This is used by the chat service to enrich chat overview data with metrics from ClickHouse.
-func (s *Service) GetChatMetricsByIDs(ctx context.Context, projectID string, chatIDs []string) (map[string]repo.ChatMetricsRow, error) {
+func (s *Service) GetChatMetricsByIDs(ctx context.Context, projectID string, chatIDs []string, eventTimeFrom time.Time) (map[string]repo.ChatMetricsRow, error) {
 	if s.chRepo == nil {
 		return make(map[string]repo.ChatMetricsRow), nil
 	}
@@ -4265,6 +4265,7 @@ func (s *Service) GetChatMetricsByIDs(ctx context.Context, projectID string, cha
 	result, err := s.chRepo.GetChatMetricsByIDs(ctx, repo.GetChatMetricsByIDsParams{
 		GramProjectID: projectID,
 		ChatIDs:       chatIDs,
+		EventTimeFrom: eventTimeFrom,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("get chat metrics by ids: %w", err)
@@ -4326,7 +4327,7 @@ func (s *Service) ListChatAnalysisVerdicts(ctx context.Context, arg repo.ListCha
 
 // GetClaudeTurnUsageByChatIDs retrieves per-turn Claude Code usage for specific chat IDs.
 // This is used by the chat service to enrich chat detail responses from ClickHouse.
-func (s *Service) GetClaudeTurnUsageByChatIDs(ctx context.Context, projectID string, chatIDs []string) (map[string][]repo.ClaudeTurnUsageRow, error) {
+func (s *Service) GetClaudeTurnUsageByChatIDs(ctx context.Context, projectID string, chatIDs []string, eventTimeFrom time.Time) (map[string][]repo.ClaudeTurnUsageRow, error) {
 	if s.chRepo == nil {
 		usageByChatID := make(map[string][]repo.ClaudeTurnUsageRow, len(chatIDs))
 		for _, chatID := range chatIDs {
@@ -4338,6 +4339,7 @@ func (s *Service) GetClaudeTurnUsageByChatIDs(ctx context.Context, projectID str
 	result, err := s.chRepo.GetClaudeTurnUsageByChatIDs(ctx, repo.GetClaudeTurnUsageByChatIDsParams{
 		GramProjectID: projectID,
 		ChatIDs:       chatIDs,
+		EventTimeFrom: eventTimeFrom,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("get Claude turn usage by chat ids: %w", err)
@@ -4347,7 +4349,7 @@ func (s *Service) GetClaudeTurnUsageByChatIDs(ctx context.Context, projectID str
 
 // GetClaudeToolUsageByChatIDs retrieves per-tool Claude Code input/result byte sizes for specific chat IDs.
 // This is used by the chat service to enrich chat detail rows from ClickHouse.
-func (s *Service) GetClaudeToolUsageByChatIDs(ctx context.Context, projectID string, chatIDs []string) (map[string][]repo.ClaudeToolUsageRow, error) {
+func (s *Service) GetClaudeToolUsageByChatIDs(ctx context.Context, projectID string, chatIDs []string, eventTimeFrom time.Time) (map[string][]repo.ClaudeToolUsageRow, error) {
 	if s.chRepo == nil {
 		usageByChatID := make(map[string][]repo.ClaudeToolUsageRow, len(chatIDs))
 		for _, chatID := range chatIDs {
@@ -4359,6 +4361,7 @@ func (s *Service) GetClaudeToolUsageByChatIDs(ctx context.Context, projectID str
 	result, err := s.chRepo.GetClaudeToolUsageByChatIDs(ctx, repo.GetClaudeTurnUsageByChatIDsParams{
 		GramProjectID: projectID,
 		ChatIDs:       chatIDs,
+		EventTimeFrom: eventTimeFrom,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("get Claude tool usage by chat ids: %w", err)

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -3013,7 +3013,6 @@ type ChatMetricsRow struct {
 // Managed assistant completions are absent from that summary, so any chat
 // missing from it falls back to the raw gen_ai.usage projection.
 //
-//nolint:errcheck,wrapcheck // Replicating SQLC syntax which doesn't comply to this lint rule
 func (q *Queries) GetChatMetricsByIDs(ctx context.Context, arg GetChatMetricsByIDsParams) (map[string]ChatMetricsRow, error) {
 	if len(arg.ChatIDs) == 0 {
 		return make(map[string]ChatMetricsRow), nil

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -2992,6 +2992,10 @@ func (q *Queries) ListChats(ctx context.Context, arg ListChatsParams) ([]ChatSum
 type GetChatMetricsByIDsParams struct {
 	GramProjectID string
 	ChatIDs       []string // UUIDs of chats to get metrics for
+
+	// EventTimeFrom, when non-zero, restricts reads to events at or after this
+	// instant so ClickHouse can prune partitions and hourly summary buckets.
+	EventTimeFrom time.Time
 }
 
 // ChatMetricsRow represents token and cost metrics for a single chat.
@@ -3004,7 +3008,10 @@ type ChatMetricsRow struct {
 }
 
 // GetChatMetricsByIDs retrieves token and cost metrics for specific chat IDs.
-// This is used to enrich chat overview data from PostgreSQL with metrics from ClickHouse.
+// Agent-session surfaces (Claude Code, Codex, Cursor, …) are served from
+// chat_session_summaries so chat.load does not scan raw telemetry_logs.
+// Managed assistant completions are absent from that summary, so any chat
+// missing from it falls back to the raw gen_ai.usage projection.
 //
 //nolint:errcheck,wrapcheck // Replicating SQLC syntax which doesn't comply to this lint rule
 func (q *Queries) GetChatMetricsByIDs(ctx context.Context, arg GetChatMetricsByIDsParams) (map[string]ChatMetricsRow, error) {
@@ -3012,6 +3019,51 @@ func (q *Queries) GetChatMetricsByIDs(ctx context.Context, arg GetChatMetricsByI
 		return make(map[string]ChatMetricsRow), nil
 	}
 
+	metricsMap, err := q.scanChatMetrics(ctx, chatMetricsFromSessionSummaries(arg))
+	if err != nil {
+		return nil, fmt.Errorf("get chat metrics from session summaries: %w", err)
+	}
+
+	missing := make([]string, 0)
+	for _, id := range arg.ChatIDs {
+		if _, ok := metricsMap[id]; !ok {
+			missing = append(missing, id)
+		}
+	}
+	if len(missing) == 0 {
+		return metricsMap, nil
+	}
+
+	raw, err := q.scanChatMetrics(ctx, chatMetricsFromRawLogs(GetChatMetricsByIDsParams{
+		GramProjectID: arg.GramProjectID,
+		ChatIDs:       missing,
+		EventTimeFrom: arg.EventTimeFrom,
+	}))
+	if err != nil {
+		return nil, fmt.Errorf("get chat metrics from telemetry logs: %w", err)
+	}
+	for id, row := range raw {
+		metricsMap[id] = row
+	}
+	return metricsMap, nil
+}
+
+func chatMetricsFromSessionSummaries(arg GetChatMetricsByIDsParams) squirrel.SelectBuilder {
+	sb := sq.Select(
+		"s.chat_id as gram_chat_id",
+		"sum(s.total_input_tokens) as total_input_tokens",
+		"sum(s.total_output_tokens) as total_output_tokens",
+		"sum(s.total_tokens) as total_tokens",
+		"sum(s.total_cost) as total_cost",
+	).
+		From("chat_session_summaries s").
+		Where("s.gram_project_id = ?", arg.GramProjectID).
+		Where(squirrel.Eq{"s.chat_id": arg.ChatIDs}).
+		GroupBy("s.chat_id")
+	return withChatMetricsEventTimeFrom(sb, "s.time_bucket >= toStartOfHour(fromUnixTimestamp64Nano(?, 'UTC'))", arg.EventTimeFrom)
+}
+
+func chatMetricsFromRawLogs(arg GetChatMetricsByIDsParams) squirrel.SelectBuilder {
 	sb := sq.Select(
 		"chat_id as gram_chat_id",
 		"sumIf(toInt64OrZero(toString(attributes.gen_ai.usage.input_tokens)), toString(attributes.gen_ai.usage.input_tokens) != '') as total_input_tokens",
@@ -3023,7 +3075,18 @@ func (q *Queries) GetChatMetricsByIDs(ctx context.Context, arg GetChatMetricsByI
 		Where("gram_project_id = ?", arg.GramProjectID).
 		Where(squirrel.Eq{"chat_id": arg.ChatIDs}).
 		GroupBy("chat_id")
+	return withChatMetricsEventTimeFrom(sb, "time_unix_nano >= ?", arg.EventTimeFrom)
+}
 
+func withChatMetricsEventTimeFrom(sb squirrel.SelectBuilder, pred string, eventTimeFrom time.Time) squirrel.SelectBuilder {
+	if eventTimeFrom.IsZero() {
+		return sb
+	}
+	return sb.Where(pred, eventTimeFrom.UnixNano())
+}
+
+//nolint:errcheck,wrapcheck // Replicating SQLC syntax which doesn't comply to this lint rule
+func (q *Queries) scanChatMetrics(ctx context.Context, sb squirrel.SelectBuilder) (map[string]ChatMetricsRow, error) {
 	query, args, err := sb.ToSql()
 	if err != nil {
 		return nil, fmt.Errorf("building get chat metrics by IDs query: %w", err)
@@ -3056,6 +3119,10 @@ func (q *Queries) GetChatMetricsByIDs(ctx context.Context, arg GetChatMetricsByI
 type GetClaudeTurnUsageByChatIDsParams struct {
 	GramProjectID string
 	ChatIDs       []string
+
+	// EventTimeFrom, when non-zero, restricts the raw telemetry_logs scan to
+	// events at or after this instant so ClickHouse can prune daily partitions.
+	EventTimeFrom time.Time
 }
 
 // ClaudeTurnUsageRow represents aggregated Claude Code usage for one prompt.id turn.
@@ -3131,7 +3198,9 @@ func (q *Queries) GetClaudeTurnUsageByChatIDs(ctx context.Context, arg GetClaude
 		Where("gram_chat_id IS NOT NULL").
 		Where("gram_chat_id != ''").
 		Where(promptIDExpr+" != ''").
-		Where(isClaudeCodeExpr).
+		Where(isClaudeCodeExpr)
+	sb = withChatMetricsEventTimeFrom(sb, "time_unix_nano >= ?", arg.EventTimeFrom)
+	sb = sb.
 		GroupBy("gram_chat_id", promptIDExpr).
 		OrderBy("gram_chat_id ASC", "start_time_unix_nano ASC", "prompt_id ASC")
 
@@ -3196,7 +3265,9 @@ func (q *Queries) GetClaudeToolUsageByChatIDs(ctx context.Context, arg GetClaude
 		Where(toolUseIDExpr+" != ''").
 		Where(promptIDExpr+" != ''").
 		Where(isToolResultExpr).
-		Where(isClaudeCodeExpr).
+		Where(isClaudeCodeExpr)
+	sb = withChatMetricsEventTimeFrom(sb, "time_unix_nano >= ?", arg.EventTimeFrom)
+	sb = sb.
 		GroupBy("gram_chat_id", toolUseIDExpr, promptIDExpr).
 		OrderBy("gram_chat_id ASC", "min(time_unix_nano) ASC", "tool_use_id ASC")
 

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -3197,7 +3197,7 @@ func (q *Queries) GetClaudeTurnUsageByChatIDs(ctx context.Context, arg GetClaude
 		Where(squirrel.Eq{"gram_chat_id": arg.ChatIDs}).
 		Where("gram_chat_id IS NOT NULL").
 		Where("gram_chat_id != ''").
-		Where(promptIDExpr+" != ''").
+		Where(promptIDExpr + " != ''").
 		Where(isClaudeCodeExpr)
 	sb = withChatMetricsEventTimeFrom(sb, "time_unix_nano >= ?", arg.EventTimeFrom)
 	sb = sb.
@@ -3262,8 +3262,8 @@ func (q *Queries) GetClaudeToolUsageByChatIDs(ctx context.Context, arg GetClaude
 		Where(squirrel.Eq{"gram_chat_id": arg.ChatIDs}).
 		Where("gram_chat_id IS NOT NULL").
 		Where("gram_chat_id != ''").
-		Where(toolUseIDExpr+" != ''").
-		Where(promptIDExpr+" != ''").
+		Where(toolUseIDExpr + " != ''").
+		Where(promptIDExpr + " != ''").
 		Where(isToolResultExpr).
 		Where(isClaudeCodeExpr)
 	sb = withChatMetricsEventTimeFrom(sb, "time_unix_nano >= ?", arg.EventTimeFrom)

--- a/server/internal/telemetry/repo/queries.sql.go
+++ b/server/internal/telemetry/repo/queries.sql.go
@@ -3012,7 +3012,6 @@ type ChatMetricsRow struct {
 // chat_session_summaries so chat.load does not scan raw telemetry_logs.
 // Managed assistant completions are absent from that summary, so any chat
 // missing from it falls back to the raw gen_ai.usage projection.
-//
 func (q *Queries) GetChatMetricsByIDs(ctx context.Context, arg GetChatMetricsByIDsParams) (map[string]ChatMetricsRow, error) {
 	if len(arg.ChatIDs) == 0 {
 		return make(map[string]ChatMetricsRow), nil


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Opening any Agent Sessions transcript called `chat.load`, which ran four sequential ClickHouse queries on the critical path — three of them full-range scans of raw `telemetry_logs`. That cost multiple seconds even for chats with only a couple of messages.

## Fix

- Read per-chat token/cost from `chat_session_summaries` (the table already used by the sessions list). Fall back to raw `telemetry_logs` only for chats the summary does not cover (managed assistant completions).
- Skip Claude Code OTEL turn/tool scans only for known non-Claude surfaces (Cursor, Codex, etc.). Unknown or unstamped sources stay on the fetch path so AgentUsage cannot disappear.
- Bound remaining raw-log reads on `chat.load` / `chat.list` to `chats.created_at` minus a one-day lookback so ClickHouse can prune partitions.
- Work-units trend metrics use the oldest matching `chats.created_at` (minus lookback), including soft-deleted chats whose verdicts still appear in the window. That keeps lifetime tokens intact and keeps the raw fallback partition-prunable. If Postgres has no matching rows, fall back to the window start minus lookback — never an unbounded scan.
- Run metrics, Claude usage, and work-units enrichment in parallel.

## Tests

- Session-summary read path for `GetChatMetricsByIDs`
- `EventTimeFrom` partition bound for Claude turn usage
- `needsClaudeTurnUsage` surface gating, including unknown sources
- Work-units trend bound prefers chat `created_at`, stays project-scoped, and includes soft-deleted chats

Linear: DNO-1049

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-1049](https://linear.app/speakeasy/issue/DNO-1049/chatload-takes-multiple-seconds)

<div><a href="https://cursor.com/agents/bc-df799a44-e071-4980-958f-6b37ba10f7d0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df799a44-e071-4980-958f-6b37ba10f7d0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up `chat.load` transcript opens so Agent Sessions no longer take multiple seconds to load (DNO-1049).

- Reads token/cost metrics from `chat_session_summaries`; falls back to raw `telemetry_logs` only for chats the summary doesn't cover (managed assistant completions).
- Bounds raw-log reads to `chats.created_at` minus a one-day lookback so ClickHouse can prune partitions; the work-units trend uses the oldest matching chat's `created_at`, including soft-deleted chats, so older sessions don't lose tokens.
- Skips Claude Code OTEL turn/tool scans only for known non-Claude surfaces (Cursor, Codex, etc.); unknown sources still fetch so AgentUsage isn't dropped.
- Runs metrics, Claude usage, and work-units enrichment in parallel.

<sup>Written for commit bc0158cd1074f1715343d274c5b2097b752c68d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

