### PR TITLE
fix: address review findings on the enable logging setup step

### DIFF
--- a/.changeset/enable-logging-step-review.md
+++ b/.changeset/enable-logging-step-review.md
@@ -1,0 +1,6 @@
+---
+"dashboard": patch
+"server": patch
+---
+
+The setup "Enable logging" step only lets you continue once logging is on, reverts a half-applied bundle when one of its writes fails, reflects changes other admins make, and the board no longer shows the task as done while logging is off.

--- a/client/dashboard/src/pages/setup/components/enable-logging-and-session-capture-setting.test.tsx
+++ b/client/dashboard/src/pages/setup/components/enable-logging-and-session-capture-setting.test.tsx
@@ -198,7 +198,7 @@ describe("EnableLoggingAndSessionCaptureSetting", () => {
   });
 
   it("lets refreshed product features override the optimistic state", async () => {
-    render(<EnableLoggingAndSessionCaptureSetting />);
+    const { rerender } = render(<EnableLoggingAndSessionCaptureSetting />);
     const bundleSwitch = () =>
       screen.getByRole("switch", {
         name: "Enable logging and session capture",
@@ -209,16 +209,24 @@ describe("EnableLoggingAndSessionCaptureSetting", () => {
       expect(invalidateAllProductFeatures).toHaveBeenCalledTimes(1);
     });
 
-    // Another admin turned session capture off; the refetch reports it.
+    // The refetch confirms the writes: the switch reads on from query data.
+    testState.data = {
+      logsEnabled: true,
+      toolIoLogsEnabled: true,
+      sessionCaptureEnabled: true,
+    };
+    rerender(<EnableLoggingAndSessionCaptureSetting />);
+    expect(bundleSwitch().getAttribute("aria-checked")).toBe("true");
+
+    // Another admin turned session capture off; a later refetch reports it
+    // and must win over what this switch last wrote.
     testState.data = {
       logsEnabled: true,
       toolIoLogsEnabled: true,
       sessionCaptureEnabled: false,
     };
-    fireEvent.click(screen.getByText("Enable logging and session capture"));
-    await waitFor(() => {
-      expect(bundleSwitch().getAttribute("aria-checked")).toBe("false");
-    });
+    rerender(<EnableLoggingAndSessionCaptureSetting />);
+    expect(bundleSwitch().getAttribute("aria-checked")).toBe("false");
   });
 
   it("enables logs, tool I/O, and session capture together", async () => {

--- a/client/dashboard/src/pages/setup/components/enable-logging-and-session-capture-setting.test.tsx
+++ b/client/dashboard/src/pages/setup/components/enable-logging-and-session-capture-setting.test.tsx
@@ -92,7 +92,93 @@ beforeEach(() => {
 
 afterEach(cleanup);
 
+/** Makes the mutation mock write through to the mocked product features. */
+function writeThroughFeatures() {
+  testState.mutateAsync.mockImplementation(
+    async (input: {
+      request: {
+        setProductFeatureRequestBody: { featureName: string; enabled: boolean };
+      };
+    }) => {
+      const { featureName, enabled } =
+        input.request.setProductFeatureRequestBody;
+      const data = testState.data;
+      if (!data) return;
+      if (featureName === "logs") data.logsEnabled = enabled;
+      if (featureName === "tool_io_logs") data.toolIoLogsEnabled = enabled;
+      if (featureName === "session_capture")
+        data.sessionCaptureEnabled = enabled;
+    },
+  );
+}
+
 describe("EnableLoggingAndSessionCaptureSetting", () => {
+  it("round-trips the bundle: enable, then disable, ends with all three off", async () => {
+    writeThroughFeatures();
+    render(<EnableLoggingAndSessionCaptureSetting />);
+    const bundleSwitch = () =>
+      screen.getByRole("switch", {
+        name: "Enable logging and session capture",
+      });
+
+    fireEvent.click(bundleSwitch());
+    await waitFor(() => {
+      expect(bundleSwitch().getAttribute("aria-checked")).toBe("true");
+    });
+    expect(testState.data).toEqual({
+      logsEnabled: true,
+      toolIoLogsEnabled: true,
+      sessionCaptureEnabled: true,
+    });
+
+    fireEvent.click(bundleSwitch());
+    await waitFor(() => {
+      expect(bundleSwitch().getAttribute("aria-checked")).toBe("false");
+    });
+    expect(testState.mutateAsync).toHaveBeenCalledTimes(6);
+    expect(testState.mutateAsync).toHaveBeenNthCalledWith(
+      4,
+      requestFor("tool_io_logs", false),
+    );
+    expect(testState.mutateAsync).toHaveBeenNthCalledWith(
+      5,
+      requestFor("session_capture", false),
+    );
+    expect(testState.mutateAsync).toHaveBeenNthCalledWith(
+      6,
+      requestFor("logs", false),
+    );
+    expect(testState.data).toEqual({
+      logsEnabled: false,
+      toolIoLogsEnabled: false,
+      sessionCaptureEnabled: false,
+    });
+  });
+
+  it("lets refreshed product features override the optimistic state", async () => {
+    render(<EnableLoggingAndSessionCaptureSetting />);
+    const bundleSwitch = () =>
+      screen.getByRole("switch", {
+        name: "Enable logging and session capture",
+      });
+
+    fireEvent.click(bundleSwitch());
+    await waitFor(() => {
+      expect(invalidateAllProductFeatures).toHaveBeenCalledTimes(1);
+    });
+
+    // Another admin turned session capture off; the refetch reports it.
+    testState.data = {
+      logsEnabled: true,
+      toolIoLogsEnabled: true,
+      sessionCaptureEnabled: false,
+    };
+    fireEvent.click(screen.getByText("Enable logging and session capture"));
+    await waitFor(() => {
+      expect(bundleSwitch().getAttribute("aria-checked")).toBe("false");
+    });
+  });
+
   it("enables logs, tool I/O, and session capture together", async () => {
     render(<EnableLoggingAndSessionCaptureSetting />);
 

--- a/client/dashboard/src/pages/setup/components/enable-logging-and-session-capture-setting.test.tsx
+++ b/client/dashboard/src/pages/setup/components/enable-logging-and-session-capture-setting.test.tsx
@@ -155,6 +155,48 @@ describe("EnableLoggingAndSessionCaptureSetting", () => {
     });
   });
 
+  it("reverts the writes that landed before a later one fails", async () => {
+    testState.mutateAsync.mockImplementation(
+      async (input: {
+        request: { setProductFeatureRequestBody: { featureName: string } };
+      }) => {
+        if (
+          input.request.setProductFeatureRequestBody.featureName ===
+          "session_capture"
+        ) {
+          throw new Error("capture boom");
+        }
+      },
+    );
+    render(<EnableLoggingAndSessionCaptureSetting />);
+
+    fireEvent.click(
+      screen.getByRole("switch", {
+        name: "Enable logging and session capture",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(handleAPIError).toHaveBeenCalledTimes(1);
+    });
+    // logs and tool_io_logs were enabled, session_capture failed, so the two
+    // that landed are turned back off in reverse order.
+    expect(testState.mutateAsync).toHaveBeenCalledTimes(5);
+    expect(testState.mutateAsync).toHaveBeenNthCalledWith(
+      4,
+      requestFor("tool_io_logs", false),
+    );
+    expect(testState.mutateAsync).toHaveBeenNthCalledWith(
+      5,
+      requestFor("logs", false),
+    );
+    expect(
+      screen
+        .getByRole("switch", { name: "Enable logging and session capture" })
+        .getAttribute("aria-checked"),
+    ).toBe("false");
+  });
+
   it("lets refreshed product features override the optimistic state", async () => {
     render(<EnableLoggingAndSessionCaptureSetting />);
     const bundleSwitch = () =>

--- a/client/dashboard/src/pages/setup/components/enable-logging-and-session-capture-setting.tsx
+++ b/client/dashboard/src/pages/setup/components/enable-logging-and-session-capture-setting.tsx
@@ -151,6 +151,13 @@ function EnableLoggingAndSessionCaptureSettingInner({
         setIsSaving(false);
         if (isCurrentOrganization()) {
           await invalidateAllProductFeatures(queryClient);
+          // The refetched product features are now authoritative; drop the
+          // optimistic overrides so a change made elsewhere shows up here.
+          if (isCurrentOrganization()) {
+            setLogsEnabled(null);
+            setToolIoLogsEnabled(null);
+            setSessionCaptureEnabled(null);
+          }
         }
       }
     })();

--- a/client/dashboard/src/pages/setup/components/enable-logging-and-session-capture-setting.tsx
+++ b/client/dashboard/src/pages/setup/components/enable-logging-and-session-capture-setting.tsx
@@ -122,22 +122,43 @@ function EnableLoggingAndSessionCaptureSettingInner({
     }
   };
 
+  const writeFeature = (
+    featureName: (typeof LOGGING_BUNDLE_FEATURES)[number],
+    enabled: boolean,
+  ) =>
+    mutation.mutateAsync({
+      request: {
+        setProductFeatureRequestBody: {
+          organizationId,
+          featureName,
+          enabled,
+        },
+      },
+    });
+
   const handleSetBundle = (enabled: boolean) => {
     void (async () => {
       setIsSaving(true);
       const order = enabled ? ENABLE_ORDER : DISABLE_ORDER;
+      // Features written so far in this attempt. If a later write fails these
+      // are reverted, best effort, so the bundle is not left half-applied.
+      const written: (typeof LOGGING_BUNDLE_FEATURES)[number][] = [];
       try {
         for (const featureName of order) {
           if (isFeatureEnabled(featureName) === enabled) continue;
-          await mutation.mutateAsync({
-            request: {
-              setProductFeatureRequestBody: {
-                organizationId,
-                featureName,
-                enabled,
-              },
-            },
-          });
+          try {
+            await writeFeature(featureName, enabled);
+          } catch (error) {
+            for (const done of written.toReversed()) {
+              try {
+                await writeFeature(done, !enabled);
+              } catch {
+                // The refetch below reports whatever state was left behind.
+              }
+            }
+            throw error;
+          }
+          written.push(featureName);
         }
         if (!isCurrentOrganization()) return;
         setLogsEnabled(enabled);

--- a/client/dashboard/src/pages/setup/components/onboarding-wizard.test.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-wizard.test.tsx
@@ -229,7 +229,6 @@ describe("SetupWizard", () => {
     onboardingStatus.current = {
       data: { ssoConfigured: true, dsyncConfigured: false },
       isLoading: false,
-      isFetching: false,
     };
 
     render(<SetupWizard />);
@@ -241,7 +240,6 @@ describe("SetupWizard", () => {
     onboardingStatus.current = {
       data: { ssoConfigured: true, dsyncConfigured: true },
       isLoading: false,
-      isFetching: false,
     };
 
     render(<SetupWizard />);

--- a/client/dashboard/src/pages/setup/components/onboarding-wizard.test.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-wizard.test.tsx
@@ -33,6 +33,7 @@ const productFeatures = vi.hoisted(() => ({
         }
       | undefined,
     isLoading: false,
+    isFetching: false,
   },
   query: vi.fn(),
 }));
@@ -103,6 +104,7 @@ beforeEach(() => {
       sessionCaptureEnabled: false,
     },
     isLoading: false,
+    isFetching: false,
   };
   productFeatures.query.mockReset();
 });
@@ -141,6 +143,7 @@ describe("SetupWizard", () => {
         sessionCaptureEnabled: true,
       },
       isLoading: false,
+      isFetching: false,
     };
 
     render(<SetupWizard />);
@@ -157,6 +160,7 @@ describe("SetupWizard", () => {
         sessionCaptureEnabled: false,
       },
       isLoading: false,
+      isFetching: false,
     };
 
     render(<SetupWizard />);
@@ -164,9 +168,30 @@ describe("SetupWizard", () => {
     expect(resumedStep()).toBe("enable-logging");
   });
 
+  it("waits out a background refetch before trusting cached logging flags", () => {
+    publishStatus.current = { data: { connected: true }, isLoading: false };
+    productFeatures.current = {
+      data: {
+        logsEnabled: true,
+        toolIoLogsEnabled: true,
+        sessionCaptureEnabled: true,
+      },
+      isLoading: false,
+      isFetching: true,
+    };
+
+    render(<SetupWizard />);
+
+    expect(resumedStep()).toBeNull();
+  });
+
   it("falls back to step 0 when the product features query fails", () => {
     publishStatus.current = { data: { connected: true }, isLoading: false };
-    productFeatures.current = { data: undefined, isLoading: false };
+    productFeatures.current = {
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+    };
 
     render(<SetupWizard />);
 
@@ -192,6 +217,7 @@ describe("SetupWizard", () => {
         sessionCaptureEnabled: false,
       },
       isLoading: true,
+      isFetching: true,
     };
 
     render(<SetupWizard />);
@@ -203,6 +229,7 @@ describe("SetupWizard", () => {
     onboardingStatus.current = {
       data: { ssoConfigured: true, dsyncConfigured: false },
       isLoading: false,
+      isFetching: false,
     };
 
     render(<SetupWizard />);
@@ -214,6 +241,7 @@ describe("SetupWizard", () => {
     onboardingStatus.current = {
       data: { ssoConfigured: true, dsyncConfigured: true },
       isLoading: false,
+      isFetching: false,
     };
 
     render(<SetupWizard />);

--- a/client/dashboard/src/pages/setup/components/onboarding-wizard.test.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-wizard.test.tsx
@@ -19,22 +19,29 @@ const publishStatus = vi.hoisted(() => ({
   current: { data: { connected: false }, isLoading: false },
 }));
 
+type ProductFeaturesQuery = {
+  data:
+    | {
+        logsEnabled: boolean;
+        toolIoLogsEnabled: boolean;
+        sessionCaptureEnabled: boolean;
+      }
+    | undefined;
+  isLoading: boolean;
+  isFetching: boolean;
+  isError?: boolean;
+};
+
 const productFeatures = vi.hoisted(() => ({
   current: {
     data: {
       logsEnabled: false,
       toolIoLogsEnabled: false,
       sessionCaptureEnabled: false,
-    } as
-      | {
-          logsEnabled: boolean;
-          toolIoLogsEnabled: boolean;
-          sessionCaptureEnabled: boolean;
-        }
-      | undefined,
+    },
     isLoading: false,
     isFetching: false,
-  },
+  } as ProductFeaturesQuery,
   query: vi.fn(),
 }));
 
@@ -105,6 +112,7 @@ beforeEach(() => {
     },
     isLoading: false,
     isFetching: false,
+    isError: false,
   };
   productFeatures.query.mockReset();
 });
@@ -183,6 +191,24 @@ describe("SetupWizard", () => {
     render(<SetupWizard />);
 
     expect(resumedStep()).toBeNull();
+  });
+
+  it("does not trust cached logging flags after a failed refetch", () => {
+    publishStatus.current = { data: { connected: true }, isLoading: false };
+    productFeatures.current = {
+      data: {
+        logsEnabled: true,
+        toolIoLogsEnabled: true,
+        sessionCaptureEnabled: true,
+      },
+      isLoading: false,
+      isFetching: false,
+      isError: true,
+    };
+
+    render(<SetupWizard />);
+
+    expect(resumedStep()).toBe("connect-idp");
   });
 
   it("falls back to step 0 when the product features query fails", () => {

--- a/client/dashboard/src/pages/setup/components/onboarding-wizard.test.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-wizard.test.tsx
@@ -25,9 +25,16 @@ const productFeatures = vi.hoisted(() => ({
       logsEnabled: false,
       toolIoLogsEnabled: false,
       sessionCaptureEnabled: false,
-    },
+    } as
+      | {
+          logsEnabled: boolean;
+          toolIoLogsEnabled: boolean;
+          sessionCaptureEnabled: boolean;
+        }
+      | undefined,
     isLoading: false,
   },
+  query: vi.fn(),
 }));
 
 vi.mock("react-router", () => ({
@@ -45,7 +52,10 @@ vi.mock("@gram/client/react-query/publishStatus", () => ({
   usePublishStatus: () => publishStatus.current,
 }));
 vi.mock("@gram/client/react-query/productFeatures.js", () => ({
-  useProductFeatures: () => productFeatures.current,
+  useProductFeatures: (...args: unknown[]) => {
+    productFeatures.query(...args);
+    return productFeatures.current;
+  },
 }));
 vi.mock("@/contexts/Auth", () => ({
   useOrganization: () => ({ id: "org1", slug: "acme" }),
@@ -94,6 +104,7 @@ beforeEach(() => {
     },
     isLoading: false,
   };
+  productFeatures.query.mockReset();
 });
 
 function resumedStep(): string | null {
@@ -151,6 +162,25 @@ describe("SetupWizard", () => {
     render(<SetupWizard />);
 
     expect(resumedStep()).toBe("enable-logging");
+  });
+
+  it("falls back to step 0 when the product features query fails", () => {
+    publishStatus.current = { data: { connected: true }, isLoading: false };
+    productFeatures.current = { data: undefined, isLoading: false };
+
+    render(<SetupWizard />);
+
+    expect(resumedStep()).toBe("connect-idp");
+  });
+
+  it("keeps the product features query from throwing to the error boundary", () => {
+    render(<SetupWizard />);
+
+    expect(productFeatures.query).toHaveBeenCalledWith(
+      { organizationId: "org1" },
+      undefined,
+      { throwOnError: false },
+    );
   });
 
   it("waits for product features before choosing a resume step", () => {

--- a/client/dashboard/src/pages/setup/components/onboarding-wizard.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-wizard.tsx
@@ -129,9 +129,13 @@ export function SetupWizard(): JSX.Element {
     data: features,
     isLoading: isFeaturesLoading,
     isFetching: isFeaturesFetching,
+    isError: isFeaturesError,
   } = useProductFeatures({ organizationId: organization.id }, undefined, {
     throwOnError: false,
   });
+  // A failed refetch keeps the previous data around, so an error means the
+  // flags cannot be trusted even when `features` is defined.
+  const featuresUsable = features !== undefined && !isFeaturesError;
   // Product features are cached across pages, so a mount can see stale flags
   // while a refetch is in flight. Wait for it before choosing where to resume.
   const statusLoading =
@@ -151,9 +155,9 @@ export function SetupWizard(): JSX.Element {
     // fail — we fall back to step 0.
     let resumeStep = 0;
     if (publishStatus?.connected) {
-      // A failed feature query leaves `features` undefined; stay on step 0
-      // rather than guessing at the logging state.
-      if (features !== undefined) {
+      // A failed feature query means the logging state is unknown; stay on
+      // step 0 rather than guessing.
+      if (featuresUsable) {
         resumeStep = indexOfStep(
           steps,
           loggingBundleEnabled ? "instrument-agents" : "enable-logging",
@@ -177,7 +181,7 @@ export function SetupWizard(): JSX.Element {
     statusLoading,
     onboardingStatus,
     publishStatus,
-    features,
+    featuresUsable,
     loggingBundleEnabled,
     setSearchParams,
     steps,

--- a/client/dashboard/src/pages/setup/components/onboarding-wizard.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-wizard.tsx
@@ -144,10 +144,14 @@ export function SetupWizard(): JSX.Element {
     // fail — we fall back to step 0.
     let resumeStep = 0;
     if (publishStatus?.connected) {
-      resumeStep = indexOfStep(
-        steps,
-        loggingBundleEnabled ? "instrument-agents" : "enable-logging",
-      );
+      // A failed feature query leaves `features` undefined; stay on step 0
+      // rather than guessing at the logging state.
+      if (features !== undefined) {
+        resumeStep = indexOfStep(
+          steps,
+          loggingBundleEnabled ? "instrument-agents" : "enable-logging",
+        );
+      }
     } else if (onboardingStatus?.dsyncConfigured) {
       resumeStep = indexOfStep(steps, "create-marketplace");
     } else if (onboardingStatus?.ssoConfigured) {
@@ -166,6 +170,7 @@ export function SetupWizard(): JSX.Element {
     statusLoading,
     onboardingStatus,
     publishStatus,
+    features,
     loggingBundleEnabled,
     setSearchParams,
     steps,

--- a/client/dashboard/src/pages/setup/components/onboarding-wizard.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-wizard.tsx
@@ -125,13 +125,20 @@ export function SetupWizard(): JSX.Element {
     useOnboardingStatus(undefined, undefined, { throwOnError: false });
   const { data: publishStatus, isLoading: isPublishStatusLoading } =
     usePublishStatus(undefined, undefined, { throwOnError: false });
-  const { data: features, isLoading: isFeaturesLoading } = useProductFeatures(
-    { organizationId: organization.id },
-    undefined,
-    { throwOnError: false },
-  );
+  const {
+    data: features,
+    isLoading: isFeaturesLoading,
+    isFetching: isFeaturesFetching,
+  } = useProductFeatures({ organizationId: organization.id }, undefined, {
+    throwOnError: false,
+  });
+  // Product features are cached across pages, so a mount can see stale flags
+  // while a refetch is in flight. Wait for it before choosing where to resume.
   const statusLoading =
-    isOnboardingStatusLoading || isPublishStatusLoading || isFeaturesLoading;
+    isOnboardingStatusLoading ||
+    isPublishStatusLoading ||
+    isFeaturesLoading ||
+    isFeaturesFetching;
   const loggingBundleEnabled =
     features?.logsEnabled === true &&
     features?.toolIoLogsEnabled === true &&

--- a/client/dashboard/src/pages/setup/components/steps/enable-logging-step.test.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/enable-logging-step.test.tsx
@@ -343,7 +343,7 @@ describe("EnableLoggingStep", () => {
   });
 
   it("keeps Continue off when the refetch reports a partial bundle", async () => {
-    renderStep();
+    const { rerender } = renderStep();
     fireEvent.click(
       screen.getByRole("switch", {
         name: "Enable logging and session capture",
@@ -353,20 +353,34 @@ describe("EnableLoggingStep", () => {
       expect(testState.mutateAsync).toHaveBeenCalledTimes(3);
     });
 
-    // Another admin turned session capture off between the writes and the
-    // refetch; the switch's optimistic state must not gate Continue.
+    // The refetch confirms all three writes: Continue opens, Skip goes away.
+    testState.data = {
+      logsEnabled: true,
+      toolIoLogsEnabled: true,
+      sessionCaptureEnabled: true,
+    };
+    rerender(<EnableLoggingStep {...stepProps()} />);
+    await waitFor(() => {
+      expect(
+        (screen.getByRole("button", { name: /Continue/ }) as HTMLButtonElement)
+          .disabled,
+      ).toBe(false);
+    });
+    expect(screen.queryByRole("button", { name: "Skip for now" })).toBeNull();
+
+    // Another admin turned session capture off; the next refetch reports it
+    // and the switch's own write history must not keep Continue open.
     testState.data = {
       logsEnabled: true,
       toolIoLogsEnabled: true,
       sessionCaptureEnabled: false,
     };
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Skip for now" })).toBeTruthy();
-    });
+    rerender(<EnableLoggingStep {...stepProps()} />);
     expect(
       (screen.getByRole("button", { name: /Continue/ }) as HTMLButtonElement)
         .disabled,
     ).toBe(true);
+    expect(screen.getByRole("button", { name: "Skip for now" })).toBeTruthy();
   });
 
   it("waits for a background refetch before gating Continue or Skip", () => {

--- a/client/dashboard/src/pages/setup/components/steps/enable-logging-step.test.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/enable-logging-step.test.tsx
@@ -133,6 +133,36 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("EnableLoggingStep", () => {
+  it("keeps the product features query from throwing to the error boundary", () => {
+    renderStep();
+
+    expect(testState.productFeaturesQuery).toHaveBeenCalledWith(
+      { organizationId: "org-active" },
+      undefined,
+      { throwOnError: false },
+    );
+  });
+
+  it("enables Continue only once the logging bundle is on", () => {
+    renderStep();
+    expect(
+      (screen.getByRole("button", { name: "Continue" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+
+    cleanup();
+    testState.data = {
+      logsEnabled: true,
+      toolIoLogsEnabled: true,
+      sessionCaptureEnabled: true,
+    };
+    renderStep();
+    expect(
+      (screen.getByRole("button", { name: "Continue" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
+  });
+
   it("shows the combined logging and session capture control", () => {
     renderStep();
 

--- a/client/dashboard/src/pages/setup/components/steps/enable-logging-step.test.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/enable-logging-step.test.tsx
@@ -324,6 +324,12 @@ describe("EnableLoggingStep", () => {
         .disabled,
     ).toBe(true);
 
+    // The refetch after the writes reports the bundle as on.
+    testState.data = {
+      logsEnabled: true,
+      toolIoLogsEnabled: true,
+      sessionCaptureEnabled: true,
+    };
     releaseMutations?.();
     await waitFor(() => {
       expect(
@@ -334,6 +340,49 @@ describe("EnableLoggingStep", () => {
     expect(screen.queryByRole("button", { name: "Skip for now" })).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: /Continue/ }));
     expect(onComplete).toHaveBeenCalledOnce();
+  });
+
+  it("keeps Continue off when the refetch reports a partial bundle", async () => {
+    renderStep();
+    fireEvent.click(
+      screen.getByRole("switch", {
+        name: "Enable logging and session capture",
+      }),
+    );
+    await waitFor(() => {
+      expect(testState.mutateAsync).toHaveBeenCalledTimes(3);
+    });
+
+    // Another admin turned session capture off between the writes and the
+    // refetch; the switch's optimistic state must not gate Continue.
+    testState.data = {
+      logsEnabled: true,
+      toolIoLogsEnabled: true,
+      sessionCaptureEnabled: false,
+    };
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Skip for now" })).toBeTruthy();
+    });
+    expect(
+      (screen.getByRole("button", { name: /Continue/ }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+  });
+
+  it("waits for a background refetch before gating Continue or Skip", () => {
+    testState.data = {
+      logsEnabled: true,
+      toolIoLogsEnabled: true,
+      sessionCaptureEnabled: true,
+    };
+    testState.isFetching = true;
+    renderStep();
+
+    expect(
+      (screen.getByRole("button", { name: /Continue/ }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(screen.queryByRole("button", { name: "Skip for now" })).toBeNull();
   });
 
   it("keeps the retry action disabled while refetching", () => {

--- a/client/dashboard/src/pages/setup/components/steps/enable-logging-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/enable-logging-step.tsx
@@ -28,18 +28,23 @@ export function EnableLoggingStep({
     undefined,
     { throwOnError: false },
   );
-  const [bundleEnabled, setBundleEnabled] = useState<boolean | null>(null);
   const [bundleBusy, setBundleBusy] = useState(false);
+  // Read only from the query. The switch invalidates product features after
+  // every write, so the refetched flags are what decide whether the step is
+  // satisfied; an optimistic value here could let Continue through on a
+  // bundle that a later refetch reports as partial.
   const loggingBundleEnabled =
-    bundleEnabled ??
-    (features.data?.logsEnabled === true &&
-      features.data?.toolIoLogsEnabled === true &&
-      features.data?.sessionCaptureEnabled === true);
+    features.data?.logsEnabled === true &&
+    features.data?.toolIoLogsEnabled === true &&
+    features.data?.sessionCaptureEnabled === true;
   const featuresLoading = features.isLoading;
   const featuresFailed =
     !featuresLoading && Boolean(features.error || !features.data);
   const featuresReady =
-    Boolean(features.data) && !featuresLoading && !featuresFailed;
+    Boolean(features.data) &&
+    !featuresLoading &&
+    !features.isFetching &&
+    !featuresFailed;
   const canSkip = featuresReady && !loggingBundleEnabled && !bundleBusy;
 
   return (
@@ -63,10 +68,7 @@ export function EnableLoggingStep({
       <div className="space-y-6">
         <LogDataRetentionBanner />
         <div className="border-border bg-card border p-4">
-          <EnableLoggingAndSessionCaptureSetting
-            onEnabledChange={setBundleEnabled}
-            onBusyChange={setBundleBusy}
-          />
+          <EnableLoggingAndSessionCaptureSetting onBusyChange={setBundleBusy} />
         </div>
         <p className="text-muted-foreground text-sm">
           This turns on Enable Logs, Record Tool I/O, and Agent Session Capture

--- a/client/dashboard/src/pages/setup/components/steps/enable-logging-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/enable-logging-step.tsx
@@ -57,7 +57,7 @@ export function EnableLoggingStep({
       onSkip={canSkip ? onSkip : undefined}
       showBack
       onBack={onBack}
-      canContinue={featuresReady && !bundleBusy}
+      canContinue={featuresReady && loggingBundleEnabled && !bundleBusy}
       isLoading={featuresLoading || bundleBusy}
     >
       <div className="space-y-6">

--- a/server/internal/organizations/listsetuptasks_test.go
+++ b/server/internal/organizations/listsetuptasks_test.go
@@ -73,6 +73,25 @@ func TestService_ListSetupTasksMarksLoggingDoneOnceTheBundleIsEnabled(t *testing
 	require.False(t, setupTask(result.Tasks, "enable-logging").CompletedByFact)
 }
 
+func TestService_ListSetupTasksDoesNotHonourManualLoggingDoneWhileBundleOff(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestOrganizationsService(t)
+	done := "done"
+	updated, err := ti.service.UpdateSetupTask(ctx, &gen.UpdateSetupTaskPayload{TaskKey: "enable-logging", Status: &done})
+	require.NoError(t, err)
+	require.Equal(t, "todo", updated.Status, "done is projected back to todo while logging is off")
+
+	inProgress := "in_progress"
+	updated, err = ti.service.UpdateSetupTask(ctx, &gen.UpdateSetupTaskPayload{TaskKey: "enable-logging", Status: &inProgress})
+	require.NoError(t, err)
+	require.Equal(t, "in_progress", updated.Status, "other manual statuses are kept")
+
+	result, err := ti.service.ListSetupTasks(ctx, &gen.ListSetupTasksPayload{})
+	require.NoError(t, err)
+	require.Equal(t, "in_progress", setupTask(result.Tasks, "enable-logging").Status)
+}
+
 func TestService_ListSetupTasksAppliesCompletionFactsWithoutWriting(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/organizations/setup_tasks.go
+++ b/server/internal/organizations/setup_tasks.go
@@ -332,6 +332,12 @@ func (s *Service) projectSetupTasks(ctx context.Context, repo *orgrepo.Queries, 
 		if completedByFact {
 			status = setupTaskStatusDone
 		}
+		// "Enable logging" means the bundle is on. A manual done from the board
+		// while it is off is not honoured, so the task cannot claim logging that
+		// is not happening.
+		if definition.Key == "enable-logging" && !facts.LoggingEnabled && status == setupTaskStatusDone {
+			status = setupTaskStatusTodo
+		}
 		tasks = append(tasks, &gen.SetupTask{Key: definition.Key, Title: definition.Title, Description: definition.Description, Status: status, CompletedByFact: completedByFact, Assignee: assignee, BlockedBy: []string{}, Hidden: hidden})
 	}
 


### PR DESCRIPTION
## Summary

Follow-up to #6219 addressing all nine cubic ultrareview findings on the restored "Enable logging" setup step. #6219 was already in the merge queue, so these landed here rather than holding it up.

- **Continue requires the bundle to be on.** `EnableLoggingStep` enables Continue only when logs, tool I/O, and session capture are all on; Skip remains the way past it while off. In the board, Continue persists the task as done, so this keeps that status honest.
- **Failed feature query resumes at step 0.** The wizard treats an undefined product-features result like the other resume queries and falls back to `connect-idp` instead of guessing at the logging state. It also waits out a background refetch, so a cached all-true snapshot cannot skip the step for an org that has since turned logging off.
- **Refetched features win over optimistic state.** After a bundle write, the switch drops its local overrides once the product-features query has been invalidated, so a change made by another admin shows up.
- **Half-applied bundles are reverted.** If the second or third write fails, the writes that already landed in that attempt are turned back, best effort, in reverse order before the error is reported. The refetch afterwards reports whatever was actually left.
- **Server: manual done does not outlive the fact.** `projectSetupTasks` projects a persisted `done` on `enable-logging` back to `todo` while the logging fact is false. Other manual statuses (in progress, awaiting support) are kept, so the task can still be assigned and tracked.
- **Tests.** Wizard: errored query, refetch wait, and a `throwOnError: false` assertion. Step: Continue gating and the same `throwOnError` assertion. Switch: a stateful enable-then-disable round trip, refreshed-data reconciliation, and the rollback path. Server: manual done projected back to todo.

## Motivation

Cubic's review on #6219 found that the step could record "logging enabled" without it being true, in three ways: Continue while the bundle was off, a persisted board status, and stale or optimistic client state. It also found that a mid-bundle failure left a partial configuration behind a single switch. Each of those makes the setup flow claim telemetry that is not being captured, which is the opposite of what the step is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sLAPX64TLgs4kHShxJ1bg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The "Enable logging" setup step can no longer claim telemetry when it isn't being captured. It previously let users Continue while the bundle was off, trusted stale or optimistic client state, and left partial configuration behind a failed write.

**Bug Fixes**
- Continue stays disabled until refetched flags confirm logs, tool I/O, and session capture are all on; the step no longer trusts the switch's optimistic state.
- A failed product-features query or refetch resumes the wizard at step 0 instead of guessing at the logging state.
- The wizard waits out background refetches so cached all-true flags can't skip the step for an org that has since turned logging off.
- After a bundle write, the switch drops optimistic overrides once features refetch.
- If a later bundle write fails, earlier writes revert best-effort in reverse order.
- Server projects `enable-logging` from `done` back to `todo` while the logging fact is false; other manual statuses are kept.

<sup>Written for commit 487ac425d7ed7f6d98546dba2137983c6abce396. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

