### PR TITLE
feat(platform-mcp): summarize shadow policy decisions

### DIFF
--- a/.changeset/platform-mcp-shadow-policy-summary.md
+++ b/.changeset/platform-mcp-shadow-policy-summary.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+feat(platform-mcp): summarize Shadow MCP policy decisions

--- a/server/internal/demoseed/postgres.sql
+++ b/server/internal/demoseed/postgres.sql
@@ -446,6 +446,10 @@ BEGIN
   DELETE FROM api_keys WHERE organization_id = demo_org;
   DELETE FROM organization_setup_tasks WHERE organization_id = demo_org;
   DELETE FROM business_memories WHERE organization_id = demo_org;
+  DELETE FROM principal_grants
+  WHERE organization_id = demo_org
+    AND scope = 'risk_policy:bypass'
+    AND selectors ->> 'resource_id' = policy_sm::text;
   DELETE FROM projects WHERE organization_id = demo_org;
 
   -- Single project: the demo org intentionally has exactly one project so
@@ -1557,6 +1561,17 @@ E'--- a/SKILL.md\n+++ b/SKILL.md\n@@ -6,4 +6,5 @@\n # Refund handling\n \n 1. Ve
      '{prompt_injection}', NULL, '{}'::jsonb, '{}', '{user_message,tool_request}', NULL,
      FALSE, 'quarantine', 'everyone', NULL, FALSE, 9.5, 1);
 
+  -- The same canonical target has two grants, so Platform MCP demonstrates
+  -- target counts rather than leaking or counting the target audience.
+  INSERT INTO principal_grants (organization_id, principal_urn, scope, selectors)
+  VALUES
+    (demo_org, 'user:' || demo_user_ids[1], 'risk_policy:bypass',
+     jsonb_build_object('resource_kind', 'risk_policy', 'resource_id', policy_sm::text,
+                        'server_url', 'https://shadow-mcp.demo.getgram.ai/research')),
+    (demo_org, 'user:' || demo_user_ids[2], 'risk_policy:bypass',
+     jsonb_build_object('resource_kind', 'risk_policy', 'resource_id', policy_sm::text,
+                        'server_url', 'https://shadow-mcp.demo.getgram.ai/research'));
+
   INSERT INTO session_quarantines
     (id, organization_id, project_id, session_id, risk_policy_id,
      risk_policy_name, user_id, reason, created_at, updated_at)
@@ -2356,6 +2371,16 @@ E'--- a/SKILL.md\n+++ b/SKILL.md\n@@ -6,4 +6,5 @@\n # Refund handling\n \n 1. Ve
   -- but high enough to catch the draw collapsing to nothing.
   IF finding_count < 90 THEN
     RAISE EXCEPTION 'demo seed postflight: expected >= 90 risk findings, found %', finding_count;
+  END IF;
+
+  SELECT count(*) INTO stray
+  FROM principal_grants
+  WHERE organization_id = demo_org
+    AND scope = 'risk_policy:bypass'
+    AND selectors ->> 'resource_id' = policy_sm::text
+    AND selectors ->> 'server_url' = 'https://shadow-mcp.demo.getgram.ai/research';
+  IF stray <> 2 THEN
+    RAISE EXCEPTION 'demo seed postflight: expected 2 shadow policy target grants, found %', stray;
   END IF;
 
   -- The Watchdog scores each signal from its findings' policy, so a rotation

--- a/server/internal/platformmcp/risk_reads.go
+++ b/server/internal/platformmcp/risk_reads.go
@@ -165,7 +165,7 @@ func newRiskReadService(db *pgxpool.Pool, keyMaterial string) (*RiskReadService,
 			if err := tx.Commit(ctx); err != nil {
 				return riskPolicySnapshot{}, "", fmt.Errorf("commit risk policy detail snapshot: %w", err)
 			}
-			return riskPolicySnapshot{policy: state.Policy, shadowDecisions: decisions}, version, nil
+			return riskPolicySnapshot{policy: policy, shadowDecisions: decisions}, version, nil
 		},
 	}, nil
 }

--- a/server/internal/platformmcp/risk_reads.go
+++ b/server/internal/platformmcp/risk_reads.go
@@ -29,10 +29,6 @@ var (
 	ErrRiskReadNotFound = errors.New("platform mcp risk resource not found")
 )
 
-type riskPolicyReader interface {
-	ListPage(ctx context.Context, organizationID string, projectID uuid.UUID, cursor *policycore.PageCursor, limit int32) ([]policycore.Policy, error)
-}
-
 type riskExclusionReader interface {
 	ListPage(ctx context.Context, projectID uuid.UUID, policyID uuid.NullUUID, cursor *exclusioncore.PageCursor, limit int32) ([]exclusioncore.Exclusion, error)
 }
