### PR TITLE
chore: update OpenRouter tests for NOT NULL disable causes

### DIFF
--- a/server/cmd/tools/migrations/openrouterdisablecauses/runner_test.go
+++ b/server/cmd/tools/migrations/openrouterdisablecauses/runner_test.go
@@ -24,6 +24,7 @@ type runnerFixture struct {
 
 func newRunnerFixture(t *testing.T) *runnerFixture {
 	t.Helper()
+	t.Skip("openrouter_api_keys.disable_causes is NOT NULL; unclassified fixtures are impossible until the classifier cleanup removes this package")
 	pool, err := testInfra.CloneTestDatabase(t, "openrouterdisablecauses")
 	require.NoError(t, err)
 	return &runnerFixture{pool: pool}

--- a/server/internal/admin/converttrial_atomic_test.go
+++ b/server/internal/admin/converttrial_atomic_test.go
@@ -273,21 +273,6 @@ func TestMarkEnterpriseTrialConverted_OutboxFailureRollsBackEverything(t *testin
 	require.Empty(t, provisioner.reconcileAttempts)
 }
 
-func TestMarkEnterpriseTrialConverted_UnclassifiedKeyRollsBack(t *testing.T) {
-	t.Parallel()
-	ctx, svc, conn, provisioner := newRearmService(t)
-	orgID := "org_convert_null_key"
-	seedOrg(t, ctx, conn, orgFixture{id: orgID, name: orgID, slug: orgID, accountType: "enterprise", whitelisted: true})
-	seedTrial(t, ctx, conn, trialFixture{orgID: orgID, tier: "enterprise", endsAt: time.Now().UTC().Add(time.Hour)})
-	seedOpenRouterKey(t, ctx, conn, orgID, keyFixture{keyType: openrouter.KeyTypeChat, monthlyCredits: 7})
-	require.NoError(t, testrepo.New(conn).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat), Disabled: false, DisableCauses: nil}))
-
-	_, err := svc.MarkEnterpriseTrialConverted(ctx, &gen.MarkEnterpriseTrialConvertedPayload{ID: orgID})
-	requireOopsCode(t, err, oops.CodeUnexpected)
-	require.False(t, readTrial(t, ctx, conn, orgID).ConvertedAt.Valid)
-	require.Empty(t, provisioner.reconcileAttempts)
-}
-
 func TestMarkEnterpriseTrialConverted_PostCommitFailureRetryConverges(t *testing.T) {
 	t.Parallel()
 	ctx, svc, conn, provisioner := newRearmService(t)

--- a/server/internal/admin/rearmtrial_test.go
+++ b/server/internal/admin/rearmtrial_test.go
@@ -498,43 +498,6 @@ func TestRearmTrial_AbsentCauseHasNoKeySideEffectOrInventedAccessAudit(t *testin
 	require.Equal(t, false, metadata["key_access_changed"])
 }
 
-func TestRearmTrial_UnclassifiedKeyRollsBackLifecycleAndAllKeyChanges(t *testing.T) {
-	t.Parallel()
-
-	ctx, svc, conn, upstream := newProductionRearmService(t)
-	const orgID = "org_rearm_null_causes"
-	seedDemotedTrial(t, ctx, conn, orgID, "enterprise")
-	seedDisabledTrialRuntimeFeatures(t, ctx, svc, conn, orgID)
-	classifyRearmKey(t, ctx, conn, orgID, openrouter.KeyTypeChat, []string{string(openrouter.DisableCauseTrialDemotion)})
-	classifyRearmKey(t, ctx, conn, orgID, openrouter.KeyTypeInternal, nil)
-	beforeTrial := readTrial(t, ctx, conn, orgID)
-	beforeAudit, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialRearmed)
-	require.NoError(t, err)
-	beforeOutbox, err := testrepo.New(conn).CountPublishOutboxRows(ctx)
-	require.NoError(t, err)
-
-	_, err = svc.RearmTrial(ctx, &gen.RearmTrialPayload{ID: orgID, Days: 14})
-	requireOopsCode(t, err, oops.CodeUnexpected)
-	require.Zero(t, upstream.count(), "no HTTP belongs inside the transaction or after rollback")
-	afterTrial := readTrial(t, ctx, conn, orgID)
-	require.Equal(t, beforeTrial.DemotedAt, afterTrial.DemotedAt)
-	require.Equal(t, beforeTrial.EndsAt, afterTrial.EndsAt)
-	require.Equal(t, []string{string(openrouter.DisableCauseTrialDemotion)}, readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeChat).DisableCauses)
-	require.Nil(t, readOpenRouterKey(t, ctx, conn, orgID, openrouter.KeyTypeInternal).DisableCauses)
-	require.Equal(t, "free", readOrgState(t, ctx, conn, orgID).GramAccountType)
-	for _, feature := range productfeatures.TrialRuntimeFeatures {
-		enabled, featureErr := svc.productFeatures.IsFeatureEnabled(ctx, orgID, feature)
-		require.NoError(t, featureErr)
-		require.False(t, enabled)
-	}
-	afterAudit, err := audittest.AuditLogCountByAction(ctx, conn, audit.ActionOrganizationEnterpriseTrialRearmed)
-	require.NoError(t, err)
-	require.Equal(t, beforeAudit, afterAudit)
-	afterOutbox, err := testrepo.New(conn).CountPublishOutboxRows(ctx)
-	require.NoError(t, err)
-	require.Equal(t, beforeOutbox, afterOutbox)
-}
-
 func seedArmAudit(t *testing.T, ctx context.Context, conn *pgxpool.Pool, orgID string) string {
 	t.Helper()
 	operationID, err := testrepo.New(conn).SeedTrialArmAuditFixture(ctx, orgID)

--- a/server/internal/background/activities/trial_demotion_test.go
+++ b/server/internal/background/activities/trial_demotion_test.go
@@ -457,28 +457,6 @@ func TestDemoteExpiredTrials_MissingKeysAreSafe(t *testing.T) {
 	require.Empty(t, ti.provisioner.reconciled)
 }
 
-func TestDemoteExpiredTrials_NullDisableCausesFailClosedAndRollBack(t *testing.T) {
-	t.Parallel()
-
-	ctx, ti := newTrialTestInstance(t)
-	orgID := newTrialOrg(t, ctx, ti, time.Now().Add(-time.Hour).UTC())
-	materializeTrialKey(t, ctx, ti, orgID, openrouter.KeyTypeChat, nil)
-
-	err := ti.activity.Demote(ctx, activities.DemoteExpiredTrialArgs{OrganizationID: orgID})
-	require.ErrorIs(t, err, openrouter.ErrAPIKeyDisableCausesUnclassified)
-
-	trial, getErr := ti.trials.GetTrial(ctx, orgID)
-	require.NoError(t, getErr)
-	require.False(t, trial.DemotedAt.Valid)
-	org, getErr := ti.orgs.GetOrganizationMetadata(ctx, orgID)
-	require.NoError(t, getErr)
-	require.Equal(t, "enterprise", org.GramAccountType)
-	key := trialKey(t, ctx, ti, orgID, openrouter.KeyTypeChat)
-	require.Nil(t, key.DisableCauses)
-	require.True(t, key.Disabled, "NULL cause state remains fail-closed")
-	require.Empty(t, ti.provisioner.reconciled)
-}
-
 func TestDemoteExpiredTrials_AuditFailureRollsBackLifecycleCausesAndOutbox(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/openrouterkeys/keys_test.go
+++ b/server/internal/openrouterkeys/keys_test.go
@@ -45,14 +45,6 @@ func TestStubProvisionerDisableCausesMirrorLocalState(t *testing.T) {
 	ctx, ti := newTestService(t)
 	orgID := seedKey(t, ctx, ti, "stub-causes", string(openrouter.KeyTypeChat), "sk-or-stub-causes")
 	queries := orgrepo.New(ti.conn)
-	require.NoError(t, testrepo.New(ti.conn).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{
-		OrganizationID: orgID, KeyType: string(openrouter.KeyTypeChat), Disabled: false, DisableCauses: nil,
-	}))
-
-	_, err := ti.provisioner.AddAPIKeyDisableCause(ctx, orgID, openrouter.KeyTypeChat, openrouter.DisableCauseAdminLock)
-	require.ErrorContains(t, err, "unclassified")
-	_, _, err = ti.provisioner.RemoveAPIKeyDisableCause(ctx, orgID, openrouter.KeyTypeChat, openrouter.DisableCauseAdminLock, nil)
-	require.ErrorContains(t, err, "unclassified")
 	change, err := ti.provisioner.AddAPIKeyDisableCause(ctx, "missing-org", openrouter.KeyTypeChat, openrouter.DisableCauseAdminLock)
 	require.NoError(t, err)
 	require.Equal(t, openrouter.DisableCauseChange{}, change)
@@ -933,26 +925,19 @@ func TestAdminDisableCauseSingleAndOverlappingTransitions(t *testing.T) {
 	require.Equal(t, []string{"billing_inactive"}, view.DisableCauses)
 }
 
-func TestAdminCauseMutationNULLFailsClosedAndMissing404s(t *testing.T) {
+func TestAdminCauseMutationMissingOrg404s(t *testing.T) {
 	t.Parallel()
 
 	ctx, ti := newTestService(t)
 	adminCtx := withAdmin(t, ctx)
-	orgID := seedKey(t, ctx, ti, "admin-null", "chat", "sk-or-admin-null")
-	setDisableCauses(t, ctx, ti, orgID, "chat", nil)
 
-	_, err := ti.service.DisableKey(adminCtx, &gen.DisableKeyPayload{OrganizationID: orgID, KeyType: "chat"})
-	requireOopsCode(t, err, oops.CodeUnexpected)
-	_, err = ti.service.EnableKey(adminCtx, &gen.EnableKeyPayload{OrganizationID: orgID, KeyType: "chat"})
-	requireOopsCode(t, err, oops.CodeUnexpected)
-
-	_, err = ti.service.DisableKey(adminCtx, &gen.DisableKeyPayload{OrganizationID: "missing-org", KeyType: "chat"})
+	_, err := ti.service.DisableKey(adminCtx, &gen.DisableKeyPayload{OrganizationID: "missing-org", KeyType: "chat"})
 	requireOopsCode(t, err, oops.CodeNotFound)
 	_, err = ti.service.EnableKey(adminCtx, &gen.EnableKeyPayload{OrganizationID: "missing-org", KeyType: "chat"})
 	requireOopsCode(t, err, oops.CodeNotFound)
 	completes, aborts := ti.coordinator.Counts()
 	require.Zero(t, completes, "permanent local failures must not occupy reconciliation")
-	require.Equal(t, 4, aborts)
+	require.Equal(t, 2, aborts)
 }
 
 func TestAdminCauseRetriesAreIdempotent(t *testing.T) {

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -1071,3 +1071,22 @@ RETURNING id;
 INSERT INTO meta_mcp_servers (id, organization_id, project_id, name)
 VALUES (@id, @organization_id, @project_id, @name)
 RETURNING id;
+
+-- name: GetOpenRouterAPIKeyDisableCausesColumnFixture :one
+-- Test-only: observes the disable_causes column contract.
+SELECT is_nullable::text AS is_nullable, column_default::text AS column_default
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND table_name = 'openrouter_api_keys'
+  AND column_name = 'disable_causes';
+
+-- name: InsertOpenRouterAPIKeyOmittingDisableCausesFixture :one
+-- Test-only: insert that relies on the column default.
+INSERT INTO openrouter_api_keys (organization_id, key_type, key_hash)
+VALUES (@organization_id, @key_type, @key_hash)
+RETURNING disable_causes;
+
+-- name: InsertOpenRouterAPIKeyNullDisableCausesFixture :exec
+-- Test-only: explicit NULL write used to prove the NOT NULL contract.
+INSERT INTO openrouter_api_keys (organization_id, key_type, key_hash, disable_causes)
+VALUES (@organization_id, @key_type, @key_hash, NULL);

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -787,6 +787,27 @@ func (q *Queries) GetLatestTrialArmAuditIDFixture(ctx context.Context, organizat
 	return id, err
 }
 
+const getOpenRouterAPIKeyDisableCausesColumnFixture = `-- name: GetOpenRouterAPIKeyDisableCausesColumnFixture :one
+SELECT is_nullable::text AS is_nullable, column_default::text AS column_default
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND table_name = 'openrouter_api_keys'
+  AND column_name = 'disable_causes'
+`
+
+type GetOpenRouterAPIKeyDisableCausesColumnFixtureRow struct {
+	IsNullable    string
+	ColumnDefault string
+}
+
+// Test-only: observes the disable_causes column contract.
+func (q *Queries) GetOpenRouterAPIKeyDisableCausesColumnFixture(ctx context.Context) (GetOpenRouterAPIKeyDisableCausesColumnFixtureRow, error) {
+	row := q.db.QueryRow(ctx, getOpenRouterAPIKeyDisableCausesColumnFixture)
+	var i GetOpenRouterAPIKeyDisableCausesColumnFixtureRow
+	err := row.Scan(&i.IsNullable, &i.ColumnDefault)
+	return i, err
+}
+
 const getOpenRouterAPIKeyStateFixture = `-- name: GetOpenRouterAPIKeyStateFixture :one
 SELECT key_hash, monthly_credits, disabled, disable_causes, deleted
 FROM openrouter_api_keys
@@ -1379,6 +1400,43 @@ type InsertNetworkIngressFixtureParams struct {
 func (q *Queries) InsertNetworkIngressFixture(ctx context.Context, arg InsertNetworkIngressFixtureParams) error {
 	_, err := q.db.Exec(ctx, insertNetworkIngressFixture, arg.ID, arg.OrganizationID, arg.DnsName)
 	return err
+}
+
+const insertOpenRouterAPIKeyNullDisableCausesFixture = `-- name: InsertOpenRouterAPIKeyNullDisableCausesFixture :exec
+INSERT INTO openrouter_api_keys (organization_id, key_type, key_hash, disable_causes)
+VALUES ($1, $2, $3, NULL)
+`
+
+type InsertOpenRouterAPIKeyNullDisableCausesFixtureParams struct {
+	OrganizationID string
+	KeyType        string
+	KeyHash        string
+}
+
+// Test-only: explicit NULL write used to prove the NOT NULL contract.
+func (q *Queries) InsertOpenRouterAPIKeyNullDisableCausesFixture(ctx context.Context, arg InsertOpenRouterAPIKeyNullDisableCausesFixtureParams) error {
+	_, err := q.db.Exec(ctx, insertOpenRouterAPIKeyNullDisableCausesFixture, arg.OrganizationID, arg.KeyType, arg.KeyHash)
+	return err
+}
+
+const insertOpenRouterAPIKeyOmittingDisableCausesFixture = `-- name: InsertOpenRouterAPIKeyOmittingDisableCausesFixture :one
+INSERT INTO openrouter_api_keys (organization_id, key_type, key_hash)
+VALUES ($1, $2, $3)
+RETURNING disable_causes
+`
+
+type InsertOpenRouterAPIKeyOmittingDisableCausesFixtureParams struct {
+	OrganizationID string
+	KeyType        string
+	KeyHash        string
+}
+
+// Test-only: insert that relies on the column default.
+func (q *Queries) InsertOpenRouterAPIKeyOmittingDisableCausesFixture(ctx context.Context, arg InsertOpenRouterAPIKeyOmittingDisableCausesFixtureParams) ([]string, error) {
+	row := q.db.QueryRow(ctx, insertOpenRouterAPIKeyOmittingDisableCausesFixture, arg.OrganizationID, arg.KeyType, arg.KeyHash)
+	var disable_causes []string
+	err := row.Scan(&disable_causes)
+	return disable_causes, err
 }
 
 const insertOrganizationTierUserSessionIssuerFixture = `-- name: InsertOrganizationTierUserSessionIssuerFixture :one

--- a/server/internal/thirdparty/openrouter/disable_causes_not_null_test.go
+++ b/server/internal/thirdparty/openrouter/disable_causes_not_null_test.go
@@ -1,0 +1,110 @@
+package openrouter
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter/repo"
+)
+
+func TestDisableCausesColumnIsNotNullWithEmptyDefault(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	provisioner, _, _ := newDisableTestProvisioner(t, "org-"+uuid.NewString()[:8])
+	column, err := testrepo.New(provisioner.db).GetOpenRouterAPIKeyDisableCausesColumnFixture(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "NO", column.IsNullable)
+	require.Contains(t, column.ColumnDefault, "{}")
+}
+
+func TestCreateOpenRouterAPIKeyWritesEmptyDisableCauses(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	_, _, queries := newDisableTestProvisioner(t, orgID)
+
+	row, err := queries.CreateOpenRouterAPIKey(ctx, repo.CreateOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeChat),
+		KeyEncrypted:   pgtype.Text{String: "ciphertext", Valid: true},
+		KeyHash:        "hash-" + orgID,
+		MonthlyCredits: 5,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, row.DisableCauses)
+	require.Empty(t, row.DisableCauses)
+	require.False(t, row.Disabled)
+}
+
+func TestInsertOmittingDisableCausesUsesEmptyDefault(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, _, _ := newDisableTestProvisioner(t, orgID)
+
+	causes, err := testrepo.New(provisioner.db).InsertOpenRouterAPIKeyOmittingDisableCausesFixture(ctx, testrepo.InsertOpenRouterAPIKeyOmittingDisableCausesFixtureParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeInternal),
+		KeyHash:        "hash-default-" + orgID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, causes)
+	require.Empty(t, causes)
+}
+
+func TestNullDisableCausesWritesAreRejected(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	orgID := "org-" + uuid.NewString()[:8]
+	provisioner, _, queries := newDisableTestProvisioner(t, orgID)
+	fixtures := testrepo.New(provisioner.db)
+
+	err := fixtures.InsertOpenRouterAPIKeyNullDisableCausesFixture(ctx, testrepo.InsertOpenRouterAPIKeyNullDisableCausesFixtureParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeChat),
+		KeyHash:        "hash-null-" + orgID,
+	})
+	requireNotNullDisableCauses(t, err)
+
+	_, err = queries.CreateOpenRouterAPIKey(ctx, repo.CreateOpenRouterAPIKeyParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeChat),
+		KeyEncrypted:   pgtype.Text{String: "ciphertext", Valid: true},
+		KeyHash:        "hash-" + orgID,
+		MonthlyCredits: 5,
+	})
+	require.NoError(t, err)
+
+	err = fixtures.SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{
+		OrganizationID: orgID,
+		KeyType:        string(KeyTypeChat),
+		Disabled:       true,
+		DisableCauses:  nil,
+	})
+	requireNotNullDisableCauses(t, err)
+
+	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
+	require.NoError(t, err)
+	require.NotNil(t, row.DisableCauses)
+	require.Empty(t, row.DisableCauses)
+	require.False(t, row.Disabled)
+}
+
+func requireNotNullDisableCauses(t *testing.T, err error) {
+	t.Helper()
+
+	var pgErr *pgconn.PgError
+	require.ErrorAs(t, err, &pgErr)
+	require.Equal(t, pgerrcode.NotNullViolation, pgErr.Code)
+	require.Equal(t, "disable_causes", pgErr.ColumnName)
+}

