### PR TITLE
refactor: move issuer URL canonicalization to its own package

### DIFF
--- a/.changeset/issuer-url-canonicalization-package.md
+++ b/.changeset/issuer-url-canonicalization-package.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Move issuer URL canonicalization into its own package so more than one grant can share it. No behaviour change.

--- a/server/internal/issuerurl/issuerurl.go
+++ b/server/internal/issuerurl/issuerurl.go
@@ -1,4 +1,4 @@
-package remotesessions
+package issuerurl
 
 import (
 	"fmt"
@@ -39,9 +39,9 @@ import (
 // self-declared issuer against the URL Gram asked for, which is a trust check on
 // a discovery response, and it stays strict on purpose. Widening it would let an
 // upstream claim an identity it does not have. Keep the two separate.
-type canonicalIssuerURL struct {
+type Canonical struct {
 	// raw is the caller-supplied spelling with surrounding whitespace trimmed.
-	// Kept so matchCandidates can probe for a stored row written exactly the way
+	// Kept so MatchCandidates can probe for a stored row written exactly the way
 	// this caller writes it.
 	raw string
 
@@ -55,25 +55,25 @@ type canonicalIssuerURL struct {
 	path string
 }
 
-// parseCanonicalIssuerURL validates raw as an issuer identifier and reduces it
+// Parse validates raw as an issuer identifier and reduces it
 // to its canonical parts.
-func parseCanonicalIssuerURL(raw string) (canonicalIssuerURL, error) {
+func Parse(raw string) (Canonical, error) {
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {
-		return canonicalIssuerURL{}, fmt.Errorf("issuer url is empty")
+		return Canonical{}, fmt.Errorf("issuer url is empty")
 	}
 
 	u, err := url.Parse(trimmed)
 	if err != nil {
-		return canonicalIssuerURL{}, fmt.Errorf("parse issuer url: %w", err)
+		return Canonical{}, fmt.Errorf("parse issuer url: %w", err)
 	}
 
 	scheme := strings.ToLower(u.Scheme)
 	if scheme != "http" && scheme != "https" {
-		return canonicalIssuerURL{}, fmt.Errorf("issuer url must use http or https, got %q", u.Scheme)
+		return Canonical{}, fmt.Errorf("issuer url must use http or https, got %q", u.Scheme)
 	}
 	if u.User != nil {
-		return canonicalIssuerURL{}, fmt.Errorf("issuer url must not carry userinfo")
+		return Canonical{}, fmt.Errorf("issuer url must not carry userinfo")
 	}
 	// Both are checked on the raw string rather than on the parsed fields,
 	// because the parsed fields do not reliably report an empty component:
@@ -83,15 +83,15 @@ func parseCanonicalIssuerURL(raw string) (canonicalIssuerURL, error) {
 	// always starts a query or fragment, and an encoded one stays percent-
 	// encoded in the path, so neither check can false-positive.
 	if strings.Contains(trimmed, "?") {
-		return canonicalIssuerURL{}, fmt.Errorf("issuer url must not carry a query string")
+		return Canonical{}, fmt.Errorf("issuer url must not carry a query string")
 	}
 	if strings.Contains(trimmed, "#") {
-		return canonicalIssuerURL{}, fmt.Errorf("issuer url must not carry a fragment")
+		return Canonical{}, fmt.Errorf("issuer url must not carry a fragment")
 	}
 
 	host := strings.ToLower(u.Hostname())
 	if host == "" {
-		return canonicalIssuerURL{}, fmt.Errorf("issuer url has no host")
+		return Canonical{}, fmt.Errorf("issuer url has no host")
 	}
 	// url.Hostname strips the brackets from an IPv6 literal; put them back so the
 	// canonical form is a URL that can be parsed again.
@@ -106,7 +106,7 @@ func parseCanonicalIssuerURL(raw string) (canonicalIssuerURL, error) {
 		port = ""
 	}
 
-	return canonicalIssuerURL{
+	return Canonical{
 		raw:    trimmed,
 		scheme: scheme,
 		host:   host,
@@ -117,7 +117,7 @@ func parseCanonicalIssuerURL(raw string) (canonicalIssuerURL, error) {
 
 // String renders the canonical form. It is the advisory-lock key for a resolve,
 // so two spellings that name one upstream also serialize against each other.
-func (c canonicalIssuerURL) String() string {
+func (c Canonical) String() string {
 	authority := c.host
 	if c.port != "" {
 		authority += ":" + c.port
@@ -126,7 +126,7 @@ func (c canonicalIssuerURL) String() string {
 	return c.scheme + "://" + authority + c.path
 }
 
-// matchCandidates returns every literal spelling a stored issuer may carry that
+// MatchCandidates returns every literal spelling a stored issuer may carry that
 // this URL should match.
 //
 // Lookup compares the raw `issuer` column against this set rather than
@@ -151,7 +151,7 @@ func (c canonicalIssuerURL) String() string {
 // them is a combinatorial explosion. If input-side matching ever proves
 // insufficient, the fix is a stored canonical column that normalizes both sides,
 // not a longer candidate list.
-func (c canonicalIssuerURL) matchCandidates() []string {
+func (c Canonical) MatchCandidates() []string {
 	canonical := c.String()
 
 	spellings := []string{canonical, canonical + "/"}
@@ -179,7 +179,7 @@ func (c canonicalIssuerURL) matchCandidates() []string {
 // withDefaultPort renders the canonical form with the scheme's default port
 // written out explicitly, or "" when an explicit non-default port is present
 // (in which case no default-port spelling of this URL exists).
-func (c canonicalIssuerURL) withDefaultPort() string {
+func (c Canonical) withDefaultPort() string {
 	if c.port != "" {
 		return ""
 	}

--- a/server/internal/issuerurl/issuerurl_test.go
+++ b/server/internal/issuerurl/issuerurl_test.go
@@ -1,4 +1,4 @@
-package remotesessions
+package issuerurl
 
 import (
 	"testing"
@@ -34,7 +34,7 @@ func TestParseCanonicalIssuerURL_Canonicalizes(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		canonical, err := parseCanonicalIssuerURL(tc.in)
+		canonical, err := Parse(tc.in)
 		require.NoError(t, err, tc.name)
 		require.Equal(t, tc.want, canonical.String(), tc.name)
 	}
@@ -63,9 +63,9 @@ func TestParseCanonicalIssuerURL_PreservesDistinctions(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		a, err := parseCanonicalIssuerURL(tc.a)
+		a, err := Parse(tc.a)
 		require.NoError(t, err, tc.name)
-		b, err := parseCanonicalIssuerURL(tc.b)
+		b, err := Parse(tc.b)
 		require.NoError(t, err, tc.name)
 		require.NotEqual(t, a.String(), b.String(), tc.name)
 	}
@@ -101,7 +101,7 @@ func TestParseCanonicalIssuerURL_Rejects(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		_, err := parseCanonicalIssuerURL(tc.in)
+		_, err := Parse(tc.in)
 		require.Error(t, err, tc.name)
 	}
 }
@@ -113,14 +113,14 @@ func TestParseCanonicalIssuerURL_Rejects(t *testing.T) {
 func TestCanonicalIssuerURL_MatchCandidates(t *testing.T) {
 	t.Parallel()
 
-	canonical, err := parseCanonicalIssuerURL("https://idp.example.com/oauth")
+	canonical, err := Parse("https://idp.example.com/oauth")
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{
 		"https://idp.example.com/oauth",
 		"https://idp.example.com/oauth/",
 		"https://idp.example.com:443/oauth",
 		"https://idp.example.com:443/oauth/",
-	}, canonical.matchCandidates())
+	}, canonical.MatchCandidates())
 }
 
 // A non-default port has no default-port spelling, so the set shrinks rather
@@ -128,12 +128,12 @@ func TestCanonicalIssuerURL_MatchCandidates(t *testing.T) {
 func TestCanonicalIssuerURL_MatchCandidatesExplicitPort(t *testing.T) {
 	t.Parallel()
 
-	canonical, err := parseCanonicalIssuerURL("https://idp.example.com:8443/oauth")
+	canonical, err := Parse("https://idp.example.com:8443/oauth")
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{
 		"https://idp.example.com:8443/oauth",
 		"https://idp.example.com:8443/oauth/",
-	}, canonical.matchCandidates())
+	}, canonical.MatchCandidates())
 }
 
 // The caller's own spelling is probed alongside the canonical ones. This is what
@@ -142,10 +142,10 @@ func TestCanonicalIssuerURL_MatchCandidatesExplicitPort(t *testing.T) {
 func TestCanonicalIssuerURL_MatchCandidatesIncludesRawSpelling(t *testing.T) {
 	t.Parallel()
 
-	canonical, err := parseCanonicalIssuerURL("https://IDP.Example.com/oauth")
+	canonical, err := Parse("https://IDP.Example.com/oauth")
 	require.NoError(t, err)
-	require.Contains(t, canonical.matchCandidates(), "https://IDP.Example.com/oauth")
-	require.Contains(t, canonical.matchCandidates(), "https://idp.example.com/oauth")
+	require.Contains(t, canonical.MatchCandidates(), "https://IDP.Example.com/oauth")
+	require.Contains(t, canonical.MatchCandidates(), "https://idp.example.com/oauth")
 }
 
 // A raw spelling that is already canonical must not be emitted twice, or the
@@ -153,10 +153,10 @@ func TestCanonicalIssuerURL_MatchCandidatesIncludesRawSpelling(t *testing.T) {
 func TestCanonicalIssuerURL_MatchCandidatesDeduplicates(t *testing.T) {
 	t.Parallel()
 
-	canonical, err := parseCanonicalIssuerURL("https://idp.example.com/oauth")
+	canonical, err := Parse("https://idp.example.com/oauth")
 	require.NoError(t, err)
 
-	candidates := canonical.matchCandidates()
+	candidates := canonical.MatchCandidates()
 	seen := make(map[string]struct{}, len(candidates))
 	for _, candidate := range candidates {
 		_, duplicate := seen[candidate]

--- a/server/internal/remotesessions/adminhandlers.go
+++ b/server/internal/remotesessions/adminhandlers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/issuerurl"
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
@@ -204,13 +205,13 @@ func (s *Service) GetGlobalIssuerDuplicatePreflight(ctx context.Context, payload
 		return nil, err
 	}
 
-	canonical, err := parseCanonicalIssuerURL(conv.PtrValOrEmpty(payload.Issuer, ""))
+	canonical, err := issuerurl.Parse(conv.PtrValOrEmpty(payload.Issuer, ""))
 	if err != nil {
 		return emptyIssuerDuplicatePreflight(), nil
 	}
 
 	candidates, err := repo.New(s.db).ListGlobalRemoteSessionIssuersByIssuerURL(ctx, repo.ListGlobalRemoteSessionIssuersByIssuerURLParams{
-		Issuers:    canonical.matchCandidates(),
+		Issuers:    canonical.MatchCandidates(),
 		LimitValue: maxIssuerDuplicateMatchesPerTier,
 	})
 	if err != nil {
@@ -711,8 +712,8 @@ func (s *Service) ListGlobalIssuerConvergenceCandidates(ctx context.Context, pay
 	// offering a candidate that names a different upstream, and the parity guard
 	// compares the same two values the same way.
 	issuers := []string{target.Issuer}
-	if canonical, canonicalErr := parseCanonicalIssuerURL(target.Issuer); canonicalErr == nil {
-		issuers = canonical.matchCandidates()
+	if canonical, canonicalErr := issuerurl.Parse(target.Issuer); canonicalErr == nil {
+		issuers = canonical.MatchCandidates()
 	}
 
 	rows, err := r.ListTenantRemoteSessionIssuersByIssuerURL(ctx, repo.ListTenantRemoteSessionIssuersByIssuerURLParams{

--- a/server/internal/remotesessions/issuerhandlers.go
+++ b/server/internal/remotesessions/issuerhandlers.go
@@ -29,6 +29,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/issuerurl"
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
@@ -730,7 +731,7 @@ func (s *Service) GetRemoteSessionIssuer(ctx context.Context, payload *gen.GetRe
 			return nil, err
 		}
 
-		canonical, err := parseCanonicalIssuerURL(*payload.Issuer)
+		canonical, err := issuerurl.Parse(*payload.Issuer)
 		if err != nil {
 			return nil, oops.E(oops.CodeBadRequest, err, "%s", err.Error()).LogError(ctx, logger)
 		}
@@ -739,7 +740,7 @@ func (s *Service) GetRemoteSessionIssuer(ctx context.Context, payload *gen.GetRe
 		// issuer describing this upstream is one the project may attach its own
 		// client to, so it counts as found.
 		candidates, err := repo.New(s.db).ListRemoteSessionIssuersByIssuerURL(ctx, repo.ListRemoteSessionIssuersByIssuerURLParams{
-			Issuers:               canonical.matchCandidates(),
+			Issuers:               canonical.MatchCandidates(),
 			ProjectID:             uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
 			IncludeOrganizational: true,
 			OrganizationID:        conv.ToPGText(authCtx.ActiveOrganizationID),
@@ -797,7 +798,7 @@ func (s *Service) GetRemoteSessionIssuerDuplicatePreflight(ctx context.Context, 
 
 	logger := s.logger.With(attr.SlogProjectID(authCtx.ProjectID.String()))
 
-	canonical, err := parseCanonicalIssuerURL(conv.PtrValOrEmpty(payload.Issuer, ""))
+	canonical, err := issuerurl.Parse(conv.PtrValOrEmpty(payload.Issuer, ""))
 	if err != nil {
 		return emptyIssuerDuplicatePreflight(), nil
 	}
@@ -807,7 +808,7 @@ func (s *Service) GetRemoteSessionIssuerDuplicatePreflight(ctx context.Context, 
 	// no LIMIT, because precedence resolution needs the whole candidate set;
 	// buildIssuerDuplicatePreflight truncates the response instead.
 	candidates, err := repo.New(s.db).ListRemoteSessionIssuersByIssuerURL(ctx, repo.ListRemoteSessionIssuersByIssuerURLParams{
-		Issuers:               canonical.matchCandidates(),
+		Issuers:               canonical.MatchCandidates(),
 		ProjectID:             uuid.NullUUID{UUID: *authCtx.ProjectID, Valid: true},
 		IncludeOrganizational: true,
 		OrganizationID:        conv.ToPGText(authCtx.ActiveOrganizationID),

--- a/server/internal/remotesessions/issuermigration.go
+++ b/server/internal/remotesessions/issuermigration.go
@@ -289,7 +289,7 @@ func pgTextEqual(a, b pgtype.Text) bool {
 
 // issuerURLsCanonicallyEqual reports whether two issuer identifiers name the
 // same upstream authorization server, collapsing the trailing-slash and
-// default-port spellings that parseCanonicalIssuerURL treats as equivalent.
+// default-port spellings that issuerurl.Parse treats as equivalent.
 //
 // A value that does not parse as an issuer identifier is only ever equal to an
 // identical string. Migration must not widen an identity comparison on input it

--- a/server/internal/remotesessions/issuermigration.go
+++ b/server/internal/remotesessions/issuermigration.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/issuerurl"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 )
@@ -298,12 +299,12 @@ func issuerURLsCanonicallyEqual(a, b string) bool {
 		return true
 	}
 
-	canonicalA, err := parseCanonicalIssuerURL(a)
+	canonicalA, err := issuerurl.Parse(a)
 	if err != nil {
 		return false
 	}
 
-	canonicalB, err := parseCanonicalIssuerURL(b)
+	canonicalB, err := issuerurl.Parse(b)
 	if err != nil {
 		return false
 	}

--- a/server/internal/remotesessions/issuermigration_internal_test.go
+++ b/server/internal/remotesessions/issuermigration_internal_test.go
@@ -303,7 +303,7 @@ func TestMigratePreflight_CanMigrate(t *testing.T) {
 }
 
 // TestIssuerURLsCanonicallyEqual_CollapsesEquivalentSpellings covers the axes
-// parseCanonicalIssuerURL treats as one upstream. These are the duplicates
+// issuerurl.Parse treats as one upstream. These are the duplicates
 // consolidation exists to clean up, and discovery finds candidates by the same
 // equality, so a stricter comparison here would surface candidates that could
 // never be migrated.

--- a/server/internal/remotesessions/organizationissuerhandlers.go
+++ b/server/internal/remotesessions/organizationissuerhandlers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/issuerurl"
 	"github.com/speakeasy-api/gram/server/internal/mv"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
@@ -371,13 +372,13 @@ func (s *Service) GetIssuerDuplicatePreflight(ctx context.Context, payload *orgi
 
 	logger := s.logger.With(attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
 
-	canonical, err := parseCanonicalIssuerURL(conv.PtrValOrEmpty(payload.Issuer, ""))
+	canonical, err := issuerurl.Parse(conv.PtrValOrEmpty(payload.Issuer, ""))
 	if err != nil {
 		return emptyIssuerDuplicatePreflight(), nil
 	}
 
 	candidates, err := repo.New(s.db).ListOrganizationRemoteSessionIssuersByIssuerURL(ctx, repo.ListOrganizationRemoteSessionIssuersByIssuerURLParams{
-		Issuers:        canonical.matchCandidates(),
+		Issuers:        canonical.MatchCandidates(),
 		OrganizationID: conv.ToPGText(authCtx.ActiveOrganizationID),
 		IncludeGlobal:  true,
 		PerTierLimit:   maxIssuerDuplicateMatchesPerTier,


### PR DESCRIPTION
## Summary

`parseCanonicalIssuerURL` and `matchCandidates` decide whether two spellings name the same authorization server. That question is about URLs, not about any table — so they move to `internal/issuerurl` and are exported as `issuerurl.Parse` and `Canonical.MatchCandidates`.

Pure relocation. No behaviour change, the tests move with it unchanged, and the four `remotesessions` call sites are updated in place.

## Motivation

The workload assertion grant needs the same canonicalization, and importing `remotesessions` to get it would reintroduce exactly the dependency the workload issuer schema decision removed.

Copying the rules instead would be worse. The canonical form deliberately treats `http` and `https` as distinct, keeps path case significant, drops only the scheme's default port, and rejects a query or fragment. Those choices fail safe *because there is one of them* — a second copy that drifted would either hide an issuer a project may legitimately use or match one it should not.

## Review notes

- `git` records both files as renames (86% and 90% similarity); the diff is the package clause, the exported names, and the import line in four handlers.
- `internal/issuerurl` and `internal/remotesessions` both build, vet clean, and pass their tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves issuer URL canonicalization from `internal/remotesessions` into a new reusable `internal/issuerurl` package so workload assertion grants can share it without depending on `remotesessions` (AIM-143). Pure relocation with no behavior change — the rules are now exported as `issuerurl.Parse` and `Canonical.MatchCandidates`.

**Refactors**
- Updates the four `remotesessions` call sites in place; tests move with the implementation unchanged.
- Adds a patch changeset for the package move.

<sup>Written for commit 87740481ade10007c8ac258dbe673382056146c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