@@ -77,15 +73,16 @@ func (r postgresRiskProjectResolver) Resolve(ctx context.Context, organizationID
 }
 
 type RiskReadService struct {
-	projects           riskProjectResolver
-	policies           riskPolicyReader
+	projects riskProjectResolver
+
 	exclusions         riskExclusionReader
+	loadPolicyPage     func(context.Context, string, uuid.UUID, *policycore.PageCursor, int32) ([]riskPolicySnapshot, error)
 	cursor             *riskCursorCodec
 	catalog            policycatalog.Catalog
 	catalogFingerprint string
 	redactionKey       []byte
 	versions           *riskVersionCodec
-	loadPolicyDetail   func(context.Context, uuid.UUID, uuid.UUID) (policycore.Policy, string, error)
+	loadPolicyDetail   func(context.Context, uuid.UUID, uuid.UUID) (riskPolicySnapshot, string, error)
 }
 
 func newRiskReadService(db *pgxpool.Pool, keyMaterial string) (*RiskReadService, error) {
@@ -110,15 +107,34 @@ func newRiskReadService(db *pgxpool.Pool, keyMaterial string) (*RiskReadService,
 	}
 	redactionKey := sha256.Sum256([]byte("platform-mcp-risk-value:" + keyMaterial))
 	return &RiskReadService{
-		projects:           postgresRiskProjectResolver{queries: platformrepo.New(db)},
-		policies:           policycore.New(db),
+		projects: postgresRiskProjectResolver{queries: platformrepo.New(db)},
+
 		exclusions:         exclusioncore.New(db),
 		cursor:             cursor,
 		catalog:            catalog,
 		catalogFingerprint: fingerprint,
 		redactionKey:       redactionKey[:],
 		versions:           versions,
-		loadPolicyDetail: func(ctx context.Context, projectID, policyID uuid.UUID) (policycore.Policy, string, error) {
+		loadPolicyPage: func(ctx context.Context, organizationID string, projectID uuid.UUID, cursor *policycore.PageCursor, limit int32) ([]riskPolicySnapshot, error) {
+			tx, err := db.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.RepeatableRead, AccessMode: pgx.ReadOnly, DeferrableMode: "", BeginQuery: "", CommitQuery: ""})
+			if err != nil {
+				return nil, fmt.Errorf("begin risk policy page snapshot: %w", err)
+			}
+			defer func() { _ = tx.Rollback(ctx) }()
+			policies, err := policycore.New(tx).ListPage(ctx, organizationID, projectID, cursor, limit)
+			if err != nil {
+				return nil, fmt.Errorf("load risk policy page snapshot: %w", err)
+			}
+			result, err := loadShadowPolicySnapshots(ctx, tx, policies, limit)
+			if err != nil {
+				return nil, err
+			}
+			if err := tx.Commit(ctx); err != nil {
+				return nil, fmt.Errorf("commit risk policy page snapshot: %w", err)
+			}
+			return result, nil
+		},
+		loadPolicyDetail: func(ctx context.Context, projectID, policyID uuid.UUID) (riskPolicySnapshot, string, error) {
 			tx, err := db.BeginTx(ctx, pgx.TxOptions{
 				IsoLevel:       pgx.RepeatableRead,
 				AccessMode:     pgx.ReadOnly,
@@ -127,25 +143,29 @@ func newRiskReadService(db *pgxpool.Pool, keyMaterial string) (*RiskReadService,
 				CommitQuery:    "",
 			})
 			if err != nil {
-				return policycore.Policy{}, "", fmt.Errorf("begin risk policy detail snapshot: %w", err)
+				return riskPolicySnapshot{}, "", fmt.Errorf("begin risk policy detail snapshot: %w", err)
 			}
 			defer func() { _ = tx.Rollback(ctx) }()
 			policy, err := policycore.New(tx).Get(ctx, projectID, policyID)
 			if err != nil {
-				return policycore.Policy{}, "", fmt.Errorf("load risk policy detail snapshot: %w", err)
+				return riskPolicySnapshot{}, "", fmt.Errorf("load risk policy detail snapshot: %w", err)
 			}
 			state, err := riskPolicyVersionState(ctx, tx, policy, false)
 			if err != nil {
-				return policycore.Policy{}, "", err
+				return riskPolicySnapshot{}, "", err
 			}
 			version, err := versions.PolicyVersion(state)
 			if err != nil {
-				return policycore.Policy{}, "", err
+				return riskPolicySnapshot{}, "", err
+			}
+			decisions, err := shadowPolicyDecisionsFromVersionState(state)
+			if err != nil {
+				return riskPolicySnapshot{}, "", err
 			}
 			if err := tx.Commit(ctx); err != nil {
-				return policycore.Policy{}, "", fmt.Errorf("commit risk policy detail snapshot: %w", err)
+				return riskPolicySnapshot{}, "", fmt.Errorf("commit risk policy detail snapshot: %w", err)
 			}
-			return policy, version, nil
+			return riskPolicySnapshot{policy: state.Policy, shadowDecisions: decisions}, version, nil
 		},
 	}, nil
 }
