### PR TITLE
mig: add organization-pinned user session issuer references

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -1868,6 +1868,9 @@ CREATE TABLE IF NOT EXISTS user_session_issuers (
 CREATE INDEX IF NOT EXISTS user_session_issuers_organization_id_idx
 ON user_session_issuers (organization_id);
 
+CREATE UNIQUE INDEX IF NOT EXISTS user_session_issuers_organization_id_id_key
+ON user_session_issuers (organization_id, id);
+
 CREATE UNIQUE INDEX IF NOT EXISTS user_session_issuers_project_slug_key
 ON user_session_issuers (project_id, slug)
 WHERE deleted IS FALSE;
@@ -5214,7 +5217,8 @@ CREATE TABLE IF NOT EXISTS meta_mcp_servers (
 
   CONSTRAINT meta_mcp_servers_pkey PRIMARY KEY (id),
   CONSTRAINT meta_mcp_servers_organization_id_project_id_fkey FOREIGN KEY (organization_id, project_id) REFERENCES projects (organization_id, id) ON DELETE CASCADE,
-  CONSTRAINT meta_mcp_servers_project_id_user_session_issuer_id_fkey FOREIGN KEY (project_id, user_session_issuer_id) REFERENCES user_session_issuers (project_id, id) ON DELETE RESTRICT
+  CONSTRAINT meta_mcp_servers_project_id_user_session_issuer_id_fkey FOREIGN KEY (project_id, user_session_issuer_id) REFERENCES user_session_issuers (project_id, id) ON DELETE RESTRICT,
+  CONSTRAINT meta_mcp_servers_organization_id_user_session_issuer_id_fkey FOREIGN KEY (organization_id, user_session_issuer_id) REFERENCES user_session_issuers (organization_id, id) ON DELETE RESTRICT
 );
 
 CREATE INDEX IF NOT EXISTS meta_mcp_servers_project_id_idx
@@ -7557,6 +7561,8 @@ CREATE TABLE IF NOT EXISTS platform_mcp_catalog_registrations (
     FOREIGN KEY (project_id, remote_mcp_server_id) REFERENCES remote_mcp_servers (project_id, id) ON DELETE NO ACTION,
   CONSTRAINT platform_mcp_catalog_registrations_session_issuer_fkey
     FOREIGN KEY (project_id, user_session_issuer_id) REFERENCES user_session_issuers (project_id, id) ON DELETE NO ACTION,
+  CONSTRAINT platform_mcp_catalog_registrations_org_session_issuer_fkey
+    FOREIGN KEY (organization_id, user_session_issuer_id) REFERENCES user_session_issuers (organization_id, id) ON DELETE NO ACTION,
   CONSTRAINT platform_mcp_catalog_registrations_mcp_server_fkey
     FOREIGN KEY (project_id, mcp_server_id) REFERENCES mcp_servers (project_id, id) ON DELETE NO ACTION,
   CONSTRAINT platform_mcp_catalog_registrations_mcp_endpoint_fkey

--- a/server/internal/demoseed/postgres.sql
+++ b/server/internal/demoseed/postgres.sql
@@ -867,8 +867,8 @@ BEGIN
   -- user_sessions all cascade from projects, which is deleted and recreated
   -- above.
   ------------------------------------------------------------------
-  INSERT INTO user_session_issuers (id, project_id, slug, authn_challenge_mode, session_duration)
-  VALUES (us_issuer, proj_a, 'acme-partner-gateway', 'interactive', interval '30 days');
+  INSERT INTO user_session_issuers (id, project_id, organization_id, slug, authn_challenge_mode, session_duration)
+  VALUES (us_issuer, proj_a, demo_org, 'acme-partner-gateway', 'interactive', interval '30 days');
 
   UPDATE toolsets SET user_session_issuer_id = us_issuer WHERE id = toolset_3;
 
@@ -967,15 +967,15 @@ BEGIN
   -- authenticate to it rather than to a member.
   -- session_duration must be a Microseconds-only interval: the user-session
   -- mint rejects Months/Days components (see usersessions/minthandler.go).
-  INSERT INTO user_session_issuers (id, project_id, slug, authn_challenge_mode,
-                                    session_duration) VALUES
-    (demo.det_uuid('gram-demo-issuer-linear'), proj_a, 'linear',
+  INSERT INTO user_session_issuers (id, project_id, organization_id, slug,
+                                    authn_challenge_mode, session_duration) VALUES
+    (demo.det_uuid('gram-demo-issuer-linear'), proj_a, demo_org, 'linear',
      'interactive', make_interval(secs => 14 * 24 * 60 * 60)),
-    (demo.det_uuid('gram-demo-issuer-slack'), proj_a, 'slack',
+    (demo.det_uuid('gram-demo-issuer-slack'), proj_a, demo_org, 'slack',
      'interactive', make_interval(secs => 14 * 24 * 60 * 60)),
-    (demo.det_uuid('gram-demo-issuer-github'), proj_a, 'github',
+    (demo.det_uuid('gram-demo-issuer-github'), proj_a, demo_org, 'github',
      'interactive', make_interval(secs => 14 * 24 * 60 * 60)),
-    (demo.det_uuid('gram-demo-issuer-gateway'), proj_a, 'acme-agent-gateway',
+    (demo.det_uuid('gram-demo-issuer-gateway'), proj_a, demo_org, 'acme-agent-gateway',
      'interactive', make_interval(secs => 14 * 24 * 60 * 60));
 
   INSERT INTO mcp_servers (id, project_id, name, slug, toolset_id,

--- a/server/internal/mcp/servepublic_mcpendpoint_test.go
+++ b/server/internal/mcp/servepublic_mcpendpoint_test.go
@@ -39,6 +39,7 @@ import (
 	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	"github.com/speakeasy-api/gram/server/internal/networkaccess"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/remotemcptest"
 	remotemcprepo "github.com/speakeasy-api/gram/server/internal/remotemcp/repo"
 	"github.com/speakeasy-api/gram/server/internal/requestorigin"
@@ -235,8 +236,12 @@ func TestServePublic_McpEndpoint_PublicTunneledBacked_FailsClosed(t *testing.T) 
 // identical to what the management API would produce.
 func createUserSessionIssuer(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID uuid.UUID) uuid.UUID {
 	t.Helper()
+	project, err := projectsrepo.New(conn).GetProjectByID(ctx, projectID)
+	require.NoError(t, err)
+
 	issuer, err := usersessionsrepo.New(conn).CreateUserSessionIssuer(ctx, usersessionsrepo.CreateUserSessionIssuerParams{
 		ProjectID:          projectID,
+		OrganizationID:     conv.ToPGText(project.OrganizationID),
 		Slug:               "issuer-" + uuid.NewString(),
 		AuthnChallengeMode: "chain",
 		SessionDuration:    pgtype.Interval{Microseconds: time.Hour.Microseconds(), Days: 0, Months: 0, Valid: true},

--- a/server/internal/mcpmetadata/setup_test.go
+++ b/server/internal/mcpmetadata/setup_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/mcpservers"
 	mcpservers_repo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	"github.com/speakeasy-api/gram/server/internal/networkaccess"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/workos"
 	toolsets_repo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
@@ -201,9 +202,12 @@ func createMcpServerWithEndpoint(
 // needed here.
 func createUserSessionIssuer(t *testing.T, ctx context.Context, ti *testInstance, projectID uuid.UUID) usersessions_repo.UserSessionIssuer {
 	t.Helper()
+	project, err := projectsrepo.New(ti.conn).GetProjectByID(ctx, projectID)
+	require.NoError(t, err)
 
 	usi, err := usersessions_repo.New(ti.conn).CreateUserSessionIssuer(ctx, usersessions_repo.CreateUserSessionIssuerParams{
 		ProjectID:          projectID,
+		OrganizationID:     conv.ToPGText(project.OrganizationID),
 		Slug:               "usi-" + uuid.NewString()[:8],
 		AuthnChallengeMode: "interactive",
 		SessionDuration: pgtype.Interval{

--- a/server/internal/metamcp/setup_test.go
+++ b/server/internal/metamcp/setup_test.go
@@ -134,9 +134,12 @@ func requireOopsCode(t *testing.T, err error, code oops.Code) {
 // project.
 func seedUserSessionIssuer(t *testing.T, ctx context.Context, conn *pgxpool.Pool, projectID uuid.UUID) uuid.UUID {
 	t.Helper()
+	project, err := projectsrepo.New(conn).GetProjectByID(ctx, projectID)
+	require.NoError(t, err)
 
 	issuer, err := usersessionsrepo.New(conn).CreateUserSessionIssuer(ctx, usersessionsrepo.CreateUserSessionIssuerParams{
 		ProjectID:          projectID,
+		OrganizationID:     conv.ToPGText(project.OrganizationID),
 		Slug:               "usi-" + uuid.NewString()[:8],
 		AuthnChallengeMode: "interactive",
 		SessionDuration:    pgtype.Interval{Microseconds: time.Hour.Microseconds(), Days: 0, Months: 0, Valid: true},

--- a/server/migrations/20260909195541_repin-issuer-fkeys-to-organization.sql
+++ b/server/migrations/20260909195541_repin-issuer-fkeys-to-organization.sql
@@ -1,0 +1,8 @@
+-- atlas:txmode none
+
+-- Create index "user_session_issuers_organization_id_id_key" to table: "user_session_issuers"
+CREATE UNIQUE INDEX CONCURRENTLY "user_session_issuers_organization_id_id_key" ON "user_session_issuers" ("organization_id", "id");
+-- Modify "meta_mcp_servers" table
+ALTER TABLE "meta_mcp_servers" ADD CONSTRAINT "meta_mcp_servers_organization_id_user_session_issuer_id_fkey" FOREIGN KEY ("organization_id", "user_session_issuer_id") REFERENCES "user_session_issuers" ("organization_id", "id") ON UPDATE NO ACTION ON DELETE RESTRICT;
+-- Modify "platform_mcp_catalog_registrations" table
+ALTER TABLE "platform_mcp_catalog_registrations" ADD CONSTRAINT "platform_mcp_catalog_registrations_org_session_issuer_fkey" FOREIGN KEY ("organization_id", "user_session_issuer_id") REFERENCES "user_session_issuers" ("organization_id", "id") ON UPDATE NO ACTION ON DELETE NO ACTION;

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:EM+APdFGMAvLHeWE0GF/hzBRLWgHsqWIwQvpfVZxTbI=
+h1:fDRUdQ5oPZObVT0+l0hmmXa4235OAUb4gbzkG8dAJOI=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -394,3 +394,4 @@ h1:EM+APdFGMAvLHeWE0GF/hzBRLWgHsqWIwQvpfVZxTbI=
 20260909100739_device-agent-ai-scan-targets.sql h1:Cdb8T6MSqBkzvBHuvnkSasl43c+BT3cqVOpVToJ5+0w=
 20260909161418_remote-sessions-upstream-identity-and-validation.sql h1:Ianq/JURh4k1bH7IvSssXtEZZRUqH7jHImfXofwQeIA=
 20260909165020_remote-session-issuers-scope-override-and-resource-indicator.sql h1:ryUGhSzH8d7Xioyo9OBET3MKuoTuqtthej5N89/v3P4=
+20260909195541_repin-issuer-fkeys-to-organization.sql h1:4tWO7vJtVTWtBJK8+WP32Hz0UJzwkig34/p4k5I/4XU=


### PR DESCRIPTION
AIM-95

## Summary

Add organization-qualified foreign keys for Meta MCP servers and Platform MCP catalog registrations while retaining the project-qualified constraints during the expand phase.

## Motivation

These references were mistakenly pinned only to the issuer's project. Organization-level tenancy pins support both issuer tiers without dropping the database tenancy guard.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements AIM-95 by adding organization-qualified issuer foreign keys for Meta MCP servers and Platform MCP catalog registrations while retaining the project-qualified keys during the expand phase. This preserves the database tenancy guard, but organization-tier issuers remain blocked by the existing project constraints until the follow-up contract migration removes them.

**Migration**
- Creates the `(organization_id, id)` issuer index concurrently and runs outside a transaction.
- Updates demo seed data and test fixtures to populate `organization_id` alongside `project_id`.

<sup>Written for commit b245bce1b2210c59c1f8af5984cdf9bc336e5963. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

