### PR TITLE
fix: use import.meta.dirname in dashboard Vite configs

### DIFF
--- a/client/dashboard/vite.config.ts
+++ b/client/dashboard/vite.config.ts
@@ -283,7 +283,10 @@ export default defineConfig(({ command }) => {
         "@gram/client": path.resolve(import.meta.dirname, "./src/sdk/src"),
         // Ensure single instances of React and related packages across all dependencies
         react: path.resolve(import.meta.dirname, "node_modules/react"),
-        "react-dom": path.resolve(import.meta.dirname, "node_modules/react-dom"),
+        "react-dom": path.resolve(
+          import.meta.dirname,
+          "node_modules/react-dom",
+        ),
         // Deduplicate @assistant-ui packages to ensure context is shared
         "@assistant-ui/react": path.resolve(
           import.meta.dirname,

--- a/client/dashboard/vite.config.ts
+++ b/client/dashboard/vite.config.ts
@@ -30,7 +30,7 @@ const manualChunkGroups: [string, string[]][] = [
   ],
 ];
 
-const themeInitPath = path.resolve(__dirname, "src/theme-init.ts");
+const themeInitPath = path.resolve(import.meta.dirname, "src/theme-init.ts");
 const themeInitScriptPattern =
   /<script src="\/src\/theme-init\.ts"\s*><\/script>/;
 
@@ -197,7 +197,7 @@ export default defineConfig(({ command }) => {
       },
       rolldownOptions: {
         input: {
-          main: path.resolve(__dirname, "index.html"),
+          main: path.resolve(import.meta.dirname, "index.html"),
         },
         output: {
           codeSplitting: {
@@ -279,18 +279,18 @@ export default defineConfig(({ command }) => {
     ],
     resolve: {
       alias: {
-        "@": path.resolve(__dirname, "./src"),
-        "@gram/client": path.resolve(__dirname, "./src/sdk/src"),
+        "@": path.resolve(import.meta.dirname, "./src"),
+        "@gram/client": path.resolve(import.meta.dirname, "./src/sdk/src"),
         // Ensure single instances of React and related packages across all dependencies
-        react: path.resolve(__dirname, "node_modules/react"),
-        "react-dom": path.resolve(__dirname, "node_modules/react-dom"),
+        react: path.resolve(import.meta.dirname, "node_modules/react"),
+        "react-dom": path.resolve(import.meta.dirname, "node_modules/react-dom"),
         // Deduplicate @assistant-ui packages to ensure context is shared
         "@assistant-ui/react": path.resolve(
-          __dirname,
+          import.meta.dirname,
           "node_modules/@assistant-ui/react",
         ),
         "@assistant-ui/react-markdown": path.resolve(
-          __dirname,
+          import.meta.dirname,
           "node_modules/@assistant-ui/react-markdown",
         ),
       },

--- a/client/dashboard/vite.config.ts
+++ b/client/dashboard/vite.config.ts
@@ -5,7 +5,7 @@ import process from "node:process";
 import { defineConfig, normalizePath, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
-import { replaceAdminServerUrl } from "./src/lib/admin-server-url";
+import { replaceAdminServerUrl } from "./src/lib/admin-server-url.ts";
 
 // Manually grouped vendor chunks. CAUTION: never group a package whose dist
 // contains a top-level `await import(...)` (check before adding). Grouping

--- a/client/dashboard/vite.consent-page.config.ts
+++ b/client/dashboard/vite.consent-page.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   base: "/mcp/consent-fonts/",
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
   build: {
@@ -25,7 +25,7 @@ export default defineConfig({
     // assets inside it means `build:consent` silently deletes them and the Go
     // embed stops compiling.
     outDir: path.resolve(
-      __dirname,
+      import.meta.dirname,
       "../../server/internal/mcp/consent_page_assets",
     ),
     emptyOutDir: true,
@@ -36,7 +36,7 @@ export default defineConfig({
     assetsInlineLimit: 0,
     assetsDir: "",
     rolldownOptions: {
-      input: path.resolve(__dirname, "src/consent-page/consent-page.css"),
+      input: path.resolve(import.meta.dirname, "src/consent-page/consent-page.css"),
       output: {
         // The stylesheet is embedded and served inline, so it carries no hash;
         // the fonts are served as immutable URLs and carry one.

--- a/client/dashboard/vite.consent-page.config.ts
+++ b/client/dashboard/vite.consent-page.config.ts
@@ -36,7 +36,10 @@ export default defineConfig({
     assetsInlineLimit: 0,
     assetsDir: "",
     rolldownOptions: {
-      input: path.resolve(import.meta.dirname, "src/consent-page/consent-page.css"),
+      input: path.resolve(
+        import.meta.dirname,
+        "src/consent-page/consent-page.css",
+      ),
       output: {
         // The stylesheet is embedded and served inline, so it carries no hash;
         // the fonts are served as immutable URLs and carry one.

--- a/client/dashboard/vite.consent.config.ts
+++ b/client/dashboard/vite.consent.config.ts
@@ -24,7 +24,10 @@ export default defineConfig({
     },
   },
   build: {
-    outDir: path.resolve(import.meta.dirname, "../../server/internal/mcp/consent_assets"),
+    outDir: path.resolve(
+      import.meta.dirname,
+      "../../server/internal/mcp/consent_assets",
+    ),
     emptyOutDir: true,
     sourcemap: false,
     rolldownOptions: {

--- a/client/dashboard/vite.consent.config.ts
+++ b/client/dashboard/vite.consent.config.ts
@@ -19,16 +19,16 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
-      "@gram/client": path.resolve(__dirname, "./src/sdk/src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
+      "@gram/client": path.resolve(import.meta.dirname, "./src/sdk/src"),
     },
   },
   build: {
-    outDir: path.resolve(__dirname, "../../server/internal/mcp/consent_assets"),
+    outDir: path.resolve(import.meta.dirname, "../../server/internal/mcp/consent_assets"),
     emptyOutDir: true,
     sourcemap: false,
     rolldownOptions: {
-      input: path.resolve(__dirname, "src/consent-tools/main.tsx"),
+      input: path.resolve(import.meta.dirname, "src/consent-tools/main.tsx"),
       output: {
         format: "iife",
         entryFileNames: "consent-tools.js",

--- a/client/dashboard/vitest.config.ts
+++ b/client/dashboard/vitest.config.ts
@@ -6,8 +6,8 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
-      "@gram/client": path.resolve(__dirname, "./src/sdk/src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
+      "@gram/client": path.resolve(import.meta.dirname, "./src/sdk/src"),
     },
     conditions: ["source"],
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Vite's native `configLoader` does not support CJS/`bundler` config habits. Dashboard Vite configs now match what Vite 8 documents for the upcoming native default:

- `__dirname` → `import.meta.dirname` (the original AGE-3394 warning)
- extensionless relative import → `./src/lib/admin-server-url.ts` (the follow-up warning seen on `vite` / dashboard dev)

`path.resolve(...)` is unchanged; only the directory root swapped. The `.ts` specifier is allowed by `tsconfig.node.json` (`allowImportingTsExtensions: true`).

## Changes

- `client/dashboard/vitest.config.ts` — `__dirname` at the reported `:9:25` site
- `client/dashboard/vite.config.ts`, `vite.consent.config.ts`, `vite.consent-page.config.ts` — same `__dirname` usage
- `client/dashboard/vite.config.ts` — add `.ts` on the `admin-server-url` import

Admin Vite configs still use `__dirname` and are intentionally out of scope (AGE-3394 is dashboard tests only).

## Test plan

- [x] Reproduced `__dirname` warning with the old vitest config
- [x] `pnpm -F dashboard test` — 342 files / 3319 tests passed, no `__dirname` warning
- [x] `loadConfigFromFile(vite.config.ts)` after the `.ts` import — no `configLoader` / extensionless-import warning
- [x] `tsc -p tsconfig.node.json --noEmit` passes

Fixes AGE-3394

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-3394](https://linear.app/speakeasy/issue/AGE-3394/fix-replace-dirname-in-vite-config)

<div><a href="https://cursor.com/agents/bc-f90c60fb-d54d-4032-a6b0-96246a360ac9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f90c60fb-d54d-4032-a6b0-96246a360ac9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces `__dirname` with `import.meta.dirname` and appends the `.ts` extension to a relative import in the dashboard Vite configs, so Vite's native config loader stops warning and dashboard tests run cleanly.

- Updates `client/dashboard/vitest.config.ts` (the file that triggered the warning) and the three other dashboard Vite configs that use the same pattern.
- Adds `.ts` to the `admin-server-url` import in `client/dashboard/vite.config.ts`, which the native loader also rejects.
- Matches the existing Storybook Vite config.
- Fixes AGE-3394.

<sup>Written for commit d0fd415ceaf9c64c2040840f7f60783ac266f3da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

