### PR TITLE
fix: derive a replay identifier for workload assertions

### DIFF
--- a/.changeset/workload-replay-identifier.md
+++ b/.changeset/workload-replay-identifier.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Derive a workload assertion's replay identifier when the platform sends no `jti` — Google sends none and Microsoft Entra calls it `uti`. Client assertions still require one.

--- a/server/internal/usersessions/clientauth/expectation.go
+++ b/server/internal/usersessions/clientauth/expectation.go
@@ -75,6 +75,11 @@ type Expectation struct {
 	// sets DefaultMaxReplayHold, so it widens the replay window for client
 	// authentication to buy something only workloads need.
 	MaxLifetime time.Duration
+
+	// ReplayID names how the identifier handed to the replay guard is
+	// derived. The zero value requires a jti, which is what a client
+	// assertion must carry.
+	ReplayID ReplayID
 }
 
 // ClientExpectation is the expectation for a client authenticating itself
@@ -94,6 +99,34 @@ func ClientExpectation(clientID string, keySource jwks.Source, replayIssuer stri
 		ReplaySubject: "",
 		Audiences:     audiences,
 		MaxLifetime:   DefaultMaxLifetime,
+		ReplayID:      ReplayIDJTI,
+	}
+}
+
+// WorkloadExpectation is the expectation for an assertion in which an
+// external platform vouches for a machine, rather than a client vouching for
+// itself.
+//
+// It exists for the same reason ClientExpectation does: to hold a profile's
+// rules where a call site cannot get them wrong. Here that means iss and sub
+// are genuinely different values and are supplied separately, the replay
+// identifier is derived rather than required, and the lifetime bound comes
+// from the platform rather than from DefaultMaxLifetime.
+//
+// replaySubject narrows a spent identifier within the issuer. One platform
+// issuer vouches for many workloads and a jti is unique per issuer, not per
+// workload, so without it one workload could spend another's identifier.
+func WorkloadExpectation(issuer, subject string, keySource jwks.Source, replayIssuer, replayParty, replaySubject string, audiences Audiences, maxLifetime time.Duration) Expectation {
+	return Expectation{
+		Issuer:        issuer,
+		Subject:       subject,
+		KeySource:     keySource,
+		ReplayIssuer:  replayIssuer,
+		ReplayParty:   replayParty,
+		ReplaySubject: replaySubject,
+		Audiences:     audiences,
+		MaxLifetime:   maxLifetime,
+		ReplayID:      ReplayIDDerived,
 	}
 }
 

