### PR TITLE
fix: Use the database clock for skill feedback windows

### DIFF
--- a/server/internal/skills/impl.go
+++ b/server/internal/skills/impl.go
@@ -1070,7 +1070,8 @@ func (s *Service) ListFeedback(ctx context.Context, payload *gen.ListFeedbackPay
 	if err != nil {
 		return nil, oops.E(oops.CodeUnexpected, err, "count skill feedback").LogError(ctx, logger)
 	}
-	windowEnd := time.Now().UTC()
+	// Use the same clock as feedback.created_at, not the application host clock.
+	windowEnd := counts.WindowEnd.Time.UTC()
 	windowStart := windowEnd.Truncate(24 * time.Hour).Add(-29 * 24 * time.Hour)
 	metrics, err := queries.GetSkillFeedbackMetrics(ctx, repo.GetSkillFeedbackMetricsParams{
 		ProjectID: *authCtx.ProjectID, SkillID: uuid.NullUUID{UUID: skillID, Valid: true},
@@ -1116,7 +1117,7 @@ func (s *Service) ListFeedback(ctx context.Context, payload *gen.ListFeedbackPay
 			DidNotHelp: counts.DidNotHelp, Misleading: counts.Misleading, Harmful: counts.Harmful,
 		},
 		Metrics: &gen.SkillFeedbackMetrics{
-			WindowStart: windowStart.Format(time.RFC3339), WindowEnd: windowEnd.Format(time.RFC3339),
+			WindowStart: windowStart.Format(time.RFC3339Nano), WindowEnd: windowEnd.Format(time.RFC3339Nano),
 			FeedbackInWindow: metrics.FeedbackInWindow, ActivationsInWindow: metrics.ActivationsInWindow,
 			FeedbackActivationsInWindow: metrics.FeedbackActivationsInWindow,
 			Unreviewed:                  metrics.Unreviewed,

--- a/server/internal/skills/list_feedback_test.go
+++ b/server/internal/skills/list_feedback_test.go
@@ -157,20 +157,23 @@ func TestListSkillFeedbackUsesDatabaseClock(t *testing.T) {
 	ctx, ti := newTestService(t)
 	created := createSkill(t, ctx, ti, "feedback-clock", "Clock regression.")
 	row := recordResolvedFeedback(t, ti, ti.projectID, uuid.MustParse(created.Skill.ID), uuid.MustParse(created.Version.ID), created.Skill.Name, skillservice.FeedbackOutcomeHelped, nil)
-	var before time.Time
-	require.NoError(t, ti.conn.QueryRow(ctx, "SELECT clock_timestamp()").Scan(&before))
+	countParams := repo.CountSkillFeedbackOutcomesParams{
+		ProjectID: ti.projectID, SkillID: uuid.NullUUID{UUID: uuid.MustParse(created.Skill.ID), Valid: true},
+	}
+	before, err := ti.repo.CountSkillFeedbackOutcomes(ctx, countParams)
+	require.NoError(t, err)
 	synctest.Test(t, func(t *testing.T) {
 		require.True(t, row.CreatedAt.Time.After(time.Now()), "database clock must be ahead of the fake application clock")
 		result, err := ti.service.ListFeedback(ctx, &gen.ListFeedbackPayload{ID: created.Skill.ID, Limit: 20, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil})
 		require.NoError(t, err)
 		require.Equal(t, int64(1), result.Counts.Total)
 		require.Equal(t, int64(1), result.Metrics.FeedbackInWindow)
-		var after time.Time
-		require.NoError(t, ti.conn.QueryRow(ctx, "SELECT clock_timestamp()").Scan(&after))
+		after, err := ti.repo.CountSkillFeedbackOutcomes(ctx, countParams)
+		require.NoError(t, err)
 		windowEnd, err := time.Parse(time.RFC3339Nano, result.Metrics.WindowEnd)
 		require.NoError(t, err)
-		require.False(t, windowEnd.Before(before))
-		require.False(t, windowEnd.After(after))
+		require.False(t, windowEnd.Before(before.WindowEnd.Time))
+		require.False(t, windowEnd.After(after.WindowEnd.Time))
 		require.Equal(t, windowEnd.UTC().Truncate(24*time.Hour).Add(-29*24*time.Hour).Format(time.RFC3339Nano), result.Metrics.WindowStart)
 		var total int64
 		for _, point := range result.Timeline {

--- a/server/internal/skills/list_feedback_test.go
+++ b/server/internal/skills/list_feedback_test.go
@@ -3,6 +3,7 @@ package skills_test
 import (
 	"reflect"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/uuid"
@@ -147,4 +148,35 @@ func TestListSkillFeedbackValidatesAccessLimitCursorAndPrivacyShape(t *testing.T
 		_, found := typeOfFeedback.FieldByName(privateField)
 		require.False(t, found)
 	}
+}
+
+// The application clock in a synctest bubble starts in 2000, while PostgreSQL
+// keeps its real clock. Feedback timestamps are left at their database defaults.
+func TestListSkillFeedbackUsesDatabaseClock(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestService(t)
+	created := createSkill(t, ctx, ti, "feedback-clock", "Clock regression.")
+	row := recordResolvedFeedback(t, ti, ti.projectID, uuid.MustParse(created.Skill.ID), uuid.MustParse(created.Version.ID), created.Skill.Name, skillservice.FeedbackOutcomeHelped, nil)
+	var before time.Time
+	require.NoError(t, ti.conn.QueryRow(ctx, "SELECT clock_timestamp()").Scan(&before))
+	synctest.Test(t, func(t *testing.T) {
+		require.True(t, row.CreatedAt.Time.After(time.Now()), "database clock must be ahead of the fake application clock")
+		result, err := ti.service.ListFeedback(ctx, &gen.ListFeedbackPayload{ID: created.Skill.ID, Limit: 20, SessionToken: nil, ApikeyToken: nil, ProjectSlugInput: nil})
+		require.NoError(t, err)
+		require.Equal(t, int64(1), result.Counts.Total)
+		require.Equal(t, int64(1), result.Metrics.FeedbackInWindow)
+		var after time.Time
+		require.NoError(t, ti.conn.QueryRow(ctx, "SELECT clock_timestamp()").Scan(&after))
+		windowEnd, err := time.Parse(time.RFC3339Nano, result.Metrics.WindowEnd)
+		require.NoError(t, err)
+		require.False(t, windowEnd.Before(before))
+		require.False(t, windowEnd.After(after))
+		require.Equal(t, windowEnd.UTC().Truncate(24*time.Hour).Add(-29*24*time.Hour).Format(time.RFC3339Nano), result.Metrics.WindowStart)
+		var total int64
+		for _, point := range result.Timeline {
+			total += point.FeedbackCount
+		}
+		require.Len(t, result.Timeline, 30)
+		require.Equal(t, result.Metrics.FeedbackInWindow, total)
+	})
 }

--- a/server/internal/skills/queries.sql
+++ b/server/internal/skills/queries.sql
@@ -51,6 +51,7 @@ LIMIT GREATEST(@page_limit::int, 0);
 
 -- name: CountSkillFeedbackOutcomes :one
 SELECT
+  clock_timestamp()::timestamptz AS window_end,
   COUNT(*)::bigint AS total,
   COUNT(*) FILTER (WHERE outcome = 'helped')::bigint AS helped,
   COUNT(*) FILTER (WHERE outcome = 'partially_helped')::bigint AS partially_helped,

--- a/server/internal/skills/repo/queries.sql.go
+++ b/server/internal/skills/repo/queries.sql.go
@@ -577,6 +577,7 @@ func (q *Queries) CountSkillEfficacyVersionLifetimeSpend(ctx context.Context, ar
 
 const countSkillFeedbackOutcomes = `-- name: CountSkillFeedbackOutcomes :one
 SELECT
+  clock_timestamp()::timestamptz AS window_end,
   COUNT(*)::bigint AS total,
   COUNT(*) FILTER (WHERE outcome = 'helped')::bigint AS helped,
   COUNT(*) FILTER (WHERE outcome = 'partially_helped')::bigint AS partially_helped,
@@ -594,6 +595,7 @@ type CountSkillFeedbackOutcomesParams struct {
 }
 
 type CountSkillFeedbackOutcomesRow struct {
+	WindowEnd       pgtype.Timestamptz
 	Total           int64
 	Helped          int64
 	PartiallyHelped int64
@@ -606,6 +608,7 @@ func (q *Queries) CountSkillFeedbackOutcomes(ctx context.Context, arg CountSkill
 	row := q.db.QueryRow(ctx, countSkillFeedbackOutcomes, arg.ProjectID, arg.SkillID)
 	var i CountSkillFeedbackOutcomesRow
 	err := row.Scan(
+		&i.WindowEnd,
 		&i.Total,
 		&i.Helped,
 		&i.PartiallyHelped,


### PR DESCRIPTION
## Summary
Use PostgreSQL time for skill-feedback reporting windows, matching the clock that timestamps feedback rows. Reuse that cutoff for metrics, timeline and response metadata, retaining subsecond precision.

## Motivation
When the database clock leads the application clock, newly committed feedback can appear in all-time counts but be excluded from windowed metrics.

## Technical details
Capture the cutoff in the existing outcome-count query without adding a database round trip. Add a deterministic clock-skew regression that leaves database timestamps intact and verifies counts, timeline totals and response bounds.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Uses the database clock to set skill-feedback reporting window boundaries instead of the application host clock, so windowed metrics and feedback timestamps stay consistent when the clocks drift. The old behavior used `time.Now().UTC()`; now the cutoff comes from `clock_timestamp()` and the response timestamps keep subsecond precision via RFC3339Nano.

- Captures the cutoff in the existing outcome-count query, avoiding an extra database round trip.
- Adds a deterministic regression test using `synctest` that verifies the database clock bounds through the generated SQLc row.

<sup>Written for commit 12f9c041bd6a53265af310fa0ea7fbf4a224eb67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