--- a/server/internal/thirdparty/openrouter/disable_test.go
+++ b/server/internal/thirdparty/openrouter/disable_test.go
@@ -470,19 +470,6 @@ func TestDisableOpenRouterAPIKeyLegacyQueryPreservesClassification(t *testing.T)
 	})
 	require.NoError(t, err)
 	require.Equal(t, []string{string(DisableCauseAdminLock), string(DisableCauseTrialDemotion)}, row.DisableCauses)
-
-	require.NoError(t, testrepo.New(provisioner.db).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{
-		OrganizationID: orgID, KeyType: string(KeyTypeInternal), Disabled: true, DisableCauses: nil,
-	}))
-	require.NoError(t, queries.DisableOpenRouterAPIKey(ctx, repo.DisableOpenRouterAPIKeyParams{
-		OrganizationID: orgID, KeyType: string(KeyTypeInternal),
-	}))
-	row, err = queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
-		OrganizationID: orgID, KeyType: string(KeyTypeInternal),
-	})
-	require.NoError(t, err)
-	require.Nil(t, row.DisableCauses)
-	require.True(t, row.Disabled)
 }
 
 func TestDisableAPIKey_PreservesClassifiedCausesAndRejectsUnclassifiedRows(t *testing.T) {
@@ -504,28 +491,6 @@ func TestDisableAPIKey_PreservesClassifiedCausesAndRejectsUnclassifiedRows(t *te
 		})
 		require.NoError(t, err)
 		require.Equal(t, []string{string(DisableCauseAdminLock), string(DisableCauseTrialDemotion)}, row.DisableCauses)
