### PR TITLE
fix: allow gram start without Temporal configuration

### DIFF
--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -832,6 +832,9 @@ func newStartCommand() *cli.Command {
 			if err != nil {
 				return fmt.Errorf("failed to create temporal client: %w", err)
 			}
+			if temporalEnv == nil && c.Bool("dev-single-process") {
+				return errors.New("dev-single-process requires temporal configuration")
+			}
 
 			temporalHealth := []*o11y.NamedResource[client.Client]{}
 			if temporalEnv != nil {

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -833,10 +833,11 @@ func newStartCommand() *cli.Command {
 				return fmt.Errorf("failed to create temporal client: %w", err)
 			}
 
-			if temporalEnv == nil {
-				return errors.New("insufficient options to create temporal client")
+			temporalHealth := []*o11y.NamedResource[client.Client]{}
+			if temporalEnv != nil {
+				shutdownFuncs = append(shutdownFuncs, shutdown)
+				temporalHealth = append(temporalHealth, &o11y.NamedResource[client.Client]{Name: "default", Resource: temporalEnv.Client()})
 			}
-			shutdownFuncs = append(shutdownFuncs, shutdown)
 
 			auditLogger := newAuditLogger()
 
@@ -2117,10 +2118,6 @@ func newStartCommand() *cli.Command {
 					DisableProfiling: false,
 				}
 
-				temporals := []*o11y.NamedResource[client.Client]{
-					{Name: "default", Resource: temporalEnv.Client()},
-				}
-
 				listenAddr := srv.Addr
 				if listenAddr == "" {
 					listenAddr = ":8080"
@@ -2148,7 +2145,7 @@ func newStartCommand() *cli.Command {
 					[]*o11y.NamedResource[*o11y.HTTPEndpoint]{{Name: "api", Resource: healthzEndpoint}},
 					[]*o11y.NamedResource[*pgxpool.Pool]{{Name: "default", Resource: db}},
 					[]*o11y.NamedResource[*redis.Client]{{Name: "default", Resource: redisClient}},
-					temporals,
+					temporalHealth,
 				))
 				if err != nil {
 					return fmt.Errorf("failed to start control server: %w", err)


### PR DESCRIPTION
AIM-262

## Summary

- Allow `gram start` to run when Temporal configuration is intentionally absent.
- Register Temporal shutdown and health checking only when a client exists.
- Preserve eager Temporal dialing and readiness checks for configured deployments.

## Motivation

A dedicated MCP and OAuth serving tier needs to start without a Temporal dependency. `newTemporalClient` already represents a missing address or namespace as no client, but `gram start` rejected that state and later dereferenced the absent environment while constructing its health check.

Scoping lifecycle and health registration to an existing client enables the configuration-free case without using a lazy client or weakening the current fail-fast behavior when Temporal is configured but unreachable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AIM-262 by allowing `gram start` to run without Temporal configuration. Previously, startup rejected missing configuration and could dereference the absent environment; now it skips Temporal lifecycle and health registration while configured deployments still dial eagerly and fail startup if Temporal is unreachable.

- `dev-single-process` now returns an explicit error when Temporal configuration is absent.

<sup>Written for commit 81cd95a63e20fb766dc0552f333ae4f3e2dbb236. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

