### PR TITLE
fix: Order risk exclusion versions after their source rows

### DIFF
--- a/server/internal/risk/chrepo/retro_exclusion.go
+++ b/server/internal/risk/chrepo/retro_exclusion.go
@@ -217,8 +217,8 @@ func reversalWhere(keep RetroReversalKeep) string {
 }
 
 // copyProjection renders the INSERT ... SELECT column projection: every
-// risk_findings column passed through verbatim except inserted_at (bound —
-// the copy must sort after every prior copy of the id) and the suppression
+// risk_findings column passed through verbatim except inserted_at (strictly
+// newer than the selected source and both clocks) and the suppression
 // columns (bound, literal or NULL per direction). excluded_reason,
 // excluded_detail and event_kind are SQL literal expressions, not bind
 // placeholders — the callers only ever stamp constants ('rule' on apply, ” on
@@ -231,7 +231,9 @@ func copyProjection(excludedAtExpr, exclusionIDExpr, excludedReasonExpr, exclude
 	for i, col := range riskFindingColumns {
 		switch col {
 		case "inserted_at":
-			projected[i] = "?"
+			// DateTime64(9) has a one-nanosecond tick. Caller monotonicity
+			// alone cannot order copies when ClickHouse's clock is ahead.
+			projected[i] = "greatest(toDateTime64(?, 9), now64(9), latest.inserted_at) + toIntervalNanosecond(1)"
 		case "excluded_at":
 			projected[i] = excludedAtExpr
 		case "exclusion_id":

--- a/server/internal/risk/chrepo/retro_exclusion_internal_test.go
+++ b/server/internal/risk/chrepo/retro_exclusion_internal_test.go
@@ -16,13 +16,17 @@ import (
 func TestCopyProjection_LockstepWithInsertColumns(t *testing.T) {
 	t.Parallel()
 
-	projected := strings.Split(copyProjection("?", "NULL", "'rule'", "''", "'suppression'"), ", ")
+	versionExpr := "greatest(toDateTime64(?, 9), now64(9), latest.inserted_at) + toIntervalNanosecond(1)"
+	projection := copyProjection("?", "NULL", "'rule'", "''", "'suppression'")
+	require.Contains(t, projection, versionExpr)
+	// Hide the expression's internal commas before splitting columns.
+	projected := strings.Split(strings.Replace(projection, versionExpr, "version", 1), ", ")
 	require.Len(t, projected, len(riskFindingColumns))
 
 	for i, col := range riskFindingColumns {
 		switch col {
 		case "inserted_at":
-			require.Equal(t, "?", projected[i])
+			require.Equal(t, "version", projected[i])
 		case "excluded_at":
 			require.Equal(t, "?", projected[i])
 		case "exclusion_id":

--- a/server/internal/risk/retro_exclusion_ch_test.go
+++ b/server/internal/risk/retro_exclusion_ch_test.go
@@ -580,3 +580,82 @@ func TestRetroExclusion_RegexSkipsReparentedCandidate(t *testing.T) {
 	require.False(t, attributed, "content from another chat must not be attributed to the stamped chat")
 	require.Equal(t, uuid.Nil, chatID, "a refused attribution never yields a usable chat id")
 }
+
+// TestRetroExclusion_FutureSourceVersion makes clock skew deterministic:
+// both apply and reversal receive timestamps older than the original row.
+func TestRetroExclusion_FutureSourceVersion(t *testing.T) {
+	t.Parallel()
+	for _, byIDs := range []bool{false, true} {
+		name := "predicate"
+		if byIDs {
+			name = "by_ids"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx, ti := newTestRiskService(t)
+			authCtx, _ := contextvalues.GetAuthContext(ctx)
+			projectID := *authCtx.ProjectID
+			orgID := authCtx.ActiveOrganizationID
+			createdAt, scope := retroDay(orgID, projectID.String())
+			finding := chOverviewFinding(t, projectID, orgID, uuid.New(), uuid.New(), createdAt,
+				"gitleaks", "secret.github_pat", "user@example.com")
+			q := chrepo.New(ti.chConn)
+			require.NoError(t, q.InsertRiskFindings(ctx, []chrepo.RiskFindingRow{finding}))
+			testenv.FlushClickHouseAsyncInserts(t, ti.chConn)
+
+			supplied := time.Now().UTC()
+			future := supplied.Add(24 * time.Hour)
+			// Add a future-dated original copy without changing its partition,
+			// event kind or payload. All subsequent writes must outrank it.
+			require.NoError(t, ti.chConn.Exec(ctx, `INSERT INTO risk_findings
+				SELECT * REPLACE (toDateTime64(?, 9) AS inserted_at)
+				FROM risk_findings WHERE id = ?`, chrepo.FormatCHTime(future), finding.ID))
+			exclusionID := uuid.New()
+			predicate := chrepo.RetroExclusionPredicate{RuleID: finding.RuleID}
+			ids := []uuid.UUID{finding.ID}
+			assertVersion := func(want time.Time, copies uint64) {
+				t.Helper()
+				rows, err := ti.chConn.Query(ctx, `SELECT max(inserted_at), count()
+					FROM risk_findings WHERE id = ?`, finding.ID)
+				require.NoError(t, err)
+				defer func() { _ = rows.Close() }()
+				require.True(t, rows.Next())
+				var version time.Time
+				var count uint64
+				require.NoError(t, rows.Scan(&version, &count))
+				require.True(t, version.Equal(want), "version = %s, want %s", version, want)
+				require.Equal(t, copies, count)
+				require.NoError(t, rows.Err())
+			}
+			for range 2 { // A sequential retry must append nothing.
+				if byIDs {
+					require.NoError(t, q.AppendRetroExclusionApplyByIDs(ctx, scope, exclusionID,
+						chrepo.FormatCHTime(supplied), chrepo.FormatCHTime(supplied), ids))
+				} else {
+					require.NoError(t, q.AppendRetroExclusionApply(ctx, scope, exclusionID,
+						chrepo.FormatCHTime(supplied), chrepo.FormatCHTime(supplied), predicate))
+				}
+				assertVersion(future.Add(time.Nanosecond), 3)
+				excluded, exID, _ := latestExclusionState(t, ti, finding.ID)
+				require.True(t, excluded)
+				require.Equal(t, exclusionID.String(), exID)
+			}
+			for range 2 {
+				older := chrepo.FormatCHTime(supplied.Add(-time.Hour))
+				if byIDs {
+					require.NoError(t, q.AppendRetroExclusionReversalByIDs(ctx, scope, exclusionID, older, ids))
+				} else {
+					require.NoError(t, q.AppendRetroExclusionReversal(ctx, scope, exclusionID, older, chrepo.BlanketReversal()))
+				}
+				assertVersion(future.Add(2*time.Nanosecond), 4)
+				excluded, exID, _ := latestExclusionState(t, ti, finding.ID)
+				require.False(t, excluded)
+				require.Empty(t, exID)
+				// Also exercise production's state-rank-aware latest-copy read.
+				count, err := q.CountRetroExclusionApply(ctx, scope, predicate)
+				require.NoError(t, err)
+				require.Equal(t, uint64(1), count)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Assign risk-exclusion apply and reversal copies a version strictly newer than their selected source row, the supplied timestamp, and ClickHouse time.

## Motivation
Application-generated timestamps can lag existing ClickHouse versions. A reversal can then sort behind an earlier suppression and leave a finding excluded.

## Technical details
Use the shared insertion projection for both predicate and ID-based paths, advancing by one DateTime64(9) tick. Add future-source regressions covering apply, reversal, effective state and sequential retry idempotency.

The ordering guarantee is relative to the source selected by each statement; this does not serialize competing reconciles.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes risk exclusion version ordering so apply and reversal copies always get a timestamp strictly newer than their source row, the supplied timestamp, and ClickHouse's clock. This prevents reversals from sorting behind earlier suppressions when application timestamps lag.

<sup>Written for commit 4dc936c49b7c2ddb84b6f377617168135532a6b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