-	})
-
-	t.Run("unclassified remains fail closed", func(t *testing.T) {
-		t.Parallel()
-		ctx := t.Context()
-		orgID := "org-" + uuid.NewString()[:8]
-		provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
-		_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeInternal)
-		require.NoError(t, err)
-		require.NoError(t, testrepo.New(provisioner.db).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{
-			OrganizationID: orgID, KeyType: string(KeyTypeInternal), Disabled: true, DisableCauses: nil,
-		}))
-
-		err = provisioner.DisableAPIKey(ctx, orgID, KeyTypeInternal)
-		require.ErrorIs(t, err, ErrAPIKeyDisableCausesUnclassified)
-		require.Empty(t, upstream.recorded())
-		row, getErr := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
-			OrganizationID: orgID, KeyType: string(KeyTypeInternal),
-		})
-		require.NoError(t, getErr)
-		require.Nil(t, row.DisableCauses)
-		require.True(t, row.Disabled)
 	})
 }
 
@@ -592,61 +557,6 @@ func TestRefreshAPIKeyLimit_PreservesClassifiedDisableCauses(t *testing.T) {
 	}
 }
 
-func TestReinstateAPIKeyLimit_DoesNotEnableAfterLegacyClassificationWins(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-	orgID := "org-" + uuid.NewString()[:8]
-	provisioner, upstream, _ := newDisableTestProvisioner(t, orgID)
-	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeInternal)
-	require.NoError(t, err)
-	require.NoError(t, testrepo.New(provisioner.db).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{
-		OrganizationID: orgID, KeyType: string(KeyTypeInternal), Disabled: true, DisableCauses: nil,
-	}))
-
-	classifier := testenv.BeginTx(t, ctx, provisioner.db)
-	require.NoError(t, repo.New(classifier).AcquireOpenRouterBillingLock(ctx, repo.AcquireOpenRouterBillingLockParams{
-		OrganizationID: orgID, KeyType: string(KeyTypeInternal),
-	}))
-
-	patchStarted := make(chan struct{})
-	releasePatch := make(chan struct{})
-	var patchOnce sync.Once
-	upstream.interceptPatch(func() {
-		patchOnce.Do(func() { close(patchStarted) })
-		<-releasePatch
-	})
-
-	refreshDone := make(chan error, 1)
-	go func() {
-		_, refreshErr := provisioner.ReinstateAPIKeyLimit(ctx, orgID, KeyTypeInternal, nil)
-		refreshDone <- refreshErr
-	}()
-
-	select {
-	case <-patchStarted:
-		// The legacy implementation reads before joining the classifier's lock.
-	case <-time.After(150 * time.Millisecond):
-	}
-	require.NoError(t, testrepo.New(classifier).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{
-		OrganizationID: orgID, KeyType: string(KeyTypeInternal), Disabled: true, DisableCauses: []string{string(DisableCauseAdminLock)},
-	}))
-	require.NoError(t, classifier.Commit(ctx))
-
-	select {
-	case <-patchStarted:
-	case <-time.After(time.Second):
-		require.FailNow(t, "reinstate did not reach upstream after classification committed")
-	}
-	close(releasePatch)
-	require.NoError(t, <-refreshDone)
-
-	patches := upstream.recorded()
-	require.Len(t, patches, 1)
-	require.JSONEq(t, `{"limit":5,"limit_reset":"monthly"}`, patches[0],
-		"a classified cause must prevent the stale legacy read from enabling upstream")
-}
-
 func TestReinstateAPIKeyLimitWithDB_ReentersTransactionBillingLock(t *testing.T) {
 	t.Parallel()
 
@@ -655,9 +565,6 @@ func TestReinstateAPIKeyLimitWithDB_ReentersTransactionBillingLock(t *testing.T)
 	provisioner, _, _ := newDisableTestProvisioner(t, orgID)
 	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeInternal)
 	require.NoError(t, err)
