### PR TITLE
feat: restore the enable logging step in organization setup

### DIFF
--- a/.changeset/setup-enable-logging-step.md
+++ b/.changeset/setup-enable-logging-step.md
@@ -1,0 +1,6 @@
+---
+"dashboard": patch
+"server": patch
+---
+
+Organization setup gets its "Enable logging" step back, in both the wizard and the board, with a single switch that turns on Enable Logs, Record Tool I/O, and Agent Session Capture together. The board marks the task done on its own once all three are on, and the wizard resumes past it. New organizations still start with the bundle enabled.

--- a/.changeset/welcome-banner-rollout-card-wizard.md
+++ b/.changeset/welcome-banner-rollout-card-wizard.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+The organization home "enterprise rollout" card now opens the linear setup wizard it describes instead of the setup board.

--- a/client/dashboard/src/pages/org/OrgHome.test.tsx
+++ b/client/dashboard/src/pages/org/OrgHome.test.tsx
@@ -94,6 +94,7 @@ vi.mock("@/routes", () => ({
     // Used by the welcome banner's route cards.
     home: { href: () => "/acme" },
     setup: { href: () => "/acme/setup" },
+    setupWizard: { href: () => "/acme/setup/wizard" },
     headless: { href: () => "/acme/headless" },
   }),
   useRoutes: ({ projectSlug }: { projectSlug?: string }) => ({

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.test.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.test.tsx
@@ -83,6 +83,7 @@ vi.mock("@/routes", () => ({
   useOrgRoutes: () => ({
     home: { href: () => "/acme" },
     setup: { href: () => "/acme/setup" },
+    setupWizard: { href: () => "/acme/setup/wizard" },
     headless: { href: () => "/acme/headless" },
   }),
   useRoutes: ({ projectSlug }: { projectSlug?: string }) => ({
@@ -182,7 +183,7 @@ describe("OrgWelcomeBanner", () => {
 
     expect(hrefFor("Enter demo org")).toBe("/explore-demo");
     expect(hrefFor("Open the guide")).toBe("/guide");
-    expect(hrefFor("Begin rollout")).toBe("/acme/setup");
+    expect(hrefFor("Begin rollout")).toBe("/acme/setup/wizard");
     expect(screen.queryByText("Announcement")).toBeNull();
     expect(
       screen.getByRole("heading", { name: /Choose your\s+first move/ }),
@@ -207,7 +208,7 @@ describe("OrgWelcomeBanner", () => {
 
     expect(screen.queryByText("Enter demo org")).toBeNull();
     expect(hrefFor("Open the guide")).toBe("/guide");
-    expect(hrefFor("Begin rollout")).toBe("/acme/setup");
+    expect(hrefFor("Begin rollout")).toBe("/acme/setup/wizard");
     expect(screen.queryByText("Announcement")).toBeNull();
   });
 
@@ -218,7 +219,7 @@ describe("OrgWelcomeBanner", () => {
     expect(hrefFor("Set up Platform MCP")).toBe(
       "/acme/headless?entrySource=organization_home",
     );
-    expect(hrefFor("Begin rollout")).toBe("/acme/setup");
+    expect(hrefFor("Begin rollout")).toBe("/acme/setup/wizard");
     expect(screen.queryByText("Announcement")).toBeNull();
     expect(
       screen.getByRole("heading", { name: /Pick up where\s+you left off/ }),
@@ -281,7 +282,7 @@ describe("OrgWelcomeBanner", () => {
     render(<OrgWelcomeBanner />);
 
     expect(hrefFor("Open the guide")).toBe("/guide");
-    expect(hrefFor("Begin rollout")).toBe("/acme/setup");
+    expect(hrefFor("Begin rollout")).toBe("/acme/setup/wizard");
     expect(screen.getByText("Announcement")).toBeTruthy();
   });
 
@@ -328,7 +329,7 @@ describe("OrgWelcomeBanner", () => {
     render(<OrgWelcomeBanner />);
 
     expect(screen.getByText("Continue enterprise rollout")).toBeTruthy();
-    expect(hrefFor("Resume rollout")).toBe("/acme/setup");
+    expect(hrefFor("Resume rollout")).toBe("/acme/setup/wizard");
   });
 
   it("drops the setup card when the org cannot run the wizard", () => {
@@ -352,7 +353,7 @@ describe("OrgWelcomeBanner", () => {
       )
         .closest("a")
         ?.getAttribute("href"),
-    ).toBe("/acme/setup");
+    ).toBe("/acme/setup/wizard");
     expect(screen.queryByText("Open project")).toBeNull();
   });
 

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.test.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.test.tsx
@@ -315,7 +315,7 @@ describe("OrgWelcomeBanner", () => {
     trial.current = activeTrial();
     render(<OrgWelcomeBanner />);
 
-    expect(screen.getByText("8 steps · resumable")).toBeTruthy();
+    expect(screen.getByText("9 steps · resumable")).toBeTruthy();
     fireEvent.click(screen.getByText("Begin rollout"));
 
     expect(localStorage.getItem("gram-org-welcome-rollout-started:acme")).toBe(

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
@@ -149,7 +149,7 @@ export function OrgWelcomeBanner(): JSX.Element | null {
           body: "SSO, directory sync, agent platforms, and policies — the wizard walks the whole sequence.",
           cta: setupStarted ? "Resume rollout" : "Begin rollout",
           meta: "8 steps · resumable",
-          to: orgRoutes.setup.href(),
+          to: orgRoutes.setupWizard.href(),
           recommended,
           onClick: markSetupStarted,
         };

--- a/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
+++ b/client/dashboard/src/pages/org/OrgWelcomeBanner.tsx
@@ -146,9 +146,9 @@ export function OrgWelcomeBanner(): JSX.Element | null {
           title: setupStarted
             ? "Continue enterprise rollout"
             : "Start enterprise rollout",
-          body: "SSO, directory sync, agent platforms, and policies — the wizard walks the whole sequence.",
+          body: "SSO, directory sync, logging, agent platforms, and policies — the wizard walks the whole sequence.",
           cta: setupStarted ? "Resume rollout" : "Begin rollout",
-          meta: "8 steps · resumable",
+          meta: "9 steps · resumable",
           to: orgRoutes.setupWizard.href(),
           recommended,
           onClick: markSetupStarted,

--- a/client/dashboard/src/pages/setup/components/enable-logging-and-session-capture-setting.test.tsx
+++ b/client/dashboard/src/pages/setup/components/enable-logging-and-session-capture-setting.test.tsx
@@ -1,0 +1,313 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testState = vi.hoisted(() => ({
+  data: {
+    logsEnabled: false,
+    toolIoLogsEnabled: false,
+    sessionCaptureEnabled: false,
+  } as
+    | {
+        logsEnabled: boolean;
+        toolIoLogsEnabled: boolean;
+        sessionCaptureEnabled: boolean;
+      }
+    | undefined,
+  organizationId: "org-active",
+  mutateAsync: vi.fn(),
+  productFeaturesQuery: vi.fn(),
+  isAdmin: true,
+}));
+
+const handleAPIError = vi.hoisted(() => vi.fn());
+const invalidateAllProductFeatures = vi.hoisted(() => vi.fn());
+
+vi.mock("@/components/require-scope", () => ({
+  RequireScope: ({ children }: { children: ReactNode }) =>
+    testState.isAdmin ? <>{children}</> : null,
+}));
+
+vi.mock("@/contexts/Auth", () => ({
+  useOrganization: () => ({ id: testState.organizationId }),
+}));
+
+vi.mock("@/lib/errors", () => ({ handleAPIError }));
+
+vi.mock("@gram/client/react-query/featuresSet.js", () => ({
+  useFeaturesSetMutation: () => ({
+    isPending: false,
+    mutateAsync: testState.mutateAsync,
+  }),
+}));
+
+vi.mock("@gram/client/react-query/productFeatures.js", () => ({
+  invalidateAllProductFeatures,
+  useProductFeatures: (...args: unknown[]) => {
+    testState.productFeaturesQuery(...args);
+    return { data: testState.data };
+  },
+}));
+
+vi.mock("@tanstack/react-query", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@tanstack/react-query")>()),
+  useQueryClient: () => ({}),
+}));
+
+import { EnableLoggingAndSessionCaptureSetting } from "./enable-logging-and-session-capture-setting";
+
+function requestFor(featureName: string, enabled: boolean) {
+  return {
+    request: {
+      setProductFeatureRequestBody: {
+        organizationId: "org-active",
+        featureName,
+        enabled,
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  testState.data = {
+    logsEnabled: false,
+    toolIoLogsEnabled: false,
+    sessionCaptureEnabled: false,
+  };
+  testState.organizationId = "org-active";
+  testState.isAdmin = true;
+  testState.mutateAsync.mockReset();
+  testState.mutateAsync.mockResolvedValue(undefined);
+  testState.productFeaturesQuery.mockReset();
+  handleAPIError.mockReset();
+  invalidateAllProductFeatures.mockReset();
+  invalidateAllProductFeatures.mockResolvedValue(undefined);
+});
+
+afterEach(cleanup);
+
+describe("EnableLoggingAndSessionCaptureSetting", () => {
+  it("enables logs, tool I/O, and session capture together", async () => {
+    render(<EnableLoggingAndSessionCaptureSetting />);
+
+    fireEvent.click(
+      screen.getByRole("switch", {
+        name: "Enable logging and session capture",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(testState.mutateAsync).toHaveBeenCalledTimes(3);
+    });
+    expect(testState.mutateAsync).toHaveBeenNthCalledWith(
+      1,
+      requestFor("logs", true),
+    );
+    expect(testState.mutateAsync).toHaveBeenNthCalledWith(
+      2,
+      requestFor("tool_io_logs", true),
+    );
+    expect(testState.mutateAsync).toHaveBeenNthCalledWith(
+      3,
+      requestFor("session_capture", true),
+    );
+  });
+
+  it("disables the same three features together", async () => {
+    testState.data = {
+      logsEnabled: true,
+      toolIoLogsEnabled: true,
+      sessionCaptureEnabled: true,
+    };
+
+    render(<EnableLoggingAndSessionCaptureSetting />);
+    fireEvent.click(
+      screen.getByRole("switch", {
+        name: "Enable logging and session capture",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(testState.mutateAsync).toHaveBeenCalledTimes(3);
+    });
+    expect(testState.mutateAsync).toHaveBeenNthCalledWith(
+      1,
+      requestFor("tool_io_logs", false),
+    );
+    expect(testState.mutateAsync).toHaveBeenNthCalledWith(
+      2,
+      requestFor("session_capture", false),
+    );
+    expect(testState.mutateAsync).toHaveBeenNthCalledWith(
+      3,
+      requestFor("logs", false),
+    );
+  });
+
+  it("only enables the features that are still off", async () => {
+    testState.data = {
+      logsEnabled: true,
+      toolIoLogsEnabled: false,
+      sessionCaptureEnabled: false,
+    };
+
+    render(<EnableLoggingAndSessionCaptureSetting />);
+    fireEvent.click(
+      screen.getByRole("switch", {
+        name: "Enable logging and session capture",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(testState.mutateAsync).toHaveBeenCalledTimes(2);
+    });
+    expect(testState.mutateAsync).toHaveBeenCalledWith(
+      requestFor("tool_io_logs", true),
+    );
+    expect(testState.mutateAsync).toHaveBeenCalledWith(
+      requestFor("session_capture", true),
+    );
+    expect(testState.mutateAsync).not.toHaveBeenCalledWith(
+      requestFor("logs", true),
+    );
+  });
+
+  it("notifies the parent after a successful enable", async () => {
+    const onEnabledChange = vi.fn();
+    render(
+      <EnableLoggingAndSessionCaptureSetting
+        onEnabledChange={(enabled) => {
+          onEnabledChange(enabled);
+        }}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("switch", {
+        name: "Enable logging and session capture",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(onEnabledChange).toHaveBeenCalledWith(true);
+    });
+    expect(invalidateAllProductFeatures).toHaveBeenCalledOnce();
+  });
+
+  it("ignores a deferred mutation completion after an organization switch", async () => {
+    const onEnabledChange = vi.fn();
+    let releaseMutations: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      releaseMutations = () => {
+        resolve();
+      };
+    });
+    testState.mutateAsync.mockImplementation(async () => {
+      await gate;
+    });
+
+    const notifyEnabled = (enabled: boolean) => {
+      onEnabledChange(enabled);
+    };
+    const { rerender } = render(
+      <EnableLoggingAndSessionCaptureSetting onEnabledChange={notifyEnabled} />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("switch", {
+        name: "Enable logging and session capture",
+      }),
+    );
+    await waitFor(() => {
+      expect(testState.mutateAsync).toHaveBeenCalled();
+    });
+
+    testState.organizationId = "org-next";
+    rerender(
+      <EnableLoggingAndSessionCaptureSetting onEnabledChange={notifyEnabled} />,
+    );
+    releaseMutations?.();
+
+    await waitFor(() => {
+      expect(testState.mutateAsync).toHaveBeenCalledTimes(3);
+    });
+    expect(onEnabledChange).not.toHaveBeenCalled();
+    expect(invalidateAllProductFeatures).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an error without marking the bundle enabled", async () => {
+    const onEnabledChange = vi.fn();
+    testState.mutateAsync.mockRejectedValue(new Error("write failed"));
+
+    render(
+      <EnableLoggingAndSessionCaptureSetting
+        onEnabledChange={(enabled) => {
+          onEnabledChange(enabled);
+        }}
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole("switch", {
+        name: "Enable logging and session capture",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(handleAPIError).toHaveBeenCalled();
+    });
+    expect(onEnabledChange).not.toHaveBeenCalled();
+    expect(invalidateAllProductFeatures).toHaveBeenCalledOnce();
+  });
+
+  it("reports busy while the bundle writes are in flight", async () => {
+    const onBusyChange = vi.fn();
+    let releaseMutations: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      releaseMutations = () => {
+        resolve();
+      };
+    });
+    testState.mutateAsync.mockImplementation(async () => {
+      await gate;
+    });
+
+    render(
+      <EnableLoggingAndSessionCaptureSetting
+        onBusyChange={(busy) => {
+          onBusyChange(busy);
+        }}
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole("switch", {
+        name: "Enable logging and session capture",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(onBusyChange).toHaveBeenCalledWith(true);
+    });
+    releaseMutations?.();
+    await waitFor(() => {
+      expect(onBusyChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it("does not render the switch for non-admins", () => {
+    testState.isAdmin = false;
+
+    render(<EnableLoggingAndSessionCaptureSetting />);
+
+    expect(
+      screen.queryByRole("switch", {
+        name: "Enable logging and session capture",
+      }),
+    ).toBeNull();
+  });
+});

--- a/client/dashboard/src/pages/setup/components/enable-logging-and-session-capture-setting.tsx
+++ b/client/dashboard/src/pages/setup/components/enable-logging-and-session-capture-setting.tsx
@@ -1,0 +1,182 @@
+import { RequireScope } from "@/components/require-scope";
+import { Switch } from "@/components/ui/Switch";
+import { Text } from "@/components/ui/Text";
+import { Stack } from "@/components/ui/Stack";
+import { useOrganization } from "@/contexts/Auth";
+import { useIsCurrentOrganization } from "@/hooks/useIsCurrentOrganization";
+import { handleAPIError } from "@/lib/errors";
+import { FeatureName } from "@gram/client/models/components/setproductfeaturerequestbody.js";
+import { useFeaturesSetMutation } from "@gram/client/react-query/featuresSet.js";
+import {
+  invalidateAllProductFeatures,
+  useProductFeatures,
+} from "@gram/client/react-query/productFeatures.js";
+import { useQueryClient } from "@tanstack/react-query";
+import { FileText } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+const TITLE = "Enable logging and session capture";
+const DESCRIPTION =
+  "Turns on Enable Logs, Record Tool I/O, and Agent Session Capture. Tool calls, request and response bodies, and agent session prompts are recorded.";
+
+/** Features flipped together by the setup onboarding toggle. */
+const LOGGING_BUNDLE_FEATURES = [
+  FeatureName.Logs,
+  FeatureName.ToolIoLogs,
+  FeatureName.SessionCapture,
+] as const;
+
+const ENABLE_ORDER = LOGGING_BUNDLE_FEATURES;
+const DISABLE_ORDER = [
+  FeatureName.ToolIoLogs,
+  FeatureName.SessionCapture,
+  FeatureName.Logs,
+] as const;
+
+interface EnableLoggingAndSessionCaptureSettingProps {
+  onEnabledChange?: (enabled: boolean) => void;
+  onBusyChange?: (busy: boolean) => void;
+}
+
+/**
+ * Setup-only switch that enables or disables the logging bundle used on
+ * Organization → Logging & Telemetry: Enable Logs, Record Tool I/O, and
+ * Agent Session Capture.
+ */
+export function EnableLoggingAndSessionCaptureSetting({
+  onEnabledChange,
+  onBusyChange,
+}: EnableLoggingAndSessionCaptureSettingProps = {}): JSX.Element | null {
+  const organization = useOrganization();
+  const isCurrentOrganization = useIsCurrentOrganization(organization.id);
+  return (
+    <EnableLoggingAndSessionCaptureSettingInner
+      key={organization.id}
+      organizationId={organization.id}
+      isCurrentOrganization={isCurrentOrganization}
+      onEnabledChange={onEnabledChange}
+      onBusyChange={onBusyChange}
+    />
+  );
+}
+
+function EnableLoggingAndSessionCaptureSettingInner({
+  organizationId,
+  isCurrentOrganization,
+  onEnabledChange,
+  onBusyChange,
+}: EnableLoggingAndSessionCaptureSettingProps & {
+  organizationId: string;
+  isCurrentOrganization: () => boolean;
+}): JSX.Element | null {
+  const queryClient = useQueryClient();
+  const features = useProductFeatures({ organizationId }, undefined, {
+    throwOnError: false,
+  });
+  const [logsEnabled, setLogsEnabled] = useState<boolean | null>(null);
+  const [toolIoLogsEnabled, setToolIoLogsEnabled] = useState<boolean | null>(
+    null,
+  );
+  const [sessionCaptureEnabled, setSessionCaptureEnabled] = useState<
+    boolean | null
+  >(null);
+
+  const effectiveLogsEnabled =
+    logsEnabled ?? features.data?.logsEnabled ?? false;
+  const effectiveToolIoLogsEnabled =
+    toolIoLogsEnabled ?? features.data?.toolIoLogsEnabled ?? false;
+  const effectiveSessionCaptureEnabled =
+    sessionCaptureEnabled ?? features.data?.sessionCaptureEnabled ?? false;
+  const bundleEnabled =
+    effectiveLogsEnabled &&
+    effectiveToolIoLogsEnabled &&
+    effectiveSessionCaptureEnabled;
+
+  const mutation = useFeaturesSetMutation();
+  const [isSaving, setIsSaving] = useState(false);
+  const onBusyChangeRef = useRef(onBusyChange);
+  onBusyChangeRef.current = onBusyChange;
+
+  useEffect(() => {
+    onBusyChange?.(isSaving);
+  }, [isSaving, onBusyChange]);
+
+  useEffect(() => {
+    return () => {
+      onBusyChangeRef.current?.(false);
+    };
+  }, []);
+
+  if (!features.data) return null;
+
+  const isFeatureEnabled = (
+    featureName: (typeof LOGGING_BUNDLE_FEATURES)[number],
+  ): boolean => {
+    switch (featureName) {
+      case FeatureName.Logs:
+        return effectiveLogsEnabled;
+      case FeatureName.ToolIoLogs:
+        return effectiveToolIoLogsEnabled;
+      case FeatureName.SessionCapture:
+        return effectiveSessionCaptureEnabled;
+    }
+  };
+
+  const handleSetBundle = (enabled: boolean) => {
+    void (async () => {
+      setIsSaving(true);
+      const order = enabled ? ENABLE_ORDER : DISABLE_ORDER;
+      try {
+        for (const featureName of order) {
+          if (isFeatureEnabled(featureName) === enabled) continue;
+          await mutation.mutateAsync({
+            request: {
+              setProductFeatureRequestBody: {
+                organizationId,
+                featureName,
+                enabled,
+              },
+            },
+          });
+        }
+        if (!isCurrentOrganization()) return;
+        setLogsEnabled(enabled);
+        setToolIoLogsEnabled(enabled);
+        setSessionCaptureEnabled(enabled);
+        onEnabledChange?.(enabled);
+      } catch (error) {
+        if (!isCurrentOrganization()) return;
+        handleAPIError(error, "Failed to update setting");
+      } finally {
+        setIsSaving(false);
+        if (isCurrentOrganization()) {
+          await invalidateAllProductFeatures(queryClient);
+        }
+      }
+    })();
+  };
+
+  return (
+    <Stack direction="horizontal" justify="space-between" align="center">
+      <Stack gap={1}>
+        <Stack direction="horizontal" align="center" gap={2}>
+          <FileText className="text-muted-foreground h-4 w-4" />
+          <Text variant="body" className="font-medium">
+            {TITLE}
+          </Text>
+        </Stack>
+        <Text variant="body" className="text-muted-foreground ml-6 text-sm">
+          {DESCRIPTION}
+        </Text>
+      </Stack>
+      <RequireScope scope="org:admin" level="component">
+        <Switch
+          checked={bundleEnabled}
+          onCheckedChange={handleSetBundle}
+          disabled={isSaving || mutation.isPending}
+          aria-label="Enable logging and session capture"
+        />
+      </RequireScope>
+    </Stack>
+  );
+}

--- a/client/dashboard/src/pages/setup/components/onboarding-wizard.test.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-wizard.test.tsx
@@ -19,6 +19,17 @@ const publishStatus = vi.hoisted(() => ({
   current: { data: { connected: false }, isLoading: false },
 }));
 
+const productFeatures = vi.hoisted(() => ({
+  current: {
+    data: {
+      logsEnabled: false,
+      toolIoLogsEnabled: false,
+      sessionCaptureEnabled: false,
+    },
+    isLoading: false,
+  },
+}));
+
 vi.mock("react-router", () => ({
   useNavigate: () => vi.fn(),
   useParams: () => ({ orgSlug: "acme" }),
@@ -32,6 +43,12 @@ vi.mock("@gram/client/react-query/onboardingStatus", () => ({
 }));
 vi.mock("@gram/client/react-query/publishStatus", () => ({
   usePublishStatus: () => publishStatus.current,
+}));
+vi.mock("@gram/client/react-query/productFeatures.js", () => ({
+  useProductFeatures: () => productFeatures.current,
+}));
+vi.mock("@/contexts/Auth", () => ({
+  useOrganization: () => ({ id: "org1", slug: "acme" }),
 }));
 
 vi.mock("@/components/ui/Skeleton", () => ({
@@ -47,6 +64,7 @@ vi.mock("./steps", () => ({
   ConnectIdpStep: () => null,
   DirectorySyncStep: () => null,
   CreateMarketplaceStep: () => null,
+  EnableLoggingStep: () => null,
   DistributeServersStep: () => null,
   InstrumentAgentsStep: () => null,
   AdditionalAgentConfigStep: () => null,
@@ -68,6 +86,14 @@ beforeEach(() => {
     isLoading: false,
   };
   publishStatus.current = { data: { connected: false }, isLoading: false };
+  productFeatures.current = {
+    data: {
+      logsEnabled: false,
+      toolIoLogsEnabled: false,
+      sessionCaptureEnabled: false,
+    },
+    isLoading: false,
+  };
 });
 
 function resumedStep(): string | null {
@@ -87,12 +113,60 @@ describe("SetupWizard", () => {
     );
   });
 
-  it("resumes at instrument-agents after the marketplace is published", () => {
+  it("resumes at enable-logging after the marketplace is published", () => {
     publishStatus.current = { data: { connected: true }, isLoading: false };
 
     render(<SetupWizard />);
 
+    expect(resumedStep()).toBe("enable-logging");
+  });
+
+  it("resumes at instrument-agents once the logging bundle is on", () => {
+    publishStatus.current = { data: { connected: true }, isLoading: false };
+    productFeatures.current = {
+      data: {
+        logsEnabled: true,
+        toolIoLogsEnabled: true,
+        sessionCaptureEnabled: true,
+      },
+      isLoading: false,
+    };
+
+    render(<SetupWizard />);
+
     expect(resumedStep()).toBe("instrument-agents");
+  });
+
+  it("stays on enable-logging when only some logging features are on", () => {
+    publishStatus.current = { data: { connected: true }, isLoading: false };
+    productFeatures.current = {
+      data: {
+        logsEnabled: true,
+        toolIoLogsEnabled: false,
+        sessionCaptureEnabled: false,
+      },
+      isLoading: false,
+    };
+
+    render(<SetupWizard />);
+
+    expect(resumedStep()).toBe("enable-logging");
+  });
+
+  it("waits for product features before choosing a resume step", () => {
+    publishStatus.current = { data: { connected: true }, isLoading: false };
+    productFeatures.current = {
+      data: {
+        logsEnabled: false,
+        toolIoLogsEnabled: false,
+        sessionCaptureEnabled: false,
+      },
+      isLoading: true,
+    };
+
+    render(<SetupWizard />);
+
+    expect(resumedStep()).toBeNull();
   });
 
   it("resumes at directory-sync when only SSO is configured", () => {

--- a/client/dashboard/src/pages/setup/components/onboarding-wizard.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-wizard.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router";
 import { useOnboardingStatus } from "@gram/client/react-query/onboardingStatus";
 import { usePublishStatus } from "@gram/client/react-query/publishStatus";
+import { useProductFeatures } from "@gram/client/react-query/productFeatures.js";
+import { useOrganization } from "@/contexts/Auth";
 import { useOrgSetupStarted } from "@/hooks/useOrgSetupStarted";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { OnboardingStepper, type Step } from "./onboarding-stepper";
@@ -10,6 +12,7 @@ import {
   ConnectIdpStep,
   DirectorySyncStep,
   CreateMarketplaceStep,
+  EnableLoggingStep,
   DistributeServersStep,
   InstrumentAgentsStep,
   AdditionalAgentConfigStep,
@@ -33,6 +36,11 @@ const CORE_STEPS: Step[] = [
     id: "create-marketplace",
     title: "Create plugin marketplace",
     description: "For distributing servers to your users",
+  },
+  {
+    id: "enable-logging",
+    title: "Enable logging",
+    description: "Record tool calls, I/O, and agent sessions",
   },
   {
     id: "instrument-agents",
@@ -77,6 +85,7 @@ function indexOfStep(steps: Step[], id: string): number {
 export function SetupWizard(): JSX.Element {
   const navigate = useNavigate();
   const { orgSlug } = useParams();
+  const organization = useOrganization();
   const [searchParams, setSearchParams] = useSearchParams();
   const { markSetupStarted } = useOrgSetupStarted(orgSlug);
 
@@ -102,10 +111,12 @@ export function SetupWizard(): JSX.Element {
 
   // Server-side onboarding signals used to resume at the right step on reload.
   // `onboardingStatus` covers SSO + DSYNC; `publishStatus` covers the
-  // marketplace step. Steps after marketplace (instrument-agents,
-  // additional-agent-config, confirm-traffic, distribute-servers) have no
-  // server signal — once marketplace is published we land on instrument-agents
-  // and let the user click forward.
+  // marketplace step; `features` covers enable-logging, which is done once the
+  // logging bundle (logs, tool I/O, session capture) is on. Steps after that
+  // (instrument-agents, additional-agent-config, confirm-traffic,
+  // distribute-servers) have no server signal — once the earlier steps are
+  // satisfied we land on the first unsatisfied one and let the user click
+  // forward.
   // throwOnError: false so a failed resume check degrades to step 0 (as the
   // effect below assumes) instead of throwing to the page error boundary. The
   // QueryClient default only suppresses 401/403, so a 500 here would otherwise
@@ -114,7 +125,17 @@ export function SetupWizard(): JSX.Element {
     useOnboardingStatus(undefined, undefined, { throwOnError: false });
   const { data: publishStatus, isLoading: isPublishStatusLoading } =
     usePublishStatus(undefined, undefined, { throwOnError: false });
-  const statusLoading = isOnboardingStatusLoading || isPublishStatusLoading;
+  const { data: features, isLoading: isFeaturesLoading } = useProductFeatures(
+    { organizationId: organization.id },
+    undefined,
+    { throwOnError: false },
+  );
+  const statusLoading =
+    isOnboardingStatusLoading || isPublishStatusLoading || isFeaturesLoading;
+  const loggingBundleEnabled =
+    features?.logsEnabled === true &&
+    features?.toolIoLogsEnabled === true &&
+    features?.sessionCaptureEnabled === true;
 
   useEffect(() => {
     if (stepSlug) return;
@@ -123,7 +144,10 @@ export function SetupWizard(): JSX.Element {
     // fail — we fall back to step 0.
     let resumeStep = 0;
     if (publishStatus?.connected) {
-      resumeStep = indexOfStep(steps, "instrument-agents");
+      resumeStep = indexOfStep(
+        steps,
+        loggingBundleEnabled ? "instrument-agents" : "enable-logging",
+      );
     } else if (onboardingStatus?.dsyncConfigured) {
       resumeStep = indexOfStep(steps, "create-marketplace");
     } else if (onboardingStatus?.ssoConfigured) {
@@ -142,6 +166,7 @@ export function SetupWizard(): JSX.Element {
     statusLoading,
     onboardingStatus,
     publishStatus,
+    loggingBundleEnabled,
     setSearchParams,
     steps,
   ]);
@@ -256,6 +281,14 @@ export function SetupWizard(): JSX.Element {
         return (
           <CreateMarketplaceStep
             onComplete={completeCurrentStep}
+            onBack={goBack}
+          />
+        );
+      case "enable-logging":
+        return (
+          <EnableLoggingStep
+            onComplete={completeCurrentStep}
+            onSkip={completeCurrentStep}
             onBack={goBack}
           />
         );

--- a/client/dashboard/src/pages/setup/components/setup-task-content.tsx
+++ b/client/dashboard/src/pages/setup/components/setup-task-content.tsx
@@ -6,6 +6,7 @@ import {
   CreateMarketplaceStep,
   DirectorySyncStep,
   DistributeServersStep,
+  EnableLoggingStep,
   InstrumentAgentsStep,
   PlatformMCPSetupStep,
 } from "./steps";
@@ -50,6 +51,15 @@ export function SetupTaskContent({
       break;
     case "create-marketplace":
       step = <CreateMarketplaceStep onComplete={onComplete} onBack={onBack} />;
+      break;
+    case "enable-logging":
+      step = (
+        <EnableLoggingStep
+          onComplete={onComplete}
+          onSkip={onSkip}
+          onBack={onBack}
+        />
+      );
       break;
     case "instrument-agents":
       step = <InstrumentAgentsStep onComplete={onComplete} onBack={onBack} />;

--- a/client/dashboard/src/pages/setup/components/steps/enable-logging-step.test.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/enable-logging-step.test.tsx
@@ -1,0 +1,321 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testState = vi.hoisted(() => ({
+  data: {
+    logsEnabled: false,
+    toolIoLogsEnabled: false,
+    sessionCaptureEnabled: false,
+  } as
+    | {
+        logsEnabled: boolean;
+        toolIoLogsEnabled: boolean;
+        sessionCaptureEnabled: boolean;
+      }
+    | undefined,
+  error: null as Error | null,
+  isFetching: false,
+  isLoading: false,
+  organizationId: "org-active",
+  mutateAsync: vi.fn(),
+  productFeaturesQuery: vi.fn(),
+  refetch: vi.fn(),
+}));
+
+vi.mock("@/contexts/Auth", () => ({
+  useOrganization: () => ({ id: testState.organizationId }),
+}));
+
+vi.mock("@/components/require-scope", () => ({
+  RequireScope: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/lib/errors", () => ({ handleAPIError: vi.fn() }));
+
+vi.mock("@/routes", () => ({
+  useOrgRoutes: () => ({
+    logs: { href: () => "/acme/logs" },
+  }),
+}));
+
+vi.mock("react-router", () => ({
+  Link: ({
+    to,
+    children,
+    className,
+  }: {
+    to: string;
+    children: ReactNode;
+    className?: string;
+  }) => (
+    <a href={to} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@gram/client/react-query/featuresSet.js", () => ({
+  useFeaturesSetMutation: () => ({
+    isPending: false,
+    mutateAsync: testState.mutateAsync,
+  }),
+}));
+
+vi.mock("@gram/client/react-query/productFeatures.js", () => ({
+  invalidateAllProductFeatures: vi.fn(),
+  useProductFeatures: (...args: unknown[]) => {
+    testState.productFeaturesQuery(...args);
+    return {
+      data: testState.data,
+      error: testState.error,
+      isFetching: testState.isFetching,
+      isLoading: testState.isLoading,
+      refetch: testState.refetch,
+    };
+  },
+}));
+
+vi.mock("@tanstack/react-query", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@tanstack/react-query")>()),
+  useQueryClient: () => ({}),
+}));
+
+import { EnableLoggingStep } from "./enable-logging-step";
+
+const onComplete = vi.fn();
+const onSkip = vi.fn();
+const onBack = vi.fn();
+
+function stepProps() {
+  return {
+    onComplete: () => {
+      onComplete();
+    },
+    onSkip: () => {
+      onSkip();
+    },
+    onBack: () => {
+      onBack();
+    },
+  };
+}
+
+function renderStep() {
+  return render(<EnableLoggingStep {...stepProps()} />);
+}
+
+beforeEach(() => {
+  testState.data = {
+    logsEnabled: false,
+    toolIoLogsEnabled: false,
+    sessionCaptureEnabled: false,
+  };
+  testState.error = null;
+  testState.isFetching = false;
+  testState.isLoading = false;
+  testState.organizationId = "org-active";
+  testState.mutateAsync.mockReset();
+  testState.mutateAsync.mockResolvedValue(undefined);
+  testState.productFeaturesQuery.mockReset();
+  testState.refetch.mockReset();
+  onComplete.mockReset();
+  onSkip.mockReset();
+  onBack.mockReset();
+});
+
+afterEach(cleanup);
+
+describe("EnableLoggingStep", () => {
+  it("shows the combined logging and session capture control", () => {
+    renderStep();
+
+    expect(
+      screen.getByText(
+        "Configure logging and telemetry settings for all your tool capture. When enabled, tool calls and traces are recorded for debugging and analytics. These power the insights and logs page on the platform.",
+      ),
+    ).toBeTruthy();
+    expect(screen.getByText("Enable logging and session capture")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Turns on Enable Logs, Record Tool I/O, and Agent Session Capture. Tool calls, request and response bodies, and agent session prompts are recorded.",
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("switch", {
+        name: "Enable logging and session capture",
+      }),
+    ).toBeTruthy();
+    expect(
+      (
+        screen.getByRole("link", {
+          name: "Logging & Telemetry",
+        }) as HTMLAnchorElement
+      ).getAttribute("href"),
+    ).toBe("/acme/logs");
+  });
+
+  it("enables logs, tool I/O, and session capture from the combined switch", async () => {
+    renderStep();
+
+    fireEvent.click(
+      screen.getByRole("switch", {
+        name: "Enable logging and session capture",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(testState.mutateAsync).toHaveBeenCalledTimes(3);
+    });
+    expect(testState.mutateAsync).toHaveBeenCalledWith({
+      request: {
+        setProductFeatureRequestBody: {
+          organizationId: "org-active",
+          featureName: "logs",
+          enabled: true,
+        },
+      },
+    });
+    expect(testState.mutateAsync).toHaveBeenCalledWith({
+      request: {
+        setProductFeatureRequestBody: {
+          organizationId: "org-active",
+          featureName: "tool_io_logs",
+          enabled: true,
+        },
+      },
+    });
+    expect(testState.mutateAsync).toHaveBeenCalledWith({
+      request: {
+        setProductFeatureRequestBody: {
+          organizationId: "org-active",
+          featureName: "session_capture",
+          enabled: true,
+        },
+      },
+    });
+  });
+
+  it("lets the admin skip without enabling logging", () => {
+    renderStep();
+
+    fireEvent.click(screen.getByRole("button", { name: "Skip for now" }));
+
+    expect(testState.mutateAsync).not.toHaveBeenCalled();
+    expect(onSkip).toHaveBeenCalledOnce();
+  });
+
+  it("hides skip when the logging bundle is already enabled", () => {
+    testState.data = {
+      logsEnabled: true,
+      toolIoLogsEnabled: true,
+      sessionCaptureEnabled: true,
+    };
+
+    renderStep();
+
+    expect(screen.queryByRole("button", { name: "Skip for now" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /Continue/ }));
+    expect(onComplete).toHaveBeenCalledOnce();
+  });
+
+  it("keeps skip available when only some logging features are on", () => {
+    testState.data = {
+      logsEnabled: true,
+      toolIoLogsEnabled: false,
+      sessionCaptureEnabled: false,
+    };
+
+    renderStep();
+
+    expect(screen.getByRole("button", { name: "Skip for now" })).toBeTruthy();
+  });
+
+  it("hides skip until the current logging setting is known", () => {
+    testState.data = undefined;
+    testState.isLoading = true;
+
+    renderStep();
+
+    expect(screen.queryByRole("button", { name: "Skip for now" })).toBeNull();
+    expect(
+      (screen.getByRole("button", { name: /Loading/ }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+  });
+
+  it("shows a retry state when product features fail to load", () => {
+    testState.data = undefined;
+    testState.error = new Error("features unavailable");
+
+    renderStep();
+
+    expect(
+      screen.getByText("Couldn't load the current logging setting."),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Skip for now" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(testState.refetch).toHaveBeenCalledOnce();
+    expect(
+      (screen.getByRole("button", { name: /Continue/ }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+  });
+
+  it("blocks skip and continue while the bundle writes are in flight", async () => {
+    let releaseMutations: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      releaseMutations = () => {
+        resolve();
+      };
+    });
+    testState.mutateAsync.mockImplementation(async () => {
+      await gate;
+    });
+
+    renderStep();
+    fireEvent.click(
+      screen.getByRole("switch", {
+        name: "Enable logging and session capture",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Skip for now" })).toBeNull();
+    });
+    expect(
+      (screen.getByRole("button", { name: /Loading/ }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+
+    releaseMutations?.();
+    await waitFor(() => {
+      expect(
+        (screen.getByRole("button", { name: /Continue/ }) as HTMLButtonElement)
+          .disabled,
+      ).toBe(false);
+    });
+    expect(screen.queryByRole("button", { name: "Skip for now" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /Continue/ }));
+    expect(onComplete).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the retry action disabled while refetching", () => {
+    testState.data = undefined;
+    testState.error = new Error("features unavailable");
+    testState.isFetching = true;
+
+    renderStep();
+
+    expect(
+      (screen.getByRole("button", { name: "Retrying…" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+  });
+});

--- a/client/dashboard/src/pages/setup/components/steps/enable-logging-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/enable-logging-step.tsx
@@ -1,0 +1,106 @@
+import { LogDataRetentionBanner } from "@/components/observe/LoggingPageHeader";
+import { Button } from "@/components/ui/Button";
+import { useOrganization } from "@/contexts/Auth";
+import { ENABLE_LOGS_PAGE_DESCRIPTION } from "@/pages/org/EnableLogsSetting";
+import { useOrgRoutes } from "@/routes";
+import { useProductFeatures } from "@gram/client/react-query/productFeatures.js";
+import { FileText } from "lucide-react";
+import { useState } from "react";
+import { Link } from "react-router";
+import { EnableLoggingAndSessionCaptureSetting } from "../enable-logging-and-session-capture-setting";
+import { StepContainer } from "../step-container";
+
+interface EnableLoggingStepProps {
+  onComplete: () => void;
+  onSkip: () => void;
+  onBack: () => void;
+}
+
+export function EnableLoggingStep({
+  onComplete,
+  onSkip,
+  onBack,
+}: EnableLoggingStepProps): JSX.Element {
+  const organization = useOrganization();
+  const orgRoutes = useOrgRoutes();
+  const features = useProductFeatures(
+    { organizationId: organization.id },
+    undefined,
+    { throwOnError: false },
+  );
+  const [bundleEnabled, setBundleEnabled] = useState<boolean | null>(null);
+  const [bundleBusy, setBundleBusy] = useState(false);
+  const loggingBundleEnabled =
+    bundleEnabled ??
+    (features.data?.logsEnabled === true &&
+      features.data?.toolIoLogsEnabled === true &&
+      features.data?.sessionCaptureEnabled === true);
+  const featuresLoading = features.isLoading;
+  const featuresFailed =
+    !featuresLoading && Boolean(features.error || !features.data);
+  const featuresReady =
+    Boolean(features.data) && !featuresLoading && !featuresFailed;
+  const canSkip = featuresReady && !loggingBundleEnabled && !bundleBusy;
+
+  return (
+    <StepContainer
+      icon={
+        <div className="bg-secondary flex h-12 w-12 items-center justify-center">
+          <FileText className="text-foreground h-6 w-6" />
+        </div>
+      }
+      title="Enable logging"
+      description={ENABLE_LOGS_PAGE_DESCRIPTION}
+      onContinue={onComplete}
+      continueLabel="Continue"
+      skipLabel="Skip for now"
+      onSkip={canSkip ? onSkip : undefined}
+      showBack
+      onBack={onBack}
+      canContinue={featuresReady && !bundleBusy}
+      isLoading={featuresLoading || bundleBusy}
+    >
+      <div className="space-y-6">
+        <LogDataRetentionBanner />
+        <div className="border-border bg-card border p-4">
+          <EnableLoggingAndSessionCaptureSetting
+            onEnabledChange={setBundleEnabled}
+            onBusyChange={setBundleBusy}
+          />
+        </div>
+        <p className="text-muted-foreground text-sm">
+          This turns on Enable Logs, Record Tool I/O, and Agent Session Capture
+          — the same settings as{" "}
+          <Link
+            to={orgRoutes.logs.href()}
+            className="underline underline-offset-2"
+          >
+            Logging &amp; Telemetry
+          </Link>
+          . Fail Open, Hook Browser Sign-In, and other options stay on that
+          page.
+        </p>
+        {featuresFailed ? (
+          <div
+            className="border-border border p-4"
+            role="alert"
+            aria-live="polite"
+          >
+            <p className="text-destructive text-sm">
+              Couldn&apos;t load the current logging setting.
+            </p>
+            <Button
+              variant="secondary"
+              size="sm"
+              className="mt-3"
+              disabled={features.isFetching}
+              onClick={() => void features.refetch()}
+            >
+              {features.isFetching ? "Retrying…" : "Retry"}
+            </Button>
+          </div>
+        ) : null}
+      </div>
+    </StepContainer>
+  );
+}

--- a/client/dashboard/src/pages/setup/components/steps/index.ts
+++ b/client/dashboard/src/pages/setup/components/steps/index.ts
@@ -1,6 +1,7 @@
 export { ConnectIdpStep } from "./connect-idp-step";
 export { DirectorySyncStep } from "./directory-sync-step";
 export { CreateMarketplaceStep } from "./create-marketplace-step";
+export { EnableLoggingStep } from "./enable-logging-step";
 export { DistributeServersStep } from "./distribute-servers-step";
 export { InstrumentAgentsStep } from "./instrument-agents-step";
 export { PlatformMCPSetupStep } from "./platform-mcp-setup-step";

--- a/server/internal/organizations/listsetuptasks_test.go
+++ b/server/internal/organizations/listsetuptasks_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
 	pluginsrepo "github.com/speakeasy-api/gram/server/internal/plugins/repo"
+	"github.com/speakeasy-api/gram/server/internal/productfeatures"
+	productfeaturesrepo "github.com/speakeasy-api/gram/server/internal/productfeatures/repo"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,13 +24,53 @@ func TestService_ListSetupTasksProjectsCatalogAndDependencies(t *testing.T) {
 	ctx, ti := newTestOrganizationsService(t)
 	result, err := ti.service.ListSetupTasks(ctx, &gen.ListSetupTasksPayload{})
 	require.NoError(t, err)
-	require.Len(t, result.Tasks, 9)
+	require.Len(t, result.Tasks, 10)
 	require.Equal(t, "connect-idp", result.Tasks[0].Key)
-	require.Equal(t, "platform-mcp", result.Tasks[8].Key)
+	require.Equal(t, "enable-logging", result.Tasks[3].Key)
+	require.Equal(t, "platform-mcp", result.Tasks[9].Key)
 	require.Equal(t, []string{"instrument-agents"}, setupTask(result.Tasks, "confirm-traffic").BlockedBy)
 	require.Equal(t, []string{"create-marketplace"}, setupTask(result.Tasks, "distribute-servers").BlockedBy)
 	require.False(t, setupTask(result.Tasks, "connect-idp").CompletedByFact)
+	require.False(t, setupTask(result.Tasks, "enable-logging").CompletedByFact)
 	require.False(t, setupTask(result.Tasks, "instrument-agents").CompletedByFact)
+}
+
+func TestService_ListSetupTasksMarksLoggingDoneOnceTheBundleIsEnabled(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestOrganizationsService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	features := productfeaturesrepo.New(ti.conn)
+	enable := func(feature productfeatures.Feature) {
+		t.Helper()
+		_, err := features.EnableFeature(ctx, productfeaturesrepo.EnableFeatureParams{
+			OrganizationID: authCtx.ActiveOrganizationID, FeatureName: string(feature),
+		})
+		require.NoError(t, err)
+	}
+
+	enable(productfeatures.FeatureLogs)
+	result, err := ti.service.ListSetupTasks(ctx, &gen.ListSetupTasksPayload{})
+	require.NoError(t, err)
+	require.Equal(t, "todo", setupTask(result.Tasks, "enable-logging").Status, "logs alone is not the full bundle")
+	require.False(t, setupTask(result.Tasks, "enable-logging").CompletedByFact)
+
+	enable(productfeatures.FeatureToolIOLogs)
+	enable(productfeatures.FeatureSessionCapture)
+	result, err = ti.service.ListSetupTasks(ctx, &gen.ListSetupTasksPayload{})
+	require.NoError(t, err)
+	require.Equal(t, "done", setupTask(result.Tasks, "enable-logging").Status)
+	require.True(t, setupTask(result.Tasks, "enable-logging").CompletedByFact)
+
+	_, err = features.DeleteFeature(ctx, productfeaturesrepo.DeleteFeatureParams{
+		OrganizationID: authCtx.ActiveOrganizationID, FeatureName: string(productfeatures.FeatureSessionCapture),
+	})
+	require.NoError(t, err)
+	result, err = ti.service.ListSetupTasks(ctx, &gen.ListSetupTasksPayload{})
+	require.NoError(t, err)
+	require.Equal(t, "todo", setupTask(result.Tasks, "enable-logging").Status, "an admin disable reopens the task")
+	require.False(t, setupTask(result.Tasks, "enable-logging").CompletedByFact)
 }
 
 func TestService_ListSetupTasksAppliesCompletionFactsWithoutWriting(t *testing.T) {

--- a/server/internal/organizations/queries.sql
+++ b/server/internal/organizations/queries.sql
@@ -932,6 +932,13 @@ SELECT
         SELECT 1
         FROM plugin_github_connections
         JOIN default_project ON default_project.id = plugin_github_connections.project_id
-    ) AS marketplace_published
+    ) AS marketplace_published,
+    (
+        SELECT COUNT(DISTINCT organization_features.feature_name) = 3
+        FROM organization_features
+        WHERE organization_features.organization_id = @organization_id
+          AND organization_features.feature_name IN ('logs', 'tool_io_logs', 'session_capture')
+          AND organization_features.deleted IS FALSE
+    )::boolean AS logging_enabled
 FROM organization_metadata
 WHERE organization_metadata.id = @organization_id;

--- a/server/internal/organizations/repo/queries.sql.go
+++ b/server/internal/organizations/repo/queries.sql.go
@@ -687,7 +687,14 @@ SELECT
         SELECT 1
         FROM plugin_github_connections
         JOIN default_project ON default_project.id = plugin_github_connections.project_id
-    ) AS marketplace_published
+    ) AS marketplace_published,
+    (
+        SELECT COUNT(DISTINCT organization_features.feature_name) = 3
+        FROM organization_features
+        WHERE organization_features.organization_id = $1
+          AND organization_features.feature_name IN ('logs', 'tool_io_logs', 'session_capture')
+          AND organization_features.deleted IS FALSE
+    )::boolean AS logging_enabled
 FROM organization_metadata
 WHERE organization_metadata.id = $1
 `
@@ -696,12 +703,18 @@ type GetSetupTaskCompletionFactsRow struct {
 	SsoConfigured        bool
 	DsyncConfigured      bool
 	MarketplacePublished bool
+	LoggingEnabled       bool
 }
 
 func (q *Queries) GetSetupTaskCompletionFacts(ctx context.Context, organizationID string) (GetSetupTaskCompletionFactsRow, error) {
 	row := q.db.QueryRow(ctx, getSetupTaskCompletionFacts, organizationID)
 	var i GetSetupTaskCompletionFactsRow
-	err := row.Scan(&i.SsoConfigured, &i.DsyncConfigured, &i.MarketplacePublished)
+	err := row.Scan(
+		&i.SsoConfigured,
+		&i.DsyncConfigured,
+		&i.MarketplacePublished,
+		&i.LoggingEnabled,
+	)
 	return i, err
 }
 

--- a/server/internal/organizations/setup_tasks.go
+++ b/server/internal/organizations/setup_tasks.go
@@ -46,6 +46,7 @@ var setupTaskCatalog = []setupTaskDefinition{
 	{Key: "connect-idp", Title: "Connect identity provider", Description: "Configure single sign-on for the organization.", Prerequisites: nil},
 	{Key: "directory-sync", Title: "Set up directory sync", Description: "Sync people and groups from the identity provider.", Prerequisites: nil},
 	{Key: "create-marketplace", Title: "Create marketplace", Description: "Publish the organization's default project marketplace.", Prerequisites: nil},
+	{Key: "enable-logging", Title: "Enable logging", Description: "Record tool calls, I/O, and agent sessions.", Prerequisites: nil},
 	{Key: "instrument-agents", Title: "Instrument agents", Description: "Connect coding agents to Gram hook telemetry.", Prerequisites: nil},
 	{Key: "additional-agent-config", Title: "Configure integrations", Description: "Add optional provider integrations for agent activity.", Prerequisites: nil},
 	{Key: "confirm-traffic", Title: "Confirm traffic", Description: "Verify that instrumented agents are sending hook events.", Prerequisites: []string{"instrument-agents"}},
@@ -326,7 +327,8 @@ func (s *Service) projectSetupTasks(ctx context.Context, repo *orgrepo.Queries, 
 		}
 		completedByFact := (definition.Key == "connect-idp" && facts.SsoConfigured) ||
 			(definition.Key == "directory-sync" && facts.DsyncConfigured) ||
-			(definition.Key == "create-marketplace" && facts.MarketplacePublished)
+			(definition.Key == "create-marketplace" && facts.MarketplacePublished) ||
+			(definition.Key == "enable-logging" && facts.LoggingEnabled)
 		if completedByFact {
 			status = setupTaskStatusDone
 		}


### PR DESCRIPTION
## Summary

Organization setup gets an **Enable logging** step again, in both views, sitting between "Create plugin marketplace" and "Instrument agents".

- **Wizard.** New `enable-logging` step rendering `EnableLoggingStep`: a single "Enable logging and session capture" switch that turns on Enable Logs, Record Tool I/O, and Agent Session Capture together, with the retention banner and a link to Logging & Telemetry for the remaining options. Skip is offered only while the bundle is off. The resume logic now also reads product features: after the marketplace is published it lands on `enable-logging`, or on `instrument-agents` once all three features are on.
- **Board.** `setupTaskCatalog` gains the `enable-logging` task and `SetupTaskContent` renders the same step for it. `GetSetupTaskCompletionFacts` gains a `logging_enabled` fact (all three features enabled and not soft-deleted), so the task is marked done by fact and reopens if an admin turns any of them back off. No new prerequisites.
- **Restored, not rewritten.** `enable-logging-step.tsx` and `enable-logging-and-session-capture-setting.tsx` and their tests come from #5948's own branch (commit `5d3598e5`), which built this step before that PR reversed course. They apply cleanly against the current `StepContainer` and routes.
- Welcome banner card copy goes to "9 steps · resumable" and mentions logging.
- Server: sqlc regenerated for the organizations package; tests cover the new catalog position and the done / partial / reopened fact transitions. Changesets for `dashboard` and `server`.

Stacked on #6218 (the card now links to `/setup/wizard`); that commit is included here so the banner edits do not conflict.

## Motivation

#5948 shipped logging as a default for **new** organizations and dropped the wizard opt-in step that earlier revisions of the same PR had built. That left organizations created before 2026-09-01 with neither the default nor a prompt: an admin has to find Organization → Logging & Telemetry on their own, and the setup flow never mentions it.

Putting the step back closes that gap without undoing #5948. New orgs still start with the bundle on, so for them the wizard resumes past the step and the board shows it done. Orgs where logging is off see an explicit switch before they instrument agents, which is the point in the sequence where the missing telemetry would otherwise go unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sLAPX64TLgs4kHShxJ1bg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores an **Enable logging** step between marketplace setup and agent instrumentation in both setup views. Previously, organizations with logging disabled skipped this prompt and went straight to instrumentation; now admins can enable all three features together, while organizations that already have them enabled still resume at instrumentation.

**Details**

- Adds a board task that is complete only when Enable Logs, Record Tool I/O, and Agent Session Capture are all enabled; disabling any feature reopens it.
- Shows retention guidance and links to Logging & Telemetry for additional settings.
- Keeps skipping available until the full logging bundle is enabled.
- Updates the organization home rollout card to open the wizard and describe all nine steps.

<sup>Written for commit 38b62da3510256ed853e2881c1b03f36d34bdeb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

