### PR TITLE
fix: remove stale beta badges from risk events and shadow mcp pages

### DIFF
--- a/.changeset/remove-stale-beta-badges.md
+++ b/.changeset/remove-stale-beta-badges.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Remove the Beta badge from the Risk Events and Shadow MCP page headers. The sidebar entries for both pages dropped their Beta label earlier, so the page titles now match the navigation.

--- a/client/dashboard/src/pages/security/RiskEvents.tsx
+++ b/client/dashboard/src/pages/security/RiskEvents.tsx
@@ -387,7 +387,6 @@ export default function RiskEvents(): JSX.Element {
       <LogWorkbench
         eyebrow="Secure"
         title="Risk Events"
-        stage="beta"
         description="Review policy findings across recent analyzed chats."
       >
         <div>
@@ -410,7 +409,6 @@ export default function RiskEvents(): JSX.Element {
       <LogWorkbench
         eyebrow="Security and Policy"
         title="Risk Events"
-        stage="beta"
         description="Review policy findings across recent analyzed chats."
         actions={
           <RevealAllToggle

--- a/client/dashboard/src/pages/shadow-mcp/ShadowMCP.tsx
+++ b/client/dashboard/src/pages/shadow-mcp/ShadowMCP.tsx
@@ -70,9 +70,7 @@ function ShadowMCPInventory({ pageTitle }: { pageTitle: string }): JSX.Element {
 
   return (
     <Page.Section>
-      <Page.Section.Title stage="beta" area="">
-        {pageTitle}
-      </Page.Section.Title>
+      <Page.Section.Title area="">{pageTitle}</Page.Section.Title>
       <Page.Section.Description>
         Every MCP server this project knows about — observed in agent traffic or
         raised in an access request — with its review state. Click a server for


### PR DESCRIPTION
## Summary

Drops the `stage="beta"` prop from the page headers of Risk Events (both the onboarding and populated render branches of the `LogWorkbench`) and Shadow MCP (`Page.Section.Title`). Adds a `dashboard` patch changeset. No other surfaces are touched; `ReleaseStageBadge` and the routing stay as they are.

## Motivation

The sidebar entries for Risk Events and Shadow MCP no longer carry a Beta label, but the page titles still rendered one. The nav badge is driven by the `stage` field on the route entry while the page badge is a separate prop on the header, so the earlier nav cleanup left the page headers stale and the two surfaces disagreed about whether the feature was GA. This brings the pages in line with the navigation.

Note: the Risk Overview family (overview plus users, rules, categories, and their detail pages) has the same drift and is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGV2kW6NBX6nGKDJSuob1x


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the stale Beta badge from the Risk Events and Shadow MCP page headers so the page titles match the sidebar, which already dropped the Beta label for both features.

- The Risk Overview family (overview, users, rules, categories, and detail pages) has the same drift and is intentionally left for a follow-up.
- Adds a `dashboard` patch changeset; no other surfaces or routing are affected.

<sup>Written for commit 60c30eb3c3b99b70979145d1d13c8ab4f7a97f6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