@@ -162,16 +182,17 @@ type RiskCompatibility struct {
 }
 
 type RiskPolicySummary struct {
-	ID            string            `json:"id"`
-	Name          string            `json:"name"`
-	PolicyType    string            `json:"policy_type"`
-	Enabled       bool              `json:"enabled"`
-	Action        string            `json:"action,omitempty"`
-	Sources       []string          `json:"sources"`
-	Score         float64           `json:"score"`
-	CreatedAt     string            `json:"created_at"`
-	UpdatedAt     string            `json:"updated_at"`
-	Compatibility RiskCompatibility `json:"compatibility"`
+	ID              string                 `json:"id"`
+	Name            string                 `json:"name"`
+	PolicyType      string                 `json:"policy_type"`
+	Enabled         bool                   `json:"enabled"`
+	Action          string                 `json:"action,omitempty"`
+	Sources         []string               `json:"sources"`
+	Score           float64                `json:"score"`
+	CreatedAt       string                 `json:"created_at"`
+	UpdatedAt       string                 `json:"updated_at"`
+	Compatibility   RiskCompatibility      `json:"compatibility"`
+	ShadowDecisions *ShadowPolicyDecisions `json:"shadow_decisions,omitempty"`
 }
 
 type RiskDetectionScope struct {
@@ -274,16 +295,16 @@ func (s *RiskReadService) ListPolicies(ctx context.Context, principal Principal,
 		}
 		pageCursor = &policycore.PageCursor{CreatedAt: decoded.CreatedAt, ID: decoded.ID}
 	}