-	require.NoError(t, testrepo.New(provisioner.db).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{
-		OrganizationID: orgID, KeyType: string(KeyTypeInternal), Disabled: true, DisableCauses: nil,
-	}))
 
 	tx := testenv.BeginTx(t, ctx, provisioner.db)
 	require.NoError(t, repo.New(tx).AcquireOpenRouterBillingLock(ctx, repo.AcquireOpenRouterBillingLockParams{
@@ -667,36 +574,8 @@ func TestReinstateAPIKeyLimitWithDB_ReentersTransactionBillingLock(t *testing.T)
 	callCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	_, err = provisioner.ReinstateAPIKeyLimitWithDB(callCtx, tx, orgID, KeyTypeInternal, nil)
-	require.ErrorIs(t, err, ErrAPIKeyDisableCausesUnclassified)
+	require.NoError(t, err)
 	require.NoError(t, tx.Commit(ctx))
-}
-
-func TestRefreshAPIKeyLimit_LegacyUnclassifiedDisabledKeyFailsClosed(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-	orgID := "org-" + uuid.NewString()[:8]
-	provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
-
-	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeInternal)
-	require.NoError(t, err)
-	require.NoError(t, testrepo.New(provisioner.db).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{
-		OrganizationID: orgID, KeyType: string(KeyTypeInternal), Disabled: true, DisableCauses: nil,
-	}))
-
-	limit := 42
-	refreshed, err := provisioner.RefreshAPIKeyLimit(ctx, orgID, KeyTypeInternal, &limit)
-	require.ErrorIs(t, err, ErrAPIKeyDisableCausesUnclassified)
-	require.Zero(t, refreshed)
-	require.Empty(t, upstream.recorded())
-
-	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
-		OrganizationID: orgID, KeyType: string(KeyTypeInternal),
-	})
-	require.NoError(t, err)
-	require.True(t, row.Disabled)
-	require.Nil(t, row.DisableCauses)
-	require.Equal(t, int64(5), row.MonthlyCredits)
 }
 
 // A refresh reads the key row, patches upstream, then writes the row back. A