--- a/server/internal/usersessions/clientauth/expectation.go
+++ b/server/internal/usersessions/clientauth/expectation.go
@@ -168,6 +168,15 @@ func (e Expectation) validate() error {
 	if e.Issuer == e.Subject && e.MaxLifetime > DefaultMaxLifetime {
 		return reject(ReasonVerifierMisconfigured, "client assertion lifetime bound exceeds %s", DefaultMaxLifetime)
 	}
+	// An unrecognised strategy is a wiring fault, not a profile: naming one
+	// by mistake must not quietly stop requiring a jti on a client
+	// assertion. resolveReplayID also treats it as the strict rung, so the
+	// two disagree only about which error an operator sees.
+	switch e.ReplayID {
+	case ReplayIDJTI, ReplayIDDerived:
+	default:
+		return reject(ReasonVerifierMisconfigured, "unknown replay identifier strategy %d", uint8(e.ReplayID))
+	}
 	// iss != sub is a workload, where one issuer vouches for many subjects.
 	// Without the subject in the replay scope they share one keyspace, and
 	// the first to spend a jti makes every other workload's assertion

--- a/server/internal/usersessions/clientauth/reason.go
+++ b/server/internal/usersessions/clientauth/reason.go
@@ -66,12 +66,19 @@ const (
 	// tolerated skew.
 	ReasonNotYetValid Reason = "assertion_not_yet_valid"
 
-	// ReasonIDMissing reports an assertion with no jti, which cannot be held
-	// against replay and so cannot be accepted.
+	// ReasonIDMissing reports an assertion with no jti on a profile that
+	// requires one.
+	//
+	// Client assertions only. A profile whose replay identifier is derived
+	// always has one to reserve, so this cannot fire there — see ReplayID.
 	ReasonIDMissing Reason = "assertion_id_missing"
 
-	// ReasonReplayed reports a jti this client already spent inside its
-	// validity window.
+	// ReasonReplayed reports an identifier this party already spent inside
+	// its validity window.
+	//
+	// Raised only for an identifier that distinguishes one token from
+	// another — a jti or Entra's uti. A repeated digest means the same
+	// bytes arrived twice, which is reported on Result rather than refused.
 	ReasonReplayed Reason = "assertion_replayed"
 
 	// ReasonReplayStoreUnavailable reports a replay guard that could not be

--- a/server/internal/usersessions/clientauth/replayid.go
+++ b/server/internal/usersessions/clientauth/replayid.go
@@ -1,0 +1,93 @@
+package clientauth
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// ReplayID names how a profile derives the identifier the replay guard
+// reserves.
+//
+// A client assertion is minted by software we can hold to RFC 7523 §3, so
+// requiring a jti is reasonable: if one is missing that is the client's bug
+// and it can fix it. A workload assertion is minted by a platform that made
+// its own choices and will not revisit them for us, and two of the four
+// platforms surveyed do not present a jti at all — Google emits no replay
+// identifier, Microsoft Entra calls it uti. Requiring one rejects both before
+// any admission logic runs.
+//
+// RFC 7523 §3 says a JWT MAY carry a jti. Requiring one is our choice, and
+// the protection it buys can be obtained without it.
+type ReplayID uint8
+
+const (
+	// ReplayIDJTI requires a jti and reserves exactly that value.
+	//
+	// The zero value on purpose, so every existing client-assertion call
+	// site keeps RFC 7523 §3 behaviour without naming a strategy.
+	ReplayIDJTI ReplayID = iota
+
+	// ReplayIDDerived resolves an identifier in order: jti, then uti, then
+	// a digest of the assertion itself.
+	//
+	// The ladder is fixed in code rather than configured per issuer,
+	// deliberately. Entra is the only platform identified that spells the
+	// claim differently, and a configured claim name would mean a column on
+	// the issuer table plus the migration and management API to set it —
+	// for one vendor's choice of word. Promoting the ladder to
+	// configuration later is additive and costs nothing now.
+	ReplayIDDerived
+)
+
+// replayIDClaims carries the claim names the ladder consults beyond the
+// registered set jwt.Claims already decodes.
+type replayIDClaims struct {
+	// UTI is Entra's spelling. Its own documentation defines it as
+	// "equivalent to jti in the JWT specification. Unique, per-token
+	// identifier that is case-sensitive."
+	UTI string `json:"uti"`
+}
+
+// resolveReplayID returns the identifier to reserve and whether that
+// identifier distinguishes this token from every other one the same party
+// mints.
+//
+// The second return is the whole reason this function exists. A repeated jti
+// is a *different* token reusing an identifier, which is a replay and must be
+// refused. A repeated digest is the same bytes arriving twice, which some
+// platforms do legitimately: Google's metadata server serves one cached token
+// for most of its validity window, so an agent that re-reads its own identity
+// gets byte-identical output rather than a fresh assertion. Refusing that
+// would break the caller rather than an attacker.
+//
+// So the digest is bounded reuse, not single use. It still costs an attacker
+// everything that matters — a captured token remains unusable past its own
+// exp, and unusable at all without the admission this runs before.
+func resolveReplayID(strategy ReplayID, jti string, extra replayIDClaims, assertion string) (id string, exact bool, ok bool) {
+	if jti != "" {
+		return jti, true, true
+	}
+	if strategy == ReplayIDJTI {
+		return "", false, false
+	}
+	if extra.UTI != "" {
+		return extra.UTI, true, true
+	}
+
+	return assertionDigest(assertion), false, true
+}
+
+// assertionDigest identifies an assertion by its own bytes.
+//
+// The prefix is not decoration: it keeps a derived identifier from ever
+// colliding with a platform-minted one that happens to be 64 hex characters,
+// which costs nothing to rule out and would be unpleasant to diagnose.
+//
+// The digest covers the whole compact serialization — header, payload and
+// signature — so two tokens differing anywhere, including in a signature over
+// identical claims, are different identifiers.
+func assertionDigest(assertion string) string {
+	sum := sha256.Sum256([]byte(assertion))
+
+	return "sha256:" + hex.EncodeToString(sum[:])
+}

--- a/server/internal/usersessions/clientauth/replayid.go
+++ b/server/internal/usersessions/clientauth/replayid.go
@@ -3,6 +3,7 @@ package clientauth
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 )
 
 // ReplayID names how a profile derives the identifier the replay guard
@@ -45,7 +46,26 @@ type replayIDClaims struct {
 	// UTI is Entra's spelling. Its own documentation defines it as
 	// "equivalent to jti in the JWT specification. Unique, per-token
 	// identifier that is case-sensitive."
-	UTI string `json:"uti"`
+	UTI optionalString `json:"uti"`
+}
+
+// optionalString is a claim read as a string when it is one and treated as
+// absent when it is anything else.
+//
+// Every profile decodes the payload into this set, including the client one
+// that never consults uti. A plain string field would make an unrelated
+// party's non-string uti fail the whole decode, rejecting an otherwise valid
+// assertion as signature-invalid. A claim that cannot be read is no
+// identifier at all, so the ladder falls to the next rung instead.
+type optionalString string
+
+func (o *optionalString) UnmarshalJSON(data []byte) error {
+	var value string
+	if json.Unmarshal(data, &value) == nil {
+		*o = optionalString(value)
+	}
+
+	return nil
 }
 
 // resolveReplayID returns the identifier to reserve and whether that
@@ -67,11 +87,14 @@ func resolveReplayID(strategy ReplayID, jti string, extra replayIDClaims, assert
 	if jti != "" {
 		return jti, true, true
 	}
-	if strategy == ReplayIDJTI {
+	// Anything but the derived strategy requires a jti, so a value this
+	// package does not recognise fails closed on the strictest rung rather
+	// than falling through to the most permissive one.
+	if strategy != ReplayIDDerived {
 		return "", false, false
 	}
 	if extra.UTI != "" {
-		return extra.UTI, true, true
+		return string(extra.UTI), true, true
 	}
 
 	return assertionDigest(assertion), false, true

--- a/server/internal/usersessions/clientauth/result.go
+++ b/server/internal/usersessions/clientauth/result.go
@@ -14,4 +14,16 @@ type Result struct {
 	// are documented to emit, and observed lifetimes are the evidence for
 	// keeping or tightening it.
 	ExpiresAt time.Time
+
+	// ReusedAssertion reports that this exact assertion had already been
+	// presented inside its validity window, and was accepted anyway.
+	//
+	// Only ever true on a profile whose replay identifier is derived from
+	// the assertion's own bytes, where a repeat means the same token
+	// arrived twice rather than a second token reusing an identifier. Some
+	// platforms serve one cached token for most of its lifetime, so this is
+	// expected traffic rather than an attack — but it is the evidence for
+	// whether that tolerance can later be tightened, which is why it is
+	// reported rather than swallowed.
+	ReusedAssertion bool
 }

--- a/server/internal/usersessions/clientauth/setup_test.go
+++ b/server/internal/usersessions/clientauth/setup_test.go
@@ -31,6 +31,9 @@ const (
 	testIssuer   = "https://gram.example.com/mcp/demo"
 	testTokenURL = "https://gram.example.com/mcp/demo/token"
 	testKeyID    = "test-key-1"
+	// testWorkloadIssuer stands in for a platform that vouches for machines,
+	// which is never the same value as the workload it vouches for.
+	testWorkloadIssuer = "https://token.actions.githubusercontent.com"
 )
 
 var infra *testenv.Environment
@@ -209,4 +212,49 @@ func requireRejected(t *testing.T, err error, want clientauth.Reason) {
 
 	require.Error(t, err)
 	require.Equal(t, want, clientauth.ReasonOf(err), "rejected for the wrong reason: %v", err)
+}
+
+// signWith serializes claims alongside an extra claim set, for the payload
+// fields jwt.Claims has no field for.
+func (s *signer) signWith(t *testing.T, claims jwt.Claims, extra any) string {
+	t.Helper()
+
+	raw, err := jwt.Signed(s.inner).Claims(claims).Claims(extra).Serialize()
+	require.NoError(t, err)
+	return raw
+}
+
+// workloadExpectationFor is the standard workload Expectation: iss and sub
+// are genuinely different values, and the replay identifier is derived.
+func workloadExpectationFor(t *testing.T, s *signer, subject string) clientauth.Expectation {
+	t.Helper()
+
+	return clientauth.WorkloadExpectation(
+		testWorkloadIssuer,
+		subject,
+		s.source(t),
+		t.Name(),
+		testWorkloadIssuer,
+		subject,
+		clientauth.Audiences{
+			Issuer:   testIssuer,
+			Endpoint: testTokenURL,
+		},
+		clientauth.DefaultMaxLifetime,
+	)
+}
+
+// workloadClaims is a platform-shaped assertion body: iss names the platform,
+// sub names the machine, and there is deliberately no jti.
+func workloadClaims(subject string) jwt.Claims {
+	now := time.Now()
+	return jwt.Claims{
+		Issuer:    testWorkloadIssuer,
+		Subject:   subject,
+		Audience:  jwt.Audience{testIssuer},
+		Expiry:    jwt.NewNumericDate(now.Add(2 * time.Minute)),
+		NotBefore: jwt.NewNumericDate(now),
+		IssuedAt:  jwt.NewNumericDate(now),
+		ID:        "",
+	}
 }

--- a/server/internal/usersessions/clientauth/verifier.go
+++ b/server/internal/usersessions/clientauth/verifier.go
@@ -155,7 +155,11 @@ func (v *Verifier) Verify(ctx context.Context, assertion Assertion, expect Expec
 	}
 
 	var claims jwt.Claims
-	if err := token.Claims(key, &claims); err != nil {
+	var replayClaims replayIDClaims
+	// Both destinations are filled from the one verified payload; the extra
+	// claim set carries the replay identifiers the registered set has no
+	// field for.
+	if err := token.Claims(key, &claims, &replayClaims); err != nil {
 		return nil, rejectWith(ReasonSignatureInvalid, err)
 	}
 
@@ -185,7 +189,8 @@ func (v *Verifier) Verify(ctx context.Context, assertion Assertion, expect Expec
 	// reports which member, for the log line.
 	audience, _ := expect.Audiences.Match(claims.Audience)
 
-	if claims.ID == "" {
+	replayID, exactID, haveID := resolveReplayID(expect.ReplayID, claims.ID, replayClaims, assertion.Value)
+	if !haveID {
 		return nil, reject(ReasonIDMissing, "jti is required")
 	}
 	// Last, so an assertion rejected for any other reason does not spend an
@@ -194,16 +199,20 @@ func (v *Verifier) Verify(ctx context.Context, assertion Assertion, expect Expec
 		Issuer:  expect.ReplayIssuer,
 		Party:   expect.ReplayParty,
 		Subject: expect.ReplaySubject,
-		ID:      claims.ID,
+		ID:      replayID,
 	}, expiresAt.Add(MaxSkew))
 	if err != nil {
 		return nil, rejectWith(ReasonReplayStoreUnavailable, err)
 	}
-	if !claimed {
-		return nil, reject(ReasonReplayed, "jti has already been presented")
+	// A repeat of an identifier that names one token is a replay. A repeat
+	// of a digest is the same token arriving twice, which some platforms
+	// serve legitimately from a cache — accepted, and reported so the
+	// tolerance can be revisited with evidence rather than assumption.
+	if !claimed && exactID {
+		return nil, reject(ReasonReplayed, "assertion identifier has already been presented")
 	}
 
-	return &Result{Audience: audience, ExpiresAt: expiresAt}, nil
+	return &Result{Audience: audience, ExpiresAt: expiresAt, ReusedAssertion: !claimed}, nil
 }
 
 // reasonForClaimError maps the library's claim validation sentinels onto this

--- a/server/internal/usersessions/clientauth/verifier_test.go
+++ b/server/internal/usersessions/clientauth/verifier_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 
@@ -673,4 +674,133 @@ func TestVerify_UnresolvableKeySourceReported(t *testing.T) {
 
 	_, err = newVerifier(t).Verify(t.Context(), assertionFor(s.sign(t, validClaims())), expect)
 	requireRejected(t, err, clientauth.ReasonKeyUnresolvable)
+}
+
+// The whole point of the change: Google's metadata server presents no replay
+// identifier at all, so requiring one rejected that platform before any
+// admission logic ran.
+func TestVerify_WorkloadWithoutAnyReplayIdentifierAccepted(t *testing.T) {
+	t.Parallel()
+
+	const subject = "repo:acme/deploy:ref:refs/heads/main"
+	s := newSigner(t, testKeyID)
+
+	result, err := newVerifier(t).Verify(
+		t.Context(),
+		assertionFor(s.sign(t, workloadClaims(subject))),
+		workloadExpectationFor(t, s, subject),
+	)
+	require.NoError(t, err)
+	require.False(t, result.ReusedAssertion)
+}
+
+// The client profile is unchanged, and this is what proves the relaxation is
+// scoped to a profile rather than applied to the package.
+func TestVerify_ClientWithoutJTIStillRejected(t *testing.T) {
+	t.Parallel()
+
+	s := newSigner(t, testKeyID)
+
+	claims := validClaims()
+	claims.ID = ""
+
+	_, err := newVerifier(t).Verify(t.Context(), assertionFor(s.sign(t, claims)), expectationFor(t, s))
+	requireRejected(t, err, clientauth.ReasonIDMissing)
+}
+
+// Entra calls the identifier uti. It is a real per-token identifier, so it
+// gets the same single-use treatment a jti does.
+func TestVerify_WorkloadUsesUTIAndRefusesItsReplay(t *testing.T) {
+	t.Parallel()
+
+	const subject = "00000000-0000-0000-0000-000000000001"
+	s := newSigner(t, testKeyID)
+	verifier := newVerifier(t)
+	expect := workloadExpectationFor(t, s, subject)
+
+	assertion := assertionFor(s.signWith(t, workloadClaims(subject), map[string]any{
+		"uti": "uti-" + uuid.NewString(),
+	}))
+
+	result, err := verifier.Verify(t.Context(), assertion, expect)
+	require.NoError(t, err)
+	require.False(t, result.ReusedAssertion)
+
+	_, err = verifier.Verify(t.Context(), assertion, expect)
+	requireRejected(t, err, clientauth.ReasonReplayed)
+}
+
+// jti wins when a platform sends both, so a platform that adopts the
+// registered claim is not held to a vendor one it also happens to emit.
+func TestVerify_WorkloadPrefersJTIOverUTI(t *testing.T) {
+	t.Parallel()
+
+	const subject = "system:serviceaccount:prod:deployer"
+	s := newSigner(t, testKeyID)
+	verifier := newVerifier(t)
+	expect := workloadExpectationFor(t, s, subject)
+
+	shared := "jti-" + uuid.NewString()
+
+	claims := workloadClaims(subject)
+	claims.ID = shared
+	first := assertionFor(s.signWith(t, claims, map[string]any{"uti": "uti-one"}))
+
+	_, err := verifier.Verify(t.Context(), first, expect)
+	require.NoError(t, err)
+
+	// Same jti, different uti and different bytes. If uti or the digest were
+	// what got reserved, this would be accepted.
+	claims.IssuedAt = jwt.NewNumericDate(time.Now().Add(time.Second))
+	second := assertionFor(s.signWith(t, claims, map[string]any{"uti": "uti-two"}))
+
+	_, err = verifier.Verify(t.Context(), second, expect)
+	requireRejected(t, err, clientauth.ReasonReplayed)
+}
+
+// A repeated digest means the same bytes arrived twice, not a second token
+// reusing an identifier. Some platforms serve one cached token for most of
+// its lifetime, so refusing this would break the caller rather than an
+// attacker. Accepted, and reported.
+func TestVerify_WorkloadRepeatedAssertionIsAcceptedAndReported(t *testing.T) {
+	t.Parallel()
+
+	const subject = "spiffe://acme.example/ns/prod/sa/deployer"
+	s := newSigner(t, testKeyID)
+	verifier := newVerifier(t)
+	expect := workloadExpectationFor(t, s, subject)
+
+	assertion := assertionFor(s.sign(t, workloadClaims(subject)))
+
+	first, err := verifier.Verify(t.Context(), assertion, expect)
+	require.NoError(t, err)
+	require.False(t, first.ReusedAssertion)
+
+	second, err := verifier.Verify(t.Context(), assertion, expect)
+	require.NoError(t, err)
+	require.True(t, second.ReusedAssertion, "a re-presented assertion must be reported as reused")
+}
+
+// The tolerance above must not degrade into "identifier-less assertions never
+// collide". Two genuinely different tokens digest differently, so neither is
+// reported as a repeat of the other.
+func TestVerify_WorkloadDistinctAssertionsAreNotReportedAsReuse(t *testing.T) {
+	t.Parallel()
+
+	const subject = "arn:aws:iam::123456789012:role/DeployRole"
+	s := newSigner(t, testKeyID)
+	verifier := newVerifier(t)
+	expect := workloadExpectationFor(t, s, subject)
+
+	first := workloadClaims(subject)
+	second := workloadClaims(subject)
+	second.IssuedAt = jwt.NewNumericDate(time.Now().Add(time.Second))
+
+	firstResult, err := verifier.Verify(t.Context(), assertionFor(s.sign(t, first)), expect)
+	require.NoError(t, err)
+	require.False(t, firstResult.ReusedAssertion)
+
+	secondResult, err := verifier.Verify(t.Context(), assertionFor(s.sign(t, second)), expect)
+	require.NoError(t, err)
+	require.False(t, secondResult.ReusedAssertion)
 }

--- a/server/internal/usersessions/clientauth/verifier_test.go
+++ b/server/internal/usersessions/clientauth/verifier_test.go
@@ -804,3 +804,55 @@ func TestVerify_WorkloadDistinctAssertionsAreNotReportedAsReuse(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, secondResult.ReusedAssertion)
 }
+
+// A client assertion carries a jti and never consults uti, so whatever an
+// unrelated party happens to put in that claim must not decide whether the
+// assertion verifies.
+func TestVerify_ClientWithUnreadableUTIStillAccepted(t *testing.T) {
+	t.Parallel()
+
+	s := newSigner(t, testKeyID)
+
+	assertion := assertionFor(s.signWith(t, validClaims(), map[string]any{"uti": 12345}))
+
+	_, err := newVerifier(t).Verify(t.Context(), assertion, expectationFor(t, s))
+	require.NoError(t, err, "a non-string uti is not this client's problem")
+}
+
+// The same claim on the profile that does read it: unreadable is absent, so
+// the ladder falls to the digest rather than the request failing.
+func TestVerify_WorkloadWithUnreadableUTIFallsBackToDigest(t *testing.T) {
+	t.Parallel()
+
+	const subject = "repo:acme/build:ref:refs/heads/main"
+	s := newSigner(t, testKeyID)
+	verifier := newVerifier(t)
+	expect := workloadExpectationFor(t, s, subject)
+
+	assertion := assertionFor(s.signWith(t, workloadClaims(subject), map[string]any{"uti": []string{"x"}}))
+
+	result, err := verifier.Verify(t.Context(), assertion, expect)
+	require.NoError(t, err)
+	require.False(t, result.ReusedAssertion)
+
+	// The digest rung, not the uti one: the same bytes re-presented are
+	// reported as reuse rather than refused.
+	repeat, err := verifier.Verify(t.Context(), assertion, expect)
+	require.NoError(t, err)
+	require.True(t, repeat.ReusedAssertion)
+}
+
+// A strategy this package does not define is a wiring fault. It must not
+// land on the derived ladder, which would stop requiring a jti on a profile
+// whose author never asked for that.
+func TestVerify_UnknownReplayIDStrategyIsMisconfiguration(t *testing.T) {
+	t.Parallel()
+
+	s := newSigner(t, testKeyID)
+
+	expect := expectationFor(t, s)
+	expect.ReplayID = clientauth.ReplayID(99)
+
+	_, err := newVerifier(t).Verify(t.Context(), assertionFor(s.sign(t, validClaims())), expect)
+	requireRejected(t, err, clientauth.ReasonVerifierMisconfigured)
+}


### PR DESCRIPTION
[AIM-176](https://linear.app/speakeasy/issue/AIM-176/fix-do-not-require-a-jti-on-a-workload-assertion-google-and-entra-do)

## Summary

`clientauth.Verify` rejected any assertion without a `jti`. That requirement becomes a per-profile strategy on `Expectation`.

- **`ReplayIDJTI`** — requires a `jti`. The **zero value**, so every existing client-assertion call site keeps RFC 7523 §3 behaviour with no change.
- **`ReplayIDDerived`** — resolves `jti`, then `uti`, then a digest of the assertion.

Also adds **`WorkloadExpectation`** alongside `ClientExpectation`. There was no workload constructor, so a call site had to assemble the struct by hand and could silently inherit the client profile's rules. It now pins the ones that differ: `iss` and `sub` supplied separately, a derived replay identifier, and a platform-set lifetime bound.

## Motivation

Two of the four platforms surveyed present no `jti`: Google's metadata-server token carries `iss, aud, sub, azp, email, iat, exp` and nothing else, and Entra names the claim `uti` — its own docs define that as *"equivalent to `jti` in the JWT specification"* while warning that an application *"shouldn't take a dependency on a claim being present."* Both were rejected before any admission logic ran.

RFC 7523 §3 says a JWT **MAY** carry a `jti`. Requiring one was our choice, and the protection it buys is obtainable without it.

Doing it now is deliberate: this is the assertion profile the whole verification milestone rests on, and it is a small change against code with no production callers. Discovering it during third-party verification means the schema, grant, dashboard and presets were all built on an assumption that does not hold for two of the platforms we most want.

## Why the ladder is fixed rather than configured

AIM-176 originally specified the alternative claim name as *configured on the issuer record*. That would mean a column on `workload_issuers`, plus the migration and management API to set it — for one vendor's choice of word, and it would have put this change behind the same Atlas dependency currently blocking the Foundation stack. Entra is the only platform anyone has identified that spells it differently. Promoting the ladder to configuration later is additive.

## The one security-relevant judgement

**A repeated digest is accepted and reported, not refused.**

A repeated `jti` or `uti` is a *different* token reusing an identifier — a replay, still refused. A repeated digest is the same bytes arriving twice, which platforms serving one cached token for most of its validity window do legitimately; an agent re-reading its own identity gets byte-identical output rather than a fresh assertion. Refusing that breaks the caller, not an attacker.

This follows the 2026-09-08 decision-log entry — *"bounded reuse first… duplicates are allowed and counted, then tightened with evidence"* — and supersedes this ticket's original acceptance line, which predates it and asked for both cases to be refused.

What an attacker still cannot do is unchanged: a captured token is unusable past its own `exp`, and unusable at all without the subject admission that runs alongside this.

`Result.ReusedAssertion` reports it, so the tolerance can be revisited with production evidence rather than assumption.

## What is unaffected

AWS IAM outbound federation sends a `jti` (documentation-confirmed), so it takes the first rung and nothing here touches it. GitHub Actions and Kubernetes likewise.

https://claude.ai/code/session_01BkWwZUepfhVUssCuUCbW3s

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes [AIM-176](https://linear.app/speakeasy/issue/AIM-176/fix-do-not-require-a-jti-on-a-workload-assertion-google-and-entra-do) by making the `jti` requirement per-profile so workload assertions from Google and Entra are accepted instead of rejected before admission logic runs. Client assertions still require a `jti`; workload assertions derive a replay identifier from `jti`, then `uti`, then a digest of the assertion.

**Behavior**
- Adds `WorkloadExpectation` so workload profiles can't accidentally inherit client rules: separate `iss`/`sub`, derived replay ID, and platform-set lifetime bound.
- Repeated `jti`/`uti` values are still refused as replay; a repeated digest (same bytes) is accepted and reported on `Result.ReusedAssertion`.
- AWS IAM, GitHub Actions, and Kubernetes all send `jti` and are unaffected.
- Unknown replay strategies fail closed as misconfiguration, and a non-string `uti` counts as absent rather than failing the decode.

**Migration**
- No migration or schema changes; the ladder is implemented in code and can be promoted to per-issuer configuration later.

<sup>Written for commit b0c556b748188a4eb89f2f3a7c214c71431400e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