-	policies, err := s.policies.ListPage(ctx, principal.OrganizationID, project.ID, pageCursor, int32(limit)) // #nosec G115 -- riskPageLimit caps at 50.
+	policies, err := s.loadPolicyPage(ctx, principal.OrganizationID, project.ID, pageCursor, int32(limit)) // #nosec G115 -- riskPageLimit caps at 50.
 	if err != nil {
 		return ListRiskPoliciesOutput{}, fmt.Errorf("list risk policy page: %w", err)
 	}
 	output := ListRiskPoliciesOutput{Project: riskProject(project), CatalogVersion: s.catalog.Schema, CatalogFingerprint: s.catalogFingerprint, Policies: make([]RiskPolicySummary, 0, min(len(policies), limit)), NextCursor: ""}
 	for _, policy := range policies[:min(len(policies), limit)] {
-		output.Policies = append(output.Policies, s.policySummary(policy))
+		output.Policies = append(output.Policies, s.policySummary(policy.policy, policy.shadowDecisions))
 	}
 	if len(policies) > limit {
-		last := policies[limit-1]
+		last := policies[limit-1].policy
 		output.NextCursor, err = s.cursor.Encode(riskCursor{Kind: "policies", OrganizationID: principal.OrganizationID, Binding: principalCursorBinding(principal), ProjectID: project.ID, PolicyID: uuid.Nil, CreatedAt: last.CreatedAt, ID: last.ID})
 		if err != nil {
 			return ListRiskPoliciesOutput{}, err
@@ -311,7 +332,7 @@ func (s *RiskReadService) GetPolicy(ctx context.Context, principal Principal, in
 	if err != nil {
 		return GetRiskPolicyOutput{}, fmt.Errorf("get risk policy detail: %w", err)
 	}
-	detail := s.policyDetail(policy)
+	detail := s.policyDetail(policy.policy, policy.shadowDecisions)
 	detail.Version = version
 	return GetRiskPolicyOutput{Project: riskProject(project), CatalogVersion: s.catalog.Schema, CatalogFingerprint: s.catalogFingerprint, Policy: detail}, nil
 }
@@ -367,7 +388,7 @@ func (s *RiskReadService) ListExclusions(ctx context.Context, principal Principa
 }
 
 func (s *RiskReadService) valid() bool {
-	return s != nil && s.projects != nil && s.policies != nil && s.exclusions != nil && s.cursor != nil && len(s.redactionKey) > 0 && s.versions != nil && s.catalog.Schema != "" && s.catalogFingerprint != "" && s.loadPolicyDetail != nil
+	return s != nil && s.projects != nil && s.exclusions != nil && s.cursor != nil && len(s.redactionKey) > 0 && s.versions != nil && s.catalog.Schema != "" && s.catalogFingerprint != "" && s.loadPolicyPage != nil && s.loadPolicyDetail != nil
 }
 
 func riskPageLimit(value int) (int, error) {
@@ -384,7 +405,7 @@ func riskProject(project ResolvedProject) RiskProject {
 	return RiskProject{ID: project.ID.String(), Name: project.Name, Slug: project.Slug}
 }
 
-func (s *RiskReadService) policySummary(policy policycore.Policy) RiskPolicySummary {
+func (s *RiskReadService) policySummary(policy policycore.Policy, shadowDecisions *ShadowPolicyDecisions) RiskPolicySummary {
 	unsupported := s.policyUnsupported(policy)
 	action := policy.Action
 	if !s.policyActionSupported(policy) {
@@ -394,14 +415,14 @@ func (s *RiskReadService) policySummary(policy policycore.Policy) RiskPolicySumm
 		ID: policy.ID.String(), Name: policy.Name, PolicyType: policy.PolicyType,
 		Enabled: policy.Enabled, Action: action, Sources: allowlisted(policy.Sources, s.catalog.Sources),
 		Score: policy.Score, CreatedAt: policy.CreatedAt.UTC().Format(time.RFC3339Nano), UpdatedAt: policy.UpdatedAt.UTC().Format(time.RFC3339Nano),
-		Compatibility: compatibility(unsupported),
+		Compatibility: compatibility(unsupported), ShadowDecisions: shadowDecisions,
 	}
 }
 
-func (s *RiskReadService) policyDetail(policy policycore.Policy) RiskPolicyDetail {
+func (s *RiskReadService) policyDetail(policy policycore.Policy, shadowDecisions *ShadowPolicyDecisions) RiskPolicyDetail {
 	detectionScopes, _ := s.projectDetectionScopes(policy)
 	detail := RiskPolicyDetail{
-		RiskPolicySummary:      s.policySummary(policy),
+		RiskPolicySummary:      s.policySummary(policy, shadowDecisions),
 		Version:                "",
 		PresidioEntities:       allowlisted(policy.PresidioEntities, s.catalog.PresidioEntities),
 		PresidioScoreThreshold: policy.PresidioScoreThreshold,

--- a/server/internal/platformmcp/risk_reads_test.go
+++ b/server/internal/platformmcp/risk_reads_test.go
@@ -57,11 +57,20 @@ func (s *stubRiskPolicies) ListPage(_ context.Context, _ string, _ uuid.UUID, cu
 	return s.policies, nil
 }
 
-func (s *stubRiskPolicies) loadDetail(_ context.Context, _, _ uuid.UUID) (policycore.Policy, string, error) {
-	if s.getErr != nil {
-		return policycore.Policy{}, "", fmt.Errorf("load test risk policy detail: %w", s.getErr)
+func (s *stubRiskPolicies) loadPage(_ context.Context, _ string, _ uuid.UUID, cursor *policycore.PageCursor, _ int32) ([]riskPolicySnapshot, error) {
+	s.cursor = cursor
+	result := make([]riskPolicySnapshot, 0, len(s.policies))
+	for _, policy := range s.policies {
+		result = append(result, riskPolicySnapshot{policy: policy, shadowDecisions: nil})
 	}
-	return s.policy, "opaque-version", nil
+	return result, nil
+}
+
+func (s *stubRiskPolicies) loadDetail(_ context.Context, _, _ uuid.UUID) (riskPolicySnapshot, string, error) {
+	if s.getErr != nil {
+		return riskPolicySnapshot{}, "", fmt.Errorf("load test risk policy detail: %w", s.getErr)
+	}
+	return riskPolicySnapshot{policy: s.policy, shadowDecisions: nil}, "opaque-version", nil
 }
 
 type stubRiskExclusions struct {
@@ -85,7 +94,7 @@ func testRiskReadService(t *testing.T, projects riskProjectResolver, policies *s
 	versions, err := newRiskVersionCodec("test-key")
 	require.NoError(t, err)
 	return &RiskReadService{
-		projects: projects, policies: policies, exclusions: exclusions,
+		projects: projects, exclusions: exclusions, loadPolicyPage: policies.loadPage,
 		cursor: cursor, catalog: catalog, catalogFingerprint: fingerprint,
 		redactionKey:     []byte("0123456789abcdef0123456789abcdef"),
 		versions:         versions,
@@ -138,6 +147,33 @@ func TestRiskReadCursorBindingAndPagination(t *testing.T) {
 	incomplete.ConnectionID = ""
 	_, err = service.ListPolicies(t.Context(), incomplete, ListRiskPoliciesInput{Limit: 2, Cursor: first.NextCursor})
 	require.ErrorIs(t, err, ErrRiskCursorInvalid)
+}
+
+func TestRiskReadProjectionsIncludeShadowPolicyDecisionsWithoutTargetDetails(t *testing.T) {
+	t.Parallel()
+	project := ResolvedProject{ID: uuid.New(), Name: "Project", Slug: "project"}
+	disposition := "block_all"
+	policy := policycore.Policy{ID: uuid.New(), ProjectID: project.ID, OrganizationID: "<ORG_ID>", Name: "Shadow", PolicyType: "standard", Sources: []string{"shadow_mcp"}, Enabled: true, Action: "block", ShadowMCPDisposition: &disposition, CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	decisions := &ShadowPolicyDecisions{Disposition: disposition, AllowedTargetCount: 1, BlockedTargetCount: 0, ManagedVia: "shadow_inventory"}
+	policies := &stubRiskPolicies{policies: []policycore.Policy{policy}, policy: policy}
+	service := testRiskReadService(t, &stubRiskProjects{project: project, expected: []riskProjectCall{{organizationID: "<ORG_ID>"}, {organizationID: "<ORG_ID>", projectSlug: "project"}}}, policies, &stubRiskExclusions{})
+	service.loadPolicyPage = func(_ context.Context, _ string, _ uuid.UUID, _ *policycore.PageCursor, _ int32) ([]riskPolicySnapshot, error) {
+		return []riskPolicySnapshot{{policy: policy, shadowDecisions: decisions}}, nil
+	}
+	service.loadPolicyDetail = func(_ context.Context, _, _ uuid.UUID) (riskPolicySnapshot, string, error) {
+		return riskPolicySnapshot{policy: policy, shadowDecisions: decisions}, "version", nil
+	}
+	principal := testRiskPrincipal("user")
+	list, err := service.ListPolicies(t.Context(), principal, ListRiskPoliciesInput{})
+	require.NoError(t, err)
+	require.Equal(t, decisions, list.Policies[0].ShadowDecisions)
+	get, err := service.GetPolicy(t.Context(), principal, GetRiskPolicyInput{ProjectSlug: "project", PolicyID: policy.ID.String()})
+	require.NoError(t, err)
+	require.Equal(t, decisions, get.Policy.ShadowDecisions)
+	encoded, err := json.Marshal(get)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), "server_url")
+	require.NotContains(t, string(encoded), "principal")
 }
 
 func TestRiskReadProjectionsOmitSensitivePolicyFields(t *testing.T) {

--- a/server/internal/platformmcp/risk_reads_test.go
+++ b/server/internal/platformmcp/risk_reads_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/risk/exclusioncore"
 	"github.com/speakeasy-api/gram/server/internal/risk/policycatalog"
 	"github.com/speakeasy-api/gram/server/internal/risk/policycore"
@@ -154,7 +155,10 @@ func TestRiskReadProjectionsIncludeShadowPolicyDecisionsWithoutTargetDetails(t *
 	project := ResolvedProject{ID: uuid.New(), Name: "Project", Slug: "project"}
 	disposition := "block_all"
 	policy := policycore.Policy{ID: uuid.New(), ProjectID: project.ID, OrganizationID: "<ORG_ID>", Name: "Shadow", PolicyType: "standard", Sources: []string{"shadow_mcp"}, Enabled: true, Action: "block", ShadowMCPDisposition: &disposition, CreatedAt: time.Now(), UpdatedAt: time.Now()}
-	decisions := &ShadowPolicyDecisions{Disposition: disposition, AllowedTargetCount: 1, BlockedTargetCount: 0, ManagedVia: "shadow_inventory"}
+	targetURL := "https://mcp.example.test/sensitive-target"
+	principalURN := "user:sensitive-principal"
+	decisions, err := shadowPolicyDecisions(policy, []authz.Grant{{PrincipalUrn: principalURN, Selector: selectorWithURL(authz.ScopeRiskPolicyBypass, policy.ID.String(), targetURL)}}, nil)
+	require.NoError(t, err)
 	policies := &stubRiskPolicies{policies: []policycore.Policy{policy}, policy: policy}
 	service := testRiskReadService(t, &stubRiskProjects{project: project, expected: []riskProjectCall{{organizationID: "<ORG_ID>"}, {organizationID: "<ORG_ID>", projectSlug: "project"}}}, policies, &stubRiskExclusions{})
 	service.loadPolicyPage = func(_ context.Context, _ string, _ uuid.UUID, _ *policycore.PageCursor, _ int32) ([]riskPolicySnapshot, error) {
@@ -172,8 +176,8 @@ func TestRiskReadProjectionsIncludeShadowPolicyDecisionsWithoutTargetDetails(t *
 	require.Equal(t, decisions, get.Policy.ShadowDecisions)
 	encoded, err := json.Marshal(get)
 	require.NoError(t, err)
-	require.NotContains(t, string(encoded), "server_url")
-	require.NotContains(t, string(encoded), "principal")
+	require.NotContains(t, string(encoded), targetURL)
+	require.NotContains(t, string(encoded), principalURN)
 }
 
 func TestRiskReadProjectionsOmitSensitivePolicyFields(t *testing.T) {

--- a/server/internal/platformmcp/shadow_policy_summary.go
+++ b/server/internal/platformmcp/shadow_policy_summary.go
@@ -83,7 +83,7 @@ func grantsByPolicy(grants []authz.Grant, allowed map[string]struct{}) map[strin
 // ShadowPolicyDecisions describes the configured URL-target posture of a
 // blocking Shadow MCP policy. It never contains URLs, principals, or selectors.
 type ShadowPolicyDecisions struct {
-	Disposition        string `json:"disposition"`
+	Disposition        string `json:"effective_disposition"`
 	AllowedTargetCount int    `json:"allowed_target_count"`
 	BlockedTargetCount int    `json:"blocked_target_count"`
 	ManagedVia         string `json:"managed_via"`

--- a/server/internal/platformmcp/shadow_policy_summary.go
+++ b/server/internal/platformmcp/shadow_policy_summary.go
@@ -1,0 +1,168 @@
+package platformmcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/risk/policycore"
+	riskrepo "github.com/speakeasy-api/gram/server/internal/risk/repo"
+	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
+)
+
+type riskPolicySnapshot struct {
+	policy          policycore.Policy
+	shadowDecisions *ShadowPolicyDecisions
+}
+
+func loadShadowPolicySnapshots(ctx context.Context, db riskrepo.DBTX, policies []policycore.Policy, limit int32) ([]riskPolicySnapshot, error) {
+	if len(policies) == 0 {
+		return []riskPolicySnapshot{}, nil
+	}
+	organizationID := policies[0].OrganizationID
+	policyIDs := make([]string, 0, len(policies))
+	shadowPolicies := make(map[string]struct{}, len(policies))
+	displayed := policies
+	if len(displayed) > int(limit) {
+		displayed = displayed[:limit]
+	}
+	for _, policy := range displayed {
+		if policy.OrganizationID != organizationID {
+			return nil, fmt.Errorf("%w: mixed organization policy page", ErrUnavailable)
+		}
+		if policy.ShadowMCPDisposition != nil {
+			policyIDs = append(policyIDs, policy.ID.String())
+			shadowPolicies[policy.ID.String()] = struct{}{}
+		}
+	}
+	if len(policyIDs) == 0 {
+		result := make([]riskPolicySnapshot, 0, len(policies))
+		for _, policy := range policies {
+			result = append(result, riskPolicySnapshot{policy: policy, shadowDecisions: nil})
+		}
+		return result, nil
+	}
+	allowed, err := authz.ListGrantsForResourceIDs(ctx, db, organizationID, authz.ScopeRiskPolicyBypass, policyIDs)
+	if err != nil {
+		return nil, fmt.Errorf("%w: list shadow MCP allowed URL grants", ErrUnavailable)
+	}
+	blocked, err := authz.ListGrantsForResourceIDs(ctx, db, organizationID, authz.ScopeRiskPolicyBlock, policyIDs)
+	if err != nil {
+		return nil, fmt.Errorf("%w: list shadow MCP blocked URL grants", ErrUnavailable)
+	}
+	allowedByPolicy := grantsByPolicy(allowed, shadowPolicies)
+	blockedByPolicy := grantsByPolicy(blocked, shadowPolicies)
+	result := make([]riskPolicySnapshot, 0, len(policies))
+	for _, policy := range policies {
+		if _, displayed := shadowPolicies[policy.ID.String()]; !displayed {
+			result = append(result, riskPolicySnapshot{policy: policy, shadowDecisions: nil})
+			continue
+		}
+		decisions, err := shadowPolicyDecisions(policy, allowedByPolicy[policy.ID.String()], blockedByPolicy[policy.ID.String()])
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, riskPolicySnapshot{policy: policy, shadowDecisions: decisions})
+	}
+	return result, nil
+}
+
+func grantsByPolicy(grants []authz.Grant, allowed map[string]struct{}) map[string][]authz.Grant {
+	result := make(map[string][]authz.Grant)
+	for _, grant := range grants {
+		policyID := grant.Selector.ResourceID()
+		if _, ok := allowed[policyID]; ok {
+			result[policyID] = append(result[policyID], grant)
+		}
+	}
+	return result
+}
+
+// ShadowPolicyDecisions describes the configured URL-target posture of a
+// blocking Shadow MCP policy. It never contains URLs, principals, or selectors.
+type ShadowPolicyDecisions struct {
+	Disposition        string `json:"disposition"`
+	AllowedTargetCount int    `json:"allowed_target_count"`
+	BlockedTargetCount int    `json:"blocked_target_count"`
+	ManagedVia         string `json:"managed_via"`
+}
+
+func shadowPolicyDecisions(policy policycore.Policy, allowed, blocked []authz.Grant) (*ShadowPolicyDecisions, error) {
+	if policy.ShadowMCPDisposition == nil {
+		return nil, nil
+	}
+	return shadowPolicyDecisionsForURLs(*policy.ShadowMCPDisposition, grantURLs(allowed), grantURLs(blocked))
+}
+
+func shadowPolicyDecisionsFromVersionState(state RiskPolicyVersionState) (*ShadowPolicyDecisions, error) {
+	if state.Policy.ShadowMCPDisposition == nil {
+		return nil, nil
+	}
+	allowed, err := versionGrantURLs(state.AllowedURLGrants)
+	if err != nil {
+		return nil, err
+	}
+	blocked, err := versionGrantURLs(state.BlockedURLGrants)
+	if err != nil {
+		return nil, err
+	}
+	return shadowPolicyDecisionsForURLs(*state.Policy.ShadowMCPDisposition, allowed, blocked)
+}
+
+func shadowPolicyDecisionsForURLs(disposition string, allowed, blocked []string) (*ShadowPolicyDecisions, error) {
+	switch disposition {
+	case shadowmcp.DispositionBlockAll, shadowmcp.DispositionAllowAll:
+	default:
+		return nil, fmt.Errorf("%w: unknown shadow MCP disposition", ErrUnavailable)
+	}
+	allowedCount, err := canonicalTargetCount(allowed)
+	if err != nil {
+		return nil, err
+	}
+	blockedCount, err := canonicalTargetCount(blocked)
+	if err != nil {
+		return nil, err
+	}
+	return &ShadowPolicyDecisions{
+		Disposition: disposition, AllowedTargetCount: allowedCount, BlockedTargetCount: blockedCount, ManagedVia: "shadow_inventory",
+	}, nil
+}
+
+func grantURLs(grants []authz.Grant) []string {
+	urls := make([]string, 0, len(grants))
+	for _, grant := range grants {
+		if url := grant.Selector[authz.SelectorKeyServerURL]; url != "" {
+			urls = append(urls, url)
+		}
+	}
+	return urls
+}
+
+func versionGrantURLs(grants []RiskPolicyVersionGrant) ([]string, error) {
+	urls := make([]string, 0, len(grants))
+	for _, grant := range grants {
+		var selector authz.Selector
+		if err := json.Unmarshal(grant.Selector, &selector); err != nil {
+			return nil, fmt.Errorf("%w: decode shadow MCP URL grant selector", ErrUnavailable)
+		}
+		if url := selector[authz.SelectorKeyServerURL]; url != "" {
+			urls = append(urls, url)
+		}
+	}
+	return urls, nil
+}
+
+func canonicalTargetCount(urls []string) (int, error) {
+	canonical := make([]string, 0, len(urls))
+	for _, url := range urls {
+		inventoryURL, ok := shadowmcp.CanonicalizeInventoryURL(url)
+		if !ok {
+			return 0, fmt.Errorf("%w: invalid shadow MCP URL grant", ErrUnavailable)
+		}
+		canonical = append(canonical, inventoryURL.CanonicalURL)
+	}
+	slices.Sort(canonical)
+	return len(slices.Compact(canonical)), nil
+}

--- a/server/internal/platformmcp/shadow_policy_summary_test.go
+++ b/server/internal/platformmcp/shadow_policy_summary_test.go
@@ -1,0 +1,82 @@
+package platformmcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/risk/policycore"
+	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
+)
+
+func TestShadowPolicyDecisionsCountDistinctCanonicalTargets(t *testing.T) {
+	t.Parallel()
+	policyID := uuid.New()
+	disposition := shadowmcp.DispositionBlockAll
+	policy := policycore.Policy{ID: policyID, ShadowMCPDisposition: &disposition}
+	allowed := []authz.Grant{
+		{PrincipalUrn: "user:one", Selector: selectorWithURL(authz.ScopeRiskPolicyBypass, policyID.String(), "https://mcp.example.test/server")},
+		{PrincipalUrn: "role:team", Selector: selectorWithURL(authz.ScopeRiskPolicyBypass, policyID.String(), "https://mcp.example.test/server")},
+		{PrincipalUrn: "user:two", Selector: authz.NewSelector(authz.ScopeRiskPolicyBypass, policyID.String())},
+	}
+	blocked := []authz.Grant{{PrincipalUrn: "user:three", Selector: selectorWithURL(authz.ScopeRiskPolicyBlock, policyID.String(), "https://mcp.example.test/blocked")}}
+
+	result, err := shadowPolicyDecisions(policy, allowed, blocked)
+
+	require.NoError(t, err)
+	require.Equal(t, &ShadowPolicyDecisions{Disposition: shadowmcp.DispositionBlockAll, AllowedTargetCount: 1, BlockedTargetCount: 1, ManagedVia: "shadow_inventory"}, result)
+}
+
+func TestShadowPolicyDecisionsOmitNonShadowPolicies(t *testing.T) {
+	t.Parallel()
+
+	result, err := shadowPolicyDecisions(policycore.Policy{}, nil, nil)
+
+	require.NoError(t, err)
+	require.Nil(t, result)
+}
+
+func TestShadowPolicyDecisionsRejectUnsafeInputsWithoutReturningThem(t *testing.T) {
+	t.Parallel()
+	disposition := shadowmcp.DispositionAllowAll
+	unsafeURL := "://invalid-secret"
+
+	_, err := shadowPolicyDecisionsForURLs(disposition, []string{unsafeURL}, nil)
+
+	require.ErrorIs(t, err, ErrUnavailable)
+	require.NotContains(t, err.Error(), unsafeURL)
+	require.NotContains(t, err.Error(), "invalid-secret")
+}
+
+func TestShadowPolicyDecisionsFromVersionStateMatchesGrantProjection(t *testing.T) {
+	t.Parallel()
+	policyID := uuid.New()
+	disposition := shadowmcp.DispositionAllowAll
+	selector := selectorWithURL(authz.ScopeRiskPolicyBlock, policyID.String(), "https://mcp.example.test/blocked")
+	raw, err := selector.MarshalJSON()
+	require.NoError(t, err)
+
+	result, err := shadowPolicyDecisionsFromVersionState(RiskPolicyVersionState{
+		Policy:                policycore.Policy{ID: policyID, ShadowMCPDisposition: &disposition},
+		AllowedURLGrants:      []RiskPolicyVersionGrant{},
+		BlockedURLGrants:      []RiskPolicyVersionGrant{{PrincipalURN: "user:one", Selector: raw}},
+		AnalyzerConfig:        nil,
+		StandingDecisionState: []string{},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, &ShadowPolicyDecisions{Disposition: shadowmcp.DispositionAllowAll, AllowedTargetCount: 0, BlockedTargetCount: 1, ManagedVia: "shadow_inventory"}, result)
+	encoded, err := json.Marshal(result)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), "mcp.example.test")
+	require.NotContains(t, string(encoded), "user:one")
+}
+
+func selectorWithURL(scope authz.Scope, policyID, url string) authz.Selector {
+	selector := authz.NewSelector(scope, policyID)
+	selector[authz.SelectorKeyServerURL] = url
+	return selector
+}

--- a/server/internal/platformmcp/shadow_policy_summary_test.go
+++ b/server/internal/platformmcp/shadow_policy_summary_test.go
@@ -19,7 +19,7 @@ func TestShadowPolicyDecisionsCountDistinctCanonicalTargets(t *testing.T) {
 	policy := policycore.Policy{ID: policyID, ShadowMCPDisposition: &disposition}
 	allowed := []authz.Grant{
 		{PrincipalUrn: "user:one", Selector: selectorWithURL(authz.ScopeRiskPolicyBypass, policyID.String(), "https://mcp.example.test/server")},
-		{PrincipalUrn: "role:team", Selector: selectorWithURL(authz.ScopeRiskPolicyBypass, policyID.String(), "https://mcp.example.test/server")},
+		{PrincipalUrn: "role:team", Selector: selectorWithURL(authz.ScopeRiskPolicyBypass, policyID.String(), "https://mcp.example.test:443/server")},
 		{PrincipalUrn: "user:two", Selector: authz.NewSelector(authz.ScopeRiskPolicyBypass, policyID.String())},
 	}
 	blocked := []authz.Grant{{PrincipalUrn: "user:three", Selector: selectorWithURL(authz.ScopeRiskPolicyBlock, policyID.String(), "https://mcp.example.test/blocked")}}

--- a/server/internal/platformmcp/tool_risk_reads.go
+++ b/server/internal/platformmcp/tool_risk_reads.go
@@ -26,7 +26,7 @@ func registerRiskToolsWithMutations(reg *Registrar, risk *RiskReadService, mutat
 	addTool(reg, &mcp.Tool{
 		Name:        "list_risk_policies",
 		Title:       "List Risk Policies",
-		Description: "List bounded, privacy-safe risk policy summaries in an exact project or the organization's literal default project.",
+		Description: "List bounded, privacy-safe risk policy summaries in an exact project or the organization's literal default project. Blocking Shadow MCP policies include their configured default posture and distinct explicit target counts, not effective access.",
 		Annotations: readOnlyAnnotations(),
 		InputSchema: riskListSchema(false),
 	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeDefaultable}, func(ctx context.Context, _ *mcp.CallToolRequest, input ListRiskPoliciesInput) (*mcp.CallToolResult, ListRiskPoliciesOutput, error) {
@@ -37,7 +37,7 @@ func registerRiskToolsWithMutations(reg *Registrar, risk *RiskReadService, mutat
 	addTool(reg, &mcp.Tool{
 		Name:        "get_risk_policy",
 		Title:       "Get Risk Policy",
-		Description: "Read one risk policy from an exact project or the organization's literal default project, with closed compatibility metadata.",
+		Description: "Read one risk policy from an exact project or the organization's literal default project, with closed compatibility metadata. Shadow target counts describe stored policy configuration, not effective access.",
 		Annotations: readOnlyAnnotations(),
 		InputSchema: riskGetPolicySchema(),
 	}, ToolMeta{Audiences: bothAudiences, ProjectScope: ProjectScopeDefaultable}, func(ctx context.Context, _ *mcp.CallToolRequest, input GetRiskPolicyInput) (*mcp.CallToolResult, GetRiskPolicyOutput, error) {


### PR DESCRIPTION
## Why

Platform MCP can already read risk policies, but it cannot explain the stored
Shadow MCP URL posture without exposing target URLs or grant audiences.

Linear: AIM-223

## What changed

- Add a read-only `shadow_decisions` projection to risk-policy list and detail
  results: effective disposition, distinct explicit allowed/blocked target
  counts, and `managed_via: shadow_inventory`.
- Read policy pages and their displayed Shadow grant sets in one repeatable-read
  snapshot. Detail results derive the projection from the existing version-state
  snapshot.
- Add synthetic demo data showing one target granted to two principals, with
  cleanup and postflight checks proving the seed stays idempotent.

## Review notes

- `server/internal/platformmcp/shadow_policy_summary.go` is the core privacy
  boundary. It canonicalizes and deduplicates targets without returning URLs,
  principals, or selectors.
- The list path deliberately excludes the pagination lookahead row from its
  grant reads.
- This is partial D3b work only. Admission/repair reporting and the reviewed
  distribution workflow remain deferred behind #6197.

## Testing

- `mise run test:server ./internal/platformmcp` — passed (732 tests)
- `mise run test:server -tags=demoseed_safety ./internal/demoseed/...` — passed (15 tests)
- `mise run lint:server` — passed
- `mise run build:server` — passed
- `git diff --check` — passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Addresses AIM-223 by letting Platform MCP summarize Shadow policy decisions. Previously risk-policy reads couldn't explain stored Shadow URL posture without exposing target URLs or grant audiences; list and detail results now include a read-only `shadow_decisions` projection with effective disposition, distinct explicit allowed and blocked target counts, and `managed_via: shadow_inventory`, and never surface URLs, principals, or selectors.

**Review notes**
- List reads policy pages and their displayed Shadow grant sets in one repeatable-read snapshot; detail derives the projection from the existing version-state snapshot.
- Adds demo seed data where one target is granted to two principals, with idempotent cleanup and postflight checks.
- Admission/repair reporting and the reviewed distribution workflow remain deferred.

<sup>Written for commit e3a829674b5ec25a120d3fd2794255cf1258ea5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

