### PR TITLE
fix: ignore unrelated PAYG key refresh events

### DIFF
--- a/server/internal/openrouterkeys/keys_test.go
+++ b/server/internal/openrouterkeys/keys_test.go
@@ -506,25 +506,15 @@ func TestAdminMutationDeadlineIncludesDurableBegin(t *testing.T) {
 	ctx, ti := newTestServiceWithAdminMutationTimeout(t, 50*time.Millisecond)
 	adminCtx := withAdmin(t, ctx)
 	orgID := seedKey(t, ctx, ti, "admin-begin-deadline", "chat", "sk-or-admin-begin-deadline")
-	requested := make(chan struct{})
-	release := make(chan struct{})
-	ti.coordinator.begin = func(context.Context, openrouterkeys.AdminReconciliationScope) error {
-		close(requested)
-		<-release
+	ti.coordinator.begin = func(beginCtx context.Context, _ openrouterkeys.AdminReconciliationScope) error {
+		// Simulate a successful durable Begin response arriving after its deadline.
+		<-beginCtx.Done()
+		require.ErrorIs(t, beginCtx.Err(), context.DeadlineExceeded)
+		require.Empty(t, readDisableCauses(t, ctx, ti, orgID, "chat"))
 		return nil
 	}
-	done := make(chan error, 1)
-	go func() {
-		_, err := ti.service.DisableKey(adminCtx, &gen.DisableKeyPayload{OrganizationID: orgID, KeyType: "chat"})
-		done <- err
-	}()
-	<-requested
-	require.Never(t, func() bool {
-		return len(readDisableCauses(t, ctx, ti, orgID, "chat")) > 0
-	}, 75*time.Millisecond, 10*time.Millisecond)
-	close(release)
 
-	err := <-done
+	_, err := ti.service.DisableKey(adminCtx, &gen.DisableKeyPayload{OrganizationID: orgID, KeyType: "chat"})
 	requireOopsCode(t, err, oops.CodeUnavailable)
 	require.Empty(t, readDisableCauses(t, ctx, ti, orgID, "chat"), "a late Begin response must not receive a fresh mutation deadline")
 	require.EqualValues(t, 0, auditCount(t, ctx, ti, audit.ActionOpenRouterAPIKeyDisable))

--- a/server/internal/usage/payg_key_refresh_handler.go
+++ b/server/internal/usage/payg_key_refresh_handler.go
@@ -36,14 +36,13 @@ func NewPaygKeyRefreshHandler(logger *slog.Logger, refresher PaygKeyRefreshSched
 }
 
 func (h *PaygKeyRefreshHandler) Handle(ctx context.Context, event *webhooksv1.Event, _ gcp.MessageMetadata) error {
-	if event == nil {
-		h.logger.ErrorContext(ctx, "dropping nil PAYG key refresh event")
+	if event == nil || event.GetEventType() != string(events.OrganizationBillingV1.EventType()) {
 		return nil
 	}
 
 	eventID := event.GetEventId()
 	organizationID := event.GetOrganizationId()
-	if eventID == "" || organizationID == "" || event.GetEventType() != string(events.OrganizationBillingV1.EventType()) {
+	if eventID == "" || organizationID == "" {
 		h.logger.ErrorContext(ctx, "dropping invalid PAYG key refresh event",
 			attr.SlogOrganizationID(organizationID),
 			attr.SlogOutboxPublicID(eventID),


### PR DESCRIPTION
## Summary
- Silently ignore nil events and event types other than organization billing in the PAYG key-refresh handler.
- Keep error logs for organization billing events missing an event or organization ID.

## Motivation
Unrelated events do not require PAYG key reconciliation and should not be logged as invalid refresh events. Filtering them before validation removes misleading error noise without changing billing-event reconciliation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silently ignores non-billing PAYG key refresh events so unrelated events no longer produce misleading error logs; billing events missing an event or organization ID still log errors as before. The admin mutation deadline test now blocks on a canceled context instead of polling, removing a flaky race.

<sup>Written for commit 527fa56d719ca81172183547a70917ca9d07195f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