@@ -1015,38 +894,6 @@ func TestRefreshAPIKeyLimit_NilPreservesPaygZeroSpendCap(t *testing.T) {
 			require.False(t, row.Disabled)
 		})
 	}
-}
-
-func TestReinstateAPIKeyLimit_LegacyUnclassifiedDisabledKeyFailsClosed(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-	orgID := "org-" + uuid.NewString()[:8]
-	provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
-
-	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
-	require.NoError(t, err)
-	require.NoError(t, queries.UpdateOpenRouterKeyMonthlyCredits(ctx, repo.UpdateOpenRouterKeyMonthlyCreditsParams{
-		OrganizationID: orgID,
-		KeyType:        string(KeyTypeChat),
-		MonthlyCredits: 0,
-	}))
-	require.NoError(t, testrepo.New(provisioner.db).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{
-		OrganizationID: orgID, KeyType: string(KeyTypeChat), Disabled: true, DisableCauses: nil,
-	}))
-
-	refreshed, err := provisioner.ReinstateAPIKeyLimit(ctx, orgID, KeyTypeChat, nil)
-	require.ErrorIs(t, err, ErrAPIKeyDisableCausesUnclassified)
-	require.Zero(t, refreshed)
-	require.Empty(t, upstream.recorded())
-
-	row, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{
-		OrganizationID: orgID, KeyType: string(KeyTypeChat),
-	})
-	require.NoError(t, err)
-	require.True(t, row.Disabled)
-	require.Nil(t, row.DisableCauses)
-	require.Zero(t, row.MonthlyCredits)
 }
 
 func TestRefreshAPIKeyLimit_ExplicitLimitRepairsLegacyEnabledZeroKey(t *testing.T) {

--- a/server/internal/thirdparty/openrouter/disable_test.go
+++ b/server/internal/thirdparty/openrouter/disable_test.go
@@ -472,7 +472,7 @@ func TestDisableOpenRouterAPIKeyLegacyQueryPreservesClassification(t *testing.T)
 	require.Equal(t, []string{string(DisableCauseAdminLock), string(DisableCauseTrialDemotion)}, row.DisableCauses)
 }
 
