### PR TITLE
fix: complete agent permission setup and session revocation

### DIFF
--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -69243,6 +69243,11 @@ components:
         owner_user_id:
           type: string
           description: Eligible same-organization human owner; defaults to the caller
+        policy_grants:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentPolicyGrantForm'
+          description: Optional initial allow-only agent policy ceilings, created atomically with the agent. Effective credential permissions remain limited by the live owner and authorizer.
       required:
         - name
     CreateAgentPolicyGrantForm:

--- a/client/dashboard/src/pages/access/GrantRuleDrawerContent.test.tsx
+++ b/client/dashboard/src/pages/access/GrantRuleDrawerContent.test.tsx
@@ -100,9 +100,8 @@ describe("grant rule server list", () => {
     expect(screen.queryByText("No servers found")).toBeNull();
   });
   it("does not claim the organization has no servers when an allow rule filters them all out", () => {
-    // An exception picker only lists what its allow rule covers. When that
-    // leaves nothing, the organization still has servers, and saying it has
-    // none sends the reader off to create one that already exists.
+    // An exception picker only lists what its allow rule covers, and that
+    // leaving nothing does not mean the organization has no servers.
     mocks.inventory = {
       ...mocks.inventory,
       settled: true,

--- a/client/dashboard/src/pages/access/GrantRuleDrawerContent.test.tsx
+++ b/client/dashboard/src/pages/access/GrantRuleDrawerContent.test.tsx
@@ -99,6 +99,29 @@ describe("grant rule server list", () => {
     expect(screen.queryByText("Loading servers…")).toBeNull();
     expect(screen.queryByText("No servers found")).toBeNull();
   });
+  it("does not claim the organization has no servers when an allow rule filters them all out", () => {
+    // An exception picker only lists what its allow rule covers. When that
+    // leaves nothing, the organization still has servers, and saying it has
+    // none sends the reader off to create one that already exists.
+    mocks.inventory = {
+      ...mocks.inventory,
+      settled: true,
+      groups: serverGroups,
+    };
+    render(
+      <GrantRuleDrawerContent
+        resourceType="mcp"
+        scope="mcp:connect"
+        selectors={[]}
+        onChangeSelectors={() => {}}
+        isDeny
+        allowSelectors={[{ resourceKind: "mcp", resourceId: "server_absent" }]}
+      />,
+    );
+    expect(screen.queryByText("Server one")).toBeNull();
+    expect(screen.queryByText("No servers found")).toBeNull();
+    expect(screen.getByText("No matching servers")).toBeTruthy();
+  });
   it("never shows inventory state in a drawer that does not read it", () => {
     // A project-scoped drawer disables the hook, so a failed MCP read must not
     // reach it as a loading or unavailable state.

--- a/client/dashboard/src/pages/access/GrantRuleDrawerContent.test.tsx
+++ b/client/dashboard/src/pages/access/GrantRuleDrawerContent.test.tsx
@@ -1,0 +1,111 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GrantRuleDrawerContent } from "./GrantRuleDrawerContent";
+import type { ServerGroup } from "./serverMerge";
+
+const mocks = vi.hoisted(() => ({
+  inventory: {
+    groups: [] as ServerGroup[],
+    settled: false,
+    isError: false,
+    refetch: vi.fn(),
+  },
+}));
+vi.mock("@/contexts/Auth", () => ({
+  useOrganization: () => ({
+    id: "org_example",
+    projects: [{ id: "project_one", name: "Project one", slug: "project-one" }],
+  }),
+}));
+vi.mock("./useOrgMcpServers", () => ({
+  useOrgMcpServers: (enabled: boolean) =>
+    enabled
+      ? mocks.inventory
+      : { groups: [], settled: false, isError: false, refetch: vi.fn() },
+}));
+
+const serverGroups: ServerGroup[] = [
+  {
+    projectId: "project_one",
+    projectName: "Project one",
+    servers: [
+      {
+        id: "server_one",
+        name: "Server one",
+        slug: "server-one",
+        tools: [{ id: "tool_one", name: "search", type: "http" }],
+        dynamicTools: false,
+        remoteBacked: false,
+      },
+    ],
+  },
+];
+
+function setup(resourceType: "mcp" | "project" = "mcp") {
+  return render(
+    <GrantRuleDrawerContent
+      resourceType={resourceType}
+      scope={resourceType === "mcp" ? "mcp:connect" : "project:read"}
+      selectors={[]}
+      onChangeSelectors={() => {}}
+    />,
+  );
+}
+
+beforeEach(() => {
+  mocks.inventory = {
+    groups: [],
+    settled: false,
+    isError: false,
+    refetch: vi.fn(),
+  };
+});
+afterEach(cleanup);
+
+describe("grant rule server list", () => {
+  it("says the inventory is loading rather than empty while it is pending", () => {
+    setup();
+    expect(screen.getByText("Loading servers…")).toBeTruthy();
+    expect(screen.queryByText("No servers found")).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+  it("says the inventory is unavailable, with a retry, when a read fails", () => {
+    mocks.inventory = { ...mocks.inventory, isError: true };
+    setup();
+    expect(screen.getByText("Servers unavailable")).toBeTruthy();
+    expect(screen.queryByText("No servers found")).toBeNull();
+    expect(screen.getByRole("alert").textContent).toMatch(
+      /Could not load this organization/,
+    );
+    screen.getByRole("button", { name: "Retry" }).click();
+    expect(mocks.inventory.refetch).toHaveBeenCalledTimes(1);
+  });
+  it("reports an empty inventory only after a settled, successful read", () => {
+    mocks.inventory = { ...mocks.inventory, settled: true };
+    setup();
+    expect(screen.getByText("No servers found")).toBeTruthy();
+    expect(screen.queryByText("Loading servers…")).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+  it("renders the servers once the inventory settles with rows", () => {
+    mocks.inventory = {
+      ...mocks.inventory,
+      settled: true,
+      groups: serverGroups,
+    };
+    setup();
+    expect(screen.getByText("Server one")).toBeTruthy();
+    expect(screen.queryByText("Loading servers…")).toBeNull();
+    expect(screen.queryByText("No servers found")).toBeNull();
+  });
+  it("never shows inventory state in a drawer that does not read it", () => {
+    // A project-scoped drawer disables the hook, so a failed MCP read must not
+    // reach it as a loading or unavailable state.
+    mocks.inventory = { ...mocks.inventory, isError: true };
+    setup("project");
+    expect(screen.queryByText("Loading servers…")).toBeNull();
+    expect(screen.queryByText("Servers unavailable")).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});

--- a/client/dashboard/src/pages/access/GrantRuleDrawerContent.tsx
+++ b/client/dashboard/src/pages/access/GrantRuleDrawerContent.tsx
@@ -415,7 +415,11 @@ export function GrantRuleDrawerContent({
             {serverListMessage({
               settled: inventory.settled,
               isError: inventory.isError,
-              hasServers: scopedMcpServers.length > 0,
+              // The organization's own inventory, not the allow-scoped view:
+              // an exception whose allow rule excludes every listed server
+              // still leaves the organization with servers, and saying it has
+              // none sends the reader off to create one.
+              hasServers: mcpServers.length > 0,
             })}
           </div>
         ) : (

--- a/client/dashboard/src/pages/access/GrantRuleDrawerContent.tsx
+++ b/client/dashboard/src/pages/access/GrantRuleDrawerContent.tsx
@@ -35,6 +35,26 @@ import { type ServerGroup, type ServerTool } from "./serverMerge";
 import { useOrgMcpServers } from "./useOrgMcpServers";
 import { toolMetadataToServerTools } from "./remoteToolMetadata";
 
+/**
+ * What an empty server list means. The inventory is withheld until both org
+ * reads succeed, so an empty `groups` is only ever "this org has no servers"
+ * after a settled, successful read — while pending or failed it says so.
+ */
+function serverListMessage({
+  settled,
+  isError,
+  hasServers,
+}: {
+  settled: boolean;
+  isError: boolean;
+  hasServers: boolean;
+}): string {
+  if (isError) return "Servers unavailable";
+  if (!settled) return "Loading servers…";
+  if (!hasServers) return "No servers found";
+  return "No matching servers";
+}
+
 interface GrantRuleDrawerContentProps {
   /** The resource type determines which resource list to show */
   resourceType: ResourceType;
@@ -392,9 +412,11 @@ export function GrantRuleDrawerContent({
           )
         ) : filteredMcpServers.length === 0 ? (
           <div className="text-muted-foreground px-3 py-3 text-sm">
-            {scopedMcpServers.length === 0
-              ? "No servers found"
-              : "No matching servers"}
+            {serverListMessage({
+              settled: inventory.settled,
+              isError: inventory.isError,
+              hasServers: scopedMcpServers.length > 0,
+            })}
           </div>
         ) : (
           // Grouped under a project heading rather than prefixing every row

--- a/client/dashboard/src/pages/access/GrantRuleDrawerContent.tsx
+++ b/client/dashboard/src/pages/access/GrantRuleDrawerContent.tsx
@@ -416,9 +416,8 @@ export function GrantRuleDrawerContent({
               settled: inventory.settled,
               isError: inventory.isError,
               // The organization's own inventory, not the allow-scoped view:
-              // an exception whose allow rule excludes every listed server
-              // still leaves the organization with servers, and saying it has
-              // none sends the reader off to create one.
+              // an exception that filters every server out does not mean the
+              // organization has none.
               hasServers: mcpServers.length > 0,
             })}
           </div>

--- a/client/dashboard/src/pages/access/RolePermissionsSection.tsx
+++ b/client/dashboard/src/pages/access/RolePermissionsSection.tsx
@@ -44,6 +44,7 @@ export function RolePermissionsSection({
   disabled,
   onToggleScope,
   renderScopeRule,
+  subjectLabel = "this role",
 }: {
   groups: ScopeGroup[];
   selectedScopes: Set<string>;
@@ -51,6 +52,8 @@ export function RolePermissionsSection({
   onToggleScope: (scope: Scope) => void;
   /** Right-hand side of a row: the rule chips that narrow this permission. */
   renderScopeRule: (scope: ScopeDefinition) => ReactNode;
+  /** What the empty states call the thing being given permissions. */
+  subjectLabel?: string;
 }): JSX.Element {
   const [tab, setTab] = useState("mcp");
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -158,8 +161,8 @@ export function RolePermissionsSection({
                 </Text>
                 <Text muted small className="mt-1">
                   {tab === "mcp"
-                    ? "Add a permission to let this role reach MCP servers and their tools."
-                    : "Add a permission to let this role work with projects, environments and skills."}
+                    ? `Add a permission to let ${subjectLabel} reach MCP servers and their tools.`
+                    : `Add a permission to let ${subjectLabel} work with projects, environments and skills.`}
                 </Text>
               </div>
             ) : (

--- a/client/dashboard/src/pages/agents/AgentAPIKeys.tsx
+++ b/client/dashboard/src/pages/agents/AgentAPIKeys.tsx
@@ -6,6 +6,7 @@ import { useFeatureFlag, type FeatureFlagResult } from "@/hooks/useFeatureFlag";
 import { FEATURE_FLAGS } from "@/lib/featureFlags";
 import { SettingsSection } from "@/components/page-templates";
 import { Button } from "@/components/ui/Button";
+import { Checkbox } from "@/components/ui/Checkbox";
 import { Dialog } from "@/components/ui/Dialog";
 import { Input } from "@/components/ui/Input";
 import { Text } from "@/components/ui/Text";
@@ -364,17 +365,17 @@ function AgentAPIKeysContent({
                 onRetry={() => void delegable.refetch()}
               />
               <label className="flex items-start gap-2">
-                <input
-                  type="checkbox"
+                <Checkbox
                   checked={withoutPermissions}
-                  onChange={(event) =>
-                    setWithoutPermissions(event.target.checked)
-                  }
+                  onCheckedChange={(value) => setWithoutPermissions(!!value)}
+                  disabled={create.isPending}
+                  className="mt-0.5"
                 />
-                <span>
-                  Create without permissions
-                  <br />
-                  <Text as="span" small muted>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-sm font-medium">
+                    Create without permissions
+                  </span>
+                  <Text as="span" small muted className="block">
                     If no grants are selected, this key will not authorize any
                     actions.
                   </Text>

--- a/client/dashboard/src/pages/agents/AgentPolicy.test.tsx
+++ b/client/dashboard/src/pages/agents/AgentPolicy.test.tsx
@@ -1071,3 +1071,171 @@ describe("A concurrent change by another administrator", () => {
     expect(screen.queryByRole("alert")).toBeNull();
   });
 });
+
+describe("Losing the editor part-way through a multi-grant save", () => {
+  const storedGrants = [
+    {
+      id: "grant_one",
+      scope: "mcp:connect",
+      effect: "allow",
+      selector: { resourceKind: "mcp", resourceId: "server_one" },
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+    },
+    {
+      id: "grant_two",
+      scope: "skill:read",
+      effect: "allow",
+      selector: { resourceKind: "skill", resourceId: "*" },
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+    },
+  ];
+  const policyKey = ["agent-policy-grants", "org_example", "agent_example"];
+  const delegableKey = [
+    "agent-delegable-grants",
+    "org_example",
+    "user_owner",
+    "agent_example",
+  ];
+
+  beforeEach(() => {
+    mocks.params = new URLSearchParams({ id: "agent_example" });
+    mocks.listPolicyGrants.mockResolvedValue(storedGrants);
+  });
+
+  it("finishes only the request already in flight, then clears the caches it made untrustworthy", async () => {
+    const { client, rerenderPage } = setup();
+    // Two removals, so there is a second request to prove never happens.
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Remove mcp:connect" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Remove skill:read" }));
+
+    // The API key dialog's candidate set, primed before the save.
+    client.setQueryData(delegableKey, []);
+
+    const firstDelete = deferred<undefined>();
+    mocks.deletePolicyGrant.mockReturnValueOnce(firstDelete.promise);
+    fireEvent.click(screen.getByRole("button", { name: "Save permissions" }));
+    await waitFor(() =>
+      expect(mocks.deletePolicyGrant).toHaveBeenCalledTimes(1),
+    );
+
+    // Write permission goes away while that request is on the wire, which
+    // remounts the section under a new key and unmounts this instance.
+    mocks.agent.permissions = {
+      read: true,
+      write: false,
+      authorize: false,
+      transfer: false,
+    };
+    rerenderPage();
+
+    firstDelete.resolve(undefined);
+
+    // The cached ceiling and the delegable candidates are dropped, because the
+    // resolved request may or may not have committed.
+    await waitFor(() =>
+      expect(client.getQueryState(delegableKey)?.data).toBeUndefined(),
+    );
+    // The second removal was never issued after the context went away.
+    expect(mocks.deletePolicyGrant).toHaveBeenCalledTimes(1);
+    expect(mocks.deletePolicyGrant.mock.calls[0]?.[0]).toEqual({
+      agentPolicyGrantIDForm: {
+        agentId: "agent_example",
+        grantId: "grant_one",
+      },
+    });
+    expect(mocks.createPolicyGrant).not.toHaveBeenCalled();
+
+    // The read-only editor that replaced it shows what the server says, not the
+    // abandoned draft, and no error was pushed into the unmounted instance.
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Remove mcp:connect" }),
+      ).toBeTruthy(),
+    );
+    expect(
+      screen.getByRole("button", { name: "Remove skill:read" }),
+    ).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Reload permissions" }),
+    ).toBeNull();
+  });
+
+  it("refetches rather than serving the cleared ceiling from cache", async () => {
+    const { client, rerenderPage } = setup();
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Remove mcp:connect" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Remove skill:read" }));
+
+    const firstDelete = deferred<undefined>();
+    mocks.deletePolicyGrant.mockReturnValueOnce(firstDelete.promise);
+    fireEvent.click(screen.getByRole("button", { name: "Save permissions" }));
+    await waitFor(() =>
+      expect(mocks.deletePolicyGrant).toHaveBeenCalledTimes(1),
+    );
+    const readsBeforeAbandon = mocks.listPolicyGrants.mock.calls.length;
+
+    mocks.agent.permissions = {
+      read: true,
+      write: false,
+      authorize: false,
+      transfer: false,
+    };
+    rerenderPage();
+    // Only one grant actually went away on the server.
+    mocks.listPolicyGrants.mockResolvedValue([storedGrants[1]]);
+    firstDelete.resolve(undefined);
+
+    // The still-active observer is made to read again rather than keep the
+    // pre-save list it was showing.
+    await waitFor(() =>
+      expect(mocks.listPolicyGrants.mock.calls.length).toBeGreaterThan(
+        readsBeforeAbandon,
+      ),
+    );
+    await waitFor(() => expect(client.getQueryData(policyKey)).toHaveLength(1));
+    expect(
+      screen.queryByRole("button", { name: "Remove mcp:connect" }),
+    ).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Remove skill:read" }),
+    ).toBeTruthy();
+  });
+
+  it("does not touch the caches when the context goes away before any request", async () => {
+    const { client, rerenderPage } = setup();
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Remove mcp:connect" }),
+    );
+    client.setQueryData(delegableKey, []);
+
+    // Hang the pre-save confirming read, so the save has issued no write yet.
+    const read = deferred<unknown[]>();
+    mocks.listPolicyGrants.mockReturnValueOnce(read.promise);
+    fireEvent.click(screen.getByRole("button", { name: "Save permissions" }));
+
+    mocks.agent.permissions = {
+      read: true,
+      write: false,
+      authorize: false,
+      transfer: false,
+    };
+    rerenderPage();
+    read.resolve(storedGrants);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Remove mcp:connect" }),
+      ).toBeTruthy(),
+    );
+    expect(mocks.deletePolicyGrant).not.toHaveBeenCalled();
+    expect(mocks.createPolicyGrant).not.toHaveBeenCalled();
+    // Nothing was written, so the primed candidate set is left alone.
+    expect(client.getQueryData(delegableKey)).toEqual([]);
+  });
+});

--- a/client/dashboard/src/pages/agents/AgentPolicy.test.tsx
+++ b/client/dashboard/src/pages/agents/AgentPolicy.test.tsx
@@ -37,10 +37,9 @@ const mocks = vi.hoisted(() => ({
   },
 }));
 
-// The reused access controls carry their own tests. Here they stand in as the
+// The reused access controls carry their own tests. These stubs are the
 // smallest surface that still exercises every callback this page wires up, so
-// the assertions are about the request the page builds rather than about a
-// dropdown opening.
+// the assertions are about the request it builds, not about a dropdown opening.
 vi.mock("@/pages/access/RolePermissionsSection", () => ({
   RolePermissionsSection: ({
     groups,
@@ -318,8 +317,6 @@ describe("Creating an agent with permissions", () => {
         },
       ],
     });
-    // Nothing is created before the single atomic request, so no separate
-    // grant call may exist.
     expect(mocks.createPolicyGrant).not.toHaveBeenCalled();
   });
 
@@ -751,8 +748,8 @@ describe("Confirming the stored ceiling after a save", () => {
       await screen.findByRole("button", { name: "Add mcp:connect" }),
     );
     const pending = deferred<unknown[]>();
-    // The pre-save read agrees with the pinned base; the confirming read after
-    // the writes is the one left hanging.
+    // The pre-save read agrees with the pinned base; the read after the writes
+    // is the one left hanging.
     mocks.listPolicyGrants
       .mockResolvedValueOnce([])
       .mockReturnValueOnce(pending.promise);
@@ -814,7 +811,7 @@ describe("Confirming the stored ceiling after a save", () => {
         /Could not confirm this agent's stored permissions/,
       ),
     );
-    // No editor at all: a base built from the pre-save cache would be stale.
+    // A base built from the pre-save cache would be stale.
     expect(
       screen.queryByRole("button", { name: "Add mcp:connect" }),
     ).toBeNull();
@@ -841,7 +838,6 @@ describe("Confirming the stored ceiling after a save", () => {
         screen.getByRole("button", { name: "Remove mcp:connect" }),
       ).toBeTruthy(),
     );
-    // The abandoned half of the edit is gone, not carried over.
     expect(screen.getByRole("button", { name: "Add mcp:read" })).toBeTruthy();
   });
 });
@@ -973,8 +969,8 @@ describe("A concurrent change by another administrator", () => {
     fireEvent.click(
       await screen.findByRole("button", { name: "Add mcp:connect" }),
     );
-    // Their grant lands on the server. Nothing refetched it, so the cache still
-    // matches the pinned base — only a fresh read can catch this.
+    // Nothing refetched, so the cache still matches the pinned base. Only a
+    // fresh read can catch this.
     mocks.listPolicyGrants.mockResolvedValue([otherAdminGrant]);
     expect(
       screen.queryByRole("button", { name: "Remove skill:read" }),
@@ -986,10 +982,9 @@ describe("A concurrent change by another administrator", () => {
         /Someone else changed this agent's permissions/,
       ),
     );
-    // Nothing at all was sent: no delete could reach their grant.
+    // Nothing was sent, so no delete could reach their grant.
     expect(mocks.deletePolicyGrant).not.toHaveBeenCalled();
     expect(mocks.createPolicyGrant).not.toHaveBeenCalled();
-    // Fail closed — no editable base until the user reloads.
     expect(
       screen.queryByRole("button", { name: "Save permissions" }),
     ).toBeNull();
@@ -1026,8 +1021,8 @@ describe("A concurrent change by another administrator", () => {
   });
 
   it("still applies a deliberate removal when nothing else changed", async () => {
-    // The save diffs against the base pinned when the draft opened, so an
-    // unchanged background refetch neither blocks it nor alters what it sends.
+    // Diffing against the pinned base means an unchanged background refetch
+    // neither blocks the save nor alters what it sends.
     mocks.listPolicyGrants.mockResolvedValue([otherAdminGrant]);
     const { client } = setup();
     fireEvent.click(
@@ -1106,7 +1101,7 @@ describe("Losing the editor part-way through a multi-grant save", () => {
 
   it("finishes only the request already in flight, then clears the caches it made untrustworthy", async () => {
     const { client, rerenderPage } = setup();
-    // Two removals, so there is a second request to prove never happens.
+    // Two removals, so there is a second request that must never be issued.
     fireEvent.click(
       await screen.findByRole("button", { name: "Remove mcp:connect" }),
     );
@@ -1122,8 +1117,8 @@ describe("Losing the editor part-way through a multi-grant save", () => {
       expect(mocks.deletePolicyGrant).toHaveBeenCalledTimes(1),
     );
 
-    // Write permission goes away while that request is on the wire, which
-    // remounts the section under a new key and unmounts this instance.
+    // Revoking write remounts the section under a new key, unmounting this
+    // instance while its request is still on the wire.
     mocks.agent.permissions = {
       read: true,
       write: false,
@@ -1134,12 +1129,10 @@ describe("Losing the editor part-way through a multi-grant save", () => {
 
     firstDelete.resolve(undefined);
 
-    // The cached ceiling and the delegable candidates are dropped, because the
-    // resolved request may or may not have committed.
+    // The resolved request may or may not have committed.
     await waitFor(() =>
       expect(client.getQueryState(delegableKey)?.data).toBeUndefined(),
     );
-    // The second removal was never issued after the context went away.
     expect(mocks.deletePolicyGrant).toHaveBeenCalledTimes(1);
     expect(mocks.deletePolicyGrant.mock.calls[0]?.[0]).toEqual({
       agentPolicyGrantIDForm: {
@@ -1149,8 +1142,8 @@ describe("Losing the editor part-way through a multi-grant save", () => {
     });
     expect(mocks.createPolicyGrant).not.toHaveBeenCalled();
 
-    // The read-only editor that replaced it shows what the server says, not the
-    // abandoned draft, and no error was pushed into the unmounted instance.
+    // The replacement editor shows the server's list, and no state was pushed
+    // into the unmounted instance.
     await waitFor(() =>
       expect(
         screen.getByRole("button", { name: "Remove mcp:connect" }),
@@ -1191,8 +1184,8 @@ describe("Losing the editor part-way through a multi-grant save", () => {
     mocks.listPolicyGrants.mockResolvedValue([storedGrants[1]]);
     firstDelete.resolve(undefined);
 
-    // The still-active observer is made to read again rather than keep the
-    // pre-save list it was showing.
+    // The still-active observer must read again rather than keep the pre-save
+    // list it was showing.
     await waitFor(() =>
       expect(mocks.listPolicyGrants.mock.calls.length).toBeGreaterThan(
         readsBeforeAbandon,

--- a/client/dashboard/src/pages/agents/AgentPolicy.test.tsx
+++ b/client/dashboard/src/pages/agents/AgentPolicy.test.tsx
@@ -751,7 +751,11 @@ describe("Confirming the stored ceiling after a save", () => {
       await screen.findByRole("button", { name: "Add mcp:connect" }),
     );
     const pending = deferred<unknown[]>();
-    mocks.listPolicyGrants.mockReturnValue(pending.promise);
+    // The pre-save read agrees with the pinned base; the confirming read after
+    // the writes is the one left hanging.
+    mocks.listPolicyGrants
+      .mockResolvedValueOnce([])
+      .mockReturnValueOnce(pending.promise);
     fireEvent.click(screen.getByRole("button", { name: "Save permissions" }));
     await waitFor(() => expect(mocks.createPolicyGrant).toHaveBeenCalled());
 
@@ -800,7 +804,9 @@ describe("Confirming the stored ceiling after a save", () => {
     mocks.createPolicyGrant
       .mockResolvedValueOnce({})
       .mockRejectedValueOnce(new Error("Rejected."));
-    mocks.listPolicyGrants.mockRejectedValue(new Error("read failed"));
+    mocks.listPolicyGrants
+      .mockResolvedValueOnce([])
+      .mockRejectedValue(new Error("read failed"));
     fireEvent.click(screen.getByRole("button", { name: "Save permissions" }));
 
     await waitFor(() =>
@@ -962,27 +968,14 @@ describe("A concurrent change by another administrator", () => {
     mocks.params = new URLSearchParams({ id: "agent_example" });
   });
 
-  it("writes nothing and keeps their grant when the ceiling moved under the draft", async () => {
-    const { client } = setup();
+  it("blocks and writes nothing when the server has a grant the cache never saw", async () => {
+    setup();
     fireEvent.click(
       await screen.findByRole("button", { name: "Add mcp:connect" }),
     );
-
-    // Their grant lands after this draft was started. The open draft keeps
-    // showing the user's own edit, which is exactly why the save must check.
-    client.setQueryData(
-      ["agent-policy-grants", "org_example", "agent_example"],
-      [otherAdminGrant],
-    );
-    await waitFor(() =>
-      expect(
-        client.getQueryData([
-          "agent-policy-grants",
-          "org_example",
-          "agent_example",
-        ]),
-      ).toHaveLength(1),
-    );
+    // Their grant lands on the server. Nothing refetched it, so the cache still
+    // matches the pinned base — only a fresh read can catch this.
+    mocks.listPolicyGrants.mockResolvedValue([otherAdminGrant]);
     expect(
       screen.queryByRole("button", { name: "Remove skill:read" }),
     ).toBeNull();
@@ -1001,7 +994,6 @@ describe("A concurrent change by another administrator", () => {
       screen.queryByRole("button", { name: "Save permissions" }),
     ).toBeNull();
 
-    mocks.listPolicyGrants.mockResolvedValue([otherAdminGrant]);
     fireEvent.click(screen.getByRole("button", { name: "Reload permissions" }));
     await waitFor(() =>
       expect(
@@ -1011,6 +1003,26 @@ describe("A concurrent change by another administrator", () => {
     expect(
       screen.getByRole("button", { name: "Add mcp:connect" }),
     ).toBeTruthy();
+  });
+
+  it("blocks and writes nothing when the pre-save read fails", async () => {
+    setup();
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Add mcp:connect" }),
+    );
+    mocks.listPolicyGrants.mockRejectedValue(new Error("read failed"));
+
+    fireEvent.click(screen.getByRole("button", { name: "Save permissions" }));
+    await waitFor(() =>
+      expect(screen.getByRole("alert").textContent).toMatch(
+        /Could not read this agent's current permissions, so nothing was saved/,
+      ),
+    );
+    expect(mocks.deletePolicyGrant).not.toHaveBeenCalled();
+    expect(mocks.createPolicyGrant).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole("button", { name: "Save permissions" }),
+    ).toBeNull();
   });
 
   it("still applies a deliberate removal when nothing else changed", async () => {

--- a/client/dashboard/src/pages/agents/AgentPolicy.test.tsx
+++ b/client/dashboard/src/pages/agents/AgentPolicy.test.tsx
@@ -130,6 +130,9 @@ vi.mock("@/pages/access/GrantRuleDrawerContent", () => ({
       >
         Pick server one
       </button>
+      <button type="button" onClick={() => onChangeSelectors(null)}>
+        Pick all servers
+      </button>
     </div>
   ),
 }));
@@ -888,5 +891,171 @@ describe("Stored constraints the editor cannot show", () => {
         selector: { resourceKind: "mcp", resourceId: "*" },
       },
     });
+  });
+});
+
+describe("Choosing the unrestricted option inside the picker", () => {
+  it("keeps Done available and saves an unrestricted grant", async () => {
+    setup();
+    fireEvent.change(screen.getByLabelText("Agent name"), {
+      target: { value: "Unrestricted" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add mcp:connect" }));
+    fireEvent.click(screen.getByRole("button", { name: "Narrow mcp:connect" }));
+    await screen.findByText("picker mcp:connect (mcp)");
+
+    // An unfinished narrowing blocks Done; the unrestricted choice must not.
+    expect(
+      (screen.getByRole("button", { name: "Done" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    fireEvent.click(screen.getByRole("button", { name: "Pick all servers" }));
+    const done = screen.getByRole("button", { name: "Done" });
+    expect((done as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(done);
+
+    expect(screen.getByText("applies mcp:connect: All servers")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Create agent" }));
+    await waitFor(() => expect(mocks.createAgent).toHaveBeenCalledTimes(1));
+    expect(createdAgentForm().policyGrants).toEqual([
+      {
+        effect: "allow",
+        scope: "mcp:connect",
+        selector: { resourceKind: "mcp", resourceId: "*" },
+      },
+    ]);
+  });
+
+  it("widens a narrowed permission back to unrestricted", async () => {
+    setup();
+    fireEvent.change(screen.getByLabelText("Agent name"), {
+      target: { value: "Rewidened" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add mcp:connect" }));
+    fireEvent.click(screen.getByRole("button", { name: "Narrow mcp:connect" }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Pick server one" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+    expect(screen.getByText("applies mcp:connect: search")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Narrow mcp:connect" }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Pick all servers" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+    expect(screen.getByText("applies mcp:connect: All servers")).toBeTruthy();
+  });
+});
+
+describe("A concurrent change by another administrator", () => {
+  const otherAdminGrant = {
+    id: "grant_other",
+    scope: "skill:read",
+    effect: "allow",
+    selector: { resourceKind: "skill", resourceId: "*" },
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  };
+
+  beforeEach(() => {
+    mocks.params = new URLSearchParams({ id: "agent_example" });
+  });
+
+  it("writes nothing and keeps their grant when the ceiling moved under the draft", async () => {
+    const { client } = setup();
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Add mcp:connect" }),
+    );
+
+    // Their grant lands after this draft was started. The open draft keeps
+    // showing the user's own edit, which is exactly why the save must check.
+    client.setQueryData(
+      ["agent-policy-grants", "org_example", "agent_example"],
+      [otherAdminGrant],
+    );
+    await waitFor(() =>
+      expect(
+        client.getQueryData([
+          "agent-policy-grants",
+          "org_example",
+          "agent_example",
+        ]),
+      ).toHaveLength(1),
+    );
+    expect(
+      screen.queryByRole("button", { name: "Remove skill:read" }),
+    ).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Save permissions" }));
+    await waitFor(() =>
+      expect(screen.getByRole("alert").textContent).toMatch(
+        /Someone else changed this agent's permissions/,
+      ),
+    );
+    // Nothing at all was sent: no delete could reach their grant.
+    expect(mocks.deletePolicyGrant).not.toHaveBeenCalled();
+    expect(mocks.createPolicyGrant).not.toHaveBeenCalled();
+    // Fail closed — no editable base until the user reloads.
+    expect(
+      screen.queryByRole("button", { name: "Save permissions" }),
+    ).toBeNull();
+
+    mocks.listPolicyGrants.mockResolvedValue([otherAdminGrant]);
+    fireEvent.click(screen.getByRole("button", { name: "Reload permissions" }));
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Remove skill:read" }),
+      ).toBeTruthy(),
+    );
+    expect(
+      screen.getByRole("button", { name: "Add mcp:connect" }),
+    ).toBeTruthy();
+  });
+
+  it("still applies a deliberate removal when nothing else changed", async () => {
+    // The save diffs against the base pinned when the draft opened, so an
+    // unchanged background refetch neither blocks it nor alters what it sends.
+    mocks.listPolicyGrants.mockResolvedValue([otherAdminGrant]);
+    const { client } = setup();
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Remove skill:read" }),
+    );
+    client.setQueryData(
+      ["agent-policy-grants", "org_example", "agent_example"],
+      [{ ...otherAdminGrant }],
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Save permissions" }));
+    await waitFor(() =>
+      expect(mocks.deletePolicyGrant).toHaveBeenCalledTimes(1),
+    );
+    expect(mocks.deletePolicyGrant.mock.calls[0]?.[0]).toEqual({
+      agentPolicyGrantIDForm: {
+        agentId: "agent_example",
+        grantId: "grant_other",
+      },
+    });
+    expect(mocks.createPolicyGrant).not.toHaveBeenCalled();
+  });
+
+  it("still saves when the refetch returns an identical ceiling", async () => {
+    mocks.listPolicyGrants.mockResolvedValue([otherAdminGrant]);
+    const { client } = setup();
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Add mcp:connect" }),
+    );
+    // Same grants, new array identity — a plain background refetch.
+    client.setQueryData(
+      ["agent-policy-grants", "org_example", "agent_example"],
+      [{ ...otherAdminGrant }],
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Save permissions" }));
+    await waitFor(() =>
+      expect(mocks.createPolicyGrant).toHaveBeenCalledTimes(1),
+    );
+    expect(mocks.deletePolicyGrant).not.toHaveBeenCalled();
+    expect(screen.queryByRole("alert")).toBeNull();
   });
 });

--- a/client/dashboard/src/pages/agents/AgentPolicy.test.tsx
+++ b/client/dashboard/src/pages/agents/AgentPolicy.test.tsx
@@ -1,0 +1,892 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import {
+  QueryClient,
+  QueryClientProvider,
+  useMutation,
+} from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import type { ScopeDefinition } from "@gram/client/models/components/scopedefinition.js";
+import type { Selector } from "@gram/client/models/components/selector.js";
+import type { ScopeRule } from "@/pages/access/types";
+import AgentsPage from "./Agents";
+
+const mocks = vi.hoisted(() => ({
+  params: new URLSearchParams(),
+  navigate: vi.fn(),
+  organizationId: "org_example",
+  userId: "user_owner",
+  list: vi.fn(),
+  detail: vi.fn(),
+  listPolicyGrants: vi.fn(),
+  createPolicyGrant: vi.fn(),
+  deletePolicyGrant: vi.fn(),
+  createAgent: vi.fn(),
+  agent: {
+    id: "agent_example",
+    name: "Example agent",
+    ownerUserId: "user_owner",
+    lifecycle: "active",
+    permissions: { read: true, write: true, authorize: true, transfer: true },
+  },
+}));
+
+// The reused access controls carry their own tests. Here they stand in as the
+// smallest surface that still exercises every callback this page wires up, so
+// the assertions are about the request the page builds rather than about a
+// dropdown opening.
+vi.mock("@/pages/access/RolePermissionsSection", () => ({
+  RolePermissionsSection: ({
+    groups,
+    selectedScopes,
+    disabled,
+    onToggleScope,
+    renderScopeRule,
+    subjectLabel,
+  }: {
+    groups: { scopes: ScopeDefinition[] }[];
+    selectedScopes: Set<string>;
+    disabled?: boolean;
+    onToggleScope: (scope: string) => void;
+    renderScopeRule: (scope: ScopeDefinition) => ReactNode;
+    subjectLabel?: string;
+  }) => (
+    <div>
+      <span>subject:{subjectLabel}</span>
+      {groups
+        .flatMap((group) => group.scopes)
+        .map((scope) => (
+          <div key={scope.slug}>
+            <button
+              type="button"
+              disabled={disabled}
+              onClick={() => onToggleScope(scope.slug)}
+            >
+              {selectedScopes.has(scope.slug)
+                ? `Remove ${scope.slug}`
+                : `Add ${scope.slug}`}
+            </button>
+            {selectedScopes.has(scope.slug) && renderScopeRule(scope)}
+          </div>
+        ))}
+    </div>
+  ),
+}));
+vi.mock("@/pages/access/PermissionScopeControl", () => ({
+  PermissionScopeControl: ({
+    allowRule,
+    allowLabel,
+    disabled,
+    canAddException,
+    denyRules,
+    onChooseSpecific,
+    onResetToAll,
+  }: {
+    allowRule: ScopeRule;
+    allowLabel: string;
+    disabled?: boolean;
+    canAddException: boolean;
+    denyRules: unknown[];
+    onChooseSpecific: () => void;
+    onResetToAll: () => void;
+  }) => (
+    <span>
+      <span>{`applies ${allowRule.id}: ${allowLabel}`}</span>
+      <span>{`exceptions ${allowRule.id}: ${canAddException ? "on" : "off"}/${denyRules.length}`}</span>
+      <button type="button" disabled={disabled} onClick={onChooseSpecific}>
+        {`Narrow ${allowRule.id}`}
+      </button>
+      <button type="button" disabled={disabled} onClick={onResetToAll}>
+        {`Widen ${allowRule.id}`}
+      </button>
+    </span>
+  ),
+}));
+vi.mock("@/pages/access/GrantRuleDrawerContent", () => ({
+  GrantRuleDrawerContent: ({
+    scope,
+    resourceType,
+    onChangeSelectors,
+  }: {
+    scope?: string;
+    resourceType: string;
+    onChangeSelectors: (selectors: Selector[] | null) => void;
+  }) => (
+    <div>
+      <span>{`picker ${scope} (${resourceType})`}</span>
+      <button
+        type="button"
+        onClick={() =>
+          onChangeSelectors([
+            { resourceKind: "mcp", resourceId: "server_one", tool: "search" },
+          ])
+        }
+      >
+        Pick server one
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("@/contexts/Auth", () => ({
+  useOrganization: () => ({
+    id: mocks.organizationId,
+    slug: "example",
+    projects: [{ id: "project_one", name: "Project one", slug: "project-one" }],
+  }),
+  useSession: () => ({
+    user: {
+      id: mocks.userId,
+      displayName: "Owner",
+      email: "owner@example.test",
+    },
+    organizationOverride: false,
+    impersonatorEmail: undefined,
+  }),
+  useIsPlatformAdmin: () => false,
+}));
+vi.mock("@/contexts/Sdk", () => ({
+  useSdkClient: () => ({
+    agents: {
+      list: mocks.list,
+      get: mocks.detail,
+      listPolicyGrants: mocks.listPolicyGrants,
+      createPolicyGrant: mocks.createPolicyGrant,
+      deletePolicyGrant: mocks.deletePolicyGrant,
+    },
+  }),
+}));
+vi.mock("@gram/client/react-query/createAgent.js", () => ({
+  useCreateAgentMutation: (options: object) =>
+    useMutation({ mutationFn: mocks.createAgent, ...options }),
+}));
+vi.mock("@gram/client/react-query/renameAgent.js", () => ({
+  useRenameAgentMutation: () => ({ mutate: vi.fn() }),
+}));
+vi.mock("@gram/client/react-query/agentsDelete.js", () => ({
+  useAgentsDeleteMutation: () => ({ mutate: vi.fn() }),
+}));
+vi.mock("@gram/client/react-query/agentsResume.js", () => ({
+  useAgentsResumeMutation: () => ({ mutate: vi.fn() }),
+}));
+vi.mock("@gram/client/react-query/agentsRevoke.js", () => ({
+  useAgentsRevokeMutation: () => ({ mutate: vi.fn() }),
+}));
+vi.mock("@gram/client/react-query/agentsSuspend.js", () => ({
+  useAgentsSuspendMutation: () => ({ mutate: vi.fn() }),
+}));
+vi.mock("./AgentAPIKeys", () => ({ AgentAPIKeys: () => <div>API keys</div> }));
+vi.mock("./ManagedAgentSessions", () => ({
+  ManagedAgentSessions: () => <div>Sessions</div>,
+}));
+vi.mock("@/components/ui/Avatar", () => ({
+  Avatar: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  AvatarImage: ({ src, alt }: { src?: string; alt: string }) => (
+    <img src={src} alt={alt} />
+  ),
+  AvatarFallback: ({ children }: { children: ReactNode }) => (
+    <span>{children}</span>
+  ),
+}));
+vi.mock("@/components/dev-toolbar-utils", () => ({
+  getRBACScopeOverrideHeader: () => null,
+}));
+vi.mock("react-router", () => ({
+  useSearchParams: () => [mocks.params, mocks.navigate],
+}));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/components/page-templates", () => {
+  const Part = ({ children }: { children: ReactNode }) => <div>{children}</div>;
+  const Section = Object.assign(Part, {
+    Header: Part,
+    Title: Part,
+    Description: Part,
+    Panel: Part,
+    Body: Part,
+    Footer: Part,
+  });
+  const Page = ({
+    children,
+    title,
+    description,
+  }: {
+    children: ReactNode;
+    title: string;
+    description: string;
+  }) => (
+    <div>
+      <h1>{title}</h1>
+      <p>{description}</p>
+      {children}
+    </div>
+  );
+  return {
+    ResourceListPage: Page,
+    SettingsPage: Page,
+    FormPage: Page,
+    SettingsSection: Section,
+    DangerSettingsSection: Section,
+  };
+});
+
+function setup() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const view = render(
+    <QueryClientProvider client={client}>
+      <AgentsPage />
+    </QueryClientProvider>,
+  );
+  return {
+    ...view,
+    client,
+    rerenderPage: () =>
+      view.rerender(
+        <QueryClientProvider client={client}>
+          <AgentsPage />
+        </QueryClientProvider>,
+      ),
+  };
+}
+
+function createdAgentForm() {
+  return mocks.createAgent.mock.calls[0]?.[0]?.request?.createAgentForm;
+}
+
+afterEach(cleanup);
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.params = new URLSearchParams({ create: "true" });
+  mocks.organizationId = "org_example";
+  mocks.userId = "user_owner";
+  mocks.agent.ownerUserId = "user_owner";
+  mocks.agent.permissions = {
+    read: true,
+    write: true,
+    authorize: true,
+    transfer: true,
+  };
+  mocks.list.mockResolvedValue([mocks.agent]);
+  mocks.detail.mockResolvedValue(mocks.agent);
+  mocks.listPolicyGrants.mockResolvedValue([]);
+  mocks.createPolicyGrant.mockResolvedValue({});
+  mocks.deletePolicyGrant.mockResolvedValue(undefined);
+  mocks.createAgent.mockResolvedValue({ ...mocks.agent, id: "agent_new" });
+});
+
+describe("Creating an agent with permissions", () => {
+  it("offers only agent-runtime-safe permissions, named for the agent", () => {
+    setup();
+    expect(screen.getByText("subject:this agent")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Add mcp:connect" }),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Add org:admin" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Add risk_policy:bypass" }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Add mcp:blocked_connect" }),
+    ).toBeNull();
+  });
+
+  it("creates the agent and its MCP permission in one request", async () => {
+    setup();
+    fireEvent.change(screen.getByLabelText("Agent name"), {
+      target: { value: "  Release assistant  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add mcp:connect" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create agent" }));
+    await waitFor(() => expect(mocks.createAgent).toHaveBeenCalledTimes(1));
+    expect(createdAgentForm()).toEqual({
+      name: "Release assistant",
+      policyGrants: [
+        {
+          effect: "allow",
+          scope: "mcp:connect",
+          selector: { resourceKind: "mcp", resourceId: "*" },
+        },
+      ],
+    });
+    // Nothing is created before the single atomic request, so no separate
+    // grant call may exist.
+    expect(mocks.createPolicyGrant).not.toHaveBeenCalled();
+  });
+
+  it("sends the narrowed selector the picker produced", async () => {
+    setup();
+    fireEvent.change(screen.getByLabelText("Agent name"), {
+      target: { value: "Narrowed" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add mcp:connect" }));
+    expect(screen.getByText("applies mcp:connect: All servers")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Narrow mcp:connect" }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Pick server one" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create agent" }));
+    await waitFor(() => expect(mocks.createAgent).toHaveBeenCalledTimes(1));
+    expect(createdAgentForm().policyGrants).toEqual([
+      {
+        effect: "allow",
+        scope: "mcp:connect",
+        selector: {
+          resourceKind: "mcp",
+          resourceId: "server_one",
+          tool: "search",
+        },
+      },
+    ]);
+  });
+
+  it("never offers an exception, because agent policy is allow-only", () => {
+    setup();
+    fireEvent.click(screen.getByRole("button", { name: "Add mcp:connect" }));
+    expect(screen.getByText("exceptions mcp:connect: off/0")).toBeTruthy();
+  });
+
+  it("gives environment and risk policy permissions no resource choice", () => {
+    setup();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Add environment:read" }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Add risk_policy:evaluate" }),
+    );
+    expect(
+      screen.queryByRole("button", { name: "Narrow environment:read" }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Narrow risk_policy:evaluate" }),
+    ).toBeNull();
+  });
+
+  it("refuses a permissionless agent until it is confirmed, then sends no grants", async () => {
+    setup();
+    fireEvent.change(screen.getByLabelText("Agent name"), {
+      target: { value: "Bare" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create agent" }));
+    expect(mocks.createAgent).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert").textContent).toMatch(
+      /Add permissions or explicitly confirm/,
+    );
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: /Create without permissions/ }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Create agent" }));
+    await waitFor(() => expect(mocks.createAgent).toHaveBeenCalledTimes(1));
+    expect(createdAgentForm()).toEqual({ name: "Bare" });
+  });
+
+  it("keeps the whole draft when the atomic create is rejected", async () => {
+    mocks.createAgent.mockRejectedValue(
+      new Error("scope is not allowed for agent policy"),
+    );
+    setup();
+    fireEvent.change(screen.getByLabelText("Agent name"), {
+      target: { value: "Retryable" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add mcp:connect" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create agent" }));
+    await waitFor(() =>
+      expect(screen.getByRole("alert").textContent).toMatch(
+        /scope is not allowed/,
+      ),
+    );
+    expect(mocks.navigate).not.toHaveBeenCalled();
+    expect(
+      (screen.getByLabelText("Agent name") as HTMLInputElement).value,
+    ).toBe("Retryable");
+    expect(
+      screen.getByRole("button", { name: "Remove mcp:connect" }),
+    ).toBeTruthy();
+
+    mocks.createAgent.mockResolvedValue({ ...mocks.agent, id: "agent_new" });
+    fireEvent.click(screen.getByRole("button", { name: "Create agent" }));
+    await waitFor(() => expect(mocks.createAgent).toHaveBeenCalledTimes(2));
+    expect(
+      mocks.createAgent.mock.calls[1]?.[0].request.createAgentForm,
+    ).toEqual({
+      name: "Retryable",
+      policyGrants: [
+        {
+          effect: "allow",
+          scope: "mcp:connect",
+          selector: { resourceKind: "mcp", resourceId: "*" },
+        },
+      ],
+    });
+  });
+
+  it("drops the stale delegable candidate set for the new agent", async () => {
+    const { client } = setup();
+    client.setQueryData(
+      ["agent-delegable-grants", "org_example", "user_owner", "agent_new"],
+      [],
+    );
+    fireEvent.change(screen.getByLabelText("Agent name"), {
+      target: { value: "Fresh" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add mcp:connect" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create agent" }));
+    await waitFor(() =>
+      expect(mocks.navigate).toHaveBeenCalledWith({ id: "agent_new" }),
+    );
+    await waitFor(() =>
+      expect(
+        client.getQueryState([
+          "agent-delegable-grants",
+          "org_example",
+          "user_owner",
+          "agent_new",
+        ])?.isInvalidated,
+      ).toBe(true),
+    );
+  });
+});
+
+describe("Editing an existing agent's permissions", () => {
+  beforeEach(() => {
+    mocks.params = new URLSearchParams({ id: "agent_example" });
+  });
+
+  it("says a permissionless agent cannot authorize anything", async () => {
+    setup();
+    expect(
+      await screen.findByText(/This agent has no permissions/),
+    ).toBeTruthy();
+  });
+
+  it("applies an added permission and refreshes key discovery", async () => {
+    const { client } = setup();
+    client.setQueryData(
+      ["agent-delegable-grants", "org_example", "user_owner", "agent_example"],
+      [],
+    );
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Add mcp:connect" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Save permissions" }));
+    await waitFor(() =>
+      expect(mocks.createPolicyGrant).toHaveBeenCalledTimes(1),
+    );
+    expect(mocks.createPolicyGrant.mock.calls[0]?.[0]).toEqual({
+      createAgentPolicyGrantForm: {
+        agentId: "agent_example",
+        effect: "allow",
+        scope: "mcp:connect",
+        selector: { resourceKind: "mcp", resourceId: "*" },
+      },
+    });
+    expect(mocks.deletePolicyGrant).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(
+        client.getQueryState([
+          "agent-delegable-grants",
+          "org_example",
+          "user_owner",
+          "agent_example",
+        ])?.isInvalidated,
+      ).toBe(true),
+    );
+  });
+
+  it("replaces a widened permission by removing the narrower grant first", async () => {
+    mocks.listPolicyGrants.mockResolvedValue([
+      {
+        id: "grant_one",
+        scope: "mcp:connect",
+        effect: "allow",
+        selector: { resourceKind: "mcp", resourceId: "server_two" },
+        createdAt: new Date(0),
+        updatedAt: new Date(0),
+      },
+    ]);
+    setup();
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Widen mcp:connect" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Save permissions" }));
+    await waitFor(() =>
+      expect(mocks.createPolicyGrant).toHaveBeenCalledTimes(1),
+    );
+    expect(mocks.deletePolicyGrant.mock.calls[0]?.[0]).toEqual({
+      agentPolicyGrantIDForm: {
+        agentId: "agent_example",
+        grantId: "grant_one",
+      },
+    });
+    expect(mocks.deletePolicyGrant.mock.invocationCallOrder[0]!).toBeLessThan(
+      mocks.createPolicyGrant.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("shows the stored ceiling, not the draft, when a change part-way fails", async () => {
+    mocks.createPolicyGrant.mockRejectedValue(new Error("Rejected."));
+    setup();
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Add mcp:connect" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Save permissions" }));
+    await waitFor(() =>
+      expect(screen.getByRole("alert").textContent).toMatch(
+        /Some changes may not have been applied/,
+      ),
+    );
+    expect(
+      screen.getByRole("button", { name: "Add mcp:connect" }),
+    ).toBeTruthy();
+  });
+
+  it("lets the owner configure policy without any RBAC grant", async () => {
+    setup();
+    const add = await screen.findByRole("button", { name: "Add mcp:connect" });
+    expect((add as HTMLButtonElement).disabled).toBe(false);
+    expect(
+      screen.getByText(/Permission changes are recorded in the organization/),
+    ).toBeTruthy();
+  });
+
+  it("locks the editor for a viewer who lost write permission", async () => {
+    mocks.agent.ownerUserId = "user_another";
+    mocks.agent.permissions = {
+      read: true,
+      write: false,
+      authorize: false,
+      transfer: false,
+    };
+    setup();
+    const add = await screen.findByRole("button", { name: "Add mcp:connect" });
+    expect((add as HTMLButtonElement).disabled).toBe(true);
+    expect(
+      screen.getByText(
+        /do not have permission to change this agent's permissions/,
+      ),
+    ).toBeTruthy();
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Save permissions",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+  });
+
+  it("keeps one organization's ceiling out of another's cache", async () => {
+    const view = setup();
+    await screen.findByRole("button", { name: "Add mcp:connect" });
+    expect(
+      view.client.getQueryData([
+        "agent-policy-grants",
+        "org_example",
+        "agent_example",
+      ]),
+    ).toBeTruthy();
+
+    mocks.organizationId = "org_other";
+    mocks.listPolicyGrants.mockReturnValue(new Promise(() => {}));
+    view.rerenderPage();
+    await screen.findByText("Loading permissions…");
+    const query = view.client.getQueryCache().find({
+      queryKey: ["agent-policy-grants", "org_other", "agent_example"],
+    });
+    expect(query?.state.data).toBeUndefined();
+    expect(query?.queryHash).toContain("org_other");
+  });
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("Draft ownership across context changes", () => {
+  it("drops an unfinished create draft and its open picker when the organization changes", async () => {
+    const view = setup();
+    fireEvent.change(screen.getByLabelText("Agent name"), {
+      target: { value: "Half-written" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add mcp:connect" }));
+    fireEvent.click(screen.getByRole("button", { name: "Narrow mcp:connect" }));
+    expect(await screen.findByText("picker mcp:connect (mcp)")).toBeTruthy();
+
+    mocks.organizationId = "org_other";
+    view.rerenderPage();
+
+    expect(screen.queryByText("picker mcp:connect (mcp)")).toBeNull();
+    expect(
+      (screen.getByLabelText("Agent name") as HTMLInputElement).value,
+    ).toBe("");
+    expect(
+      screen.getByRole("button", { name: "Add mcp:connect" }),
+    ).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Create agent" }));
+    expect(mocks.createAgent).not.toHaveBeenCalled();
+  });
+
+  it("drops an unfinished create draft when the signed-in user changes", () => {
+    const view = setup();
+    fireEvent.change(screen.getByLabelText("Agent name"), {
+      target: { value: "Someone else's draft" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add mcp:connect" }));
+
+    mocks.userId = "user_other";
+    view.rerenderPage();
+
+    expect(
+      (screen.getByLabelText("Agent name") as HTMLInputElement).value,
+    ).toBe("");
+    expect(
+      screen.getByRole("button", { name: "Add mcp:connect" }),
+    ).toBeTruthy();
+  });
+
+  it("drops a dirty policy draft and closes the picker when write access is lost", async () => {
+    const view = setup();
+    mocks.params = new URLSearchParams({ id: "agent_example" });
+    view.rerenderPage();
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Add mcp:connect" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Narrow mcp:connect" }));
+    expect(await screen.findByText("picker mcp:connect (mcp)")).toBeTruthy();
+
+    mocks.agent.permissions = {
+      read: true,
+      write: false,
+      authorize: false,
+      transfer: false,
+    };
+    view.rerenderPage();
+
+    expect(screen.queryByText("picker mcp:connect (mcp)")).toBeNull();
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Add mcp:connect" }),
+      ).toBeTruthy(),
+    );
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Save permissions",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+
+    // Regaining the permission must not resurrect the abandoned edit.
+    mocks.agent.permissions = {
+      read: true,
+      write: true,
+      authorize: true,
+      transfer: true,
+    };
+    view.rerenderPage();
+    await waitFor(() =>
+      expect(
+        (
+          screen.getByRole("button", {
+            name: "Add mcp:connect",
+          }) as HTMLButtonElement
+        ).disabled,
+      ).toBe(false),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Save permissions" }));
+    expect(mocks.createPolicyGrant).not.toHaveBeenCalled();
+  });
+
+  it("refuses to open the picker for a viewer who cannot write", async () => {
+    mocks.params = new URLSearchParams({ id: "agent_example" });
+    mocks.agent.permissions = {
+      read: true,
+      write: false,
+      authorize: false,
+      transfer: false,
+    };
+    mocks.listPolicyGrants.mockResolvedValue([
+      {
+        id: "grant_one",
+        scope: "mcp:connect",
+        effect: "allow",
+        selector: { resourceKind: "mcp", resourceId: "server_two" },
+        createdAt: new Date(0),
+        updatedAt: new Date(0),
+      },
+    ]);
+    setup();
+    const narrow = await screen.findByRole("button", {
+      name: "Narrow mcp:connect",
+    });
+    expect((narrow as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(narrow);
+    expect(screen.queryByText("picker mcp:connect (mcp)")).toBeNull();
+  });
+});
+
+describe("Confirming the stored ceiling after a save", () => {
+  beforeEach(() => {
+    mocks.params = new URLSearchParams({ id: "agent_example" });
+  });
+
+  it("keeps the editor locked until the confirming read resolves", async () => {
+    setup();
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Add mcp:connect" }),
+    );
+    const pending = deferred<unknown[]>();
+    mocks.listPolicyGrants.mockReturnValue(pending.promise);
+    fireEvent.click(screen.getByRole("button", { name: "Save permissions" }));
+    await waitFor(() => expect(mocks.createPolicyGrant).toHaveBeenCalled());
+
+    await waitFor(() =>
+      expect(
+        (
+          screen.getByRole("button", {
+            name: "Remove mcp:connect",
+          }) as HTMLButtonElement
+        ).disabled,
+      ).toBe(true),
+    );
+    expect(screen.getByRole("button", { name: "Saving…" })).toBeTruthy();
+
+    pending.resolve([
+      {
+        id: "grant_new",
+        scope: "mcp:connect",
+        effect: "allow",
+        selector: { resourceKind: "mcp", resourceId: "*" },
+        createdAt: new Date(0),
+        updatedAt: new Date(0),
+      },
+    ]);
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Remove mcp:connect" }),
+      ).toBeTruthy(),
+    );
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Save permissions",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+  });
+
+  it("fails closed with no editable base when the confirming read fails after a partial write", async () => {
+    mocks.listPolicyGrants.mockResolvedValueOnce([]);
+    setup();
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Add mcp:connect" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Add mcp:read" }));
+    mocks.createPolicyGrant
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error("Rejected."));
+    mocks.listPolicyGrants.mockRejectedValue(new Error("read failed"));
+    fireEvent.click(screen.getByRole("button", { name: "Save permissions" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert").textContent).toMatch(
+        /Could not confirm this agent's stored permissions/,
+      ),
+    );
+    // No editor at all: a base built from the pre-save cache would be stale.
+    expect(
+      screen.queryByRole("button", { name: "Add mcp:connect" }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Save permissions" }),
+    ).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Reload permissions" }),
+    ).toBeTruthy();
+
+    mocks.listPolicyGrants.mockResolvedValue([
+      {
+        id: "grant_new",
+        scope: "mcp:connect",
+        effect: "allow",
+        selector: { resourceKind: "mcp", resourceId: "*" },
+        createdAt: new Date(0),
+        updatedAt: new Date(0),
+      },
+    ]);
+    fireEvent.click(screen.getByRole("button", { name: "Reload permissions" }));
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Remove mcp:connect" }),
+      ).toBeTruthy(),
+    );
+    // The abandoned half of the edit is gone, not carried over.
+    expect(screen.getByRole("button", { name: "Add mcp:read" })).toBeTruthy();
+  });
+});
+
+describe("Stored constraints the editor cannot show", () => {
+  beforeEach(() => {
+    mocks.params = new URLSearchParams({ id: "agent_example" });
+    mocks.listPolicyGrants.mockResolvedValue([
+      {
+        id: "grant_risk",
+        scope: "risk_policy:evaluate",
+        effect: "allow",
+        selector: {
+          resourceKind: "risk_policy",
+          resourceId: "*",
+          serverUrl: "https://mcp.example.test",
+          serverIdentity: "identity_one",
+        },
+        createdAt: new Date(0),
+        updatedAt: new Date(0),
+      },
+    ]);
+  });
+
+  it("says the grant is left as stored and does not offer its scope", async () => {
+    setup();
+    expect(
+      await screen.findByText(/use constraints this editor cannot show/),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Add risk_policy:evaluate" }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Remove risk_policy:evaluate" }),
+    ).toBeNull();
+  });
+
+  it("does not touch it when an unrelated permission is saved", async () => {
+    setup();
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Add mcp:read" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Save permissions" }));
+    await waitFor(() =>
+      expect(mocks.createPolicyGrant).toHaveBeenCalledTimes(1),
+    );
+    expect(mocks.deletePolicyGrant).not.toHaveBeenCalled();
+    expect(mocks.createPolicyGrant.mock.calls[0]?.[0]).toEqual({
+      createAgentPolicyGrantForm: {
+        agentId: "agent_example",
+        effect: "allow",
+        scope: "mcp:read",
+        selector: { resourceKind: "mcp", resourceId: "*" },
+      },
+    });
+  });
+});

--- a/client/dashboard/src/pages/agents/AgentPolicyEditor.tsx
+++ b/client/dashboard/src/pages/agents/AgentPolicyEditor.tsx
@@ -1,0 +1,197 @@
+import { Button } from "@/components/ui/Button";
+import { Dialog } from "@/components/ui/Dialog";
+import { Text } from "@/components/ui/Text";
+import { useOrganization } from "@/contexts/Auth";
+import { GrantRuleDrawerContent } from "@/pages/access/GrantRuleDrawerContent";
+import { PermissionScopeControl } from "@/pages/access/PermissionScopeControl";
+import { RolePermissionsSection } from "@/pages/access/RolePermissionsSection";
+import { computeRuleLabel } from "@/pages/access/roleDialogState";
+import type { Scope } from "@gram/client/models/components/rolegrant.js";
+import type { ScopeDefinition } from "@gram/client/models/components/scopedefinition.js";
+import type { Selector } from "@gram/client/models/components/selector.js";
+import { useEffect, useMemo, useState, type JSX } from "react";
+
+import {
+  AGENT_POLICY_SCOPES,
+  AGENT_POLICY_SCOPE_GROUPS,
+  isAgentPolicyNarrowable,
+  type AgentPolicyDraft,
+} from "./agent-policy-grants";
+
+/**
+ * The permissions an agent may ever be delegated, as the same list-and-narrow
+ * control roles use.
+ *
+ * This is a ceiling, not a credential: adding a permission here grants nothing
+ * on its own. Issuing an API key intersects this list with the owner's live
+ * permissions and the issuer's own, so a ceiling can safely be set by an owner
+ * who holds no RBAC grant of their own.
+ */
+export function AgentPolicyEditor({
+  draft,
+  onChange,
+  disabled,
+  lockedScopes,
+}: {
+  draft: AgentPolicyDraft;
+  onChange: (next: AgentPolicyDraft) => void;
+  disabled?: boolean;
+  /** Scopes held by a stored grant the editor must not rewrite. */
+  lockedScopes?: string[];
+}): JSX.Element {
+  const organization = useOrganization();
+  const [editingScope, setEditingScope] = useState<string | null>(null);
+  const [pending, setPending] = useState<Selector[]>([]);
+
+  const groups = useMemo(() => {
+    if (!lockedScopes?.length) return AGENT_POLICY_SCOPE_GROUPS;
+    const locked = new Set(lockedScopes);
+    // A locked scope is not offered at all. Adding it here would sit a fresh
+    // wildcard grant beside the constrained one it cannot replace.
+    return AGENT_POLICY_SCOPE_GROUPS.map((group) => ({
+      ...group,
+      scopes: group.scopes.filter((scope) => !locked.has(scope.slug)),
+    }));
+  }, [lockedScopes]);
+
+  // Losing write access mid-edit must not leave a live picker behind: the
+  // dialog sits above the disabled rows and would otherwise still accept a
+  // choice. Saving cannot begin while it is open, so `disabled` turning true
+  // here only ever means the permission went away.
+  useEffect(() => {
+    if (disabled) {
+      setEditingScope(null);
+      setPending([]);
+    }
+  }, [disabled]);
+
+  const projectList = useMemo(
+    () =>
+      (organization.projects ?? []).map((project) => ({
+        id: project.id,
+        name: project.name,
+      })),
+    [organization.projects],
+  );
+
+  const editingDefinition = editingScope
+    ? (AGENT_POLICY_SCOPES.find((scope) => scope.slug === editingScope) ?? null)
+    : null;
+
+  const toggleScope = (scope: Scope) => {
+    const next = { ...draft };
+    // A permission starts at the breadth the scope itself has — "All servers",
+    // "All projects" — stated on the row and narrowable in place. It is never
+    // applied to a permission the user did not add.
+    if (scope in next) delete next[scope];
+    else next[scope] = null;
+    onChange(next);
+  };
+
+  const openResourcePicker = (scope: string) => {
+    setEditingScope(scope);
+    setPending(draft[scope] ?? []);
+  };
+
+  const closeResourcePicker = () => {
+    setEditingScope(null);
+    setPending([]);
+  };
+
+  return (
+    <>
+      <RolePermissionsSection
+        groups={groups}
+        selectedScopes={new Set(Object.keys(draft))}
+        disabled={disabled}
+        onToggleScope={toggleScope}
+        subjectLabel="this agent"
+        renderScopeRule={(definition: ScopeDefinition) => {
+          if (!(definition.slug in draft)) return null;
+          // Environments and risk policies are not lists you pick from, so the
+          // row carries no control rather than an "All" chip that cannot
+          // change.
+          if (!isAgentPolicyNarrowable(definition.resourceType)) return null;
+          const selectors = draft[definition.slug] ?? null;
+          return (
+            <PermissionScopeControl
+              allowRule={{
+                id: definition.slug,
+                effect: "allow",
+                selectors,
+              }}
+              // Agent policy is allow-only: the server rejects any other
+              // effect, so there is no exception to state or add.
+              denyRules={[]}
+              canAddException={false}
+              resourceType={definition.resourceType}
+              allowLabel={computeRuleLabel(
+                selectors,
+                definition.resourceType,
+                projectList,
+              )}
+              denyLabel={() => ""}
+              disabled={disabled}
+              onChooseSpecific={() => openResourcePicker(definition.slug)}
+              onResetToAll={() =>
+                onChange({ ...draft, [definition.slug]: null })
+              }
+              onAddException={() => {}}
+              onEditException={() => {}}
+              onRemoveException={() => {}}
+            />
+          );
+        }}
+      />
+
+      <Dialog
+        open={editingScope !== null && !disabled}
+        onOpenChange={(open) => {
+          if (!open) closeResourcePicker();
+        }}
+      >
+        <Dialog.Content className="max-w-3xl">
+          <Dialog.Header>
+            <Dialog.Title>
+              Choose resources for {editingDefinition?.slug}
+            </Dialog.Title>
+            <Dialog.Description>
+              The agent may never be delegated more than what you pick here.
+              What a given API key actually carries is narrowed again when the
+              key is issued.
+            </Dialog.Description>
+          </Dialog.Header>
+          {editingDefinition && (
+            <GrantRuleDrawerContent
+              resourceType={editingDefinition.resourceType}
+              scope={editingDefinition.slug}
+              selectors={pending}
+              onChangeSelectors={(selectors) => setPending(selectors ?? [])}
+            />
+          )}
+          {pending.length === 0 && (
+            <Text muted small>
+              Nothing is selected yet, so this permission applies to nothing.
+              Pick at least one resource, or cancel to leave it unrestricted.
+            </Text>
+          )}
+          <Dialog.Footer>
+            <Button variant="secondary" onClick={closeResourcePicker}>
+              Cancel
+            </Button>
+            <Button
+              disabled={disabled || pending.length === 0}
+              onClick={() => {
+                if (!editingScope || disabled) return;
+                onChange({ ...draft, [editingScope]: pending });
+                closeResourcePicker();
+              }}
+            >
+              Done
+            </Button>
+          </Dialog.Footer>
+        </Dialog.Content>
+      </Dialog>
+    </>
+  );
+}

--- a/client/dashboard/src/pages/agents/AgentPolicyEditor.tsx
+++ b/client/dashboard/src/pages/agents/AgentPolicyEditor.tsx
@@ -41,7 +41,9 @@ export function AgentPolicyEditor({
 }): JSX.Element {
   const organization = useOrganization();
   const [editingScope, setEditingScope] = useState<string | null>(null);
-  const [pending, setPending] = useState<Selector[]>([]);
+  // null is the picker's "All servers" / "All projects", which is a valid
+  // choice; an empty array is a narrowing the user has not finished.
+  const [pending, setPending] = useState<Selector[] | null>([]);
 
   const groups = useMemo(() => {
     if (!lockedScopes?.length) return AGENT_POLICY_SCOPE_GROUPS;
@@ -90,6 +92,8 @@ export function AgentPolicyEditor({
 
   const openResourcePicker = (scope: string) => {
     setEditingScope(scope);
+    // Opened from "Specific servers…", so an unrestricted permission starts on
+    // the resource list rather than back on "All".
     setPending(draft[scope] ?? []);
   };
 
@@ -166,13 +170,14 @@ export function AgentPolicyEditor({
               resourceType={editingDefinition.resourceType}
               scope={editingDefinition.slug}
               selectors={pending}
-              onChangeSelectors={(selectors) => setPending(selectors ?? [])}
+              onChangeSelectors={setPending}
             />
           )}
-          {pending.length === 0 && (
+          {pending !== null && pending.length === 0 && (
             <Text muted small>
               Nothing is selected yet, so this permission applies to nothing.
-              Pick at least one resource, or cancel to leave it unrestricted.
+              Pick at least one resource, or choose the unrestricted option
+              above.
             </Text>
           )}
           <Dialog.Footer>
@@ -180,7 +185,7 @@ export function AgentPolicyEditor({
               Cancel
             </Button>
             <Button
-              disabled={disabled || pending.length === 0}
+              disabled={disabled || (pending !== null && pending.length === 0)}
               onClick={() => {
                 if (!editingScope || disabled) return;
                 onChange({ ...draft, [editingScope]: pending });

--- a/client/dashboard/src/pages/agents/AgentPolicyEditor.tsx
+++ b/client/dashboard/src/pages/agents/AgentPolicyEditor.tsx
@@ -22,10 +22,10 @@ import {
  * The permissions an agent may ever be delegated, as the same list-and-narrow
  * control roles use.
  *
- * This is a ceiling, not a credential: adding a permission here grants nothing
- * on its own. Issuing an API key intersects this list with the owner's live
- * permissions and the issuer's own, so a ceiling can safely be set by an owner
- * who holds no RBAC grant of their own.
+ * A ceiling, not a credential: adding a permission here grants nothing on its
+ * own, because issuing an API key intersects this list with the owner's live
+ * permissions and the issuer's. That is why an owner holding no RBAC grant can
+ * safely set it.
  */
 export function AgentPolicyEditor({
   draft,
@@ -56,10 +56,9 @@ export function AgentPolicyEditor({
     }));
   }, [lockedScopes]);
 
-  // Losing write access mid-edit must not leave a live picker behind: the
-  // dialog sits above the disabled rows and would otherwise still accept a
+  // The dialog sits above the disabled rows and would otherwise still accept a
   // choice. Saving cannot begin while it is open, so `disabled` turning true
-  // here only ever means the permission went away.
+  // here only ever means write access went away.
   useEffect(() => {
     if (disabled) {
       setEditingScope(null);
@@ -82,9 +81,8 @@ export function AgentPolicyEditor({
 
   const toggleScope = (scope: Scope) => {
     const next = { ...draft };
-    // A permission starts at the breadth the scope itself has — "All servers",
-    // "All projects" — stated on the row and narrowable in place. It is never
-    // applied to a permission the user did not add.
+    // A permission starts at the scope's own breadth, stated on the row and
+    // narrowable in place. Never applied to a permission the user did not add.
     if (scope in next) delete next[scope];
     else next[scope] = null;
     onChange(next);
@@ -112,9 +110,8 @@ export function AgentPolicyEditor({
         subjectLabel="this agent"
         renderScopeRule={(definition: ScopeDefinition) => {
           if (!(definition.slug in draft)) return null;
-          // Environments and risk policies are not lists you pick from, so the
-          // row carries no control rather than an "All" chip that cannot
-          // change.
+          // Not lists you pick from, so no control rather than an unchangeable
+          // "All" chip.
           if (!isAgentPolicyNarrowable(definition.resourceType)) return null;
           const selectors = draft[definition.slug] ?? null;
           return (

--- a/client/dashboard/src/pages/agents/AgentPolicySection.tsx
+++ b/client/dashboard/src/pages/agents/AgentPolicySection.tsx
@@ -5,7 +5,7 @@ import { useOrganization, useSession } from "@/contexts/Auth";
 import { useSdkClient } from "@/contexts/Sdk";
 import type { ManagedAgent } from "@gram/client/models/components/managedagent.js";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useState, type JSX } from "react";
+import { useEffect, useRef, useState, type JSX } from "react";
 import { toast } from "sonner";
 
 import {
@@ -78,6 +78,18 @@ function AgentPolicyContent({
   const [error, setError] = useState<string | null>(null);
   const [blocked, setBlocked] = useState(false);
 
+  // A save spans several awaits. These survive them; `canWrite` and `draft`
+  // captured in the closure do not.
+  const mounted = useRef(true);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+  const canWriteRef = useRef(canWrite);
+  canWriteRef.current = canWrite;
+
   const grants = useQuery({
     queryKey: ["agent-policy-grants", organizationId, agent.id],
     queryFn: ({ signal }) =>
@@ -109,14 +121,56 @@ function AgentPolicyContent({
 
   const save = async () => {
     if (!draft || saving) return;
+    // Taken before the first await, so a second click cannot start a parallel
+    // save that writes the same diff twice.
+    setSaving(true);
+    setError(null);
+
+    const stop = (message: string) => {
+      setSaving(false);
+      setBlocked(true);
+      setError(message);
+    };
+
+    // The cache only learns of another administrator's change when something
+    // happens to refetch it, which may be never while this draft is open. Read
+    // the ceiling now and judge against that, not against whatever the cache
+    // happens to hold.
+    //
+    // This narrows the window; it does not close it. There is no precondition
+    // on `agents.createPolicyGrant` / `deletePolicyGrant`, so this is not a
+    // compare-and-swap: a change landing between this read and the writes below
+    // is still missed. Pinning the base does reliably stop a grant this draft
+    // never saw from being deleted. Closing the window needs an API that takes
+    // an expected version.
+    let confirmed;
+    try {
+      confirmed = await grants.refetch();
+    } catch {
+      confirmed = undefined;
+    }
+    // The agent, organization, or signed-in user may have changed while that
+    // read was in flight; this instance is gone and must not write.
+    if (!mounted.current) return;
+    if (!confirmed || confirmed.isError || confirmed.data === undefined) {
+      stop(
+        "Could not read this agent's current permissions, so nothing was saved. Reload and try again.",
+      );
+      return;
+    }
+    if (!canWriteRef.current) {
+      stop(
+        "Your permission to change this agent's permissions ended before the save began, so nothing was saved.",
+      );
+      return;
+    }
 
     // Someone else changed the ceiling since this draft was started. Diffing
     // against the newer list would delete their grants, because a grant this
     // draft never saw looks exactly like one the user removed. Write nothing
     // and make them reload, so the other change survives intact.
-    if (agentPolicyFingerprint(grants.data ?? []) !== draft.fingerprint) {
-      setBlocked(true);
-      setError(
+    if (agentPolicyFingerprint(confirmed.data) !== draft.fingerprint) {
+      stop(
         "Someone else changed this agent's permissions while you were editing. Nothing was saved, and their changes are intact. Reload and make your changes again.",
       );
       return;
@@ -129,18 +183,18 @@ function AgentPolicyContent({
       draft.base,
       agentPolicyGrantsFromDraft(draft.value),
     );
-    setSaving(true);
-    setError(null);
     let writeError: unknown = null;
     try {
       // Removals first: a narrowed permission would otherwise collide with the
       // grant it replaces, which the server rejects as a duplicate.
       for (const grant of remove) {
+        if (!mounted.current || !canWriteRef.current) return;
         await sdk.agents.deletePolicyGrant({
           agentPolicyGrantIDForm: { agentId: agent.id, grantId: grant.id },
         });
       }
       for (const form of create) {
+        if (!mounted.current || !canWriteRef.current) return;
         await sdk.agents.createPolicyGrant({
           createAgentPolicyGrantForm: { agentId: agent.id, ...form },
         });
@@ -159,6 +213,7 @@ function AgentPolicyContent({
     } catch {
       refreshed = undefined;
     }
+    if (!mounted.current) return;
     setSaving(false);
 
     if (!refreshed || refreshed.isError || refreshed.data === undefined) {

--- a/client/dashboard/src/pages/agents/AgentPolicySection.tsx
+++ b/client/dashboard/src/pages/agents/AgentPolicySection.tsx
@@ -9,13 +9,24 @@ import { useState, type JSX } from "react";
 import { toast } from "sonner";
 
 import {
+  agentPolicyFingerprint,
   agentPolicyGrantsFromDraft,
   agentPolicyViewFromGrants,
   diffAgentPolicyGrants,
   invalidateAgentPolicy,
   type AgentPolicyDraft,
 } from "./agent-policy-grants";
+import type { AgentPolicyGrant } from "@gram/client/models/components/agentpolicygrant.js";
 import { AgentPolicyEditor } from "./AgentPolicyEditor";
+
+/** An in-progress edit, pinned to the ceiling it started from. */
+interface PolicyDraft {
+  value: AgentPolicyDraft;
+  /** The editable grants as they stood when the first change was made. */
+  base: AgentPolicyGrant[];
+  /** Identity of the whole stored ceiling at that moment. */
+  fingerprint: string;
+}
 
 export function AgentPolicySection({
   agent,
@@ -62,10 +73,10 @@ function AgentPolicyContent({
   const sdk = useSdkClient();
   const queryClient = useQueryClient();
   const canWrite = agent.permissions.write;
-  const [draft, setDraft] = useState<AgentPolicyDraft | null>(null);
+  const [draft, setDraft] = useState<PolicyDraft | null>(null);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [refreshFailed, setRefreshFailed] = useState(false);
+  const [blocked, setBlocked] = useState(false);
 
   const grants = useQuery({
     queryKey: ["agent-policy-grants", organizationId, agent.id],
@@ -78,16 +89,45 @@ function AgentPolicyContent({
   const view = agentPolicyViewFromGrants(grants.data ?? []);
   // The stored ceiling is the draft until the user edits it, so a background
   // refetch is not silently overwritten by a stale local copy.
-  const current = draft ?? view.draft;
+  const current = draft?.value ?? view.draft;
   const dirty = draft !== null;
+
+  // The first edit pins the ceiling the draft was built from. Everything after
+  // it is measured against that base, never against a version that arrived
+  // while the user was still typing.
+  const edit = (value: AgentPolicyDraft) => {
+    setDraft((previous): PolicyDraft =>
+      previous
+        ? { ...previous, value }
+        : {
+            value,
+            base: view.editable,
+            fingerprint: agentPolicyFingerprint(grants.data ?? []),
+          },
+    );
+  };
 
   const save = async () => {
     if (!draft || saving) return;
-    // Only the grants the editor could represent are diffed. Preserved ones are
-    // never removed and never re-created.
+
+    // Someone else changed the ceiling since this draft was started. Diffing
+    // against the newer list would delete their grants, because a grant this
+    // draft never saw looks exactly like one the user removed. Write nothing
+    // and make them reload, so the other change survives intact.
+    if (agentPolicyFingerprint(grants.data ?? []) !== draft.fingerprint) {
+      setBlocked(true);
+      setError(
+        "Someone else changed this agent's permissions while you were editing. Nothing was saved, and their changes are intact. Reload and make your changes again.",
+      );
+      return;
+    }
+
+    // Only the grants the editor could represent are diffed, and only as they
+    // stood when the draft began. Preserved ones are never removed and never
+    // re-created.
     const { create, remove } = diffAgentPolicyGrants(
-      view.editable,
-      agentPolicyGrantsFromDraft(draft),
+      draft.base,
+      agentPolicyGrantsFromDraft(draft.value),
     );
     setSaving(true);
     setError(null);
@@ -124,7 +164,7 @@ function AgentPolicyContent({
     if (!refreshed || refreshed.isError || refreshed.data === undefined) {
       // Fail closed: an editable base built from the pre-save cache would
       // invite the user to save again on top of a ceiling that has moved.
-      setRefreshFailed(true);
+      setBlocked(true);
       setError(
         "Could not confirm this agent's stored permissions after saving, so some changes may not have been applied. Reload before editing again.",
       );
@@ -147,7 +187,7 @@ function AgentPolicyContent({
   const reload = async () => {
     const refreshed = await grants.refetch();
     if (refreshed.isError || refreshed.data === undefined) return;
-    setRefreshFailed(false);
+    setBlocked(false);
     setDraft(null);
     setError(null);
   };
@@ -159,7 +199,7 @@ function AgentPolicyContent({
       </SettingsSection.Body>
     );
 
-  if (grants.isError || refreshFailed)
+  if (grants.isError || blocked)
     return (
       <SettingsSection.Body>
         <div role="alert">
@@ -186,7 +226,7 @@ function AgentPolicyContent({
         )}
         <AgentPolicyEditor
           draft={current}
-          onChange={setDraft}
+          onChange={edit}
           disabled={!canWrite || saving}
           lockedScopes={view.preservedScopes}
         />

--- a/client/dashboard/src/pages/agents/AgentPolicySection.tsx
+++ b/client/dashboard/src/pages/agents/AgentPolicySection.tsx
@@ -1,0 +1,231 @@
+import { SettingsSection } from "@/components/page-templates";
+import { Button } from "@/components/ui/Button";
+import { Text } from "@/components/ui/Text";
+import { useOrganization, useSession } from "@/contexts/Auth";
+import { useSdkClient } from "@/contexts/Sdk";
+import type { ManagedAgent } from "@gram/client/models/components/managedagent.js";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState, type JSX } from "react";
+import { toast } from "sonner";
+
+import {
+  agentPolicyGrantsFromDraft,
+  agentPolicyViewFromGrants,
+  diffAgentPolicyGrants,
+  invalidateAgentPolicy,
+  type AgentPolicyDraft,
+} from "./agent-policy-grants";
+import { AgentPolicyEditor } from "./AgentPolicyEditor";
+
+export function AgentPolicySection({
+  agent,
+}: {
+  agent: ManagedAgent;
+}): JSX.Element {
+  const organization = useOrganization();
+  const { user } = useSession();
+  return (
+    <SettingsSection>
+      <SettingsSection.Header>
+        <SettingsSection.Title>Permissions</SettingsSection.Title>
+        <SettingsSection.Description>
+          The most this agent may ever be delegated. Adding a permission here
+          grants nothing on its own — each API key is narrowed again at
+          issuance, against the owner's live permissions and your own.
+        </SettingsSection.Description>
+      </SettingsSection.Header>
+      <SettingsSection.Panel>
+        <AgentPolicyContent
+          // A draft belongs to one organization, one agent, one signed-in
+          // human, and one answer to "may this human write". Any of them
+          // changing makes the pending edit meaningless, so it is dropped
+          // rather than carried into a context it was not built for.
+          key={`${organization.id}:${user.id}:${agent.id}:${agent.permissions.write}`}
+          agent={agent}
+          organizationId={organization.id}
+          userId={user.id}
+        />
+      </SettingsSection.Panel>
+    </SettingsSection>
+  );
+}
+
+function AgentPolicyContent({
+  agent,
+  organizationId,
+  userId,
+}: {
+  agent: ManagedAgent;
+  organizationId: string;
+  userId: string;
+}) {
+  const sdk = useSdkClient();
+  const queryClient = useQueryClient();
+  const canWrite = agent.permissions.write;
+  const [draft, setDraft] = useState<AgentPolicyDraft | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshFailed, setRefreshFailed] = useState(false);
+
+  const grants = useQuery({
+    queryKey: ["agent-policy-grants", organizationId, agent.id],
+    queryFn: ({ signal }) =>
+      sdk.agents.listPolicyGrants({ agentId: agent.id }, undefined, { signal }),
+    retry: false,
+    throwOnError: false,
+  });
+
+  const view = agentPolicyViewFromGrants(grants.data ?? []);
+  // The stored ceiling is the draft until the user edits it, so a background
+  // refetch is not silently overwritten by a stale local copy.
+  const current = draft ?? view.draft;
+  const dirty = draft !== null;
+
+  const save = async () => {
+    if (!draft || saving) return;
+    // Only the grants the editor could represent are diffed. Preserved ones are
+    // never removed and never re-created.
+    const { create, remove } = diffAgentPolicyGrants(
+      view.editable,
+      agentPolicyGrantsFromDraft(draft),
+    );
+    setSaving(true);
+    setError(null);
+    let writeError: unknown = null;
+    try {
+      // Removals first: a narrowed permission would otherwise collide with the
+      // grant it replaces, which the server rejects as a duplicate.
+      for (const grant of remove) {
+        await sdk.agents.deletePolicyGrant({
+          agentPolicyGrantIDForm: { agentId: agent.id, grantId: grant.id },
+        });
+      }
+      for (const form of create) {
+        await sdk.agents.createPolicyGrant({
+          createAgentPolicyGrantForm: { agentId: agent.id, ...form },
+        });
+      }
+    } catch (cause) {
+      writeError = cause;
+    }
+
+    // Each grant is its own request, so after a failure part-way the cached
+    // list is neither the draft nor what is stored. Nothing may be presented as
+    // the stored ceiling until a read confirms it, so the editor stays locked
+    // until this resolves.
+    let refreshed;
+    try {
+      refreshed = await grants.refetch();
+    } catch {
+      refreshed = undefined;
+    }
+    setSaving(false);
+
+    if (!refreshed || refreshed.isError || refreshed.data === undefined) {
+      // Fail closed: an editable base built from the pre-save cache would
+      // invite the user to save again on top of a ceiling that has moved.
+      setRefreshFailed(true);
+      setError(
+        "Could not confirm this agent's stored permissions after saving, so some changes may not have been applied. Reload before editing again.",
+      );
+      return;
+    }
+
+    setDraft(null);
+    void invalidateAgentPolicy(queryClient, organizationId, userId, agent.id);
+    if (writeError) {
+      setError(
+        writeError instanceof Error && writeError.message
+          ? `${writeError.message} Some changes may not have been applied — the list below is what is stored.`
+          : "Could not update agent permissions. Some changes may not have been applied — the list below is what is stored.",
+      );
+      return;
+    }
+    toast.success("Agent permissions updated");
+  };
+
+  const reload = async () => {
+    const refreshed = await grants.refetch();
+    if (refreshed.isError || refreshed.data === undefined) return;
+    setRefreshFailed(false);
+    setDraft(null);
+    setError(null);
+  };
+
+  if (grants.isLoading)
+    return (
+      <SettingsSection.Body>
+        <Text muted>Loading permissions…</Text>
+      </SettingsSection.Body>
+    );
+
+  if (grants.isError || refreshFailed)
+    return (
+      <SettingsSection.Body>
+        <div role="alert">
+          <Text>{error ?? "Could not load this agent's permissions."}</Text>
+        </div>
+        <Button
+          variant="secondary"
+          disabled={grants.isFetching}
+          onClick={() => void reload()}
+        >
+          Reload permissions
+        </Button>
+      </SettingsSection.Body>
+    );
+
+  return (
+    <>
+      <SettingsSection.Body>
+        {(grants.data ?? []).length === 0 && !dirty && (
+          <Text muted small>
+            This agent has no permissions, so any API key issued for it will not
+            authorize anything. Add permissions to make it usable.
+          </Text>
+        )}
+        <AgentPolicyEditor
+          draft={current}
+          onChange={setDraft}
+          disabled={!canWrite || saving}
+          lockedScopes={view.preservedScopes}
+        />
+        {view.preserved.length > 0 && (
+          <Text muted small>
+            {`${view.preserved.length} stored permission${view.preserved.length === 1 ? "" : "s"} (${view.preservedScopes.join(", ")}) use constraints this editor cannot show, so ${view.preserved.length === 1 ? "it is" : "they are"} left exactly as stored. Use the API to change ${view.preserved.length === 1 ? "it" : "them"}.`}
+          </Text>
+        )}
+        {error && (
+          <p role="alert" className="text-sm">
+            {error}
+          </p>
+        )}
+      </SettingsSection.Body>
+      <SettingsSection.Footer>
+        <Text muted small>
+          {canWrite
+            ? "Permission changes are recorded in the organization audit log."
+            : "You do not have permission to change this agent's permissions."}
+        </Text>
+        <div className="flex gap-2">
+          <Button
+            variant="secondary"
+            onClick={() => {
+              setDraft(null);
+              setError(null);
+            }}
+            disabled={!dirty || saving}
+          >
+            Discard changes
+          </Button>
+          <Button
+            onClick={() => void save()}
+            disabled={!canWrite || !dirty || saving}
+          >
+            {saving ? "Saving…" : "Save permissions"}
+          </Button>
+        </div>
+      </SettingsSection.Footer>
+    </>
+  );
+}

--- a/client/dashboard/src/pages/agents/AgentPolicySection.tsx
+++ b/client/dashboard/src/pages/agents/AgentPolicySection.tsx
@@ -10,6 +10,7 @@ import { toast } from "sonner";
 
 import {
   agentPolicyFingerprint,
+  discardAgentPolicyCaches,
   agentPolicyGrantsFromDraft,
   agentPolicyViewFromGrants,
   diffAgentPolicyGrants,
@@ -183,24 +184,68 @@ function AgentPolicyContent({
       draft.base,
       agentPolicyGrantsFromDraft(draft.value),
     );
+    // The ids this save runs under. Cleanup below must target these, never
+    // whatever the app has moved to by the time it finishes.
+    const savedOrganizationId = organizationId;
+    const savedUserId = userId;
+    const savedAgentID = agent.id;
+
+    // True once a request has been put on the wire. A rejection is as ambiguous
+    // as an abandonment — the server may have committed before the response was
+    // lost — so this is set before the await, not after it.
+    let issued = false;
+    let abandoned = false;
     let writeError: unknown = null;
     try {
       // Removals first: a narrowed permission would otherwise collide with the
       // grant it replaces, which the server rejects as a duplicate.
       for (const grant of remove) {
-        if (!mounted.current || !canWriteRef.current) return;
+        if (!mounted.current || !canWriteRef.current) {
+          abandoned = true;
+          break;
+        }
+        issued = true;
         await sdk.agents.deletePolicyGrant({
-          agentPolicyGrantIDForm: { agentId: agent.id, grantId: grant.id },
+          agentPolicyGrantIDForm: { agentId: savedAgentID, grantId: grant.id },
         });
       }
       for (const form of create) {
-        if (!mounted.current || !canWriteRef.current) return;
+        if (abandoned) break;
+        if (!mounted.current || !canWriteRef.current) {
+          abandoned = true;
+          break;
+        }
+        issued = true;
         await sdk.agents.createPolicyGrant({
-          createAgentPolicyGrantForm: { agentId: agent.id, ...form },
+          createAgentPolicyGrantForm: { agentId: savedAgentID, ...form },
         });
       }
     } catch (cause) {
       writeError = cause;
+    }
+
+    // Whatever was issued may have landed. Leaving the caches alone would hand
+    // the next editor, and the API key dialog's delegable candidates, a ceiling
+    // that never existed. This runs before any early return below.
+    if (!mounted.current || abandoned) {
+      if (issued) {
+        await discardAgentPolicyCaches(
+          queryClient,
+          savedOrganizationId,
+          savedUserId,
+          savedAgentID,
+        );
+      }
+      // Nothing may touch this instance's state once it is gone.
+      if (!mounted.current) return;
+      setSaving(false);
+      setBlocked(true);
+      setError(
+        issued
+          ? "Your permission to change this agent's permissions ended part-way through saving, so some changes may have been applied. Reload to see what is stored."
+          : "Your permission to change this agent's permissions ended before anything was saved.",
+      );
+      return;
     }
 
     // Each grant is its own request, so after a failure part-way the cached
@@ -213,7 +258,20 @@ function AgentPolicyContent({
     } catch {
       refreshed = undefined;
     }
-    if (!mounted.current) return;
+    if (!mounted.current) {
+      // The confirming read landed too late to be shown. Its result is still
+      // in the cache, but nothing confirmed it against this save, so drop it
+      // rather than let the next reader trust it.
+      if (issued) {
+        await discardAgentPolicyCaches(
+          queryClient,
+          savedOrganizationId,
+          savedUserId,
+          savedAgentID,
+        );
+      }
+      return;
+    }
     setSaving(false);
 
     if (!refreshed || refreshed.isError || refreshed.data === undefined) {
@@ -227,7 +285,12 @@ function AgentPolicyContent({
     }
 
     setDraft(null);
-    void invalidateAgentPolicy(queryClient, organizationId, userId, agent.id);
+    void invalidateAgentPolicy(
+      queryClient,
+      savedOrganizationId,
+      savedUserId,
+      savedAgentID,
+    );
     if (writeError) {
       setError(
         writeError instanceof Error && writeError.message
@@ -241,6 +304,7 @@ function AgentPolicyContent({
 
   const reload = async () => {
     const refreshed = await grants.refetch();
+    if (!mounted.current) return;
     if (refreshed.isError || refreshed.data === undefined) return;
     setBlocked(false);
     setDraft(null);

--- a/client/dashboard/src/pages/agents/AgentPolicySection.tsx
+++ b/client/dashboard/src/pages/agents/AgentPolicySection.tsx
@@ -48,10 +48,8 @@ export function AgentPolicySection({
       </SettingsSection.Header>
       <SettingsSection.Panel>
         <AgentPolicyContent
-          // A draft belongs to one organization, one agent, one signed-in
-          // human, and one answer to "may this human write". Any of them
-          // changing makes the pending edit meaningless, so it is dropped
-          // rather than carried into a context it was not built for.
+          // A draft is only valid for the context it was built in, so any of
+          // these changing must discard it.
           key={`${organization.id}:${user.id}:${agent.id}:${agent.permissions.write}`}
           agent={agent}
           organizationId={organization.id}
@@ -79,8 +77,7 @@ function AgentPolicyContent({
   const [error, setError] = useState<string | null>(null);
   const [blocked, setBlocked] = useState(false);
 
-  // A save spans several awaits. These survive them; `canWrite` and `draft`
-  // captured in the closure do not.
+  // A save spans several awaits; values captured in its closure go stale.
   const mounted = useRef(true);
   useEffect(() => {
     mounted.current = true;
@@ -100,14 +97,10 @@ function AgentPolicyContent({
   });
 
   const view = agentPolicyViewFromGrants(grants.data ?? []);
-  // The stored ceiling is the draft until the user edits it, so a background
-  // refetch is not silently overwritten by a stale local copy.
   const current = draft?.value ?? view.draft;
   const dirty = draft !== null;
 
-  // The first edit pins the ceiling the draft was built from. Everything after
-  // it is measured against that base, never against a version that arrived
-  // while the user was still typing.
+  // The first edit pins the base every later comparison is measured against.
   const edit = (value: AgentPolicyDraft) => {
     setDraft((previous): PolicyDraft =>
       previous
@@ -122,8 +115,7 @@ function AgentPolicyContent({
 
   const save = async () => {
     if (!draft || saving) return;
-    // Taken before the first await, so a second click cannot start a parallel
-    // save that writes the same diff twice.
+    // Locked before the first await, so a second click cannot write twice.
     setSaving(true);
     setError(null);
 
@@ -133,25 +125,21 @@ function AgentPolicyContent({
       setError(message);
     };
 
-    // The cache only learns of another administrator's change when something
-    // happens to refetch it, which may be never while this draft is open. Read
-    // the ceiling now and judge against that, not against whatever the cache
-    // happens to hold.
+    // Judge against a fresh read: nothing need ever have refetched the cache
+    // while this draft was open.
     //
-    // This narrows the window; it does not close it. There is no precondition
-    // on `agents.createPolicyGrant` / `deletePolicyGrant`, so this is not a
-    // compare-and-swap: a change landing between this read and the writes below
-    // is still missed. Pinning the base does reliably stop a grant this draft
-    // never saw from being deleted. Closing the window needs an API that takes
-    // an expected version.
+    // This narrows the window, it does not close it. The grant endpoints take
+    // no precondition, so this is not a compare-and-swap — a change landing
+    // between this read and the writes below is still missed. What the pinned
+    // base does guarantee is that a grant this draft never saw is not deleted.
     let confirmed;
     try {
       confirmed = await grants.refetch();
     } catch {
       confirmed = undefined;
     }
-    // The agent, organization, or signed-in user may have changed while that
-    // read was in flight; this instance is gone and must not write.
+    // Context may have changed while the read was in flight; this instance is
+    // gone and must not write.
     if (!mounted.current) return;
     if (!confirmed || confirmed.isError || confirmed.data === undefined) {
       stop(
@@ -166,10 +154,9 @@ function AgentPolicyContent({
       return;
     }
 
-    // Someone else changed the ceiling since this draft was started. Diffing
-    // against the newer list would delete their grants, because a grant this
-    // draft never saw looks exactly like one the user removed. Write nothing
-    // and make them reload, so the other change survives intact.
+    // A grant this draft never saw is indistinguishable from one the user
+    // removed, so diffing against a moved ceiling would delete someone else's
+    // work. Write nothing.
     if (agentPolicyFingerprint(confirmed.data) !== draft.fingerprint) {
       stop(
         "Someone else changed this agent's permissions while you were editing. Nothing was saved, and their changes are intact. Reload and make your changes again.",
@@ -177,22 +164,20 @@ function AgentPolicyContent({
       return;
     }
 
-    // Only the grants the editor could represent are diffed, and only as they
-    // stood when the draft began. Preserved ones are never removed and never
+    // Preserved grants are outside `base`, so they are never removed or
     // re-created.
     const { create, remove } = diffAgentPolicyGrants(
       draft.base,
       agentPolicyGrantsFromDraft(draft.value),
     );
-    // The ids this save runs under. Cleanup below must target these, never
-    // whatever the app has moved to by the time it finishes.
+    // Cleanup below must target the ids this save began under, never whatever
+    // the app has moved to by the time it finishes.
     const savedOrganizationId = organizationId;
     const savedUserId = userId;
     const savedAgentID = agent.id;
 
-    // True once a request has been put on the wire. A rejection is as ambiguous
-    // as an abandonment — the server may have committed before the response was
-    // lost — so this is set before the await, not after it.
+    // Set before the await, not after: a rejection is as ambiguous as an
+    // abandonment, because the server may commit and lose the response.
     let issued = false;
     let abandoned = false;
     let writeError: unknown = null;
@@ -224,9 +209,9 @@ function AgentPolicyContent({
       writeError = cause;
     }
 
-    // Whatever was issued may have landed. Leaving the caches alone would hand
-    // the next editor, and the API key dialog's delegable candidates, a ceiling
-    // that never existed. This runs before any early return below.
+    // Anything issued may have landed, so the cached ceiling and the delegable
+    // candidates it feeds may describe a state that never existed. This must
+    // run before any early return below.
     if (!mounted.current || abandoned) {
       if (issued) {
         await discardAgentPolicyCaches(
@@ -236,7 +221,6 @@ function AgentPolicyContent({
           savedAgentID,
         );
       }
-      // Nothing may touch this instance's state once it is gone.
       if (!mounted.current) return;
       setSaving(false);
       setBlocked(true);
@@ -248,10 +232,9 @@ function AgentPolicyContent({
       return;
     }
 
-    // Each grant is its own request, so after a failure part-way the cached
-    // list is neither the draft nor what is stored. Nothing may be presented as
-    // the stored ceiling until a read confirms it, so the editor stays locked
-    // until this resolves.
+    // Each grant is its own request, so after a partial failure the cache is
+    // neither the draft nor what is stored. The editor stays locked until a
+    // read confirms the ceiling.
     let refreshed;
     try {
       refreshed = await grants.refetch();
@@ -259,9 +242,8 @@ function AgentPolicyContent({
       refreshed = undefined;
     }
     if (!mounted.current) {
-      // The confirming read landed too late to be shown. Its result is still
-      // in the cache, but nothing confirmed it against this save, so drop it
-      // rather than let the next reader trust it.
+      // The confirming read landed too late to be shown, so nothing checked it
+      // against this save. Drop it rather than let the next reader trust it.
       if (issued) {
         await discardAgentPolicyCaches(
           queryClient,
@@ -275,8 +257,8 @@ function AgentPolicyContent({
     setSaving(false);
 
     if (!refreshed || refreshed.isError || refreshed.data === undefined) {
-      // Fail closed: an editable base built from the pre-save cache would
-      // invite the user to save again on top of a ceiling that has moved.
+      // Fail closed: an editable base from the pre-save cache would invite a
+      // second save on top of a ceiling that has moved.
       setBlocked(true);
       setError(
         "Could not confirm this agent's stored permissions after saving, so some changes may not have been applied. Reload before editing again.",

--- a/client/dashboard/src/pages/agents/Agents.tsx
+++ b/client/dashboard/src/pages/agents/Agents.tsx
@@ -10,6 +10,7 @@ import { Table, type Column } from "@/components/ui/Table";
 import { useSdkClient } from "@/contexts/Sdk";
 import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
+import { Checkbox } from "@/components/ui/Checkbox";
 import { Input } from "@/components/ui/Input";
 import { Label } from "@/components/ui/Label";
 import { getRBACScopeOverrideHeader } from "@/components/dev-toolbar-utils";
@@ -35,6 +36,13 @@ import { useState, type FormEvent } from "react";
 import { useSearchParams } from "react-router";
 import { toast } from "sonner";
 import { AgentAPIKeys } from "./AgentAPIKeys";
+import {
+  agentPolicyGrantsFromDraft,
+  invalidateAgentPolicy,
+  type AgentPolicyDraft,
+} from "./agent-policy-grants";
+import { AgentPolicyEditor } from "./AgentPolicyEditor";
+import { AgentPolicySection } from "./AgentPolicySection";
 import { ManagedAgentSessions } from "./ManagedAgentSessions";
 
 export default function AgentsPage(): JSX.Element {
@@ -67,6 +75,10 @@ export default function AgentsPage(): JSX.Element {
   if (!agentID && searchParams.get("create") === "true") {
     return (
       <CreateAgent
+        // A draft is built for one organization, one signed-in human, and one
+        // answer to "may this human create here". Switching any of them would
+        // otherwise submit a name and a set of permissions chosen elsewhere.
+        key={`${organization.id}:${session.user.id}:${isDemo}`}
         disabled={isDemo}
         onCreated={(id) => {
           setSearchParams({ id });
@@ -204,24 +216,52 @@ function CreateAgent({
   onCreated: (id: string) => void;
 }) {
   const [name, setName] = useState("");
+  const [draft, setDraft] = useState<AgentPolicyDraft>({});
+  const [withoutPermissions, setWithoutPermissions] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const organization = useOrganization();
+  const { user } = useSession();
   const queryClient = useQueryClient();
   const create = useCreateAgentMutation({
     onSuccess: (agent) => {
-      void queryClient.invalidateQueries({
-        queryKey: ["managed-agents", organization.id],
-      });
+      void invalidateAgentPolicy(
+        queryClient,
+        organization.id,
+        user.id,
+        agent.id,
+      );
       toast.success("Agent created");
       onCreated(agent.id);
     },
-    onError: (error) => toast.error(error.message || "Unable to create agent"),
+    // The whole create is one transaction, so a failure leaves no agent behind
+    // and the draft below is still exactly what to retry.
+    onError: (error) =>
+      setError(
+        error.message ||
+          "Unable to create agent. Your name and permissions have been kept.",
+      ),
   });
 
   function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     const trimmedName = name.trim();
     if (!trimmedName) return;
-    create.mutate({ request: { createAgentForm: { name: trimmedName } } });
+    const policyGrants = agentPolicyGrantsFromDraft(draft);
+    if (policyGrants.length === 0 && !withoutPermissions) {
+      setError(
+        "Add permissions or explicitly confirm Create without permissions.",
+      );
+      return;
+    }
+    setError(null);
+    create.mutate({
+      request: {
+        createAgentForm: {
+          name: trimmedName,
+          ...(policyGrants.length > 0 ? { policyGrants } : {}),
+        },
+      },
+    });
   }
 
   return (
@@ -255,6 +295,42 @@ function CreateAgent({
             autoFocus
           />
         </div>
+        <div className="mt-6 space-y-2">
+          <Label>Permissions</Label>
+          <Text muted small>
+            The most this agent may ever be delegated. An agent with no
+            permissions can hold API keys, but they will not authorize anything.
+            Each key is narrowed again at issuance, against your live
+            permissions and the owner's.
+          </Text>
+          <AgentPolicyEditor
+            draft={draft}
+            onChange={setDraft}
+            disabled={disabled || create.isPending}
+          />
+        </div>
+        <label className="mt-4 flex items-start gap-2">
+          <Checkbox
+            checked={withoutPermissions}
+            onCheckedChange={(value) => setWithoutPermissions(!!value)}
+            disabled={disabled || create.isPending}
+            className="mt-0.5"
+          />
+          <span className="min-w-0 flex-1">
+            <span className="block text-sm font-medium">
+              Create without permissions
+            </span>
+            <Text as="span" small muted className="block">
+              Only needed if you leave the list above empty. You can add
+              permissions later.
+            </Text>
+          </span>
+        </label>
+        {error && (
+          <p role="alert" className="mt-4 text-sm">
+            {error}
+          </p>
+        )}
         <div className="mt-6 flex justify-end">
           <Button
             type="submit"
@@ -263,7 +339,9 @@ function CreateAgent({
             <Button.LeftIcon>
               <Plus className="size-4" />
             </Button.LeftIcon>
-            <Button.Text>Create agent</Button.Text>
+            <Button.Text>
+              {create.isPending ? "Creating\u2026" : "Create agent"}
+            </Button.Text>
           </Button>
         </div>
       </form>
@@ -334,6 +412,10 @@ function AgentSettings({
         key={`identity-${agentQuery.data.id}`}
         agent={agentQuery.data}
         refresh={refresh}
+      />
+      <AgentPolicySection
+        key={`policy-${agentQuery.data.id}`}
+        agent={agentQuery.data}
       />
       <AgentAPIKeys agent={agentQuery.data} />
       <ManagedAgentSessions

--- a/client/dashboard/src/pages/agents/Agents.tsx
+++ b/client/dashboard/src/pages/agents/Agents.tsx
@@ -75,9 +75,8 @@ export default function AgentsPage(): JSX.Element {
   if (!agentID && searchParams.get("create") === "true") {
     return (
       <CreateAgent
-        // A draft is built for one organization, one signed-in human, and one
-        // answer to "may this human create here". Switching any of them would
-        // otherwise submit a name and a set of permissions chosen elsewhere.
+        // Switching any of these would otherwise submit a name and permissions
+        // chosen in a different context.
         key={`${organization.id}:${session.user.id}:${isDemo}`}
         disabled={isDemo}
         onCreated={(id) => {
@@ -233,8 +232,8 @@ function CreateAgent({
       toast.success("Agent created");
       onCreated(agent.id);
     },
-    // The whole create is one transaction, so a failure leaves no agent behind
-    // and the draft below is still exactly what to retry.
+    // The create is one transaction, so a failure leaves no agent behind and
+    // the draft is still exactly what to retry.
     onError: (error) =>
       setError(
         error.message ||

--- a/client/dashboard/src/pages/agents/agent-api-key-grants.ts
+++ b/client/dashboard/src/pages/agents/agent-api-key-grants.ts
@@ -131,11 +131,12 @@ function buildRequestedGrant(selection: GrantSelection): AgentPolicyGrantForm {
  */
 export function delegableGrantKey(form: AgentPolicyGrantForm): string {
   const selector = form.selector as Record<string, string | undefined>;
-  // Structured and escaped rather than joined with delimiters: a selector value
-  // is an arbitrary string, and `projectId: "a&tool=b"` keyed identically to
-  // `{ projectId: "a", tool: "b" }` under a `key=value` join. Two different
-  // grants sharing a key are treated as one by every caller — the duplicate
-  // check, the diff, and the per-candidate editor state.
+  // Structured and escaped rather than joined with delimiters. Selector values
+  // are arbitrary strings, so under a sorted `key=value` join two adjacent
+  // free-form dimensions collide: a `serverIdentity` ending in
+  // `&serverUrl=…` keyed identically to a grant constraining both. Every caller
+  // treats a shared key as one grant — the duplicate check, the diff, and the
+  // per-candidate editor state.
   return JSON.stringify([
     form.scope,
     Object.keys(selector)

--- a/client/dashboard/src/pages/agents/agent-api-key-grants.ts
+++ b/client/dashboard/src/pages/agents/agent-api-key-grants.ts
@@ -131,11 +131,18 @@ function buildRequestedGrant(selection: GrantSelection): AgentPolicyGrantForm {
  */
 export function delegableGrantKey(form: AgentPolicyGrantForm): string {
   const selector = form.selector as Record<string, string | undefined>;
-  const pairs = Object.keys(selector)
-    .filter((key) => selector[key] !== undefined)
-    .sort()
-    .map((key) => `${key}=${selector[key]}`);
-  return `${form.scope}|${pairs.join("&")}`;
+  // Structured and escaped rather than joined with delimiters: a selector value
+  // is an arbitrary string, and `projectId: "a&tool=b"` keyed identically to
+  // `{ projectId: "a", tool: "b" }` under a `key=value` join. Two different
+  // grants sharing a key are treated as one by every caller — the duplicate
+  // check, the diff, and the per-candidate editor state.
+  return JSON.stringify([
+    form.scope,
+    Object.keys(selector)
+      .filter((key) => selector[key] !== undefined)
+      .sort()
+      .map((key) => [key, selector[key]]),
+  ]);
 }
 
 /**

--- a/client/dashboard/src/pages/agents/agent-policy-grants.test.ts
+++ b/client/dashboard/src/pages/agents/agent-policy-grants.test.ts
@@ -28,10 +28,9 @@ function storedGrant(
 }
 
 describe("agent policy scope catalog", () => {
-  // Mirrors the safeRuntimeScope() entries of runtimeScopeDefinitions in
-  // server/internal/agents/runtimepolicy/scopes.go. A scope the server does not
-  // consider agent-runtime-safe is rejected with 400, so drift here is a bug in
-  // one direction and a missing capability in the other.
+  // Pins the mirror of safeRuntimeScope() in
+  // server/internal/agents/runtimepolicy/scopes.go. Drift is a 400 in one
+  // direction and a missing capability in the other.
   it("offers exactly the agent-runtime-safe scopes", () => {
     expect(AGENT_POLICY_SCOPES.map((scope) => scope.slug).sort()).toEqual([
       "environment:read",
@@ -287,9 +286,9 @@ describe("policy diff", () => {
 });
 
 // The server accepts server_url and server_identity on risk policy selectors
-// (allowedSelectorKeys in server/internal/authz/selector.go), but the editor
-// has no control for either. Rewriting such a grant through the draft would
-// drop the constraint, so it is preserved verbatim and its scope is locked.
+// (allowedSelectorKeys in server/internal/authz/selector.go) and the editor has
+// no control for either, so rewriting one through the draft would drop the
+// constraint.
 describe("stored constraints the editor cannot show", () => {
   const riskGrant = (
     id: string,
@@ -413,9 +412,8 @@ describe("stored constraints the editor cannot show", () => {
   });
 });
 
-// The server stores whatever string it was handed. An empty tool or project id
-// still constrains the grant, so truthiness must not decide whether it survives
-// a trip through the editor.
+// An empty tool or project id still constrains the grant, so truthiness must
+// not decide whether it survives a trip through the editor.
 describe("empty-string dimensions", () => {
   it.each([
     ["tool", { tool: "" }],
@@ -532,14 +530,10 @@ describe("ceiling fingerprint", () => {
   });
 });
 
-// `delegableGrantKey` used to join selector entries as `key=value` pairs
-// separated by `&`. Sorting the keys defeats most of the obvious cases, but two
+// Sorting the keys defeats the obvious `key=value` join collisions, but two
 // adjacent free-form dimensions still collide: `server_identity` is validated
 // nowhere and sorts immediately before `server_url`, so an identity ending in
-// `&serverUrl=…` keys identically to a grant that really constrains both. Every
-// caller treats a shared key as one grant — the duplicate check drops one, the
-// diff thinks a stored grant is still requested, and the fingerprint lets a
-// stale edit through.
+// `&serverUrl=…` keys identically to a grant constraining both.
 describe("selector values containing the old delimiters", () => {
   const split = storedGrant("grant_split", "risk_policy:evaluate", {
     resourceKind: "risk_policy",

--- a/client/dashboard/src/pages/agents/agent-policy-grants.test.ts
+++ b/client/dashboard/src/pages/agents/agent-policy-grants.test.ts
@@ -1,0 +1,413 @@
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_POLICY_SCOPES,
+  agentPolicyDraftFromGrants,
+  agentPolicyGrantsFromDraft,
+  agentPolicyResourceKind,
+  agentPolicyViewFromGrants,
+  diffAgentPolicyGrants,
+  isAgentPolicyGrantRepresentable,
+  isAgentPolicyNarrowable,
+} from "./agent-policy-grants";
+import type { AgentPolicyGrant } from "@gram/client/models/components/agentpolicygrant.js";
+
+function storedGrant(
+  id: string,
+  scope: string,
+  selector: AgentPolicyGrant["selector"],
+): AgentPolicyGrant {
+  return {
+    id,
+    scope,
+    effect: "allow",
+    selector,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  };
+}
+
+describe("agent policy scope catalog", () => {
+  // Mirrors the safeRuntimeScope() entries of runtimeScopeDefinitions in
+  // server/internal/agents/runtimepolicy/scopes.go. A scope the server does not
+  // consider agent-runtime-safe is rejected with 400, so drift here is a bug in
+  // one direction and a missing capability in the other.
+  it("offers exactly the agent-runtime-safe scopes", () => {
+    expect(AGENT_POLICY_SCOPES.map((scope) => scope.slug).sort()).toEqual([
+      "environment:read",
+      "environment:write",
+      "mcp:connect",
+      "mcp:read",
+      "mcp:write",
+      "project:read",
+      "project:write",
+      "risk_policy:evaluate",
+      "skill:read",
+      "skill:write",
+    ]);
+  });
+
+  it("never offers a scope outside the safe set", () => {
+    for (const scope of AGENT_POLICY_SCOPES) {
+      expect(scope.slug).not.toMatch(/blocked_/);
+      expect(scope.slug.split(":")[0]).not.toBe("org");
+      expect(scope.slug.split(":")[0]).not.toBe("chat");
+      expect(scope.slug.split(":")[0]).not.toBe("agent");
+      expect(scope.slug).not.toBe("risk_policy:bypass");
+      expect(scope.slug).not.toBe("risk_policy:block");
+    }
+  });
+
+  it("fixes the resource kind from the scope family", () => {
+    for (const scope of AGENT_POLICY_SCOPES) {
+      expect(agentPolicyResourceKind(scope.slug)).toBe(scope.resourceType);
+    }
+  });
+
+  it("withholds a resource choice where the picker cannot name the right kind", () => {
+    expect(isAgentPolicyNarrowable("environment")).toBe(false);
+    expect(isAgentPolicyNarrowable("risk_policy")).toBe(false);
+    expect(isAgentPolicyNarrowable("mcp")).toBe(true);
+    expect(isAgentPolicyNarrowable("skill")).toBe(true);
+  });
+});
+
+describe("agent policy draft to grants", () => {
+  it("adds nothing for an empty draft", () => {
+    expect(agentPolicyGrantsFromDraft({})).toEqual([]);
+  });
+
+  it("sends one wildcard grant per unrestricted permission", () => {
+    expect(
+      agentPolicyGrantsFromDraft({ "mcp:connect": null, "skill:read": null }),
+    ).toEqual([
+      {
+        effect: "allow",
+        scope: "mcp:connect",
+        selector: { resourceKind: "mcp", resourceId: "*" },
+      },
+      {
+        effect: "allow",
+        scope: "skill:read",
+        selector: { resourceKind: "skill", resourceId: "*" },
+      },
+    ]);
+  });
+
+  it("sends one grant per narrowed resource and keeps the MCP dimensions", () => {
+    expect(
+      agentPolicyGrantsFromDraft({
+        "mcp:connect": [
+          {
+            resourceKind: "mcp",
+            resourceId: "server_one",
+            tool: "search",
+            disposition: "read_only",
+            projectId: "project_one",
+          },
+          { resourceKind: "mcp", resourceId: "server_two" },
+        ],
+      }),
+    ).toEqual([
+      {
+        effect: "allow",
+        scope: "mcp:connect",
+        selector: {
+          resourceKind: "mcp",
+          resourceId: "server_one",
+          projectId: "project_one",
+          disposition: "read_only",
+          tool: "search",
+        },
+      },
+      {
+        effect: "allow",
+        scope: "mcp:connect",
+        selector: { resourceKind: "mcp", resourceId: "server_two" },
+      },
+    ]);
+  });
+
+  // authz.ValidateSelector derives resource_kind from the scope and rejects a
+  // mismatch, and rejects any extra key outside allowedSelectorKeys.
+  it("forces the scope's own resource kind and drops keys it does not allow", () => {
+    expect(
+      agentPolicyGrantsFromDraft({
+        "skill:read": [
+          {
+            resourceKind: "mcp",
+            resourceId: "project_one",
+            tool: "search",
+            disposition: "destructive",
+            projectId: "project_two",
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        effect: "allow",
+        scope: "skill:read",
+        selector: { resourceKind: "skill", resourceId: "project_one" },
+      },
+    ]);
+  });
+
+  it("omits a wildcard dimension rather than sending it", () => {
+    expect(
+      agentPolicyGrantsFromDraft({
+        "mcp:read": [
+          { resourceKind: "mcp", resourceId: "*", projectId: "*", tool: "*" },
+        ],
+      })[0]?.selector,
+    ).toEqual({ resourceKind: "mcp", resourceId: "*" });
+  });
+
+  it("collapses duplicates the server would reject", () => {
+    expect(
+      agentPolicyGrantsFromDraft({
+        "mcp:read": [
+          { resourceKind: "mcp", resourceId: "server_one" },
+          { resourceKind: "mcp", resourceId: "server_one" },
+        ],
+      }),
+    ).toHaveLength(1);
+  });
+});
+
+describe("stored ceiling to draft", () => {
+  it("reads a wildcard grant as unrestricted", () => {
+    expect(
+      agentPolicyDraftFromGrants([
+        storedGrant("grant_one", "mcp:connect", {
+          resourceKind: "mcp",
+          resourceId: "*",
+        }),
+      ]),
+    ).toEqual({ "mcp:connect": null });
+  });
+
+  it("collects narrowed grants for one scope into one permission", () => {
+    expect(
+      agentPolicyDraftFromGrants([
+        storedGrant("grant_one", "mcp:connect", {
+          resourceKind: "mcp",
+          resourceId: "server_one",
+        }),
+        storedGrant("grant_two", "mcp:connect", {
+          resourceKind: "mcp",
+          resourceId: "server_two",
+          tool: "search",
+        }),
+      ]),
+    ).toEqual({
+      "mcp:connect": [
+        { resourceKind: "mcp", resourceId: "server_one" },
+        { resourceKind: "mcp", resourceId: "server_two", tool: "search" },
+      ],
+    });
+  });
+
+  it("keeps an unrestricted permission unrestricted when a narrower grant sits beside it", () => {
+    expect(
+      agentPolicyDraftFromGrants([
+        storedGrant("grant_one", "mcp:read", {
+          resourceKind: "mcp",
+          resourceId: "*",
+        }),
+        storedGrant("grant_two", "mcp:read", {
+          resourceKind: "mcp",
+          resourceId: "server_one",
+        }),
+      ]),
+    ).toEqual({ "mcp:read": null });
+  });
+
+  it("round-trips a stored ceiling without proposing any change", () => {
+    const stored = [
+      storedGrant("grant_one", "mcp:connect", {
+        resourceKind: "mcp",
+        resourceId: "server_one",
+        tool: "search",
+      }),
+      storedGrant("grant_two", "project:read", {
+        resourceKind: "project",
+        resourceId: "*",
+      }),
+    ];
+    const diff = diffAgentPolicyGrants(
+      stored,
+      agentPolicyGrantsFromDraft(agentPolicyDraftFromGrants(stored)),
+    );
+    expect(diff).toEqual({ create: [], remove: [] });
+  });
+});
+
+describe("policy diff", () => {
+  it("treats a narrowed permission as a removal and an addition", () => {
+    const stored = [
+      storedGrant("grant_one", "mcp:connect", {
+        resourceKind: "mcp",
+        resourceId: "*",
+      }),
+    ];
+    const diff = diffAgentPolicyGrants(
+      stored,
+      agentPolicyGrantsFromDraft({
+        "mcp:connect": [{ resourceKind: "mcp", resourceId: "server_one" }],
+      }),
+    );
+    expect(diff.remove.map((grant) => grant.id)).toEqual(["grant_one"]);
+    expect(diff.create).toEqual([
+      {
+        effect: "allow",
+        scope: "mcp:connect",
+        selector: { resourceKind: "mcp", resourceId: "server_one" },
+      },
+    ]);
+  });
+
+  it("removes everything when the ceiling is emptied", () => {
+    const stored = [
+      storedGrant("grant_one", "mcp:connect", {
+        resourceKind: "mcp",
+        resourceId: "*",
+      }),
+      storedGrant("grant_two", "skill:read", {
+        resourceKind: "skill",
+        resourceId: "*",
+      }),
+    ];
+    const diff = diffAgentPolicyGrants(stored, agentPolicyGrantsFromDraft({}));
+    expect(diff.create).toEqual([]);
+    expect(diff.remove.map((grant) => grant.id).sort()).toEqual([
+      "grant_one",
+      "grant_two",
+    ]);
+  });
+});
+
+// The server accepts server_url and server_identity on risk policy selectors
+// (allowedSelectorKeys in server/internal/authz/selector.go), but the editor
+// has no control for either. Rewriting such a grant through the draft would
+// drop the constraint, so it is preserved verbatim and its scope is locked.
+describe("stored constraints the editor cannot show", () => {
+  const riskGrant = (
+    id: string,
+    selector: AgentPolicyGrant["selector"],
+  ): AgentPolicyGrant => storedGrant(id, "risk_policy:evaluate", selector);
+
+  it.each([
+    [
+      "server_url",
+      {
+        resourceKind: "risk_policy" as const,
+        resourceId: "*",
+        serverUrl: "https://mcp.example.test",
+      },
+    ],
+    [
+      "server_identity",
+      {
+        resourceKind: "risk_policy" as const,
+        resourceId: "*",
+        serverIdentity: "identity_one",
+      },
+    ],
+    [
+      "both dimensions",
+      {
+        resourceKind: "risk_policy" as const,
+        resourceId: "*",
+        serverUrl: "https://mcp.example.test",
+        serverIdentity: "identity_one",
+      },
+    ],
+  ])(
+    "keeps a risk policy grant constrained by %s exactly as stored",
+    (_, selector) => {
+      const stored = [riskGrant("grant_risk", selector)];
+      const view = agentPolicyViewFromGrants(stored);
+      expect(isAgentPolicyGrantRepresentable(stored[0]!)).toBe(false);
+      expect(view.preserved).toEqual(stored);
+      expect(view.editable).toEqual([]);
+      expect(view.preservedScopes).toEqual(["risk_policy:evaluate"]);
+      // Absent from the draft, so no edit can rewrite or widen it.
+      expect(view.draft).toEqual({});
+    },
+  );
+
+  it("leaves a preserved grant untouched while an unrelated permission is added", () => {
+    const preserved = riskGrant("grant_risk", {
+      resourceKind: "risk_policy",
+      resourceId: "*",
+      serverUrl: "https://mcp.example.test",
+      serverIdentity: "identity_one",
+    });
+    const view = agentPolicyViewFromGrants([preserved]);
+    const diff = diffAgentPolicyGrants(
+      view.editable,
+      agentPolicyGrantsFromDraft({ ...view.draft, "mcp:read": null }),
+    );
+    expect(diff.remove).toEqual([]);
+    expect(diff.create).toEqual([
+      {
+        effect: "allow",
+        scope: "mcp:read",
+        selector: { resourceKind: "mcp", resourceId: "*" },
+      },
+    ]);
+  });
+
+  it("locks every grant of a scope when only one of them is unrepresentable", () => {
+    const constrained = riskGrant("grant_risk", {
+      resourceKind: "risk_policy",
+      resourceId: "*",
+      serverUrl: "https://mcp.example.test",
+    });
+    const plain = riskGrant("grant_plain", {
+      resourceKind: "risk_policy",
+      resourceId: "*",
+    });
+    const view = agentPolicyViewFromGrants([constrained, plain]);
+    expect(view.preserved).toEqual([constrained, plain]);
+    expect(view.editable).toEqual([]);
+    expect(
+      diffAgentPolicyGrants(
+        view.editable,
+        agentPolicyGrantsFromDraft(view.draft),
+      ),
+    ).toEqual({ create: [], remove: [] });
+  });
+
+  it("does not treat a wildcard-only risk policy grant as unrepresentable", () => {
+    const plain = riskGrant("grant_plain", {
+      resourceKind: "risk_policy",
+      resourceId: "*",
+    });
+    expect(isAgentPolicyGrantRepresentable(plain)).toBe(true);
+    expect(agentPolicyViewFromGrants([plain]).draft).toEqual({
+      "risk_policy:evaluate": null,
+    });
+  });
+
+  it("locks a grant whose resource kind does not match its scope", () => {
+    const mismatched = storedGrant("grant_bad", "skill:read", {
+      resourceKind: "mcp",
+      resourceId: "server_one",
+    });
+    const view = agentPolicyViewFromGrants([mismatched]);
+    expect(view.preserved).toEqual([mismatched]);
+    expect(view.draft).toEqual({});
+  });
+
+  it("still reads a wildcard extra dimension as unconstrained", () => {
+    const wildcarded = storedGrant("grant_wild", "mcp:read", {
+      resourceKind: "mcp",
+      resourceId: "*",
+      projectId: "*",
+    });
+    expect(isAgentPolicyGrantRepresentable(wildcarded)).toBe(true);
+    expect(agentPolicyDraftFromGrants([wildcarded])).toEqual({
+      "mcp:read": null,
+    });
+  });
+});

--- a/client/dashboard/src/pages/agents/agent-policy-grants.test.ts
+++ b/client/dashboard/src/pages/agents/agent-policy-grants.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   AGENT_POLICY_SCOPES,
+  agentPolicyFingerprint,
   agentPolicyDraftFromGrants,
   agentPolicyGrantsFromDraft,
   agentPolicyResourceKind,
@@ -409,5 +410,124 @@ describe("stored constraints the editor cannot show", () => {
     expect(agentPolicyDraftFromGrants([wildcarded])).toEqual({
       "mcp:read": null,
     });
+  });
+});
+
+// The server stores whatever string it was handed. An empty tool or project id
+// still constrains the grant, so truthiness must not decide whether it survives
+// a trip through the editor.
+describe("empty-string dimensions", () => {
+  it.each([
+    ["tool", { tool: "" }],
+    ["projectId", { projectId: "" }],
+    ["both", { tool: "", projectId: "" }],
+  ])("round-trips a grant constrained by an empty %s", (_, extra) => {
+    const stored = [
+      storedGrant("grant_empty", "mcp:connect", {
+        resourceKind: "mcp",
+        resourceId: "server_one",
+        ...extra,
+      }),
+    ];
+    const view = agentPolicyViewFromGrants(stored);
+    expect(view.editable).toEqual(stored);
+    expect(
+      diffAgentPolicyGrants(
+        view.editable,
+        agentPolicyGrantsFromDraft(view.draft),
+      ),
+    ).toEqual({ create: [], remove: [] });
+  });
+
+  it("does not read an empty dimension as unrestricted", () => {
+    expect(
+      agentPolicyDraftFromGrants([
+        storedGrant("grant_empty", "mcp:connect", {
+          resourceKind: "mcp",
+          resourceId: "*",
+          tool: "",
+        }),
+      ]),
+    ).toEqual({
+      "mcp:connect": [{ resourceKind: "mcp", resourceId: "*", tool: "" }],
+    });
+  });
+
+  it("leaves it alone while an unrelated permission is added", () => {
+    const stored = [
+      storedGrant("grant_empty", "mcp:connect", {
+        resourceKind: "mcp",
+        resourceId: "server_one",
+        tool: "",
+      }),
+    ];
+    const view = agentPolicyViewFromGrants(stored);
+    const diff = diffAgentPolicyGrants(
+      view.editable,
+      agentPolicyGrantsFromDraft({ ...view.draft, "skill:read": null }),
+    );
+    expect(diff.remove).toEqual([]);
+    expect(diff.create).toEqual([
+      {
+        effect: "allow",
+        scope: "skill:read",
+        selector: { resourceKind: "skill", resourceId: "*" },
+      },
+    ]);
+  });
+});
+
+describe("ceiling fingerprint", () => {
+  const base = [
+    storedGrant("grant_one", "mcp:connect", {
+      resourceKind: "mcp",
+      resourceId: "server_one",
+    }),
+  ];
+
+  it("ignores the order grants arrive in", () => {
+    const second = storedGrant("grant_two", "skill:read", {
+      resourceKind: "skill",
+      resourceId: "*",
+    });
+    expect(agentPolicyFingerprint([...base, second])).toBe(
+      agentPolicyFingerprint([second, ...base]),
+    );
+  });
+
+  it.each([
+    [
+      "an added grant",
+      [
+        ...base,
+        storedGrant("grant_two", "skill:read", {
+          resourceKind: "skill",
+          resourceId: "*",
+        }),
+      ],
+    ],
+    ["a removed grant", []],
+    [
+      "a grant rewritten in place",
+      [
+        storedGrant("grant_one", "mcp:connect", {
+          resourceKind: "mcp",
+          resourceId: "server_two",
+        }),
+      ],
+    ],
+    [
+      "a change to a preserved grant",
+      [
+        ...base,
+        storedGrant("grant_risk", "risk_policy:evaluate", {
+          resourceKind: "risk_policy",
+          resourceId: "*",
+          serverUrl: "https://mcp.example.test",
+        }),
+      ],
+    ],
+  ])("changes for %s", (_, next) => {
+    expect(agentPolicyFingerprint(next)).not.toBe(agentPolicyFingerprint(base));
   });
 });

--- a/client/dashboard/src/pages/agents/agent-policy-grants.test.ts
+++ b/client/dashboard/src/pages/agents/agent-policy-grants.test.ts
@@ -531,3 +531,84 @@ describe("ceiling fingerprint", () => {
     expect(agentPolicyFingerprint(next)).not.toBe(agentPolicyFingerprint(base));
   });
 });
+
+// `delegableGrantKey` used to join selector entries as `key=value` pairs
+// separated by `&`. Sorting the keys defeats most of the obvious cases, but two
+// adjacent free-form dimensions still collide: `server_identity` is validated
+// nowhere and sorts immediately before `server_url`, so an identity ending in
+// `&serverUrl=…` keys identically to a grant that really constrains both. Every
+// caller treats a shared key as one grant — the duplicate check drops one, the
+// diff thinks a stored grant is still requested, and the fingerprint lets a
+// stale edit through.
+describe("selector values containing the old delimiters", () => {
+  const split = storedGrant("grant_split", "risk_policy:evaluate", {
+    resourceKind: "risk_policy",
+    resourceId: "*",
+    serverIdentity: "x",
+    serverUrl: "https://a.test",
+  });
+  const joined = storedGrant("grant_joined", "risk_policy:evaluate", {
+    resourceKind: "risk_policy",
+    resourceId: "*",
+    serverIdentity: "x&serverUrl=https://a.test",
+  });
+
+  it("fingerprints two such grants differently", () => {
+    expect(agentPolicyFingerprint([split])).not.toBe(
+      agentPolicyFingerprint([joined]),
+    );
+  });
+
+  it("does not let one stand in for the other in a ceiling of the same size", () => {
+    expect(agentPolicyFingerprint([split])).not.toBe(
+      agentPolicyFingerprint([{ ...joined, id: split.id }]),
+    );
+  });
+
+  it("keeps them apart in a diff", () => {
+    const diff = diffAgentPolicyGrants(
+      [split],
+      [{ effect: "allow", scope: joined.scope, selector: joined.selector }],
+    );
+    expect(diff.remove.map((grant) => grant.id)).toEqual(["grant_split"]);
+    expect(diff.create).toHaveLength(1);
+  });
+
+  it("keeps them apart in the duplicate check", () => {
+    expect(
+      agentPolicyGrantsFromDraft({
+        "mcp:connect": [
+          { resourceKind: "mcp", resourceId: "s", projectId: "a", tool: "b" },
+          { resourceKind: "mcp", resourceId: "s", projectId: "a&tool=b" },
+        ],
+      }),
+    ).toHaveLength(2);
+  });
+
+  it.each([
+    ["an ampersand", "one&two"],
+    ["an equals sign", "one=two"],
+    ["both", "one&two=three"],
+    ["a quote and a backslash", 'one"two\\three'],
+    ["an empty string", ""],
+  ])("survives a server identity containing %s", (_, serverIdentity) => {
+    const grant = storedGrant("grant_odd", "risk_policy:evaluate", {
+      resourceKind: "risk_policy",
+      resourceId: "*",
+      serverIdentity,
+    });
+    const bare = storedGrant("grant_odd", "risk_policy:evaluate", {
+      resourceKind: "risk_policy",
+      resourceId: "*",
+    });
+    expect(agentPolicyFingerprint([grant])).not.toBe(
+      agentPolicyFingerprint([bare]),
+    );
+  });
+
+  it("stays independent of the order the grants arrive in", () => {
+    expect(agentPolicyFingerprint([split, joined])).toBe(
+      agentPolicyFingerprint([joined, split]),
+    );
+  });
+});

--- a/client/dashboard/src/pages/agents/agent-policy-grants.ts
+++ b/client/dashboard/src/pages/agents/agent-policy-grants.ts
@@ -431,6 +431,40 @@ export function diffAgentPolicyGrants(
  * with *their* live permissions, and leaving it cached is what makes a
  * freshly permitted agent still look unusable.
  */
+/**
+ * Drop the caches a half-finished save made untrustworthy.
+ *
+ * `resetQueries` rather than `invalidateQueries`: after an abandoned or
+ * ambiguous write the cached ceiling is not merely old, it may never have been
+ * true. Invalidating would let the next editor render it as the stored base
+ * while a refetch runs behind it, which is exactly the "edit on top of
+ * something unconfirmed" this code exists to prevent. Resetting clears it, so
+ * an observer that is still active refetches and one that mounts later loads
+ * from scratch.
+ *
+ * Always called with the ids the save began under. If the app has since moved
+ * to another organization or agent, those keys are inactive and this only
+ * clears them — it cannot pull the old context's data into the new one.
+ */
+export function discardAgentPolicyCaches(
+  queryClient: QueryClient,
+  organizationId: string,
+  userId: string,
+  agentID: string,
+): Promise<unknown> {
+  return Promise.all([
+    queryClient.resetQueries({
+      queryKey: ["agent-policy-grants", organizationId, agentID],
+    }),
+    queryClient.resetQueries({
+      queryKey: ["agent-delegable-grants", organizationId, userId, agentID],
+    }),
+    queryClient.invalidateQueries({
+      queryKey: ["managed-agents", organizationId],
+    }),
+  ]);
+}
+
 export function invalidateAgentPolicy(
   queryClient: QueryClient,
   organizationId: string,

--- a/client/dashboard/src/pages/agents/agent-policy-grants.ts
+++ b/client/dashboard/src/pages/agents/agent-policy-grants.ts
@@ -17,16 +17,13 @@ import { ANY_RESOURCE, delegableGrantKey } from "./agent-api-key-grants";
  * The scopes an agent policy ceiling may use.
  *
  * Mirrors the `safeRuntimeScope()` entries of `runtimeScopeDefinitions` in
- * server/internal/agents/runtimepolicy/scopes.go. Everything else in the
- * registry — org, chat, agent, every `blocked_` exclusion, risk policy bypass
- * and block — is rejected with 400, and `ValidateRuntimeScope` walks the whole
- * implication closure, so a scope only belongs here if everything it implies is
- * safe too.
+ * server/internal/agents/runtimepolicy/scopes.go; anything else is a 400. A
+ * scope only belongs here if its whole implication closure is safe.
  *
- * This is mirrored rather than filtered out of `access.listScopes` because that
- * endpoint requires `org:read`, and an owner configuring their own agent is
- * meant to need no RBAC grant at all. The server stays authoritative: a stale
- * mirror fails closed on a scope the server rejects, it cannot widen anything.
+ * Mirrored rather than filtered out of `access.listScopes` because that
+ * endpoint needs `org:read`, and an owner configuring their own agent is meant
+ * to need no RBAC grant. The server stays authoritative, so a stale mirror
+ * fails closed and cannot widen anything.
  */
 export const AGENT_POLICY_SCOPES: ScopeDefinition[] = [
   {
@@ -136,11 +133,9 @@ export type AgentPolicyDraft = Record<string, Selector[] | null>;
  * Whether this permission offers a resource choice.
  *
  * Environments are not a list you pick from, matching the role editor. Risk
- * policies are excluded for a different reason: their selectors are identified
- * by a risk policy id and narrowed by `server_url` / `server_identity`, and the
- * shared picker emits MCP server ids. Offering it would build a selector whose
- * resource id names the wrong kind of thing, so the permission applies to all
- * risk policies or is not added at all.
+ * policy selectors are identified by a risk policy id while the shared picker
+ * emits MCP server ids, so offering it would build a selector naming the wrong
+ * kind of resource.
  */
 export function isAgentPolicyNarrowable(resourceType: ResourceType): boolean {
   return (
@@ -151,11 +146,9 @@ export function isAgentPolicyNarrowable(resourceType: ResourceType): boolean {
 }
 
 /**
- * The resource kind a scope's selectors must carry.
- *
- * Mirrors `ResourceKindForScope` in server/internal/authz/selector.go, which
- * derives the kind from the scope rather than trusting the request:
- * `ValidateSelector` rejects any selector whose kind does not match.
+ * The resource kind a scope's selectors must carry. Mirrors
+ * `ResourceKindForScope` in server/internal/authz/selector.go, which derives it
+ * from the scope; `ValidateSelector` rejects a selector that disagrees.
  */
 const RESOURCE_KIND_BY_SCOPE_FAMILY: Record<
   string,
@@ -238,12 +231,9 @@ export function agentPolicyGrantsFromDraft(
 }
 
 /**
- * The dimensions the editor's draft can hold and reproduce exactly.
- *
- * Narrower than `ALLOWED_SELECTOR_KEYS`: the server also accepts `server_url`
- * and `server_identity` on risk policy selectors, but the editor has no control
- * for them and the draft selector has nowhere to put them. A grant carrying one
- * is preserved verbatim rather than rewritten — see `agentPolicyViewFromGrants`.
+ * The dimensions the editor's draft can hold and reproduce exactly. Narrower
+ * than `ALLOWED_SELECTOR_KEYS`: the server also accepts `server_url` and
+ * `server_identity`, which have no control and nowhere in the draft selector.
  */
 const DRAFT_DIMENSIONS: Record<string, readonly string[]> = {
   mcp: ["projectId", "disposition", "tool"],
@@ -270,10 +260,9 @@ function constrainedDimensions(
 /**
  * Whether the editor can hold this grant and write it back unchanged.
  *
- * A grant that constrains a dimension the draft cannot carry would come back
- * out of the editor broader than it went in, and the save path replaces a
- * changed grant rather than updating it — so an edit to an unrelated permission
- * would silently drop the constraint. Such grants are never put in the draft.
+ * A grant constraining a dimension the draft cannot carry would come back out
+ * broader than it went in, and the save path replaces rather than updates — so
+ * an unrelated edit would silently drop the constraint.
  */
 export function isAgentPolicyGrantRepresentable(
   grant: AgentPolicyGrant,
@@ -312,10 +301,8 @@ export function agentPolicyDraftFromGrants(
       {
         resourceKind: selector.resourceKind,
         resourceId: selector.resourceId,
-        // Presence, not truthiness: the server stores whatever string it was
-        // given, and an empty `tool` or `project_id` still constrains the
-        // grant. Dropping it here would widen the grant on the next save of
-        // any unrelated permission.
+        // Presence, not truthiness: an empty `tool` or `project_id` still
+        // constrains the grant, and dropping it here would widen it.
         ...(selector.projectId !== undefined
           ? { projectId: selector.projectId }
           : {}),
@@ -341,12 +328,9 @@ export interface AgentPolicyView {
 
 /**
  * Split the stored ceiling into what the editor may rewrite and what it must
- * leave alone.
- *
- * A scope with even one unrepresentable grant is locked whole. Editing half of
- * a scope would let a save remove the constrained grant and re-add a broader
- * one under the same scope, which is the silent widening this split exists to
- * prevent.
+ * leave alone. A scope with even one unrepresentable grant is locked whole:
+ * editing half of one would let a save drop the constrained grant and re-add a
+ * broader one under the same scope.
  */
 export function agentPolicyViewFromGrants(
   grants: AgentPolicyGrant[],
@@ -367,11 +351,9 @@ export function agentPolicyViewFromGrants(
 }
 
 /**
- * A stable identity for the whole stored ceiling.
- *
- * Includes every grant, preserved ones too, and both the grant id and its
- * contents: another administrator can add, remove, or rewrite a grant in place,
- * and any of those makes an open draft's base stale.
+ * A stable identity for the whole stored ceiling. Covers every grant, preserved
+ * ones included, by id and by contents: a grant rewritten in place makes an
+ * open draft's base just as stale as one added or removed.
  */
 export function agentPolicyFingerprint(grants: AgentPolicyGrant[]): string {
   return JSON.stringify(
@@ -424,27 +406,15 @@ export function diffAgentPolicyGrants(
 }
 
 /**
- * Invalidate everything a changed ceiling makes stale.
- *
- * The delegable candidate set matters most: it is what the API key dialog
- * narrows, it is keyed by the authorizing user because it is an intersection
- * with *their* live permissions, and leaving it cached is what makes a
- * freshly permitted agent still look unusable.
- */
-/**
  * Drop the caches a half-finished save made untrustworthy.
  *
- * `resetQueries` rather than `invalidateQueries`: after an abandoned or
- * ambiguous write the cached ceiling is not merely old, it may never have been
- * true. Invalidating would let the next editor render it as the stored base
- * while a refetch runs behind it, which is exactly the "edit on top of
- * something unconfirmed" this code exists to prevent. Resetting clears it, so
- * an observer that is still active refetches and one that mounts later loads
- * from scratch.
+ * `resetQueries`, not `invalidateQueries`: an invalidated query still serves
+ * its cached data as a success while it refetches, which would let the next
+ * editor build a draft on a ceiling that may never have existed. Resetting
+ * clears it, so an active observer refetches and a later one loads fresh.
  *
- * Always called with the ids the save began under. If the app has since moved
- * to another organization or agent, those keys are inactive and this only
- * clears them — it cannot pull the old context's data into the new one.
+ * Always called with the ids the save began under, so keys belonging to a
+ * context the app has since moved to are left alone.
  */
 export function discardAgentPolicyCaches(
   queryClient: QueryClient,
@@ -465,6 +435,11 @@ export function discardAgentPolicyCaches(
   ]);
 }
 
+/**
+ * Invalidate what a committed ceiling change makes stale. The delegable
+ * candidate set matters most: it is what the API key dialog narrows, and it is
+ * keyed by the authorizing user because it intersects *their* permissions.
+ */
 export function invalidateAgentPolicy(
   queryClient: QueryClient,
   organizationId: string,

--- a/client/dashboard/src/pages/agents/agent-policy-grants.ts
+++ b/client/dashboard/src/pages/agents/agent-policy-grants.ts
@@ -374,17 +374,20 @@ export function agentPolicyViewFromGrants(
  * and any of those makes an open draft's base stale.
  */
 export function agentPolicyFingerprint(grants: AgentPolicyGrant[]): string {
-  return grants
-    .map(
-      (grant) =>
-        `${grant.id}\u0000${delegableGrantKey({
-          effect: "allow",
-          scope: grant.scope,
-          selector: grant.selector,
-        })}`,
-    )
-    .sort()
-    .join("\u0001");
+  return JSON.stringify(
+    grants
+      .map((grant) =>
+        JSON.stringify([
+          grant.id,
+          delegableGrantKey({
+            effect: "allow",
+            scope: grant.scope,
+            selector: grant.selector,
+          }),
+        ]),
+      )
+      .sort(),
+  );
 }
 
 export interface AgentPolicyDiff {

--- a/client/dashboard/src/pages/agents/agent-policy-grants.ts
+++ b/client/dashboard/src/pages/agents/agent-policy-grants.ts
@@ -1,0 +1,419 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+import type { AgentPolicyGrant } from "@gram/client/models/components/agentpolicygrant.js";
+import type { AgentPolicyGrantForm } from "@gram/client/models/components/agentpolicygrantform.js";
+import type {
+  AgentPolicySelector,
+  AgentPolicySelectorResourceKind,
+} from "@gram/client/models/components/agentpolicyselector.js";
+import type { ScopeDefinition } from "@gram/client/models/components/scopedefinition.js";
+import type { Selector } from "@gram/client/models/components/selector.js";
+import type { ScopeGroup } from "@/pages/access/RolePermissionsSection";
+import type { ResourceType } from "@/pages/access/types";
+
+import { ANY_RESOURCE, delegableGrantKey } from "./agent-api-key-grants";
+
+/**
+ * The scopes an agent policy ceiling may use.
+ *
+ * Mirrors the `safeRuntimeScope()` entries of `runtimeScopeDefinitions` in
+ * server/internal/agents/runtimepolicy/scopes.go. Everything else in the
+ * registry — org, chat, agent, every `blocked_` exclusion, risk policy bypass
+ * and block — is rejected with 400, and `ValidateRuntimeScope` walks the whole
+ * implication closure, so a scope only belongs here if everything it implies is
+ * safe too.
+ *
+ * This is mirrored rather than filtered out of `access.listScopes` because that
+ * endpoint requires `org:read`, and an owner configuring their own agent is
+ * meant to need no RBAC grant at all. The server stays authoritative: a stale
+ * mirror fails closed on a scope the server rejects, it cannot widen anything.
+ */
+export const AGENT_POLICY_SCOPES: ScopeDefinition[] = [
+  {
+    slug: "mcp:connect",
+    resourceType: "mcp",
+    visibility: "user_visible",
+    description: "Connect to MCP servers and call their tools.",
+  },
+  {
+    slug: "mcp:read",
+    resourceType: "mcp",
+    visibility: "user_visible",
+    description: "View MCP servers and configuration.",
+  },
+  {
+    slug: "mcp:write",
+    resourceType: "mcp",
+    visibility: "user_visible",
+    description: "Create and modify MCP servers and configuration.",
+  },
+  {
+    slug: "project:read",
+    resourceType: "project",
+    visibility: "user_visible",
+    description: "View projects and project-related resources.",
+  },
+  {
+    slug: "project:write",
+    resourceType: "project",
+    visibility: "user_visible",
+    description: "Create and modify projects and project-related resources.",
+  },
+  {
+    slug: "environment:read",
+    resourceType: "environment",
+    visibility: "user_visible",
+    description: "View environments and their entries within the project.",
+  },
+  {
+    slug: "environment:write",
+    resourceType: "environment",
+    visibility: "user_visible",
+    description:
+      "Add, edit, clone, and remove environments within the project.",
+  },
+  {
+    slug: "skill:read",
+    resourceType: "skill",
+    visibility: "user_visible",
+    description: "View skills within the project.",
+  },
+  {
+    slug: "skill:write",
+    resourceType: "skill",
+    visibility: "user_visible",
+    description: "Create and modify skills within the project.",
+  },
+  {
+    slug: "risk_policy:evaluate",
+    resourceType: "risk_policy",
+    visibility: "user_visible",
+    description: "Evaluate risk policies.",
+  },
+];
+
+export const AGENT_POLICY_SCOPE_GROUPS: ScopeGroup[] = [
+  {
+    label: "MCP Servers",
+    resourceType: "mcp",
+    description: "MCP server configuration and connections.",
+    scopes: AGENT_POLICY_SCOPES.filter((s) => s.resourceType === "mcp"),
+  },
+  {
+    label: "Build & Deploy",
+    resourceType: "project",
+    description: "Projects and their related resources.",
+    scopes: AGENT_POLICY_SCOPES.filter((s) => s.resourceType === "project"),
+  },
+  {
+    label: "Environments",
+    resourceType: "environment",
+    description: "Environments and their entries within projects.",
+    scopes: AGENT_POLICY_SCOPES.filter((s) => s.resourceType === "environment"),
+  },
+  {
+    label: "Skills",
+    resourceType: "skill",
+    description: "Skills available within projects.",
+    scopes: AGENT_POLICY_SCOPES.filter((s) => s.resourceType === "skill"),
+  },
+  {
+    label: "Risk Policies",
+    resourceType: "risk_policy",
+    description: "Risk policy evaluation for MCP traffic.",
+    scopes: AGENT_POLICY_SCOPES.filter((s) => s.resourceType === "risk_policy"),
+  },
+];
+
+/**
+ * A permission per scope, in the shape the role editor's resource picker
+ * already speaks: `null` is unrestricted, an array is one selector per chosen
+ * resource, and `[]` is a choice the user has started but not finished.
+ */
+export type AgentPolicyDraft = Record<string, Selector[] | null>;
+
+/**
+ * Whether this permission offers a resource choice.
+ *
+ * Environments are not a list you pick from, matching the role editor. Risk
+ * policies are excluded for a different reason: their selectors are identified
+ * by a risk policy id and narrowed by `server_url` / `server_identity`, and the
+ * shared picker emits MCP server ids. Offering it would build a selector whose
+ * resource id names the wrong kind of thing, so the permission applies to all
+ * risk policies or is not added at all.
+ */
+export function isAgentPolicyNarrowable(resourceType: ResourceType): boolean {
+  return (
+    resourceType === "mcp" ||
+    resourceType === "project" ||
+    resourceType === "skill"
+  );
+}
+
+/**
+ * The resource kind a scope's selectors must carry.
+ *
+ * Mirrors `ResourceKindForScope` in server/internal/authz/selector.go, which
+ * derives the kind from the scope rather than trusting the request:
+ * `ValidateSelector` rejects any selector whose kind does not match.
+ */
+const RESOURCE_KIND_BY_SCOPE_FAMILY: Record<
+  string,
+  AgentPolicySelectorResourceKind
+> = {
+  project: "project",
+  mcp: "mcp",
+  environment: "environment",
+  skill: "skill",
+  risk_policy: "risk_policy",
+};
+
+export function agentPolicyResourceKind(
+  scope: string,
+): AgentPolicySelectorResourceKind {
+  return RESOURCE_KIND_BY_SCOPE_FAMILY[scope.split(":")[0] ?? ""] ?? "*";
+}
+
+/**
+ * The extra selector keys each resource kind accepts. Mirrors
+ * `allowedSelectorKeys` in server/internal/authz/selector.go; any other key is
+ * a 400, so the conversion drops rather than forwards them.
+ */
+const ALLOWED_SELECTOR_KEYS: Record<
+  string,
+  ("projectId" | "disposition" | "tool" | "serverUrl" | "serverIdentity")[]
+> = {
+  mcp: ["projectId", "disposition", "tool"],
+  environment: ["projectId"],
+  risk_policy: ["serverUrl", "serverIdentity"],
+};
+
+function policySelector(
+  scope: string,
+  source: Partial<Selector> | undefined,
+): AgentPolicySelector {
+  const resourceKind = agentPolicyResourceKind(scope);
+  const selector: AgentPolicySelector = {
+    resourceKind,
+    resourceId: source?.resourceId ?? ANY_RESOURCE,
+  };
+  for (const key of ALLOWED_SELECTOR_KEYS[resourceKind] ?? []) {
+    const value = (source as Record<string, string | undefined> | undefined)?.[
+      key
+    ];
+    // An absent dimension and a wildcard mean the same thing to the matcher,
+    // so the narrower wire shape is the one that omits it.
+    if (value !== undefined && value !== ANY_RESOURCE) {
+      (selector as Record<string, string>)[key] = value;
+    }
+  }
+  return selector;
+}
+
+/**
+ * The grants to send for a draft: one per chosen resource, with the resource
+ * kind forced from the scope and unsupported dimensions dropped. Duplicates
+ * are collapsed because the server rejects a request that repeats a grant.
+ */
+export function agentPolicyGrantsFromDraft(
+  draft: AgentPolicyDraft,
+): AgentPolicyGrantForm[] {
+  const forms: AgentPolicyGrantForm[] = [];
+  const seen = new Set<string>();
+  for (const [scope, selectors] of Object.entries(draft)) {
+    const sources = selectors === null ? [undefined] : selectors;
+    for (const source of sources) {
+      const form: AgentPolicyGrantForm = {
+        effect: "allow",
+        scope,
+        selector: policySelector(scope, source),
+      };
+      const key = delegableGrantKey(form);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      forms.push(form);
+    }
+  }
+  return forms;
+}
+
+/**
+ * The dimensions the editor's draft can hold and reproduce exactly.
+ *
+ * Narrower than `ALLOWED_SELECTOR_KEYS`: the server also accepts `server_url`
+ * and `server_identity` on risk policy selectors, but the editor has no control
+ * for them and the draft selector has nowhere to put them. A grant carrying one
+ * is preserved verbatim rather than rewritten — see `agentPolicyViewFromGrants`.
+ */
+const DRAFT_DIMENSIONS: Record<string, readonly string[]> = {
+  mcp: ["projectId", "disposition", "tool"],
+  environment: ["projectId"],
+};
+
+/**
+ * The dimensions a selector actually constrains. A wildcard constrains nothing,
+ * so it reads the same as an absent key — which is how `Selector.Matches` in
+ * server/internal/authz/selector.go treats it.
+ */
+function constrainedDimensions(
+  selector: AgentPolicySelector,
+): Record<string, string> {
+  const constrained: Record<string, string> = {};
+  for (const [key, value] of Object.entries(selector)) {
+    if (key === "resourceKind" || key === "resourceId") continue;
+    if (typeof value !== "string" || value === ANY_RESOURCE) continue;
+    constrained[key] = value;
+  }
+  return constrained;
+}
+
+/**
+ * Whether the editor can hold this grant and write it back unchanged.
+ *
+ * A grant that constrains a dimension the draft cannot carry would come back
+ * out of the editor broader than it went in, and the save path replaces a
+ * changed grant rather than updating it — so an edit to an unrelated permission
+ * would silently drop the constraint. Such grants are never put in the draft.
+ */
+export function isAgentPolicyGrantRepresentable(
+  grant: AgentPolicyGrant,
+): boolean {
+  if (grant.selector.resourceKind !== agentPolicyResourceKind(grant.scope)) {
+    return false;
+  }
+  const carriable = new Set(
+    DRAFT_DIMENSIONS[grant.selector.resourceKind] ?? [],
+  );
+  return Object.keys(constrainedDimensions(grant.selector)).every((key) =>
+    carriable.has(key),
+  );
+}
+
+/** The stored ceiling as a draft the editor can change. */
+export function agentPolicyDraftFromGrants(
+  grants: AgentPolicyGrant[],
+): AgentPolicyDraft {
+  const draft: AgentPolicyDraft = {};
+  for (const grant of grants) {
+    const { selector } = grant;
+    if (
+      selector.resourceId === ANY_RESOURCE &&
+      Object.keys(constrainedDimensions(selector)).length === 0
+    ) {
+      draft[grant.scope] = null;
+      continue;
+    }
+    // A scope already read as unrestricted stays unrestricted: it covers every
+    // narrower selector stored alongside it.
+    if (draft[grant.scope] === null) continue;
+    const existing = draft[grant.scope] ?? [];
+    draft[grant.scope] = [
+      ...existing,
+      {
+        resourceKind: selector.resourceKind,
+        resourceId: selector.resourceId,
+        ...(selector.projectId ? { projectId: selector.projectId } : {}),
+        ...(selector.disposition ? { disposition: selector.disposition } : {}),
+        ...(selector.tool ? { tool: selector.tool } : {}),
+      },
+    ];
+  }
+  return draft;
+}
+
+export interface AgentPolicyView {
+  /** The permissions the editor may change. */
+  draft: AgentPolicyDraft;
+  /** The stored grants the draft was built from; the only ones it may replace. */
+  editable: AgentPolicyGrant[];
+  /** Stored grants kept exactly as they are, and the scopes they lock. */
+  preserved: AgentPolicyGrant[];
+  preservedScopes: string[];
+}
+
+/**
+ * Split the stored ceiling into what the editor may rewrite and what it must
+ * leave alone.
+ *
+ * A scope with even one unrepresentable grant is locked whole. Editing half of
+ * a scope would let a save remove the constrained grant and re-add a broader
+ * one under the same scope, which is the silent widening this split exists to
+ * prevent.
+ */
+export function agentPolicyViewFromGrants(
+  grants: AgentPolicyGrant[],
+): AgentPolicyView {
+  const locked = new Set(
+    grants
+      .filter((grant) => !isAgentPolicyGrantRepresentable(grant))
+      .map((grant) => grant.scope),
+  );
+  const preserved = grants.filter((grant) => locked.has(grant.scope));
+  const editable = grants.filter((grant) => !locked.has(grant.scope));
+  return {
+    draft: agentPolicyDraftFromGrants(editable),
+    editable,
+    preserved,
+    preservedScopes: [...locked],
+  };
+}
+
+export interface AgentPolicyDiff {
+  create: AgentPolicyGrantForm[];
+  remove: AgentPolicyGrant[];
+}
+
+/**
+ * What to send to reach `next` from the stored ceiling. Grant identity is the
+ * scope and selector together, so a changed permission is a removal and an
+ * addition rather than an update.
+ */
+export function diffAgentPolicyGrants(
+  stored: AgentPolicyGrant[],
+  next: AgentPolicyGrantForm[],
+): AgentPolicyDiff {
+  const storedByKey = new Map(
+    stored.map((grant) => [
+      delegableGrantKey({
+        effect: "allow",
+        scope: grant.scope,
+        selector: grant.selector,
+      }),
+      grant,
+    ]),
+  );
+  const nextKeys = new Set(next.map(delegableGrantKey));
+  return {
+    create: next.filter((form) => !storedByKey.has(delegableGrantKey(form))),
+    remove: [...storedByKey]
+      .filter(([key]) => !nextKeys.has(key))
+      .map(([, grant]) => grant),
+  };
+}
+
+/**
+ * Invalidate everything a changed ceiling makes stale.
+ *
+ * The delegable candidate set matters most: it is what the API key dialog
+ * narrows, it is keyed by the authorizing user because it is an intersection
+ * with *their* live permissions, and leaving it cached is what makes a
+ * freshly permitted agent still look unusable.
+ */
+export function invalidateAgentPolicy(
+  queryClient: QueryClient,
+  organizationId: string,
+  userId: string,
+  agentID: string,
+): Promise<unknown> {
+  return Promise.all([
+    queryClient.invalidateQueries({
+      queryKey: ["managed-agents", organizationId],
+    }),
+    queryClient.invalidateQueries({
+      queryKey: ["agent-policy-grants", organizationId, agentID],
+    }),
+    queryClient.invalidateQueries({
+      queryKey: ["agent-delegable-grants", organizationId, userId, agentID],
+    }),
+  ]);
+}

--- a/client/dashboard/src/pages/agents/agent-policy-grants.ts
+++ b/client/dashboard/src/pages/agents/agent-policy-grants.ts
@@ -312,9 +312,17 @@ export function agentPolicyDraftFromGrants(
       {
         resourceKind: selector.resourceKind,
         resourceId: selector.resourceId,
-        ...(selector.projectId ? { projectId: selector.projectId } : {}),
-        ...(selector.disposition ? { disposition: selector.disposition } : {}),
-        ...(selector.tool ? { tool: selector.tool } : {}),
+        // Presence, not truthiness: the server stores whatever string it was
+        // given, and an empty `tool` or `project_id` still constrains the
+        // grant. Dropping it here would widen the grant on the next save of
+        // any unrelated permission.
+        ...(selector.projectId !== undefined
+          ? { projectId: selector.projectId }
+          : {}),
+        ...(selector.disposition !== undefined
+          ? { disposition: selector.disposition }
+          : {}),
+        ...(selector.tool !== undefined ? { tool: selector.tool } : {}),
       },
     ];
   }
@@ -356,6 +364,27 @@ export function agentPolicyViewFromGrants(
     preserved,
     preservedScopes: [...locked],
   };
+}
+
+/**
+ * A stable identity for the whole stored ceiling.
+ *
+ * Includes every grant, preserved ones too, and both the grant id and its
+ * contents: another administrator can add, remove, or rewrite a grant in place,
+ * and any of those makes an open draft's base stale.
+ */
+export function agentPolicyFingerprint(grants: AgentPolicyGrant[]): string {
+  return grants
+    .map(
+      (grant) =>
+        `${grant.id}\u0000${delegableGrantKey({
+          effect: "allow",
+          scope: grant.scope,
+          selector: grant.selector,
+        })}`,
+    )
+    .sort()
+    .join("\u0001");
 }
 
 export interface AgentPolicyDiff {

--- a/client/dashboard/src/sdk/src/models/components/agentpolicygrantform.ts
+++ b/client/dashboard/src/sdk/src/models/components/agentpolicygrantform.ts
@@ -17,21 +17,19 @@ import {
 /**
  * Grant effect; direct agent policy is allow-only
  */
-export const AgentPolicyGrantFormEffect = {
+export const Effect = {
   Allow: "allow",
 } as const;
 /**
  * Grant effect; direct agent policy is allow-only
  */
-export type AgentPolicyGrantFormEffect = ClosedEnum<
-  typeof AgentPolicyGrantFormEffect
->;
+export type Effect = ClosedEnum<typeof Effect>;
 
 export type AgentPolicyGrantForm = {
   /**
    * Grant effect; direct agent policy is allow-only
    */
-  effect: AgentPolicyGrantFormEffect;
+  effect: Effect;
   /**
    * Agent-runtime-safe scope to grant
    */
@@ -43,20 +41,19 @@ export type AgentPolicyGrantForm = {
 };
 
 /** @internal */
-export const AgentPolicyGrantFormEffect$inboundSchema: z.ZodMiniEnum<
-  typeof AgentPolicyGrantFormEffect
-> = z.enum(AgentPolicyGrantFormEffect);
+export const Effect$inboundSchema: z.ZodMiniEnum<typeof Effect> = z.enum(
+  Effect,
+);
 /** @internal */
-export const AgentPolicyGrantFormEffect$outboundSchema: z.ZodMiniEnum<
-  typeof AgentPolicyGrantFormEffect
-> = AgentPolicyGrantFormEffect$inboundSchema;
+export const Effect$outboundSchema: z.ZodMiniEnum<typeof Effect> =
+  Effect$inboundSchema;
 
 /** @internal */
 export const AgentPolicyGrantForm$inboundSchema: z.ZodMiniType<
   AgentPolicyGrantForm,
   unknown
 > = z.object({
-  effect: AgentPolicyGrantFormEffect$inboundSchema,
+  effect: Effect$inboundSchema,
   scope: z.string(),
   selector: AgentPolicySelector$inboundSchema,
 });
@@ -72,7 +69,7 @@ export const AgentPolicyGrantForm$outboundSchema: z.ZodMiniType<
   AgentPolicyGrantForm$Outbound,
   AgentPolicyGrantForm
 > = z.object({
-  effect: AgentPolicyGrantFormEffect$outboundSchema,
+  effect: Effect$outboundSchema,
   scope: z.string(),
   selector: AgentPolicySelector$outboundSchema,
 });

--- a/client/dashboard/src/sdk/src/models/components/createagentform.ts
+++ b/client/dashboard/src/sdk/src/models/components/createagentform.ts
@@ -4,6 +4,11 @@
 
 import * as z from "zod/v4-mini";
 import { remap as remap$ } from "../../lib/primitives.js";
+import {
+  AgentPolicyGrantForm,
+  AgentPolicyGrantForm$Outbound,
+  AgentPolicyGrantForm$outboundSchema,
+} from "./agentpolicygrantform.js";
 
 export type CreateAgentForm = {
   name: string;
@@ -11,12 +16,17 @@ export type CreateAgentForm = {
    * Eligible same-organization human owner; defaults to the caller
    */
   ownerUserId?: string | undefined;
+  /**
+   * Optional initial allow-only agent policy ceilings, created atomically with the agent. Effective credential permissions remain limited by the live owner and authorizer.
+   */
+  policyGrants?: Array<AgentPolicyGrantForm> | undefined;
 };
 
 /** @internal */
 export type CreateAgentForm$Outbound = {
   name: string;
   owner_user_id?: string | undefined;
+  policy_grants?: Array<AgentPolicyGrantForm$Outbound> | undefined;
 };
 
 /** @internal */
@@ -27,10 +37,12 @@ export const CreateAgentForm$outboundSchema: z.ZodMiniType<
   z.object({
     name: z.string(),
     ownerUserId: z.optional(z.string()),
+    policyGrants: z.optional(z.array(AgentPolicyGrantForm$outboundSchema)),
   }),
   z.transform((v) => {
     return remap$(v, {
       ownerUserId: "owner_user_id",
+      policyGrants: "policy_grants",
     });
   }),
 );

--- a/client/dashboard/src/sdk/src/models/components/createagentpolicygrantform.ts
+++ b/client/dashboard/src/sdk/src/models/components/createagentpolicygrantform.ts
@@ -14,13 +14,15 @@ import {
 /**
  * Grant effect; direct agent policy is allow-only
  */
-export const Effect = {
+export const CreateAgentPolicyGrantFormEffect = {
   Allow: "allow",
 } as const;
 /**
  * Grant effect; direct agent policy is allow-only
  */
-export type Effect = ClosedEnum<typeof Effect>;
+export type CreateAgentPolicyGrantFormEffect = ClosedEnum<
+  typeof CreateAgentPolicyGrantFormEffect
+>;
 
 export type CreateAgentPolicyGrantForm = {
   /**
@@ -30,7 +32,7 @@ export type CreateAgentPolicyGrantForm = {
   /**
    * Grant effect; direct agent policy is allow-only
    */
-  effect: Effect;
+  effect: CreateAgentPolicyGrantFormEffect;
   /**
    * Agent-runtime-safe scope to grant
    */
@@ -42,9 +44,9 @@ export type CreateAgentPolicyGrantForm = {
 };
 
 /** @internal */
-export const Effect$outboundSchema: z.ZodMiniEnum<typeof Effect> = z.enum(
-  Effect,
-);
+export const CreateAgentPolicyGrantFormEffect$outboundSchema: z.ZodMiniEnum<
+  typeof CreateAgentPolicyGrantFormEffect
+> = z.enum(CreateAgentPolicyGrantFormEffect);
 
 /** @internal */
 export type CreateAgentPolicyGrantForm$Outbound = {
@@ -61,7 +63,7 @@ export const CreateAgentPolicyGrantForm$outboundSchema: z.ZodMiniType<
 > = z.pipe(
   z.object({
     agentId: z.string(),
-    effect: Effect$outboundSchema,
+    effect: CreateAgentPolicyGrantFormEffect$outboundSchema,
     scope: z.string(),
     selector: AgentPolicySelector$outboundSchema,
   }),

--- a/seed/demo/verify.md
+++ b/seed/demo/verify.md
@@ -172,14 +172,39 @@ Connector` appears under **Inactive** with no connections. Its row menu's
       seeds no agent policy grants. Confirm **Create API key** explains that
       none can be delegated rather than showing an editor or a raw grant
       field — the empty state is the correct result here, not a failure.
-    - To exercise the editor, add synthetic grants locally to all three
-      principals the candidate set intersects: the agent principal, the
-      agent's owner (Amara for Release assistant), and your own calling user.
-      A scope only appears when all three hold it, so grant one narrowable MCP
-      scope (`mcp:connect` over a wildcard server selector is the useful case)
-      and one project scope. Dropping the grant from any one principal must
-      make the candidate disappear; that is the check that discovery really
-      intersects rather than echoing agent policy.
+    - Seed rationale: retain the three lifecycle fixtures, zero agent policy
+      grants, zero API keys, and expired non-authenticating session. They expose
+      the later policy-viewing entry point and its empty state; existing seeded
+      MCP servers/tools supply selector choices. Open Release assistant's policy
+      view and confirm an explicit empty policy, not a loading/error state.
+      No SQL changes are needed: populated policies are verified through local
+      UI creation below, not claimed as seeded data.
+    - **Fresh creation is required acceptance evidence.** As an ordinary human
+      in the local organization, create a new agent owned by that human using
+      the dashboard. Enter a unique test name and configure initial permissions
+      in the creation form: add `mcp:connect`, choose a project and a
+      toolset-backed MCP server, and narrow to one harmless tool. Use structured
+      controls, not raw JSON, grant strings, or free-text tool names. The
+      owner/caller must have matching delegable access; missing access is a
+      setup blocker, not a reason to prepopulate the agent's grants.
+      **API-, SQL-, or script-prepared agent grants are not an acceptance
+      substitute**, even if they make the key picker work. Seeded identities
+      and API-only creation do not prove fresh UI creation.
+    - **Atomic failure and retry:** force a controlled local rejection of an
+      initial policy grant during submission using a test-only server validation
+      failure. Do not assume deleting a selected resource invalidates a policy
+      selector: policy ceilings can describe resources without current access.
+      Confirm a visible error, no persisted
+      agent or partial grants (no orphan identity), and the creation form retains
+      the name and permission draft. A network failure before submission does
+      not prove rollback. Correct the draft through the UI and retry: exactly
+      one agent appears with its initial server/tool-narrowed policy. Reopen its
+      detail and reload; the saved policy must remain unchanged.
+    - Open the new agent's **Create API key** picker without out-of-band grant
+      preparation. Candidates must intersect the saved agent policy, owner's
+      permissions, and calling human's permissions, never broaden to other
+      servers/tools. No delegable access produces an explanatory empty state,
+      not raw grant input.
     - With candidates present, confirm the structured narrowing: a wildcard
       candidate offers a **Server** choice listing the seeded MCP servers, a
       chosen toolset-backed server then offers its **Tool** list, and **Tool
@@ -196,12 +221,34 @@ Connector` appears under **Inactive** with no connections. Its row menu's
       that server's **Inspect** tab, then reselect it; revoking your access to
       the owning project instead surfaces **Retry tools**. Neither path ever
       offers a free-text tool name.
-    - Create a key from a narrowed candidate and confirm the secret appears
-      exactly once, the row's **Expires** column shows an absolute future date
-      (never "ago"), then revoke it. Keep every locally created key local:
-      revoke it when done, never paste a secret into the repo, a PR, or a
-      screenshot, and never promote one into shared SQL or `RunLocalFixtures`
-      as a usable credential.
+    - **Subsequent policy edits:** use the new agent's structured policy
+      editor to add, narrow, and remove permissions. Save and reload after each
+      change; the policy view must show the saved selectors. Reopen the key
+      picker after each save, before reloading: candidates must refresh, with
+      additions only when owner/caller also permit them, removed scopes absent,
+      and narrowed scopes no longer offering the broader choice. Removing
+      matching access from either the local owner or caller must also remove
+      the candidate; restore temporary test access when done.
+    - **Allowed and denied usage (local only):** use a private standalone MCP
+      endpoint without a session issuer and a locally executable harmless tool.
+      Send the UI-issued key in `Authorization: Bearer <key>` to its `/mcp/…`
+      endpoint. Issuer-gated gateways require OAuth/session credentials instead;
+      `gram-agent-mcp-authorization-m2` controls OAuth agent selection, not
+      standalone API-key admission. Display-only seeded tools cannot prove
+      successful tool execution; filtered `tools/list` proves discovery only.
+      Create a short-lived key from the UI's narrowed candidate. Confirm the
+      secret appears exactly once and **Expires** shows an absolute future
+      date (never "ago"). With that key, prove a selected tool succeeds and
+      an unselected tool/server is denied by authorization, not merely absent
+      from the picker or failing downstream. After narrowing/removing the
+      policy, retry the previously allowed call with the existing key: it must
+      be denied, not retain stale access. Record only redacted outcomes.
+    - Revoke every verification key, including after failed or interrupted
+      runs, and remove the temporary local agent. Never retain usable demo
+      keys, paste secrets into the repo, a PR, screenshots, or logs, or promote
+      a test key into shared SQL or `RunLocalFixtures`. Do not mutate the shared
+      demo remotely for these checks. Missing live-usage prerequisites mean
+      the check is blocked, not passed.
     - Rerun `mise run seed`: the same three identities/lifecycles return, agent
       policy grants are reset, and no visitor-created API keys survive the
       shared SQL. Local-only developer keys may be restored by

--- a/server/design/agents/design.go
+++ b/server/design/agents/design.go
@@ -25,6 +25,7 @@ var Permissions = Type("AgentPermissions", func() {
 var CreateForm = Type("CreateAgentForm", func() {
 	Attribute("name", String, func() { MinLength(1); MaxLength(120) })
 	Attribute("owner_user_id", String, "Eligible same-organization human owner; defaults to the caller")
+	Attribute("policy_grants", ArrayOf(PolicyGrantForm), "Optional initial allow-only agent policy ceilings, created atomically with the agent. Effective credential permissions remain limited by the live owner and authorizer.")
 	Required("name")
 })
 

--- a/server/gen/agents/service.go
+++ b/server/gen/agents/service.go
@@ -150,6 +150,10 @@ type CreatePayload struct {
 	Name         string
 	// Eligible same-organization human owner; defaults to the caller
 	OwnerUserID *string
+	// Optional initial allow-only agent policy ceilings, created atomically with
+	// the agent. Effective credential permissions remain limited by the live owner
+	// and authorizer.
+	PolicyGrants []*AgentPolicyGrantForm
 }
 
 // CreatePolicyGrantPayload is the payload type of the agents service

--- a/server/gen/http/agents/client/cli.go
+++ b/server/gen/http/agents/client/cli.go
@@ -128,13 +128,20 @@ func BuildCreatePayload(agentsCreateBody string, agentsCreateSessionToken string
 	{
 		err = json.Unmarshal([]byte(agentsCreateBody), &body)
 		if err != nil {
-			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"name\": \"aa\",\n      \"owner_user_id\": \"abc123\"\n   }'")
+			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"name\": \"aa\",\n      \"owner_user_id\": \"abc123\",\n      \"policy_grants\": [\n         {\n            \"effect\": \"allow\",\n            \"scope\": \"aa\",\n            \"selector\": {\n               \"disposition\": \"destructive\",\n               \"project_id\": \"abc123\",\n               \"resource_id\": \"abc123\",\n               \"resource_kind\": \"mcp\",\n               \"server_identity\": \"abc123\",\n               \"server_url\": \"https://example.com/foo\",\n               \"tool\": \"abc123\"\n            }\n         }\n      ]\n   }'")
 		}
 		if utf8.RuneCountInString(body.Name) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("body.name", body.Name, utf8.RuneCountInString(body.Name), 1, true))
 		}
 		if utf8.RuneCountInString(body.Name) > 120 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("body.name", body.Name, utf8.RuneCountInString(body.Name), 120, false))
+		}
+		for _, e := range body.PolicyGrants {
+			if e != nil {
+				if err2 := ValidateAgentPolicyGrantFormRequestBodyRequestBody(e); err2 != nil {
+					err = goa.MergeErrors(err, err2)
+				}
+			}
 		}
 		if err != nil {
 			return nil, err
@@ -149,6 +156,16 @@ func BuildCreatePayload(agentsCreateBody string, agentsCreateSessionToken string
 	v := &agents.CreatePayload{
 		Name:        body.Name,
 		OwnerUserID: body.OwnerUserID,
+	}
+	if body.PolicyGrants != nil {
+		v.PolicyGrants = make([]*agents.AgentPolicyGrantForm, len(body.PolicyGrants))
+		for i, val := range body.PolicyGrants {
+			if val == nil {
+				v.PolicyGrants[i] = nil
+				continue
+			}
+			v.PolicyGrants[i] = marshalAgentPolicyGrantFormRequestBodyRequestBodyToAgentsAgentPolicyGrantForm(val)
+		}
 	}
 	v.SessionToken = sessionToken
 

--- a/server/gen/http/agents/client/encode_decode.go
+++ b/server/gen/http/agents/client/encode_decode.go
@@ -4042,6 +4042,76 @@ func unmarshalAgentPermissionsResponseToAgentsAgentPermissions(v *AgentPermissio
 	return res
 }
 
+// marshalAgentsAgentPolicyGrantFormToAgentPolicyGrantFormRequestBodyRequestBody
+// builds a value of type *AgentPolicyGrantFormRequestBodyRequestBody from a
+// value of type *agents.AgentPolicyGrantForm.
+func marshalAgentsAgentPolicyGrantFormToAgentPolicyGrantFormRequestBodyRequestBody(v *agents.AgentPolicyGrantForm) *AgentPolicyGrantFormRequestBodyRequestBody {
+	if v == nil {
+		return nil
+	}
+	res := &AgentPolicyGrantFormRequestBodyRequestBody{
+		Scope:  v.Scope,
+		Effect: v.Effect,
+	}
+	if v.Selector != nil {
+		res.Selector = marshalAgentsAgentPolicySelectorToAgentPolicySelectorRequestBodyRequestBody(v.Selector)
+	}
+
+	return res
+}
+
+// marshalAgentsAgentPolicySelectorToAgentPolicySelectorRequestBodyRequestBody
+// builds a value of type *AgentPolicySelectorRequestBodyRequestBody from a
+// value of type *agents.AgentPolicySelector.
+func marshalAgentsAgentPolicySelectorToAgentPolicySelectorRequestBodyRequestBody(v *agents.AgentPolicySelector) *AgentPolicySelectorRequestBodyRequestBody {
+	res := &AgentPolicySelectorRequestBodyRequestBody{
+		ResourceKind:   v.ResourceKind,
+		ResourceID:     v.ResourceID,
+		Disposition:    v.Disposition,
+		Tool:           v.Tool,
+		ProjectID:      v.ProjectID,
+		ServerURL:      v.ServerURL,
+		ServerIdentity: v.ServerIdentity,
+	}
+
+	return res
+}
+
+// marshalAgentPolicyGrantFormRequestBodyRequestBodyToAgentsAgentPolicyGrantForm
+// builds a value of type *agents.AgentPolicyGrantForm from a value of type
+// *AgentPolicyGrantFormRequestBodyRequestBody.
+func marshalAgentPolicyGrantFormRequestBodyRequestBodyToAgentsAgentPolicyGrantForm(v *AgentPolicyGrantFormRequestBodyRequestBody) *agents.AgentPolicyGrantForm {
+	if v == nil {
+		return nil
+	}
+	res := &agents.AgentPolicyGrantForm{
+		Scope:  v.Scope,
+		Effect: v.Effect,
+	}
+	if v.Selector != nil {
+		res.Selector = marshalAgentPolicySelectorRequestBodyRequestBodyToAgentsAgentPolicySelector(v.Selector)
+	}
+
+	return res
+}
+
+// marshalAgentPolicySelectorRequestBodyRequestBodyToAgentsAgentPolicySelector
+// builds a value of type *agents.AgentPolicySelector from a value of type
+// *AgentPolicySelectorRequestBodyRequestBody.
+func marshalAgentPolicySelectorRequestBodyRequestBodyToAgentsAgentPolicySelector(v *AgentPolicySelectorRequestBodyRequestBody) *agents.AgentPolicySelector {
+	res := &agents.AgentPolicySelector{
+		ResourceKind:   v.ResourceKind,
+		ResourceID:     v.ResourceID,
+		Disposition:    v.Disposition,
+		Tool:           v.Tool,
+		ProjectID:      v.ProjectID,
+		ServerURL:      v.ServerURL,
+		ServerIdentity: v.ServerIdentity,
+	}
+
+	return res
+}
+
 // unmarshalAgentOwnerProfileResponseBodyToAgentsAgentOwnerProfile builds a
 // value of type *agents.AgentOwnerProfile from a value of type
 // *AgentOwnerProfileResponseBody.

--- a/server/gen/http/agents/client/types.go
+++ b/server/gen/http/agents/client/types.go
@@ -28,6 +28,10 @@ type CreateRequestBody struct {
 	Name string `form:"name" json:"name" xml:"name"`
 	// Eligible same-organization human owner; defaults to the caller
 	OwnerUserID *string `form:"owner_user_id,omitempty" json:"owner_user_id,omitempty" xml:"owner_user_id,omitempty"`
+	// Optional initial allow-only agent policy ceilings, created atomically with
+	// the agent. Effective credential permissions remain limited by the live owner
+	// and authorizer.
+	PolicyGrants []*AgentPolicyGrantFormRequestBodyRequestBody `form:"policy_grants,omitempty" json:"policy_grants,omitempty" xml:"policy_grants,omitempty"`
 }
 
 // RenameRequestBody is the type of the "agents" service "rename" endpoint HTTP
@@ -3432,6 +3436,35 @@ type AgentPermissionsResponse struct {
 	Transfer *bool `form:"transfer,omitempty" json:"transfer,omitempty" xml:"transfer,omitempty"`
 }
 
+// AgentPolicyGrantFormRequestBodyRequestBody is used to define fields on
+// request body types.
+type AgentPolicyGrantFormRequestBodyRequestBody struct {
+	// Agent-runtime-safe scope to grant
+	Scope string `form:"scope" json:"scope" xml:"scope"`
+	// Grant effect; direct agent policy is allow-only
+	Effect   string                                     `form:"effect" json:"effect" xml:"effect"`
+	Selector *AgentPolicySelectorRequestBodyRequestBody `form:"selector" json:"selector" xml:"selector"`
+}
+
+// AgentPolicySelectorRequestBodyRequestBody is used to define fields on
+// request body types.
+type AgentPolicySelectorRequestBodyRequestBody struct {
+	// The kind of resource this selector targets.
+	ResourceKind string `form:"resource_kind" json:"resource_kind" xml:"resource_kind"`
+	// The resource identifier, or '*' for all resources of this kind.
+	ResourceID string `form:"resource_id" json:"resource_id" xml:"resource_id"`
+	// Tool disposition filter (MCP scopes only).
+	Disposition *string `form:"disposition,omitempty" json:"disposition,omitempty" xml:"disposition,omitempty"`
+	// Specific tool name filter (MCP scopes only).
+	Tool *string `form:"tool,omitempty" json:"tool,omitempty" xml:"tool,omitempty"`
+	// Project filter (MCP scopes only).
+	ProjectID *string `form:"project_id,omitempty" json:"project_id,omitempty" xml:"project_id,omitempty"`
+	// Server URL filter (risk policy scopes only).
+	ServerURL *string `form:"server_url,omitempty" json:"server_url,omitempty" xml:"server_url,omitempty"`
+	// Server identity filter (risk policy scopes only).
+	ServerIdentity *string `form:"server_identity,omitempty" json:"server_identity,omitempty" xml:"server_identity,omitempty"`
+}
+
 // AgentOwnerProfileResponseBody is used to define fields on response body
 // types.
 type AgentOwnerProfileResponseBody struct {
@@ -3541,6 +3574,16 @@ func NewCreateRequestBody(p *agents.CreatePayload) *CreateRequestBody {
 	body := &CreateRequestBody{
 		Name:        p.Name,
 		OwnerUserID: p.OwnerUserID,
+	}
+	if p.PolicyGrants != nil {
+		body.PolicyGrants = make([]*AgentPolicyGrantFormRequestBodyRequestBody, len(p.PolicyGrants))
+		for i, val := range p.PolicyGrants {
+			if val == nil {
+				body.PolicyGrants[i] = nil
+				continue
+			}
+			body.PolicyGrants[i] = marshalAgentsAgentPolicyGrantFormToAgentPolicyGrantFormRequestBodyRequestBody(val)
+		}
 	}
 	return body
 }
@@ -11144,6 +11187,43 @@ func ValidateAgentPermissionsResponse(body *AgentPermissionsResponse) (err error
 	}
 	if body.Transfer == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("transfer", "body"))
+	}
+	return
+}
+
+// ValidateAgentPolicyGrantFormRequestBodyRequestBody runs the validations
+// defined on AgentPolicyGrantFormRequestBodyRequestBody
+func ValidateAgentPolicyGrantFormRequestBodyRequestBody(body *AgentPolicyGrantFormRequestBodyRequestBody) (err error) {
+	if body.Selector == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("selector", "body"))
+	}
+	if utf8.RuneCountInString(body.Scope) < 1 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("body.scope", body.Scope, utf8.RuneCountInString(body.Scope), 1, true))
+	}
+	if !(body.Effect == "allow") {
+		err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.effect", body.Effect, []any{"allow"}))
+	}
+	if body.Selector != nil {
+		if err2 := ValidateAgentPolicySelectorRequestBodyRequestBody(body.Selector); err2 != nil {
+			err = goa.MergeErrors(err, err2)
+		}
+	}
+	return
+}
+
+// ValidateAgentPolicySelectorRequestBodyRequestBody runs the validations
+// defined on AgentPolicySelectorRequestBodyRequestBody
+func ValidateAgentPolicySelectorRequestBodyRequestBody(body *AgentPolicySelectorRequestBodyRequestBody) (err error) {
+	if !(body.ResourceKind == "project" || body.ResourceKind == "mcp" || body.ResourceKind == "org" || body.ResourceKind == "environment" || body.ResourceKind == "skill" || body.ResourceKind == "risk_policy" || body.ResourceKind == "chat" || body.ResourceKind == "agent" || body.ResourceKind == "*") {
+		err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.resource_kind", body.ResourceKind, []any{"project", "mcp", "org", "environment", "skill", "risk_policy", "chat", "agent", "*"}))
+	}
+	if body.Disposition != nil {
+		if !(*body.Disposition == "read_only" || *body.Disposition == "destructive" || *body.Disposition == "idempotent" || *body.Disposition == "open_world") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.disposition", *body.Disposition, []any{"read_only", "destructive", "idempotent", "open_world"}))
+		}
+	}
+	if body.ServerURL != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.server_url", *body.ServerURL, goa.FormatURI))
 	}
 	return
 }

--- a/server/gen/http/agents/server/encode_decode.go
+++ b/server/gen/http/agents/server/encode_decode.go
@@ -3670,6 +3670,39 @@ func marshalAgentsAgentPermissionsToAgentPermissionsResponse(v *agents.AgentPerm
 	return res
 }
 
+// unmarshalAgentPolicyGrantFormRequestBodyRequestBodyToAgentsAgentPolicyGrantForm
+// builds a value of type *agents.AgentPolicyGrantForm from a value of type
+// *AgentPolicyGrantFormRequestBodyRequestBody.
+func unmarshalAgentPolicyGrantFormRequestBodyRequestBodyToAgentsAgentPolicyGrantForm(v *AgentPolicyGrantFormRequestBodyRequestBody) *agents.AgentPolicyGrantForm {
+	if v == nil {
+		return nil
+	}
+	res := &agents.AgentPolicyGrantForm{
+		Scope:  *v.Scope,
+		Effect: *v.Effect,
+	}
+	res.Selector = unmarshalAgentPolicySelectorRequestBodyRequestBodyToAgentsAgentPolicySelector(v.Selector)
+
+	return res
+}
+
+// unmarshalAgentPolicySelectorRequestBodyRequestBodyToAgentsAgentPolicySelector
+// builds a value of type *agents.AgentPolicySelector from a value of type
+// *AgentPolicySelectorRequestBodyRequestBody.
+func unmarshalAgentPolicySelectorRequestBodyRequestBodyToAgentsAgentPolicySelector(v *AgentPolicySelectorRequestBodyRequestBody) *agents.AgentPolicySelector {
+	res := &agents.AgentPolicySelector{
+		ResourceKind:   *v.ResourceKind,
+		ResourceID:     *v.ResourceID,
+		Disposition:    v.Disposition,
+		Tool:           v.Tool,
+		ProjectID:      v.ProjectID,
+		ServerURL:      v.ServerURL,
+		ServerIdentity: v.ServerIdentity,
+	}
+
+	return res
+}
+
 // marshalAgentsAgentOwnerProfileToAgentOwnerProfileResponseBody builds a value
 // of type *AgentOwnerProfileResponseBody from a value of type
 // *agents.AgentOwnerProfile.

--- a/server/gen/http/agents/server/types.go
+++ b/server/gen/http/agents/server/types.go
@@ -28,6 +28,10 @@ type CreateRequestBody struct {
 	Name *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	// Eligible same-organization human owner; defaults to the caller
 	OwnerUserID *string `form:"owner_user_id,omitempty" json:"owner_user_id,omitempty" xml:"owner_user_id,omitempty"`
+	// Optional initial allow-only agent policy ceilings, created atomically with
+	// the agent. Effective credential permissions remain limited by the live owner
+	// and authorizer.
+	PolicyGrants []*AgentPolicyGrantFormRequestBodyRequestBody `form:"policy_grants,omitempty" json:"policy_grants,omitempty" xml:"policy_grants,omitempty"`
 }
 
 // RenameRequestBody is the type of the "agents" service "rename" endpoint HTTP
@@ -3519,6 +3523,35 @@ type AgentPolicySelectorResponseBody struct {
 	ServerIdentity *string `form:"server_identity,omitempty" json:"server_identity,omitempty" xml:"server_identity,omitempty"`
 }
 
+// AgentPolicyGrantFormRequestBodyRequestBody is used to define fields on
+// request body types.
+type AgentPolicyGrantFormRequestBodyRequestBody struct {
+	// Agent-runtime-safe scope to grant
+	Scope *string `form:"scope,omitempty" json:"scope,omitempty" xml:"scope,omitempty"`
+	// Grant effect; direct agent policy is allow-only
+	Effect   *string                                    `form:"effect,omitempty" json:"effect,omitempty" xml:"effect,omitempty"`
+	Selector *AgentPolicySelectorRequestBodyRequestBody `form:"selector,omitempty" json:"selector,omitempty" xml:"selector,omitempty"`
+}
+
+// AgentPolicySelectorRequestBodyRequestBody is used to define fields on
+// request body types.
+type AgentPolicySelectorRequestBodyRequestBody struct {
+	// The kind of resource this selector targets.
+	ResourceKind *string `form:"resource_kind,omitempty" json:"resource_kind,omitempty" xml:"resource_kind,omitempty"`
+	// The resource identifier, or '*' for all resources of this kind.
+	ResourceID *string `form:"resource_id,omitempty" json:"resource_id,omitempty" xml:"resource_id,omitempty"`
+	// Tool disposition filter (MCP scopes only).
+	Disposition *string `form:"disposition,omitempty" json:"disposition,omitempty" xml:"disposition,omitempty"`
+	// Specific tool name filter (MCP scopes only).
+	Tool *string `form:"tool,omitempty" json:"tool,omitempty" xml:"tool,omitempty"`
+	// Project filter (MCP scopes only).
+	ProjectID *string `form:"project_id,omitempty" json:"project_id,omitempty" xml:"project_id,omitempty"`
+	// Server URL filter (risk policy scopes only).
+	ServerURL *string `form:"server_url,omitempty" json:"server_url,omitempty" xml:"server_url,omitempty"`
+	// Server identity filter (risk policy scopes only).
+	ServerIdentity *string `form:"server_identity,omitempty" json:"server_identity,omitempty" xml:"server_identity,omitempty"`
+}
+
 // AgentPolicySelector is used to define fields on request body types.
 type AgentPolicySelector struct {
 	// The kind of resource this selector targets.
@@ -6242,6 +6275,16 @@ func NewCreatePayload(body *CreateRequestBody, sessionToken *string) *agents.Cre
 		Name:        *body.Name,
 		OwnerUserID: body.OwnerUserID,
 	}
+	if body.PolicyGrants != nil {
+		v.PolicyGrants = make([]*agents.AgentPolicyGrantForm, len(body.PolicyGrants))
+		for i, val := range body.PolicyGrants {
+			if val == nil {
+				v.PolicyGrants[i] = nil
+				continue
+			}
+			v.PolicyGrants[i] = unmarshalAgentPolicyGrantFormRequestBodyRequestBodyToAgentsAgentPolicyGrantForm(val)
+		}
+	}
 	v.SessionToken = sessionToken
 
 	return v
@@ -6421,6 +6464,13 @@ func ValidateCreateRequestBody(body *CreateRequestBody) (err error) {
 	if body.Name != nil {
 		if utf8.RuneCountInString(*body.Name) > 120 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("body.name", *body.Name, utf8.RuneCountInString(*body.Name), 120, false))
+		}
+	}
+	for _, e := range body.PolicyGrants {
+		if e != nil {
+			if err2 := ValidateAgentPolicyGrantFormRequestBodyRequestBody(e); err2 != nil {
+				err = goa.MergeErrors(err, err2)
+			}
 		}
 	}
 	return
@@ -6616,6 +6666,61 @@ func ValidateDeleteRequestBody(body *DeleteRequestBody) (err error) {
 	}
 	if body.AgentID != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.agent_id", *body.AgentID, goa.FormatUUID))
+	}
+	return
+}
+
+// ValidateAgentPolicyGrantFormRequestBodyRequestBody runs the validations
+// defined on AgentPolicyGrantFormRequestBodyRequestBody
+func ValidateAgentPolicyGrantFormRequestBodyRequestBody(body *AgentPolicyGrantFormRequestBodyRequestBody) (err error) {
+	if body.Scope == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("scope", "body"))
+	}
+	if body.Effect == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("effect", "body"))
+	}
+	if body.Selector == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("selector", "body"))
+	}
+	if body.Scope != nil {
+		if utf8.RuneCountInString(*body.Scope) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.scope", *body.Scope, utf8.RuneCountInString(*body.Scope), 1, true))
+		}
+	}
+	if body.Effect != nil {
+		if !(*body.Effect == "allow") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.effect", *body.Effect, []any{"allow"}))
+		}
+	}
+	if body.Selector != nil {
+		if err2 := ValidateAgentPolicySelectorRequestBodyRequestBody(body.Selector); err2 != nil {
+			err = goa.MergeErrors(err, err2)
+		}
+	}
+	return
+}
+
+// ValidateAgentPolicySelectorRequestBodyRequestBody runs the validations
+// defined on AgentPolicySelectorRequestBodyRequestBody
+func ValidateAgentPolicySelectorRequestBodyRequestBody(body *AgentPolicySelectorRequestBodyRequestBody) (err error) {
+	if body.ResourceKind == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("resource_kind", "body"))
+	}
+	if body.ResourceID == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("resource_id", "body"))
+	}
+	if body.ResourceKind != nil {
+		if !(*body.ResourceKind == "project" || *body.ResourceKind == "mcp" || *body.ResourceKind == "org" || *body.ResourceKind == "environment" || *body.ResourceKind == "skill" || *body.ResourceKind == "risk_policy" || *body.ResourceKind == "chat" || *body.ResourceKind == "agent" || *body.ResourceKind == "*") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.resource_kind", *body.ResourceKind, []any{"project", "mcp", "org", "environment", "skill", "risk_policy", "chat", "agent", "*"}))
+		}
+	}
+	if body.Disposition != nil {
+		if !(*body.Disposition == "read_only" || *body.Disposition == "destructive" || *body.Disposition == "idempotent" || *body.Disposition == "open_world") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body.disposition", *body.Disposition, []any{"read_only", "destructive", "idempotent", "open_world"}))
+		}
+	}
+	if body.ServerURL != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("body.server_url", *body.ServerURL, goa.FormatURI))
 	}
 	return
 }

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -11199,7 +11199,7 @@ func agentsCreateUsage() {
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "agents create --body '{\n      \"name\": \"aa\",\n      \"owner_user_id\": \"abc123\"\n   }' --session-token \"abc123\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "agents create --body '{\n      \"name\": \"aa\",\n      \"owner_user_id\": \"abc123\",\n      \"policy_grants\": [\n         {\n            \"effect\": \"allow\",\n            \"scope\": \"aa\",\n            \"selector\": {\n               \"disposition\": \"destructive\",\n               \"project_id\": \"abc123\",\n               \"resource_id\": \"abc123\",\n               \"resource_kind\": \"mcp\",\n               \"server_identity\": \"abc123\",\n               \"server_url\": \"https://example.com/foo\",\n               \"tool\": \"abc123\"\n            }\n         }\n      ]\n   }' --session-token \"abc123\"")
 }
 
 func agentsGetUsage() {

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -72077,6 +72077,11 @@ components:
                 owner_user_id:
                     type: string
                     description: Eligible same-organization human owner; defaults to the caller
+                policy_grants:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AgentPolicyGrantForm'
+                    description: Optional initial allow-only agent policy ceilings, created atomically with the agent. Effective credential permissions remain limited by the live owner and authorizer.
             required:
                 - name
         CreateAgentPolicyGrantForm:

--- a/server/internal/agentmanagement/create_policy_test.go
+++ b/server/internal/agentmanagement/create_policy_test.go
@@ -1,0 +1,151 @@
+package agentmanagement
+
+import (
+	"context"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/speakeasy-api/gram/server/internal/feature"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+	"testing"
+
+	gen "github.com/speakeasy-api/gram/server/gen/agents"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/testenv/testrepo"
+	"github.com/stretchr/testify/require"
+)
+
+func initialMCPGrant() *gen.AgentPolicyGrantForm {
+	return &gen.AgentPolicyGrantForm{Scope: string(authz.ScopeMCPRead), Effect: "allow", Selector: &gen.AgentPolicySelector{ResourceKind: authz.ResourceKindMCP, ResourceID: "*"}}
+}
+
+func TestCreateAgentWithInitialPolicy(t *testing.T) {
+	t.Parallel()
+	conn := newTestDB(t)
+	seedOrganization(t, conn, "org-create-policy")
+	seedOrganizationUser(t, conn, "org-create-policy", "owner")
+	// Owners may configure policy ceilings without management RBAC. This does not issue credentials.
+	engine := authz.NewEngine(testenv.NewLogger(t), conn, func(context.Context, string) (bool, error) { return false, nil }, nil)
+	service := newTestService(conn, engine)
+	service.features = &recordingAgentManagementFeatures{evaluation: feature.EvaluationEnabled}
+	ctx := validatedHumanContext(t, "org-create-policy", "owner")
+	created, err := service.Create(ctx, &gen.CreatePayload{Name: "Configured agent", PolicyGrants: []*gen.AgentPolicyGrantForm{initialMCPGrant()}})
+	require.NoError(t, err)
+	require.Equal(t, gen.AgentLifecycle("active"), created.Lifecycle)
+	require.True(t, created.Permissions.Write)
+	grants, err := service.ListPolicyGrants(ctx, &gen.ListPolicyGrantsPayload{AgentID: created.ID})
+	require.NoError(t, err)
+	require.Len(t, grants, 1)
+	require.Equal(t, string(authz.ScopeMCPRead), grants[0].Scope)
+	// Configuring a broad policy must not create delegable powers absent from the owner.
+	delegable, err := service.ListDelegableGrants(ctx, &gen.ListDelegableGrantsPayload{AgentID: created.ID})
+	require.NoError(t, err)
+	require.Empty(t, delegable)
+	seedGrant(t, ctx, conn, "org-create-policy", urn.NewPrincipal(urn.PrincipalTypeUser, "owner"), authz.ScopeMCPRead, "*")
+	delegable, err = service.ListDelegableGrants(ctx, &gen.ListDelegableGrantsPayload{AgentID: created.ID})
+	require.NoError(t, err)
+	require.Len(t, delegable, 1)
+
+	require.Equal(t, []string{"agent:create", "agent:policy_grant_create"}, agentWebhookOutboxActions(t, conn, "org-create-policy"))
+	_, err = service.CreatePolicyGrant(ctx, &gen.CreatePolicyGrantPayload{AgentID: created.ID, Scope: grants[0].Scope, Effect: "allow", Selector: grants[0].Selector})
+	requireOopsCode(t, err, oops.CodeConflict)
+	for _, initial := range [][]*gen.AgentPolicyGrantForm{nil, {}} {
+		created, err := service.Create(ctx, &gen.CreatePayload{Name: "Empty agent", PolicyGrants: initial})
+		require.NoError(t, err)
+		grants, err := service.ListPolicyGrants(ctx, &gen.ListPolicyGrantsPayload{AgentID: created.ID})
+		require.NoError(t, err)
+		require.Empty(t, grants)
+		require.NoError(t, service.Delete(ctx, &gen.DeletePayload{AgentID: created.ID}))
+	}
+}
+
+func TestCreateAgentInitialPolicyFailureIsAtomic(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name               string
+		grants             []*gen.AgentPolicyGrantForm
+		otherOwner         bool
+		auditFailure       bool
+		policyAuditFailure bool
+	}{
+		{name: "duplicate", grants: []*gen.AgentPolicyGrantForm{initialMCPGrant(), initialMCPGrant()}},
+		{name: "nil", grants: []*gen.AgentPolicyGrantForm{initialMCPGrant(), nil}},
+		{name: "unsafe", grants: []*gen.AgentPolicyGrantForm{initialMCPGrant(), {Scope: string(authz.ScopeAgentWrite), Effect: "allow", Selector: &gen.AgentPolicySelector{ResourceKind: "agent", ResourceID: "*"}}}},
+		{name: "deny", grants: []*gen.AgentPolicyGrantForm{initialMCPGrant(), {Scope: string(authz.ScopeMCPRead), Effect: "deny", Selector: &gen.AgentPolicySelector{ResourceKind: "mcp", ResourceID: "*"}}}},
+		{name: "selector", grants: []*gen.AgentPolicyGrantForm{initialMCPGrant(), {Scope: string(authz.ScopeMCPRead), Effect: "allow"}}},
+		{name: "other owner", grants: []*gen.AgentPolicyGrantForm{initialMCPGrant()}, otherOwner: true},
+		{name: "audit", grants: []*gen.AgentPolicyGrantForm{initialMCPGrant()}, auditFailure: true},
+		{name: "policy audit", grants: []*gen.AgentPolicyGrantForm{initialMCPGrant()}, policyAuditFailure: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			conn := newTestDB(t)
+			seedOrganization(t, conn, "org-create-policy")
+			seedOrganizationUser(t, conn, "org-create-policy", "owner")
+			seedOrganizationUser(t, conn, "org-create-policy", "other")
+			service := newTestService(conn, &fakeAuthorizationEngine{allowed: map[string]bool{}})
+			ctx := validatedHumanContext(t, "org-create-policy", "owner")
+			payload := &gen.CreatePayload{Name: "Failed agent", PolicyGrants: test.grants}
+			if test.otherOwner {
+				owner := "other"
+				payload.OwnerUserID = &owner
+			}
+			if test.auditFailure {
+				require.NoError(t, testrepo.New(conn).RejectPublishOutboxWritesFixture(ctx))
+			}
+			if test.policyAuditFailure {
+				require.NoError(t, testrepo.New(conn).RejectAgentPolicyGrantAuditWritesFixture(ctx))
+			}
+			_, err := service.Create(ctx, payload)
+			require.Error(t, err)
+			if test.policyAuditFailure {
+				var pgerr *pgconn.PgError
+				require.ErrorAs(t, err, &pgerr)
+				require.Equal(t, "reject_agent_policy_grant_audit_fixture", pgerr.ConstraintName)
+			}
+			if test.otherOwner {
+				requireOopsCode(t, err, oops.CodeForbidden)
+			}
+			var agents, grants, audits int
+			//nolint:glint // notestingrawsql: directly verifies atomic rollback of agent, grants and audit rows
+			err = conn.QueryRow(ctx, `SELECT (SELECT count(*) FROM agents WHERE organization_id = $1), (SELECT count(*) FROM principal_grants WHERE organization_id = $1), (SELECT count(*) FROM audit_logs WHERE organization_id = $1)`, "org-create-policy").Scan(&agents, &grants, &audits)
+			require.NoError(t, err)
+			require.Zero(t, agents)
+			require.Zero(t, grants)
+			require.Zero(t, audits)
+			require.Empty(t, agentWebhookOutboxActions(t, conn, "org-create-policy"))
+		})
+	}
+}
+
+func TestCreateAgentInitialPolicyForOtherOwnerRequiresTenantMembership(t *testing.T) {
+	t.Parallel()
+	conn := newTestDB(t)
+	seedOrganization(t, conn, "org-create-policy")
+	seedOrganization(t, conn, "org-other-policy")
+	seedOrganizationUser(t, conn, "org-create-policy", "caller")
+	seedOrganizationUser(t, conn, "org-create-policy", "owner")
+	seedOrganizationUser(t, conn, "org-other-policy", "outside")
+	ctx := validatedHumanContext(t, "org-create-policy", "caller")
+	// The grant covers the prospective agent ID, not a pre-existing agent.
+	seedGrant(t, ctx, conn, "org-create-policy", urn.NewPrincipal(urn.PrincipalTypeUser, "caller"), authz.ScopeAgentWrite, "*")
+	engine := authz.NewEngine(testenv.NewLogger(t), conn, func(context.Context, string) (bool, error) { return false, nil }, nil)
+	service := newTestService(conn, engine)
+	owner := "owner"
+	created, err := service.Create(ctx, &gen.CreatePayload{Name: "Other owned agent", OwnerUserID: &owner, PolicyGrants: []*gen.AgentPolicyGrantForm{initialMCPGrant()}})
+	require.NoError(t, err)
+	grants, err := service.ListPolicyGrants(validatedHumanContext(t, "org-create-policy", owner), &gen.ListPolicyGrantsPayload{AgentID: created.ID})
+	require.NoError(t, err)
+	require.Len(t, grants, 1)
+	require.Equal(t, string(authz.ScopeMCPRead), grants[0].Scope)
+	owner = "outside"
+	_, err = service.Create(ctx, &gen.CreatePayload{Name: "Cross tenant agent", OwnerUserID: &owner, PolicyGrants: []*gen.AgentPolicyGrantForm{initialMCPGrant()}})
+	requireOopsCode(t, err, oops.CodeForbidden)
+	var agents, policies int
+	//nolint:glint // notestingrawsql: verifies failed cross-tenant creation did not persist agent or policy
+	err = conn.QueryRow(ctx, `SELECT (SELECT count(*) FROM agents WHERE organization_id = $1), (SELECT count(*) FROM principal_grants WHERE organization_id = $1 AND principal_urn LIKE 'agent:%')`, "org-create-policy").Scan(&agents, &policies)
+	require.NoError(t, err)
+	require.Equal(t, 1, agents)
+	require.Equal(t, 1, policies)
+	require.Equal(t, []string{"agent:create", "agent:policy_grant_create"}, agentWebhookOutboxActions(t, conn, "org-create-policy"))
+}

--- a/server/internal/agentmanagement/create_policy_test.go
+++ b/server/internal/agentmanagement/create_policy_test.go
@@ -24,7 +24,6 @@ func TestCreateAgentWithInitialPolicy(t *testing.T) {
 	conn := newTestDB(t)
 	seedOrganization(t, conn, "org-create-policy")
 	seedOrganizationUser(t, conn, "org-create-policy", "owner")
-	// Owners may configure policy ceilings without management RBAC. This does not issue credentials.
 	engine := authz.NewEngine(testenv.NewLogger(t), conn, func(context.Context, string) (bool, error) { return false, nil }, nil)
 	service := newTestService(conn, engine)
 	service.features = &recordingAgentManagementFeatures{evaluation: feature.EvaluationEnabled}
@@ -37,15 +36,13 @@ func TestCreateAgentWithInitialPolicy(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, grants, 1)
 	require.Equal(t, string(authz.ScopeMCPRead), grants[0].Scope)
-	// Configuring a broad policy must not create delegable powers absent from the owner.
 	delegable, err := service.ListDelegableGrants(ctx, &gen.ListDelegableGrantsPayload{AgentID: created.ID})
 	require.NoError(t, err)
 	require.Empty(t, delegable)
 	seedGrant(t, ctx, conn, "org-create-policy", urn.NewPrincipal(urn.PrincipalTypeUser, "owner"), authz.ScopeMCPRead, "*")
 	delegable, err = service.ListDelegableGrants(ctx, &gen.ListDelegableGrantsPayload{AgentID: created.ID})
 	require.NoError(t, err)
-	// Discovery includes the safe implication closure: mcp:read also allows
-	// mcp:connect, but neither grant permits mcp:write or changes the selector.
+	// mcp:read implies mcp:connect.
 	require.ElementsMatch(t, []*gen.AgentPolicyGrantForm{
 		initialMCPGrant(),
 		{Scope: string(authz.ScopeMCPConnect), Effect: "allow", Selector: &gen.AgentPolicySelector{ResourceKind: authz.ResourceKindMCP, ResourceID: "*"}},
@@ -132,7 +129,6 @@ func TestCreateAgentInitialPolicyForOtherOwnerRequiresTenantMembership(t *testin
 	seedOrganizationUser(t, conn, "org-create-policy", "owner")
 	seedOrganizationUser(t, conn, "org-other-policy", "outside")
 	ctx := validatedHumanContext(t, "org-create-policy", "caller")
-	// The grant covers the prospective agent ID, not a pre-existing agent.
 	seedGrant(t, ctx, conn, "org-create-policy", urn.NewPrincipal(urn.PrincipalTypeUser, "caller"), authz.ScopeAgentWrite, "*")
 	engine := authz.NewEngine(testenv.NewLogger(t), conn, func(context.Context, string) (bool, error) { return false, nil }, nil)
 	service := newTestService(conn, engine)

--- a/server/internal/agentmanagement/create_policy_test.go
+++ b/server/internal/agentmanagement/create_policy_test.go
@@ -44,7 +44,12 @@ func TestCreateAgentWithInitialPolicy(t *testing.T) {
 	seedGrant(t, ctx, conn, "org-create-policy", urn.NewPrincipal(urn.PrincipalTypeUser, "owner"), authz.ScopeMCPRead, "*")
 	delegable, err = service.ListDelegableGrants(ctx, &gen.ListDelegableGrantsPayload{AgentID: created.ID})
 	require.NoError(t, err)
-	require.Len(t, delegable, 1)
+	// Discovery includes the safe implication closure: mcp:read also allows
+	// mcp:connect, but neither grant permits mcp:write or changes the selector.
+	require.ElementsMatch(t, []*gen.AgentPolicyGrantForm{
+		initialMCPGrant(),
+		{Scope: string(authz.ScopeMCPConnect), Effect: "allow", Selector: &gen.AgentPolicySelector{ResourceKind: authz.ResourceKindMCP, ResourceID: "*"}},
+	}, delegable)
 
 	require.Equal(t, []string{"agent:create", "agent:policy_grant_create"}, agentWebhookOutboxActions(t, conn, "org-create-policy"))
 	_, err = service.CreatePolicyGrant(ctx, &gen.CreatePolicyGrantPayload{AgentID: created.ID, Scope: grants[0].Scope, Effect: "allow", Selector: grants[0].Selector})

--- a/server/internal/agentmanagement/delegable.go
+++ b/server/internal/agentmanagement/delegable.go
@@ -17,6 +17,20 @@ import (
 
 // ListDelegableGrants exposes only safe issuance candidates, never raw policy.
 func (s *Service) ListDelegableGrants(ctx context.Context, payload *gen.ListDelegableGrantsPayload) ([]*gen.AgentPolicyGrantForm, error) {
+	// Gate the ordinary authenticated session before any transaction, owner
+	// lookup, membership lock, or grant loading. Disabled cohorts reveal no
+	// agent existence or eligibility information.
+	authCtx, err := ordinaryHumanAuth(ctx)
+	if err != nil {
+		return nil, err
+	}
+	evaluation, err := feature.EvaluateFlag(ctx, s.features, feature.FlagAgentIdentityCredentials, authCtx.ActiveOrganizationID, feature.OrgProjectGroups(authCtx.OrganizationSlug, ""))
+	if err != nil {
+		s.logger.WarnContext(ctx, "failed to evaluate agent credential rollout flag", attr.SlogError(err))
+	}
+	if evaluation != feature.EvaluationEnabled {
+		return nil, oops.C(oops.CodeNotFound)
+	}
 	agentID, err := parseAgentID(payload.AgentID)
 	if err != nil {
 		return nil, err
@@ -26,13 +40,6 @@ func (s *Service) ListDelegableGrants(ctx context.Context, payload *gen.ListDele
 		human, agent, err := s.authorizer.RequireAgentOwnerForUpdate(ctx, tx, agentID, OwnedAgentAuthorize)
 		if err != nil {
 			return fmt.Errorf("authorize delegable grant discovery: %w", err)
-		}
-		evaluation, err := feature.EvaluateFlag(ctx, s.features, feature.FlagAgentIdentityCredentials, human.Auth.ActiveOrganizationID, feature.OrgProjectGroups(human.Auth.OrganizationSlug, ""))
-		if err != nil {
-			s.logger.WarnContext(ctx, "failed to evaluate agent credential rollout flag", attr.SlogError(err))
-		}
-		if evaluation != feature.EvaluationEnabled {
-			return oops.C(oops.CodeNotFound)
 		}
 		if agents.DeriveLifecycle(agent) != agents.LifecycleActive || agent.OwnerReassignmentRequiredAt.Valid {
 			return oops.C(oops.CodeForbidden)

--- a/server/internal/agentmanagement/delegable_test.go
+++ b/server/internal/agentmanagement/delegable_test.go
@@ -318,3 +318,46 @@ func TestListDelegableGrantsGeneratedEndpointCannotBypassManagementGate(t *testi
 		})
 	}
 }
+
+func TestListDelegableGrantsGatePrecedesAuthorizationPreparation(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name     string
+		provider feature.Provider
+	}{
+		{name: "disabled", provider: &recordingAgentManagementFeatures{evaluation: feature.EvaluationDisabled}},
+		{name: "indeterminate", provider: &recordingAgentManagementFeatures{evaluation: feature.EvaluationIndeterminate}},
+		{name: "provider error", provider: &recordingAgentManagementFeatures{err: errors.New("feature provider unavailable")}},
+		{name: "missing provider", provider: nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// No database or authorization engine: even an unknown agent and caller
+			// must receive the cohort's 404 without opening a transaction or loading grants.
+			service := newTestService(nil, nil)
+			service.features = tc.provider
+			var logs bytes.Buffer
+			service.logger = slog.New(slog.NewTextHandler(&logs, nil))
+			ctx := validatedHumanContext(t, "org-disabled", "unknown-member")
+			for _, agentID := range []string{uuid.NewString(), "invalid-id"} {
+				result, err := service.ListDelegableGrants(ctx, &gen.ListDelegableGrantsPayload{AgentID: agentID})
+				requireOopsCode(t, err, oops.CodeNotFound)
+				require.Nil(t, result)
+			}
+			if tc.name == "provider error" {
+				require.Contains(t, logs.String(), "feature provider unavailable")
+			}
+		})
+	}
+}
+
+func TestListDelegableGrantsAuthenticatesBeforeCredentialGate(t *testing.T) {
+	t.Parallel()
+	service := newTestService(nil, nil)
+	flags := &recordingAgentManagementFeatures{evaluation: feature.EvaluationDisabled}
+	service.features = flags
+	result, err := service.ListDelegableGrants(t.Context(), &gen.ListDelegableGrantsPayload{AgentID: uuid.NewString()})
+	requireOopsCode(t, err, oops.CodeUnauthorized)
+	require.Nil(t, result)
+	require.Empty(t, flags.flag, "unauthenticated callers must not evaluate tenant flags")
+}

--- a/server/internal/agentmanagement/policy.go
+++ b/server/internal/agentmanagement/policy.go
@@ -74,24 +74,33 @@ func (s *Service) CreatePolicyGrant(ctx context.Context, payload *gen.CreatePoli
 		if err != nil {
 			return err
 		}
-		row, err := repo.New(tx).CreateAgentPolicyGrant(ctx, repo.CreateAgentPolicyGrantParams{
-			OrganizationID: human.Auth.ActiveOrganizationID,
-			AgentID:        agent.ID,
-			Scope:          string(scope),
-			Selectors:      selectorRaw,
-		})
-		if err != nil {
-			return mapWriteError(err, "agent policy grant already exists")
-		}
-		grantRow := policyGrantRow{ID: row.ID, Scope: row.Scope, Selectors: row.Selectors, CreatedAt: row.CreatedAt.Time, UpdatedAt: row.UpdatedAt.Time}
-		result, err = policyGrantView(grantRow)
-		if err != nil {
-			return err
-		}
-		return s.logPolicyGrant(ctx, tx, human, agent, audit.ActionAgentPolicyGrantCreate, nil, policyGrantAuditSnapshot(grantRow))
+		result, err = s.createPolicyGrant(ctx, tx, human, agent, scope, selectorRaw)
+		return err
 	})
 	if err != nil {
 		return nil, s.serviceError(ctx, err, string(audit.ActionAgentPolicyGrantCreate))
+	}
+	return result, nil
+}
+
+// createPolicyGrant persists and audits a validated policy ceiling within the caller transaction.
+func (s *Service) createPolicyGrant(ctx context.Context, tx pgx.Tx, human HumanContext, agent repo.Agent, scope authz.Scope, selectorRaw []byte) (*gen.AgentPolicyGrant, error) {
+	row, err := repo.New(tx).CreateAgentPolicyGrant(ctx, repo.CreateAgentPolicyGrantParams{
+		OrganizationID: human.Auth.ActiveOrganizationID,
+		AgentID:        agent.ID,
+		Scope:          string(scope),
+		Selectors:      selectorRaw,
+	})
+	if err != nil {
+		return nil, mapWriteError(err, "agent policy grant already exists")
+	}
+	grantRow := policyGrantRow{ID: row.ID, Scope: row.Scope, Selectors: row.Selectors, CreatedAt: row.CreatedAt.Time, UpdatedAt: row.UpdatedAt.Time}
+	result, err := policyGrantView(grantRow)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.logPolicyGrant(ctx, tx, human, agent, audit.ActionAgentPolicyGrantCreate, nil, policyGrantAuditSnapshot(grantRow)); err != nil {
+		return nil, err
 	}
 	return result, nil
 }

--- a/server/internal/agentmanagement/policy.go
+++ b/server/internal/agentmanagement/policy.go
@@ -83,7 +83,6 @@ func (s *Service) CreatePolicyGrant(ctx context.Context, payload *gen.CreatePoli
 	return result, nil
 }
 
-// createPolicyGrant persists and audits a validated policy ceiling within the caller transaction.
 func (s *Service) createPolicyGrant(ctx context.Context, tx pgx.Tx, human HumanContext, agent repo.Agent, scope authz.Scope, selectorRaw []byte) (*gen.AgentPolicyGrant, error) {
 	row, err := repo.New(tx).CreateAgentPolicyGrant(ctx, repo.CreateAgentPolicyGrantParams{
 		OrganizationID: human.Auth.ActiveOrganizationID,

--- a/server/internal/agentmanagement/service.go
+++ b/server/internal/agentmanagement/service.go
@@ -158,6 +158,20 @@ func (s *Service) Create(ctx context.Context, payload *gen.CreatePayload) (*gen.
 		if err := s.logAgent(ctx, tx, human, audit.ActionAgentCreate, nil, &agent); err != nil {
 			return err
 		}
+		// Policy grants are ceilings, not credentials. As with CreatePolicyGrant,
+		// intrinsic ownership permits setup; issuance still intersects live authority.
+		for _, grant := range payload.PolicyGrants {
+			if grant == nil {
+				return oops.E(oops.CodeBadRequest, nil, "agent policy grant is required")
+			}
+			scope, selectorRaw, err := validatePolicyGrant(grant.Scope, grant.Effect, grant.Selector)
+			if err != nil {
+				return err
+			}
+			if _, err := s.createPolicyGrant(ctx, tx, human, agent, scope, selectorRaw); err != nil {
+				return err
+			}
+		}
 		result, err = s.view(ctx, tx, human, agent)
 		return err
 	})

--- a/server/internal/agentmanagement/sessions.go
+++ b/server/internal/agentmanagement/sessions.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	gen "github.com/speakeasy-api/gram/server/gen/agents"
 	"github.com/speakeasy-api/gram/server/internal/agents/repo"
@@ -22,7 +23,7 @@ type sessionTokenRevoker interface {
 	RevokeToken(context.Context, string) error
 }
 type agentSessionRevoker interface {
-	SoftDeleteAgentSubjectSessions(context.Context, remoterepo.DBTX, urn.SessionSubject, uuid.UUID, uuid.UUID, string) ([]remotesessions.RevokedCredentials, error)
+	SoftDeleteAgentSubjectSessions(context.Context, remoterepo.DBTX, urn.SessionSubject, uuid.UUID, uuid.UUID, string, pgtype.Timestamptz, bool) ([]remotesessions.RevokedCredentials, error)
 	RevokeAllDetached(context.Context, []remotesessions.RevokedCredentials)
 }
 
@@ -134,7 +135,11 @@ func (s *Service) RevokeSession(ctx context.Context, payload *gen.RevokeSessionP
 			return fmt.Errorf("audit agent session revocation: %w", err)
 		}
 	}
-	upstream, err := s.sessionRevoker.SoftDeleteAgentSubjectSessions(ctx, tx, subject, row.UserSessionIssuerID, projectID, human.Auth.ActiveOrganizationID)
+	issuerProjectID := uuid.Nil
+	if row.IssuerProjectID.Valid {
+		issuerProjectID = row.IssuerProjectID.UUID
+	}
+	upstream, err := s.sessionRevoker.SoftDeleteAgentSubjectSessions(ctx, tx, subject, row.UserSessionIssuerID, issuerProjectID, human.Auth.ActiveOrganizationID, row.DeletedAt, row.AlreadyRevoked)
 	if err != nil {
 		return fmt.Errorf("revoke agent upstream sessions: %w", err)
 	}

--- a/server/internal/agentmanagement/sessions_legacy_test.go
+++ b/server/internal/agentmanagement/sessions_legacy_test.go
@@ -20,6 +20,7 @@ func TestAgentSessionLegacyOrganizationFallback(t *testing.T) {
 		{"all sources agree", "org-a", "org-a", "org-a", "org-a", true},
 		{"issuer fallback", "org-a", nil, "org-a", "org-a", true},
 		{"project fallback", nil, nil, "org-a", "org-a", true},
+		{"session project fallback", nil, nil, "", "org-a", true},
 		{"explicit session mismatch", "org-a", "org-b", "org-a", "org-a", false},
 		{"explicit issuer mismatch", "org-b", nil, "org-a", "org-a", false},
 		{"session hides issuer mismatch", "org-b", "org-a", "org-a", "org-a", false},
@@ -37,15 +38,25 @@ func TestAgentSessionLegacyOrganizationFallback(t *testing.T) {
 			agent := createAgent(t, db, "org-a", "owner", "Legacy agent")
 			session, issuer := seedManagedSession(t, db, "org-a", "agent:"+agent.ID.String())
 			project := uuid.New()
-			_, err := db.Exec(t.Context(), `INSERT INTO projects (id, organization_id, name, slug) VALUES ($1,$2,'Legacy project','legacy')`, project, tc.projectOrg) //nolint:glint // notestingrawsql: legacy project-tier fixture
+			projectOrg := tc.projectOrg
+			if projectOrg == "" {
+				projectOrg = "org-a"
+			}
+			_, err := db.Exec(t.Context(), `INSERT INTO projects (id, organization_id, name, slug) VALUES ($1,$2,'Legacy project','legacy')`, project, projectOrg) //nolint:glint // notestingrawsql: legacy project-tier fixture
 			require.NoError(t, err)
-			_, err = db.Exec(t.Context(), `UPDATE user_session_issuers SET project_id=$1, organization_id=$2 WHERE id=$3`, project, tc.issuerOrg, issuer) //nolint:glint // notestingrawsql: legacy nullable issuer tenancy
+			_, err = db.Exec(t.Context(), `UPDATE user_session_issuers SET project_id=$1, organization_id=$2 WHERE id=$3`, uuid.NullUUID{UUID: project, Valid: tc.projectOrg != ""}, tc.issuerOrg, issuer) //nolint:glint // notestingrawsql: legacy nullable issuer tenancy
 			require.NoError(t, err)
 			sessionProject := uuid.New()
 			_, err = db.Exec(t.Context(), `INSERT INTO projects (id, organization_id, name, slug) VALUES ($1,$2,'Session project','session')`, sessionProject, tc.sessionProjectOrg) //nolint:glint // notestingrawsql: independently test the session's project tenancy
 			require.NoError(t, err)
 			_, err = db.Exec(t.Context(), `UPDATE user_sessions SET project_id=$1, organization_id=$2 WHERE id=$3`, sessionProject, tc.sessionOrg, session) //nolint:glint // notestingrawsql: legacy nullable session tenancy
 			require.NoError(t, err)
+			var upstream uuid.UUID
+			if tc.projectOrg != "" {
+				upstream = seedManagedUpstream(t, db, "org-a", issuer, "agent:"+agent.ID.String())
+				_, err = db.Exec(t.Context(), `UPDATE remote_session_clients SET project_id=$1 WHERE id=(SELECT remote_session_client_id FROM remote_sessions WHERE id=$2)`, project, upstream) //nolint:glint // notestingrawsql: cascade must use issuer project, not the different same-org session project
+				require.NoError(t, err)
+			}
 			service := newTestService(db, &fakeAuthorizationEngine{allowed: map[string]bool{}})
 			revoker := &testAgentSessionRevoker{}
 			service.sessionTokens, service.sessionRevoker = revoker, revoker
@@ -56,6 +67,12 @@ func TestAgentSessionLegacyOrganizationFallback(t *testing.T) {
 			if tc.visible {
 				require.Len(t, listed.Items, 1)
 				require.NoError(t, err)
+				if upstream != uuid.Nil {
+					require.Equal(t, 1, revoker.credentials)
+					var deleted bool
+					require.NoError(t, db.QueryRow(ctx, `SELECT deleted FROM remote_sessions WHERE id=$1`, upstream).Scan(&deleted)) //nolint:glint // notestingrawsql: mismatched same-org projects still cascade upstream
+					require.True(t, deleted)
+				}
 			} else {
 				require.Empty(t, listed.Items)
 				requireOopsCode(t, err, oops.CodeNotFound)

--- a/server/internal/agentmanagement/sessions_test.go
+++ b/server/internal/agentmanagement/sessions_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
@@ -26,10 +27,13 @@ type testAgentSessionRevoker struct {
 	afterCommit      func()
 	checkPushContext func(context.Context)
 	credentials      int
+	lastCredentials  []remotesessions.RevokedCredentials
+	revokedJTIs      []string
 }
 
-func (r *testAgentSessionRevoker) RevokeToken(ctx context.Context, _ string) error {
+func (r *testAgentSessionRevoker) RevokeToken(ctx context.Context, jti string) error {
 	r.events = append(r.events, "token")
+	r.revokedJTIs = append(r.revokedJTIs, jti)
 	if r.afterCommit != nil {
 		r.afterCommit()
 	}
@@ -38,12 +42,12 @@ func (r *testAgentSessionRevoker) RevokeToken(ctx context.Context, _ string) err
 	}
 	return r.pushErr
 }
-func (r *testAgentSessionRevoker) SoftDeleteAgentSubjectSessions(ctx context.Context, tx remoterepo.DBTX, subject urn.SessionSubject, issuerID, projectID uuid.UUID, orgID string) ([]remotesessions.RevokedCredentials, error) {
+func (r *testAgentSessionRevoker) SoftDeleteAgentSubjectSessions(ctx context.Context, tx remoterepo.DBTX, subject urn.SessionSubject, issuerID, projectID uuid.UUID, orgID string, revokedAt pgtype.Timestamptz, alreadyRevoked bool) ([]remotesessions.RevokedCredentials, error) {
 	r.events = append(r.events, "cascade")
 	if r.cascadeErr != nil {
 		return nil, r.cascadeErr
 	}
-	credentials, err := (&remotesessions.UpstreamRevoker{}).SoftDeleteAgentSubjectSessions(ctx, tx, subject, issuerID, projectID, orgID)
+	credentials, err := (&remotesessions.UpstreamRevoker{}).SoftDeleteAgentSubjectSessions(ctx, tx, subject, issuerID, projectID, orgID, revokedAt, alreadyRevoked)
 	if err != nil {
 		return nil, fmt.Errorf("delete test subject sessions: %w", err)
 	}
@@ -52,6 +56,7 @@ func (r *testAgentSessionRevoker) SoftDeleteAgentSubjectSessions(ctx context.Con
 func (r *testAgentSessionRevoker) RevokeAllDetached(_ context.Context, creds []remotesessions.RevokedCredentials) {
 	r.events = append(r.events, "upstream")
 	r.credentials += len(creds)
+	r.lastCredentials = creds
 }
 
 func seedManagedSession(t *testing.T, db *pgxpool.Pool, orgID, subject string) (uuid.UUID, uuid.UUID) {
@@ -160,9 +165,30 @@ func TestAgentSessionRevocationFailureOrderingAndRetry(t *testing.T) {
 	revoker.events = nil
 	requireOopsCode(t, service.RevokeSession(ctx, payload), oops.CodeUnexpected)
 	require.Equal(t, []string{"cascade", "token", "upstream"}, revoker.events)
+	// Reconnect on the same issuer and remote client after the committed revoke.
+	freshSession := uuid.New()
+	_, err = db.Exec(ctx, `INSERT INTO user_sessions (id, organization_id, user_session_issuer_id, subject_urn, authorizer_user_id, jti, refresh_token_hash, expires_at, refresh_expires_at) SELECT $2, organization_id, user_session_issuer_id, subject_urn, authorizer_user_id, 'fresh-jti', 'fresh-hash', expires_at, refresh_expires_at FROM user_sessions WHERE id=$1`, session, freshSession) //nolint:glint // notestingrawsql: reconnect must retain its distinct session and tokens
+	require.NoError(t, err)
+	freshUpstream := uuid.New()
+	_, err = db.Exec(ctx, `INSERT INTO remote_sessions (id, subject_urn, user_session_issuer_id, remote_session_client_id, access_token_encrypted, refresh_token_encrypted, upstream_subject) SELECT $2, subject_urn, user_session_issuer_id, remote_session_client_id, 'fresh-access', 'fresh-refresh', 'fresh-identity' FROM remote_sessions WHERE id=$1`, upstream, freshUpstream) //nolint:glint // notestingrawsql: same subject/client but fresh live credentials
+	require.NoError(t, err)
+	_, err = db.Exec(ctx, `INSERT INTO remote_sessions (subject_urn, user_session_issuer_id, remote_session_client_id, access_token_encrypted, deleted_at) SELECT subject_urn, user_session_issuer_id, remote_session_client_id, 'unrelated-old-access', deleted_at - interval '1 second' FROM remote_sessions WHERE id=$1`, upstream) //nolint:glint // notestingrawsql: an older unrelated tombstone must not match the retry boundary
+	require.NoError(t, err)
+	var sameBoundary bool
+	require.NoError(t, db.QueryRow(ctx, `SELECT r.deleted_at = s.deleted_at FROM remote_sessions r JOIN user_sessions s ON s.id=$2 WHERE r.id=$1`, upstream, session).Scan(&sameBoundary)) //nolint:glint // notestingrawsql: exact persisted boundary shared by original tombstones
+	require.True(t, sameBoundary)
 	revoker.pushErr = nil
 	revoker.events = nil
 	require.NoError(t, service.RevokeSession(ctx, payload))
+	require.Len(t, revoker.lastCredentials, 1)
+	require.Equal(t, "fixture-not-a-token", revoker.lastCredentials[0].AccessTokenEncrypted)
+	require.Equal(t, "fixture-refresh", revoker.lastCredentials[0].RefreshTokenEncrypted.String)
+	require.Equal(t, []string{"jti-" + session.String(), "jti-" + session.String()}, revoker.revokedJTIs)
+	var freshPreserved bool
+	require.NoError(t, db.QueryRow(ctx, `SELECT NOT deleted AND access_token_encrypted='fresh-access' AND refresh_token_encrypted='fresh-refresh' AND upstream_subject='fresh-identity' FROM remote_sessions WHERE id=$1`, freshUpstream).Scan(&freshPreserved)) //nolint:glint // notestingrawsql: retry cannot alter the reconnect's credentials or identity
+	require.True(t, freshPreserved)
+	require.NoError(t, db.QueryRow(ctx, `SELECT NOT deleted AND jti='fresh-jti' AND refresh_token_hash='fresh-hash' FROM user_sessions WHERE id=$1`, freshSession).Scan(&freshPreserved)) //nolint:glint // notestingrawsql: reconnect's JWT and refresh session remain live
+	require.True(t, freshPreserved)
 	require.Equal(t, []string{"cascade", "token", "upstream"}, revoker.events)
 	require.Equal(t, 2, revoker.credentials, "retry must repeat upstream revocation with retained credentials")
 	var count int

--- a/server/internal/agents/queries.sql
+++ b/server/internal/agents/queries.sql
@@ -231,7 +231,7 @@ JOIN user_session_issuers AS iss ON iss.id = s.user_session_issuer_id
 LEFT JOIN projects AS p ON p.id = iss.project_id
 LEFT JOIN projects AS session_project ON session_project.id = s.project_id
 LEFT JOIN user_session_clients AS c ON c.id = s.user_session_client_id AND c.user_session_issuer_id = iss.id
-WHERE COALESCE(s.organization_id, iss.organization_id, p.organization_id) = @organization_id::text
+WHERE COALESCE(s.organization_id, iss.organization_id, p.organization_id, session_project.organization_id) = @organization_id::text
   AND (s.organization_id IS NULL OR s.organization_id = @organization_id::text)
   AND (iss.organization_id IS NULL OR iss.organization_id = @organization_id::text)
   AND (p.organization_id IS NULL OR p.organization_id = @organization_id::text)
@@ -246,12 +246,12 @@ LIMIT @limit_value;
 -- Lock the pre-update row so retries invalidate caches without duplicating audit.
 -- All known tenancy sources must agree before legacy fallback.
 WITH target AS MATERIALIZED (
-  SELECT s.id, s.deleted
+  SELECT s.id, s.deleted, iss.project_id AS issuer_project_id
   FROM user_sessions AS s
   JOIN user_session_issuers AS iss ON iss.id = s.user_session_issuer_id
   LEFT JOIN projects AS p ON p.id = iss.project_id
   LEFT JOIN projects AS session_project ON session_project.id = s.project_id
-  WHERE COALESCE(s.organization_id, iss.organization_id, p.organization_id) = @organization_id::text
+  WHERE COALESCE(s.organization_id, iss.organization_id, p.organization_id, session_project.organization_id) = @organization_id::text
     AND (s.organization_id IS NULL OR s.organization_id = @organization_id::text)
     AND (iss.organization_id IS NULL OR iss.organization_id = @organization_id::text)
     AND (p.organization_id IS NULL OR p.organization_id = @organization_id::text)
@@ -264,4 +264,4 @@ UPDATE user_sessions AS s
 SET deleted_at = COALESCE(s.deleted_at, clock_timestamp())
 FROM target
 WHERE s.id = target.id
-RETURNING s.id, s.project_id, s.user_session_issuer_id, s.jti, target.deleted AS already_revoked;
+RETURNING s.id, s.project_id, s.user_session_issuer_id, s.jti, s.deleted_at, target.issuer_project_id, target.deleted AS already_revoked;

--- a/server/internal/agents/repo/queries.sql.go
+++ b/server/internal/agents/repo/queries.sql.go
@@ -594,7 +594,7 @@ JOIN user_session_issuers AS iss ON iss.id = s.user_session_issuer_id
 LEFT JOIN projects AS p ON p.id = iss.project_id
 LEFT JOIN projects AS session_project ON session_project.id = s.project_id
 LEFT JOIN user_session_clients AS c ON c.id = s.user_session_client_id AND c.user_session_issuer_id = iss.id
-WHERE COALESCE(s.organization_id, iss.organization_id, p.organization_id) = $1::text
+WHERE COALESCE(s.organization_id, iss.organization_id, p.organization_id, session_project.organization_id) = $1::text
   AND (s.organization_id IS NULL OR s.organization_id = $1::text)
   AND (iss.organization_id IS NULL OR iss.organization_id = $1::text)
   AND (p.organization_id IS NULL OR p.organization_id = $1::text)
@@ -853,12 +853,12 @@ func (q *Queries) RevokeAgent(ctx context.Context, arg RevokeAgentParams) (Agent
 
 const revokeManagedAgentSession = `-- name: RevokeManagedAgentSession :one
 WITH target AS MATERIALIZED (
-  SELECT s.id, s.deleted
+  SELECT s.id, s.deleted, iss.project_id AS issuer_project_id
   FROM user_sessions AS s
   JOIN user_session_issuers AS iss ON iss.id = s.user_session_issuer_id
   LEFT JOIN projects AS p ON p.id = iss.project_id
   LEFT JOIN projects AS session_project ON session_project.id = s.project_id
-  WHERE COALESCE(s.organization_id, iss.organization_id, p.organization_id) = $1::text
+  WHERE COALESCE(s.organization_id, iss.organization_id, p.organization_id, session_project.organization_id) = $1::text
     AND (s.organization_id IS NULL OR s.organization_id = $1::text)
     AND (iss.organization_id IS NULL OR iss.organization_id = $1::text)
     AND (p.organization_id IS NULL OR p.organization_id = $1::text)
@@ -871,7 +871,7 @@ UPDATE user_sessions AS s
 SET deleted_at = COALESCE(s.deleted_at, clock_timestamp())
 FROM target
 WHERE s.id = target.id
-RETURNING s.id, s.project_id, s.user_session_issuer_id, s.jti, target.deleted AS already_revoked
+RETURNING s.id, s.project_id, s.user_session_issuer_id, s.jti, s.deleted_at, target.issuer_project_id, target.deleted AS already_revoked
 `
 
 type RevokeManagedAgentSessionParams struct {
@@ -885,6 +885,8 @@ type RevokeManagedAgentSessionRow struct {
 	ProjectID           uuid.NullUUID
 	UserSessionIssuerID uuid.UUID
 	Jti                 string
+	DeletedAt           pgtype.Timestamptz
+	IssuerProjectID     uuid.NullUUID
 	AlreadyRevoked      bool
 }
 
@@ -898,6 +900,8 @@ func (q *Queries) RevokeManagedAgentSession(ctx context.Context, arg RevokeManag
 		&i.ProjectID,
 		&i.UserSessionIssuerID,
 		&i.Jti,
+		&i.DeletedAt,
+		&i.IssuerProjectID,
 		&i.AlreadyRevoked,
 	)
 	return i, err

--- a/server/internal/background/openrouter_admin_mutation_generation_test.go
+++ b/server/internal/background/openrouter_admin_mutation_generation_test.go
@@ -73,6 +73,7 @@ func TestOpenRouterAdminConcurrentCompletionsDoNotBlockWorkflow(t *testing.T) {
 	var reconciles atomic.Int32
 	var completed atomic.Int32
 	tokens := make([]int64, operationCount)
+	var begun int
 	env.RegisterActivityWithOptions(func(context.Context, openrouterkeys.AdminReconciliationScope) (int64, error) {
 		return 0, nil
 	}, activity.RegisterOptions{Name: OpenRouterAdminCaptureCursorActivityName})
@@ -80,22 +81,7 @@ func TestOpenRouterAdminConcurrentCompletionsDoNotBlockWorkflow(t *testing.T) {
 		reconciles.Add(1)
 		return checkpoint.Cursor, nil
 	}, activity.RegisterOptions{Name: OpenRouterAdminReconcileActivityName})
-	env.RegisterDelayedCallback(func() {
-		for i := range operationCount {
-			index := i
-			env.UpdateWorkflow(OpenRouterAdminBeginUpdate, fmt.Sprintf("begin-%d", i), &testsuite.TestUpdateCallback{
-				OnReject: func(err error) { require.NoError(t, err) },
-				OnAccept: func() {},
-				OnComplete: func(result any, err error) {
-					require.NoError(t, err)
-					var ok bool
-					tokens[index], ok = result.(int64)
-					require.True(t, ok)
-				},
-			})
-		}
-	}, time.Millisecond)
-	env.RegisterDelayedCallback(func() {
+	completeAll := func() {
 		for i, token := range tokens {
 			require.NotZero(t, token)
 			env.UpdateWorkflow(OpenRouterAdminCompleteUpdate, fmt.Sprintf("complete-%d", i), &testsuite.TestUpdateCallback{
@@ -107,7 +93,29 @@ func TestOpenRouterAdminConcurrentCompletionsDoNotBlockWorkflow(t *testing.T) {
 				},
 			}, token)
 		}
-	}, 2*time.Millisecond)
+	}
+	env.RegisterDelayedCallback(func() {
+		for i := range operationCount {
+			index := i
+			env.UpdateWorkflow(OpenRouterAdminBeginUpdate, fmt.Sprintf("begin-%d", i), &testsuite.TestUpdateCallback{
+				OnReject: func(err error) { require.NoError(t, err) },
+				OnAccept: func() {},
+				OnComplete: func(result any, err error) {
+					require.NoError(t, err)
+					var ok bool
+					tokens[index], ok = result.(int64)
+					require.True(t, ok)
+					begun++
+					if begun == operationCount {
+						// Capture activities run asynchronously; elapsed time does not
+						// guarantee every Begin has returned its token. Keep Complete
+						// concurrent, but only submit the burst after all Begins finish.
+						env.RegisterDelayedCallback(completeAll, 0)
+					}
+				},
+			})
+		}
+	}, time.Millisecond)
 
 	env.ExecuteWorkflow(testOpenRouterAdminWorkflow, openrouterkeys.AdminReconciliationScope{OrganizationID: "organization_placeholder", KeyType: "chat"})
 	require.NoError(t, env.GetWorkflowError())

--- a/server/internal/keys/agent_initial_policy_test.go
+++ b/server/internal/keys/agent_initial_policy_test.go
@@ -1,0 +1,70 @@
+package keys_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	agentgen "github.com/speakeasy-api/gram/server/gen/agents"
+	gen "github.com/speakeasy-api/gram/server/gen/keys"
+	"github.com/speakeasy-api/gram/server/internal/agentmanagement"
+	"github.com/speakeasy-api/gram/server/internal/audit"
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	orgrepo "github.com/speakeasy-api/gram/server/internal/organizations/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+	usersrepo "github.com/speakeasy-api/gram/server/internal/users/repo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeysService_InitialAgentPolicyCannotElevateCredentialAuthority(t *testing.T) {
+	t.Parallel()
+	for _, constrained := range []string{"owner", "authorizer"} {
+		t.Run(constrained, func(t *testing.T) {
+			t.Parallel()
+			ctx, ti := newTestKeysService(t)
+			authCtx := testAuthContext(t, ctx)
+			require.NotNil(t, authCtx.ProjectID)
+			ownerID := "owner-" + uuid.NewString()
+			_, err := usersrepo.New(ti.conn).UpsertUser(ctx, usersrepo.UpsertUserParams{ID: ownerID, Email: ownerID + "@example.com", DisplayName: ownerID, PhotoUrl: conv.PtrToPGText(nil), Admin: false})
+			require.NoError(t, err)
+			_, err = orgrepo.New(ti.conn).UpsertOrganizationUserRelationship(ctx, orgrepo.UpsertOrganizationUserRelationshipParams{OrganizationID: authCtx.ActiveOrganizationID, UserID: conv.ToPGText(ownerID)})
+			require.NoError(t, err)
+			caller := urn.NewPrincipal(urn.PrincipalTypeUser, authCtx.UserID)
+			owner := urn.NewPrincipal(urn.PrincipalTypeUser, ownerID)
+			upsertGrant(t, ctx, ti, caller, authz.ScopeAgentWrite, "*")
+			logger := testenv.NewLogger(t)
+			engine := authz.NewEngine(logger, ti.conn, func(context.Context, string) (bool, error) { return false, nil }, nil)
+			management := agentmanagement.NewService(logger, testenv.NewTracerProvider(t), ti.conn, ti.sessionManager, engine, audit.NewLogger(), ti.features, nil, nil)
+			agent, err := management.Create(ctx, &agentgen.CreatePayload{Name: "Initial policy agent", OwnerUserID: &ownerID, PolicyGrants: []*agentgen.AgentPolicyGrantForm{{Scope: string(authz.ScopeMCPConnect), Effect: "allow", Selector: &agentgen.AgentPolicySelector{ResourceKind: "mcp", ResourceID: "*"}}}})
+			require.NoError(t, err)
+			agentID, err := uuid.Parse(agent.ID)
+			require.NoError(t, err)
+			upsertGrant(t, ctx, ti, caller, authz.ScopeAgentAuthorize, agent.ID)
+			limited, broad := owner, caller
+			if constrained == "authorizer" {
+				limited, broad = caller, owner
+			}
+			upsertGrant(t, ctx, ti, broad, authz.ScopeMCPConnect, "*")
+			payload := agentKeyPayload(agentID, *authCtx.ProjectID)
+			payload.RequestedGrants = []*gen.AgentPolicyGrantForm{{Scope: string(authz.ScopeMCPConnect), Effect: "allow", Selector: &gen.AgentPolicySelector{ResourceKind: "mcp", ResourceID: "example-server", Tool: new("allowed-tool")}}}
+			// The initial broad policy and explicit management rights cannot supply missing live resource rights.
+			_, err = ti.service.CreateKey(ctx, payload)
+			requireOopsCode(t, err, oops.CodeForbidden)
+			narrow := authz.NewSelector(authz.ScopeMCPConnect, "example-server")
+			narrow[authz.SelectorKeyTool] = "allowed-tool"
+			upsertGrantSelector(t, ctx, ti, limited, authz.ScopeMCPConnect, narrow)
+			payload.RequestedGrants[0].Selector.Tool = nil
+			_, err = ti.service.CreateKey(ctx, payload)
+			requireOopsCode(t, err, oops.CodeForbidden)
+			payload.RequestedGrants[0].Selector.Tool = new("allowed-tool")
+			created, err := ti.service.CreateKey(ctx, payload)
+			require.NoError(t, err)
+			require.NotNil(t, created.Key)
+			require.Len(t, created.DelegatedGrants.Requested, 1)
+			require.Equal(t, "allowed-tool", *created.DelegatedGrants.Requested[0].Selector.Tool)
+		})
+	}
+}

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -1388,10 +1388,11 @@ WHERE s.subject_urn = @subject_urn
 -- from INSERT, not a lookup key, so a revoke through one bound issuer must
 -- still tombstone a row minted by another. A revoke that left the upstream
 -- tokens alive would not be a revoke.
--- Only agent-management retries include tombstones, retaining ciphertext and
--- subject linkage for best-effort RFC 7009 calls after a failed cache push.
+-- Agent-management stamps grants with the durable user-session revocation boundary.
+-- Retries match only that exact boundary, never live or unrelated deleted grants.
+-- Ordinary revocations pass no boundary and only match live grants.
 UPDATE remote_sessions AS s
-SET deleted_at = COALESCE(s.deleted_at, clock_timestamp()),
+SET deleted_at = COALESCE(s.deleted_at, sqlc.narg('revoked_at')::timestamptz, clock_timestamp()),
     -- Tombstones keep credentials for upstream revocation but no identity.
     upstream_subject = NULL,
     upstream_email = NULL,
@@ -1401,7 +1402,8 @@ SET deleted_at = COALESCE(s.deleted_at, clock_timestamp()),
 FROM remote_session_clients AS c,
      user_session_issuers AS usi
 WHERE s.subject_urn = @subject_urn
-  AND (s.deleted IS FALSE OR @include_deleted::boolean)
+  AND ((NOT @already_revoked::boolean AND s.deleted IS FALSE)
+       OR (@already_revoked::boolean AND s.deleted_at = sqlc.narg('revoked_at')::timestamptz))
   AND c.id = s.remote_session_client_id
   -- No liveness predicate on usi: a revoke must never fail open.
   AND usi.id = @user_session_issuer_id

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -5637,7 +5637,7 @@ func (q *Queries) SoftDeleteRemoteSessionsByClientIDs(ctx context.Context, remot
 
 const softDeleteRemoteSessionsBySubjectAndUserSessionIssuer = `-- name: SoftDeleteRemoteSessionsBySubjectAndUserSessionIssuer :many
 UPDATE remote_sessions AS s
-SET deleted_at = COALESCE(s.deleted_at, clock_timestamp()),
+SET deleted_at = COALESCE(s.deleted_at, $1::timestamptz, clock_timestamp()),
     -- Tombstones keep credentials for upstream revocation but no identity.
     upstream_subject = NULL,
     upstream_email = NULL,
@@ -5646,13 +5646,14 @@ SET deleted_at = COALESCE(s.deleted_at, clock_timestamp()),
     enrichment = NULL
 FROM remote_session_clients AS c,
      user_session_issuers AS usi
-WHERE s.subject_urn = $1
-  AND (s.deleted IS FALSE OR $2::boolean)
+WHERE s.subject_urn = $2
+  AND ((NOT $3::boolean AND s.deleted IS FALSE)
+       OR ($3::boolean AND s.deleted_at = $1::timestamptz))
   AND c.id = s.remote_session_client_id
   -- No liveness predicate on usi: a revoke must never fail open.
-  AND usi.id = $3
-  AND (usi.project_id = $4::uuid OR (usi.project_id IS NULL AND usi.organization_id = $5::text))
-  AND (c.project_id = $4::uuid OR (c.project_id IS NULL AND (c.organization_id IS NULL OR c.organization_id = $5::text)))
+  AND usi.id = $4
+  AND (usi.project_id = $5::uuid OR (usi.project_id IS NULL AND usi.organization_id = $6::text))
+  AND (c.project_id = $5::uuid OR (c.project_id IS NULL AND (c.organization_id IS NULL OR c.organization_id = $6::text)))
   AND c.deleted IS FALSE
   AND (
     EXISTS (
@@ -5667,8 +5668,9 @@ RETURNING s.remote_session_client_id, s.access_token_encrypted, s.refresh_token_
 `
 
 type SoftDeleteRemoteSessionsBySubjectAndUserSessionIssuerParams struct {
+	RevokedAt           pgtype.Timestamptz
 	SubjectUrn          urn.SessionSubject
-	IncludeDeleted      bool
+	AlreadyRevoked      bool
 	UserSessionIssuerID uuid.UUID
 	ProjectID           uuid.UUID
 	OrganizationID      string
@@ -5697,12 +5699,14 @@ type SoftDeleteRemoteSessionsBySubjectAndUserSessionIssuerRow struct {
 // from INSERT, not a lookup key, so a revoke through one bound issuer must
 // still tombstone a row minted by another. A revoke that left the upstream
 // tokens alive would not be a revoke.
-// Only agent-management retries include tombstones, retaining ciphertext and
-// subject linkage for best-effort RFC 7009 calls after a failed cache push.
+// Agent-management stamps grants with the durable user-session revocation boundary.
+// Retries match only that exact boundary, never live or unrelated deleted grants.
+// Ordinary revocations pass no boundary and only match live grants.
 func (q *Queries) SoftDeleteRemoteSessionsBySubjectAndUserSessionIssuer(ctx context.Context, arg SoftDeleteRemoteSessionsBySubjectAndUserSessionIssuerParams) ([]SoftDeleteRemoteSessionsBySubjectAndUserSessionIssuerRow, error) {
 	rows, err := q.db.Query(ctx, softDeleteRemoteSessionsBySubjectAndUserSessionIssuer,
+		arg.RevokedAt,
 		arg.SubjectUrn,
-		arg.IncludeDeleted,
+		arg.AlreadyRevoked,
 		arg.UserSessionIssuerID,
 		arg.ProjectID,
 		arg.OrganizationID,

--- a/server/internal/remotesessions/upstreamrevoke.go
+++ b/server/internal/remotesessions/upstreamrevoke.go
@@ -191,23 +191,27 @@ func revokedCredentials(rows []repo.SoftDeleteRemoteSessionsByClientIDRow) []Rev
 // Takes a DBTX rather than a transaction type so callers in other packages can
 // pass whichever handle their own transaction gave them.
 func (r *UpstreamRevoker) SoftDeleteSubjectSessions(ctx context.Context, tx repo.DBTX, subject urn.SessionSubject, userSessionIssuerID uuid.UUID, projectID uuid.UUID, organizationID string) ([]RevokedCredentials, error) {
-	return r.softDeleteSubjectSessions(ctx, tx, subject, userSessionIssuerID, projectID, organizationID, false)
+	return r.softDeleteSubjectSessions(ctx, tx, subject, userSessionIssuerID, projectID, organizationID, pgtype.Timestamptz{Time: time.Time{}, InfinityModifier: pgtype.Finite, Valid: false}, false)
 }
 
-// SoftDeleteAgentSubjectSessions includes tombstoned grants so agent-management
-// retries can repeat upstream revocation after a failed post-commit cache push.
+// SoftDeleteAgentSubjectSessions uses the persisted user-session deletion time
+// to retry only the original grants after a failed post-commit cache push.
 // Ordinary session revocation must use SoftDeleteSubjectSessions instead.
-func (r *UpstreamRevoker) SoftDeleteAgentSubjectSessions(ctx context.Context, tx repo.DBTX, subject urn.SessionSubject, userSessionIssuerID uuid.UUID, projectID uuid.UUID, organizationID string) ([]RevokedCredentials, error) {
-	return r.softDeleteSubjectSessions(ctx, tx, subject, userSessionIssuerID, projectID, organizationID, true)
+func (r *UpstreamRevoker) SoftDeleteAgentSubjectSessions(ctx context.Context, tx repo.DBTX, subject urn.SessionSubject, userSessionIssuerID uuid.UUID, projectID uuid.UUID, organizationID string, revokedAt pgtype.Timestamptz, alreadyRevoked bool) ([]RevokedCredentials, error) {
+	if !revokedAt.Valid {
+		return nil, errors.New("agent session revocation boundary is required")
+	}
+	return r.softDeleteSubjectSessions(ctx, tx, subject, userSessionIssuerID, projectID, organizationID, revokedAt, alreadyRevoked)
 }
 
-func (r *UpstreamRevoker) softDeleteSubjectSessions(ctx context.Context, tx repo.DBTX, subject urn.SessionSubject, userSessionIssuerID uuid.UUID, projectID uuid.UUID, organizationID string, includeDeleted bool) ([]RevokedCredentials, error) {
+func (r *UpstreamRevoker) softDeleteSubjectSessions(ctx context.Context, tx repo.DBTX, subject urn.SessionSubject, userSessionIssuerID uuid.UUID, projectID uuid.UUID, organizationID string, revokedAt pgtype.Timestamptz, alreadyRevoked bool) ([]RevokedCredentials, error) {
 	rows, err := repo.New(tx).SoftDeleteRemoteSessionsBySubjectAndUserSessionIssuer(ctx, repo.SoftDeleteRemoteSessionsBySubjectAndUserSessionIssuerParams{
 		SubjectUrn:          subject,
 		UserSessionIssuerID: userSessionIssuerID,
 		ProjectID:           projectID,
 		OrganizationID:      organizationID,
-		IncludeDeleted:      includeDeleted,
+		RevokedAt:           revokedAt,
+		AlreadyRevoked:      alreadyRevoked,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("soft delete remote sessions for subject: %w", err)

--- a/server/internal/testenv/queries.sql
+++ b/server/internal/testenv/queries.sql
@@ -205,6 +205,10 @@ ALTER TABLE audit_logs DISABLE TRIGGER fail_admin_key_audit;
 -- Test-only failure injection proving audit callers roll back when enqueueing fails.
 ALTER TABLE publish_outbox ADD CONSTRAINT reject_publish_outbox_writes_fixture CHECK (false) NOT VALID;
 
+-- name: RejectAgentPolicyGrantAuditWritesFixture :exec
+-- Allow agent creation audit, then fail after the policy grant has been persisted.
+ALTER TABLE audit_logs ADD CONSTRAINT reject_agent_policy_grant_audit_fixture CHECK (action <> 'agent:policy_grant_create') NOT VALID;
+
 -- name: CountOutboxEntriesByEventType :one
 -- Counts enqueued webhook events of a given type. The event type lives in a
 -- Pub/Sub message attribute rather than a column now, because the outbox row

--- a/server/internal/testenv/testrepo/queries.sql.go
+++ b/server/internal/testenv/testrepo/queries.sql.go
@@ -2177,6 +2177,16 @@ func (q *Queries) RedemoteTrialLifecycleFixture(ctx context.Context, organizatio
 	return err
 }
 
+const rejectAgentPolicyGrantAuditWritesFixture = `-- name: RejectAgentPolicyGrantAuditWritesFixture :exec
+ALTER TABLE audit_logs ADD CONSTRAINT reject_agent_policy_grant_audit_fixture CHECK (action <> 'agent:policy_grant_create') NOT VALID
+`
+
+// Allow agent creation audit, then fail after the policy grant has been persisted.
+func (q *Queries) RejectAgentPolicyGrantAuditWritesFixture(ctx context.Context) error {
+	_, err := q.db.Exec(ctx, rejectAgentPolicyGrantAuditWritesFixture)
+	return err
+}
+
 const rejectPublishOutboxWritesFixture = `-- name: RejectPublishOutboxWritesFixture :exec
 ALTER TABLE publish_outbox ADD CONSTRAINT reject_publish_outbox_writes_fixture CHECK (false) NOT VALID
 `


### PR DESCRIPTION
## Summary
Complete agent permission setup with structured policy configuration during creation and on existing agents. Retain the session-revocation, legacy-tenancy, credential-discovery, and permission-inventory corrections following #6198.

## Motivation
The dashboard could create agent identities and narrow credential permissions, but could not establish the agent policy those credentials depend on. Owners need a complete setup path without out-of-band grants.

## Technical details
### Creation and policy editing
Accept optional initial policy grants and persist the agent, grants, and audit/outbox records in one transaction. Omitted grants preserve existing API behavior. Reuse the structured permission controls for MCP server/tool narrowing, retain failed creation drafts, and refresh delegated-key candidates after policy changes. Intrinsic ownership remains an alternative to explicit management permission; policy ceilings do not bypass live credential authority checks.

Existing-agent edits use the policy CRUD endpoints. Partial failures require a confirmed refresh before further editing. Constraints the picker cannot represent remain untouched and their scopes are locked against replacement. Organization, user, and permission changes reset editing state. Align the explicit permissionless-creation checkbox with existing controls.

### Session revocation and legacy tenancy
Retry only upstream tombstones matching the original persisted session-revocation boundary, leaving later reconnect credentials untouched. Use the session project's organization as the final legacy tenancy fallback with agreement checks across known sources. Scope upstream cascades to the issuer project while retaining session-project audit attribution.

### Credential discovery and inventory states
Evaluate the credential feature gate after ordinary-session authentication and before transaction/authorization preparation. Distinguish loading, unavailable, empty, and search-filtered MCP inventories rather than presenting failed or pending reads as empty results.
