### PR TITLE
mig: recognize inference hook surfaces in adoption analytics

### DIFF
--- a/.changeset/inference-hook-adoption-surfaces.md
+++ b/.changeset/inference-hook-adoption-surfaces.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Recognize Claude Chat Web and Claude Code Web in weekly AI surface adoption analytics.

--- a/server/clickhouse/local/golang_migrate/20260909194428_add-inference-hook-surfaces.down.sql
+++ b/server/clickhouse/local/golang_migrate/20260909194428_add-inference-hook-surfaces.down.sql
@@ -1,0 +1,6 @@
+-- reverse: modify "weekly_ai_surface_adoption" view
+CREATE OR REPLACE VIEW `marts`.`weekly_ai_surface_adoption` (
+  `week_start` Date,
+  `surface` String,
+  `active_users` UInt64
+) DEFINER = `marts_definer` SQL SECURITY DEFINER AS WITH lowerUTF8(trimBoth(user_email)) AS normalized_email SELECT toMonday(time_bucket) AS week_start, if((hook_source IN ('claude-code', 'claude-chat', 'chatgpt', 'chatgpt-work', 'codex', 'cowork', 'cursor', 'litellm', 'local', 'mcp', 'openclaw', 'opencode')), hook_source, 'other') AS surface, uniqExactIf(normalized_email, normalized_email != '') AS active_users FROM gram.attribute_metrics_summaries WHERE (is_active = 1) AND (time_bucket >= toDateTime(toMonday(now('UTC')) - toIntervalWeek(12), 'UTC')) AND (time_bucket < toDateTime(toMonday(now('UTC')), 'UTC')) AND (hook_source NOT IN ('', 'assistants', 'chat-analysis', 'elements', 'gram', 'mcp-research', 'playground', 'risk-analysis', 'skill-efficacy', 'skill-suggestions', 'slack')) GROUP BY week_start, surface HAVING active_users >= 10;

--- a/server/clickhouse/local/golang_migrate/20260909194428_add-inference-hook-surfaces.up.sql
+++ b/server/clickhouse/local/golang_migrate/20260909194428_add-inference-hook-surfaces.up.sql
@@ -1,0 +1,6 @@
+-- modify "weekly_ai_surface_adoption" view
+CREATE OR REPLACE VIEW `marts`.`weekly_ai_surface_adoption` (
+  `week_start` Date,
+  `surface` String,
+  `active_users` UInt64
+) DEFINER = `marts_definer` SQL SECURITY DEFINER AS WITH lowerUTF8(trimBoth(user_email)) AS normalized_email SELECT toMonday(time_bucket) AS week_start, if((hook_source IN ('claude-code', 'claude-code-web', 'claude-chat', 'claude-chat-web', 'chatgpt', 'chatgpt-work', 'codex', 'cowork', 'cursor', 'litellm', 'local', 'mcp', 'openclaw', 'opencode')), hook_source, 'other') AS surface, uniqExactIf(normalized_email, normalized_email != '') AS active_users FROM gram.attribute_metrics_summaries WHERE (is_active = 1) AND (time_bucket >= toDateTime(toMonday(now('UTC')) - toIntervalWeek(12), 'UTC')) AND (time_bucket < toDateTime(toMonday(now('UTC')), 'UTC')) AND (hook_source NOT IN ('', 'assistants', 'chat-analysis', 'elements', 'gram', 'mcp-research', 'playground', 'risk-analysis', 'skill-efficacy', 'skill-suggestions', 'slack')) GROUP BY week_start, surface HAVING active_users >= 10;

--- a/server/clickhouse/local/golang_migrate/atlas.sum
+++ b/server/clickhouse/local/golang_migrate/atlas.sum
@@ -1,4 +1,4 @@
-h1:RNpXU5O5iNZVWVohi0SSGN/GHMFelNzcz72kNmd4l1c=
+h1:JISje20lvk8IjCW1MNs60yJgs9NFayVVF+D8ObVjQb4=
 20251127155815_initial_golang_migrate.up.sql h1:fkATa14aucJEoldFi1VgW7TRT8gyC6NGe1Hq/OzXVuI=
 20251208142630_add-tool-logs-table.up.sql h1:cGJCiWBvLPFwOlpx0jYYLgdPZD21+gKSF/x4mVksBcI=
 20251209104438_add-id-col-to-tool-logs-table.up.sql h1:+Ubsl1ZKfeCZL9dBhohUnkBksKZj6nwdZSXm7WwowaE=
@@ -105,3 +105,4 @@ h1:RNpXU5O5iNZVWVohi0SSGN/GHMFelNzcz72kNmd4l1c=
 20260907100046_normalize-mart-email-identities.up.sql h1:ZHh7Sr1NtGNegBrmEXkAT/rMwVcabEFJXz94ERhPM0g=
 20260907100756_include-supported-chat-surfaces.up.sql h1:QtoqiWXGECI0f5kwzsV79kKL9EIGx9prQFB0aRSPGw0=
 20260908155707_preserve-trace-tool-name.up.sql h1:fsOD0y5BjF6BclA2dK+eXU+xuOtML1dtFcdVvl7qwPY=