-func TestDisableAPIKey_PreservesClassifiedCausesAndRejectsUnclassifiedRows(t *testing.T) {
+func TestDisableAPIKey_PreservesClassifiedCauses(t *testing.T) {
 	t.Parallel()
 
 	t.Run("preserves existing causes", func(t *testing.T) {

--- a/server/internal/thirdparty/openrouter/enterprise_trial_conversion_test.go
+++ b/server/internal/thirdparty/openrouter/enterprise_trial_conversion_test.go
@@ -134,14 +134,6 @@ func TestPrepareEnterpriseTrialConversionKeyWithDBConcurrentGuardFailure(t *test
 			wantCauses: []string{"trial_demotion"},
 		},
 		{
-			name: "current causes become unclassified",
-			hook: func(ctx context.Context, db DBTX, orgID string) error {
-				return testrepo.New(db).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{OrganizationID: orgID, KeyType: string(KeyTypeChat), Disabled: true, DisableCauses: nil})
-			},
-			wantHash:   func(orgID string) string { return "hash-" + orgID },
-			wantCauses: nil,
-		},
-		{
 			name: "current row becomes soft deleted",
 			hook: func(ctx context.Context, db DBTX, orgID string) error {
 				return testrepo.New(db).SoftDeleteOpenRouterAPIKeyFixture(ctx, testrepo.SoftDeleteOpenRouterAPIKeyFixtureParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
@@ -178,32 +170,4 @@ func TestPrepareEnterpriseTrialConversionKeyWithDBConcurrentGuardFailure(t *test
 			require.Zero(t, upstream.requestCount())
 		})
 	}
-}
-
-func TestPrepareEnterpriseTrialConversionKeyWithDBNullFailsClosed(t *testing.T) {
-	t.Parallel()
-
-	ctx := t.Context()
-	orgID := "org-" + uuid.NewString()[:8]
-	provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
-	_, err := queries.CreateOpenRouterAPIKey(ctx, repo.CreateOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat), KeyEncrypted: pgtype.Text{String: "ciphertext", Valid: true}, KeyHash: "hash-" + orgID, MonthlyCredits: 5})
-	require.NoError(t, err)
-	require.NoError(t, testrepo.New(provisioner.db).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{OrganizationID: orgID, KeyType: string(KeyTypeChat), Disabled: true, DisableCauses: nil}))
-
-	tx := testenv.BeginTx(t, ctx, provisioner.db)
-	_, err = provisioner.PrepareEnterpriseTrialConversionKeyWithDB(ctx, tx, orgID, KeyTypeChat, 50)
-	require.ErrorContains(t, err, "disable causes are unclassified")
-	inTransaction, err := repo.New(tx).GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
-	require.NoError(t, err)
-	require.Nil(t, inTransaction.DisableCauses)
-	require.True(t, inTransaction.Disabled)
-	require.EqualValues(t, 5, inTransaction.MonthlyCredits, "unclassified preparation must perform no write even before rollback")
-	require.NoError(t, tx.Rollback(ctx))
-
-	after, err := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
-	require.NoError(t, err)
-	require.Nil(t, after.DisableCauses)
-	require.True(t, after.Disabled)
-	require.EqualValues(t, 5, after.MonthlyCredits)
-	require.Zero(t, upstream.requestCount())
 }

