### PR TITLE
fix: open the setup wizard from the org home rollout card

### DIFF
--- a/.changeset/welcome-banner-rollout-card-wizard.md
+++ b/.changeset/welcome-banner-rollout-card-wizard.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+The organization home "enterprise rollout" card now opens the linear setup wizard it describes instead of the setup board.

--- a/client/dashboard/src/pages/org/OrgHome.test.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.test.tsx
@@ -94,6 +94,7 @@ vi.mock("@/routes", () => ({
     // Used by the welcome banner's route cards.
     home: { href: () => "/acme" },
     setup: { href: () => "/acme/setup" },
+    setupWizard: { href: () => "/acme/setup/wizard" },
     headless: { href: () => "/acme/headless" },
   }),
   useRoutes: ({ projectSlug }: { projectSlug?: string }) => ({

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.test.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.test.tsx
@@ -83,6 +83,7 @@ vi.mock("@/routes", () => ({
   useOrgRoutes: () => ({
     home: { href: () => "/acme" },
     setup: { href: () => "/acme/setup" },
+    setupWizard: { href: () => "/acme/setup/wizard" },
     headless: { href: () => "/acme/headless" },
   }),
   useRoutes: ({ projectSlug }: { projectSlug?: string }) => ({
@@ -182,7 +183,7 @@ describe("OrgWelcomeBanner", () => {
 
     expect(hrefFor("Enter demo org")).toBe("/explore-demo");
     expect(hrefFor("Open the guide")).toBe("/guide");
-    expect(hrefFor("Begin rollout")).toBe("/acme/setup");
+    expect(hrefFor("Begin rollout")).toBe("/acme/setup/wizard");
     expect(screen.queryByText("Announcement")).toBeNull();
     expect(
       screen.getByRole("heading", { name: /Choose your\s+first move/ }),
@@ -207,7 +208,7 @@ describe("OrgWelcomeBanner", () => {
 
     expect(screen.queryByText("Enter demo org")).toBeNull();
     expect(hrefFor("Open the guide")).toBe("/guide");
-    expect(hrefFor("Begin rollout")).toBe("/acme/setup");
+    expect(hrefFor("Begin rollout")).toBe("/acme/setup/wizard");
     expect(screen.queryByText("Announcement")).toBeNull();
   });
 
@@ -218,7 +219,7 @@ describe("OrgWelcomeBanner", () => {
     expect(hrefFor("Set up Platform MCP")).toBe(
       "/acme/headless?entrySource=organization_home",
     );
-    expect(hrefFor("Begin rollout")).toBe("/acme/setup");
+    expect(hrefFor("Begin rollout")).toBe("/acme/setup/wizard");
     expect(screen.queryByText("Announcement")).toBeNull();
     expect(
       screen.getByRole("heading", { name: /Pick up where\s+you left off/ }),
@@ -281,7 +282,7 @@ describe("OrgWelcomeBanner", () => {
     render(<OrgWelcomeBanner />);
 
     expect(hrefFor("Open the guide")).toBe("/guide");
-    expect(hrefFor("Begin rollout")).toBe("/acme/setup");
+    expect(hrefFor("Begin rollout")).toBe("/acme/setup/wizard");
     expect(screen.getByText("Announcement")).toBeTruthy();
   });
 
@@ -328,7 +329,7 @@ describe("OrgWelcomeBanner", () => {
     render(<OrgWelcomeBanner />);
 
     expect(screen.getByText("Continue enterprise rollout")).toBeTruthy();
-    expect(hrefFor("Resume rollout")).toBe("/acme/setup");
+    expect(hrefFor("Resume rollout")).toBe("/acme/setup/wizard");
   });
 
   it("drops the setup card when the org cannot run the wizard", () => {
@@ -352,7 +353,7 @@ describe("OrgWelcomeBanner", () => {
       )
         .closest("a")
         ?.getAttribute("href"),
-    ).toBe("/acme/setup");
+    ).toBe("/acme/setup/wizard");
     expect(screen.queryByText("Open project")).toBeNull();
   });
 

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
@@ -149,7 +149,7 @@ export function OrgWelcomeBanner(): JSX.Element | null {
           body: "SSO, directory sync, agent platforms, and policies — the wizard walks the whole sequence.",
           cta: setupStarted ? "Resume rollout" : "Begin rollout",
           meta: "8 steps · resumable",
-          to: orgRoutes.setup.href(),
+          to: orgRoutes.setupWizard.href(),
           recommended,
           onClick: markSetupStarted,
         };


### PR DESCRIPTION
## Summary

The "Start enterprise rollout" / "Continue enterprise rollout" card on organization home now links to `/setup/wizard` instead of `/setup`.

- `OrgWelcomeBanner.tsx`: the enterprise card uses `orgRoutes.setupWizard` for its destination. Copy is unchanged.
- `OrgWelcomeBanner.test.tsx`: the route mock gains `setupWizard`, and every assertion on the card's href follows it.
- Changeset: `dashboard` patch.

## Motivation

The card's copy is written for the linear wizard: "the wizard walks the whole sequence" and "8 steps · resumable" (eight required steps, Platform MCP is the optional ninth). It was pointed at `/setup` back when that URL was the wizard.

#6031 made the multi-owner setup board the default view at `/setup`, and #6098 brought the wizard back at a new URL, `/setup/wizard`. The card kept its old destination, so it promised a step-by-step walkthrough and landed on the board. This restores the card's promise without touching the `/setup` default, which the sidebar and the rest of the app keep pointing at the board. The board remains one click away through the setup view switcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sLAPX64TLgs4kHShxJ1bg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The "Start enterprise rollout" / "Continue enterprise rollout" card on organization home now opens the linear setup wizard at `/setup/wizard` instead of the setup board at `/setup`, matching the card's step-by-step copy. The board stays available through the setup view switcher.

<sup>Written for commit fddbf7bdb641d8e1bb3a9e13144d4ea22abafe53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