+20260909194428_add-inference-hook-surfaces.up.sql h1:opToxCEIvOGzUxIuWodGaU6ebfJfBML4ENt2+eDwCok=

--- a/server/clickhouse/mart.sql
+++ b/server/clickhouse/mart.sql
@@ -18,7 +18,7 @@ WITH lowerUTF8(trimBoth(user_email)) AS normalized_email
 SELECT
     toMonday(time_bucket) AS week_start,
     if(
-        hook_source IN ('claude-code', 'claude-chat', 'chatgpt', 'chatgpt-work', 'codex', 'cowork', 'cursor', 'litellm', 'local', 'mcp', 'openclaw', 'opencode'),
+        hook_source IN ('claude-code', 'claude-code-web', 'claude-chat', 'claude-chat-web', 'chatgpt', 'chatgpt-work', 'codex', 'cowork', 'cursor', 'litellm', 'local', 'mcp', 'openclaw', 'opencode'),
         hook_source,
         'other'
     ) AS surface,

--- a/server/clickhouse/migrations/20260909194424_add-inference-hook-surfaces.sql
+++ b/server/clickhouse/migrations/20260909194424_add-inference-hook-surfaces.sql
@@ -1,0 +1,6 @@
+-- Modify "weekly_ai_surface_adoption" view
+CREATE OR REPLACE VIEW `marts`.`weekly_ai_surface_adoption` (
+  `week_start` Date,
+  `surface` String,
+  `active_users` UInt64
+) DEFINER = `marts_definer` SQL SECURITY DEFINER AS WITH lowerUTF8(trimBoth(user_email)) AS normalized_email SELECT toMonday(time_bucket) AS week_start, if((hook_source IN ('claude-code', 'claude-code-web', 'claude-chat', 'claude-chat-web', 'chatgpt', 'chatgpt-work', 'codex', 'cowork', 'cursor', 'litellm', 'local', 'mcp', 'openclaw', 'opencode')), hook_source, 'other') AS surface, uniqExactIf(normalized_email, normalized_email != '') AS active_users FROM gram.attribute_metrics_summaries WHERE (is_active = 1) AND (time_bucket >= toDateTime(toMonday(now('UTC')) - toIntervalWeek(12), 'UTC')) AND (time_bucket < toDateTime(toMonday(now('UTC')), 'UTC')) AND (hook_source NOT IN ('', 'assistants', 'chat-analysis', 'elements', 'gram', 'mcp-research', 'playground', 'risk-analysis', 'skill-efficacy', 'skill-suggestions', 'slack')) GROUP BY week_start, surface HAVING active_users >= 10;

--- a/server/clickhouse/migrations/atlas.sum
+++ b/server/clickhouse/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:ZZBhxsV8ALjrHJp/o1tDHgEW8Gy3+/9JGP9jzJ+yQwY=
+h1:M8zKjDb68wyOG/D+DIWS1ptBR+BqV9/MPjbwsEDHvwo=
 20251013090028_initial.sql h1:I90GAjfJN/3i4nLe4AThT5OW/Qgc0+5LOI2jZ6WQZME=
 20251028141444_add_indexes.sql h1:CDwn2EdBZ7Nrn9hx5vYguR1ljlP5hTxiOI6n/I25Cpk=
 20251029120230_add_other_indexes.sql h1:3EtD+3hW8+s5me23va+BdfiIKmfQKOdv4glrQ34fle4=
@@ -110,3 +110,4 @@ h1:ZZBhxsV8ALjrHJp/o1tDHgEW8Gy3+/9JGP9jzJ+yQwY=
 20260907100041_normalize-mart-email-identities.sql h1:OwpDu4oE35e+z/0Qsdgx0fUnlvO9mmT+phj9gpD9bsw=
 20260907100751_include-supported-chat-surfaces.sql h1:6pnN3qJzcm3/XYQwrWy6NpI04jDhmQNSdXETwuvRAM0=
 20260908155637_preserve-trace-tool-name.sql h1:6z9m9qCCpkuca8FXPQPKHM6a+7o4zJ7Bv/43AG3PCXA=
+20260909194424_add-inference-hook-surfaces.sql h1:SDenjiEJOlce8TzyLc1MDnhkyvcUmT0GGqqmFb67bCE=


### PR DESCRIPTION
## Summary

Update the ClickHouse weekly AI surface adoption view to recognize `claude-chat-web` and `claude-code-web`. Includes the matching Atlas and local golang-migrate artifacts; no application code or data backfill.

## Motivation

Inference hook activity would otherwise be grouped under `other`. This separates the migration from #6208 so it can be reviewed and deployed independently. The webhook does not depend on this migration to operate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the weekly AI surface adoption view to recognize `claude-chat-web` and `claude-code-web` instead of grouping inference hook activity under `other`. Includes matching Atlas and golang-migrate artifacts; no application code or data backfill.

<sup>Written for commit 57e582c85c603ad5ed5584e266a2ae123f8f7467. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