--- a/server/internal/thirdparty/openrouter/remove_disable_cause_test.go
+++ b/server/internal/thirdparty/openrouter/remove_disable_cause_test.go
@@ -384,58 +384,17 @@ func TestRemoveAPIKeyDisableCauseUsesCanonicalDistinctCauses(t *testing.T) {
 	})
 }
 
-func TestReconcileAPIKeyDisabledWithDBNullFailsClosed(t *testing.T) {
+func TestRemoveAPIKeyDisableCauseMissingKeyIsNoop(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
 	orgID := "org-" + uuid.NewString()[:8]
 	provisioner, upstream, _ := newDisableTestProvisioner(t, orgID)
-	_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
+	limit, change, err := provisioner.RemoveAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseAdminLock, nil)
 	require.NoError(t, err)
-	require.NoError(t, testrepo.New(provisioner.db).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{
-		OrganizationID: orgID, KeyType: string(KeyTypeChat), Disabled: true, DisableCauses: nil,
-	}))
-	patchesBefore := len(upstream.recorded())
-
-	err = provisioner.ReconcileAPIKeyDisabledWithDB(ctx, provisioner.db, orgID, KeyTypeChat)
-	require.ErrorContains(t, err, "disable causes are unclassified")
-	require.Len(t, upstream.recorded(), patchesBefore)
-}
-
-func TestRemoveAPIKeyDisableCauseMissingAndUnclassifiedFailClosed(t *testing.T) {
-	t.Parallel()
-
-	t.Run("missing key is a no-op", func(t *testing.T) {
-		t.Parallel()
-
-		ctx := t.Context()
-		orgID := "org-" + uuid.NewString()[:8]
-		provisioner, upstream, _ := newDisableTestProvisioner(t, orgID)
-		limit, change, err := provisioner.RemoveAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseAdminLock, nil)
-		require.NoError(t, err)
-		require.Zero(t, limit)
-		require.Equal(t, DisableCauseChange{}, change)
-		require.Empty(t, upstream.recorded())
-	})
-
-	t.Run("NULL classification fails closed", func(t *testing.T) {
-		t.Parallel()
-
-		ctx := t.Context()
-		orgID := "org-" + uuid.NewString()[:8]
-		provisioner, upstream, queries := newDisableTestProvisioner(t, orgID)
-		_, err := provisioner.ProvisionAPIKey(ctx, orgID, KeyTypeChat)
-		require.NoError(t, err)
-		require.NoError(t, testrepo.New(provisioner.db).SetOpenRouterAPIKeyClassificationFixture(ctx, testrepo.SetOpenRouterAPIKeyClassificationFixtureParams{OrganizationID: orgID, KeyType: string(KeyTypeChat), Disabled: true, DisableCauses: nil}))
-
-		_, _, err = provisioner.RemoveAPIKeyDisableCause(ctx, orgID, KeyTypeChat, DisableCauseAdminLock, nil)
-		require.ErrorContains(t, err, "unclassified")
-		require.Empty(t, upstream.recorded())
-		row, getErr := queries.GetOpenRouterAPIKey(ctx, repo.GetOpenRouterAPIKeyParams{OrganizationID: orgID, KeyType: string(KeyTypeChat)})
-		require.NoError(t, getErr)
-		require.Nil(t, row.DisableCauses)
-		require.True(t, row.Disabled)
-	})
+	require.Zero(t, limit)
+	require.Equal(t, DisableCauseChange{}, change)
+	require.Empty(t, upstream.recorded())
 }
 
 func TestRemoveAPIKeyDisableCauseUpstreamFailureAndHashMismatchLeaveLocalUnchanged(t *testing.T) {

--- a/server/internal/usage/spend_cap_test.go
+++ b/server/internal/usage/spend_cap_test.go
@@ -217,7 +217,6 @@ func TestDisablePaygOpenRouterChatKeyPreservesClassification(t *testing.T) {
 		disableCauses []string
 		wantCauses    []string
 	}{
-		{name: "legacy unclassified", disableCauses: nil, wantCauses: nil},
 		{name: "classified empty", disableCauses: []string{}, wantCauses: []string{"billing_inactive"}},
 		{name: "classified admin lock", disableCauses: []string{"admin_lock"}, wantCauses: []string{"admin_lock", "billing_inactive"}},
 	}

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -2275,31 +2275,6 @@ func TestStripeSubscriptionDeletionAddsOnlyBillingInactiveCause(t *testing.T) {
 	require.EqualValues(t, 321, chat.MonthlyCredits)
 }
 
-func TestStripeSubscriptionDeletionRejectsUnclassifiedKeyAndRollsBackAtomically(t *testing.T) {
-	t.Parallel()
-
-	service, db := newStripeWebhookService(t, "customer_placeholder", nil)
-	configurePaygSubscriptionDeletion(t, service, "event_unclassified_key", "subscription_current", "subscription_current")
-	createOpenRouterKeyFixture(t, db, openrouter.KeyTypeChat, 321)
-	setOpenRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat, false, nil, 321)
-
-	require.Equal(t, http.StatusInternalServerError, serveStripeWebhook(service, "deactivate").Code)
-
-	metadata, err := repo.New(db).GetBillingMetadata(t.Context(), stripeWebhookOrganizationID)
-	require.NoError(t, err)
-	require.Equal(t, "subscription_current", metadata.StripeSubscriptionID.String)
-	organization, err := orgrepo.New(db).GetOrganizationMetadata(t.Context(), stripeWebhookOrganizationID)
-	require.NoError(t, err)
-	require.Equal(t, "payg", organization.GramAccountType)
-	require.True(t, organization.Whitelisted)
-	chat := openRouterKeyLifecycleFixture(t, db, openrouter.KeyTypeChat)
-	require.Nil(t, chat.DisableCauses)
-	require.False(t, chat.Disabled)
-	require.EqualValues(t, 321, chat.MonthlyCredits)
-	require.Zero(t, stripeWebhookReceiptCount(t, db))
-	require.Zero(t, organizationBillingActionIntentCount(t, db, audit.ActionOrganizationPaygDeactivated))
-}
-
 func TestStripeSubscriptionDeletionPostCommitReconcileFailurePreservesDurableIntent(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
GRW-67 (INC-452 follow-up). Stacked on the migration that makes `openrouter_api_keys.disable_causes` `NOT NULL`.

## Summary

Adds focused catalog and write-path coverage for the new constraint: the column is `NOT NULL` with a `{}` default, create/omit writes an empty non-nil array, and explicit NULL insert/update is rejected with `23502` on `disable_causes`.

Drops tests that seeded unclassified (`NULL`) keys, because those inserts cannot succeed after the constraint. The one-off classifier runner fixtures skip until that package is removed in a later cleanup. Remaining fail-closed coverage stays on empty arrays and missing orgs.

No schema or migration files in this PR.

## Motivation

Repo hygiene requires migrations to ship alone. The migration PR fails server tests that still insert `NULL` disable causes; those fixtures belong here, stacked on top of the schema change.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [GRW-67](https://linear.app/speakeasy/issue/GRW-67/mig-enforce-non-null-openrouter-disable-causes)

<div><a href="https://cursor.com/agents/bc-62414339-d6a2-4822-8c41-f9a59c97eef0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62414339-d6a2-4822-8c41-f9a59c97eef0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates OpenRouter tests for the `disable_causes` NOT NULL constraint so the suite passes after the migration that enforces it (GRW-67).

- Adds coverage asserting the column is NOT NULL with an empty-array default, that create and omit writes store an empty non-nil array, and that explicit NULL insert/update fails with `23502`.
- Removes tests that seeded NULL `disable_causes`, since those inserts can no longer succeed.
- Skips the one-off classifier runner fixtures until that package is removed; remaining fail-closed coverage stays on empty arrays and missing orgs.
- Contains no schema or migration changes; the migration ships separately.

<sup>Written for commit 5cad761e3d1c29fb13d51879b1c81791dab9279e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

