### PR TITLE
fix: emit structured assistant runtime logs at info level

### DIFF
--- a/agents/runner/Cargo.lock
+++ b/agents/runner/Cargo.lock
@@ -2976,6 +2976,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2985,12 +2995,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/agents/runner/Cargo.toml
+++ b/agents/runner/Cargo.toml
@@ -48,7 +48,7 @@ rmcp = { version = "1.5.0", default-features = false, features = [
 ] }
 tracing = "0.1"
 tracing-opentelemetry = "0.33"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 
 async-trait = "0.1"
 axum = { version = "0.8", features = ["http1", "json"] }

--- a/agents/runner/src/main.rs
+++ b/agents/runner/src/main.rs
@@ -158,6 +158,8 @@ fn init_tracing(
     let filter = tracing_subscriber::EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
     let fmt_layer = tracing_subscriber::fmt::layer()
+        .json()
+        .flatten_event(true)
         .with_writer(std::io::stderr)
         .with_target(true);
 

--- a/agents/runner/src/main.rs
+++ b/agents/runner/src/main.rs
@@ -155,11 +155,8 @@ fn init_tracing(
     otel_protocol: Option<OtlpProtocol>,
     identity: Arc<SpanIdentity>,
 ) -> Option<SdkTracerProvider> {
-    let filter = tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-        tracing_subscriber::EnvFilter::new(
-            "info,agentkit=trace,agentkit_loop=trace,agentkit_reporting=trace,agentkit_mcp=trace",
-        )
-    });
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
     let fmt_layer = tracing_subscriber::fmt::layer()
         .with_writer(std::io::stderr)
         .with_target(true);

--- a/agents/runner/src/main.rs
+++ b/agents/runner/src/main.rs
@@ -159,7 +159,6 @@ fn init_tracing(
         .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
     let fmt_layer = tracing_subscriber::fmt::layer()
         .json()
-        .flatten_event(true)
         .with_writer(std::io::stderr)
         .with_target(true);
 


### PR DESCRIPTION
## Summary

Default assistant runtime logging to INFO by removing the TRACE overrides for AgentKit targets. Preserve explicit `RUST_LOG` overrides for debugging.

Emit newline-delimited JSON on stderr instead of ANSI-colored text. Keep formatter metadata (`level`, `timestamp`, `target`) at the root and event attributes, including `message`, under `fields` to prevent key collisions. Preserve structured span context and enable the tracing subscriber's JSON support.

## Motivation

The runtime emits excessive TRACE logs by default, and its plain-text INFO and DEBUG records are classified as errors in Datadog. An INFO default reduces noise; structured output makes severity and event attributes available for log ingestion without parsing terminal formatting.
