### PR TITLE
fix: install hooks from Git Bash on Windows

### DIFF
--- a/server/internal/plugins/generate.go
+++ b/server/internal/plugins/generate.go
@@ -382,7 +382,7 @@ const platformMCPGeneratorVersion = "3"
 // line when it pins a new binary, because new checksums always change the
 // rendered bootstrap script. Any other change to hooks generation needs a
 // manual bump, which the Plugin Generate Check CI workflow enforces.
-const hooksGeneratorVersion = "39"
+const hooksGeneratorVersion = "40"
 
 // Fixed, non-empty sentinels substituted for the per-publish API keys when
 // computing a fingerprint. They must be non-empty: an empty HooksAPIKey omits

--- a/server/internal/plugins/generate_test.go
+++ b/server/internal/plugins/generate_test.go
@@ -1634,6 +1634,27 @@ func TestHooksBootstrapChecksumMismatchNeverExecutes(t *testing.T) {
 	require.NoFileExists(t, marker)
 }
 
+func TestHooksBootstrapAvoidsWindowsChecksumFilenameEscaping(t *testing.T) {
+	t.Parallel()
+	script := string(renderHooksBootstrap(GenerateConfig{}))
+
+	// Git Bash receives LOCALAPPDATA with native backslashes. Normalizing the
+	// cache root avoids mixed paths for every downstream MSYS utility.
+	require.Contains(t, script, `printf '%s' "$LOCALAPPDATA" | tr '\\' '/'`)
+
+	// More importantly, never give checksum utilities the filename: GNU
+	// coreutils prefixes the digest with an escape marker when that filename
+	// contains a backslash. Stdin produces an unconditionally plain digest.
+	for _, command := range []string{
+		`sha256sum < "$archive"`,
+		`shasum -a 256 < "$archive"`,
+		`openssl dgst -sha256 < "$archive"`,
+	} {
+		require.Contains(t, script, command)
+	}
+	require.NotContains(t, script, `sha256sum "$archive"`)
+}
+
 func TestHooksBootstrapInstallFailOpenExitsZeroWithoutExecuting(t *testing.T) {
 	t.Parallel()
 	target := currentHooksBootstrapTarget(t)

--- a/server/internal/plugins/hooks_bootstrap.go
+++ b/server/internal/plugins/hooks_bootstrap.go
@@ -266,7 +266,10 @@ if [ -n "${GRAM_HOOKS_HOME:-}" ]; then
 elif [ "$os" = darwin ]; then
   cache_root="${HOME}/Library/Caches/Speakeasy/hooks"
 elif [ "$os" = windows ] && [ -n "${LOCALAPPDATA:-}" ]; then
-  cache_root="${LOCALAPPDATA}/Speakeasy/hooks"
+  # Git Bash inherits LOCALAPPDATA in native C:\Users\... form. Normalize it
+  # before handing derived paths to MSYS tools: GNU checksum utilities switch
+  # to escaped output when a filename contains a backslash.
+  cache_root="$(printf '%%s' "$LOCALAPPDATA" | tr '\\' '/')/Speakeasy/hooks"
 else
   cache_root="${XDG_CACHE_HOME:-${HOME}/.cache}/speakeasy/hooks"
 fi
@@ -356,12 +359,16 @@ if ! cache_valid; then
     install_failure 'curl or wget is required for first install'
   fi
 
+  # Hash stdin rather than naming the archive. GNU sha256sum and compatible
+  # tools prefix their digest with a backslash when a filename needs escaping;
+  # Git Bash therefore produced "\<correct hash>" for LOCALAPPDATA paths and
+  # deterministically rejected valid Windows archives.
   if command -v sha256sum >/dev/null 2>&1; then
-    actual_sha=$(sha256sum "$archive" | cut -d ' ' -f 1) || install_failure 'checksum computation failed'
+    actual_sha=$(sha256sum < "$archive" | cut -d ' ' -f 1) || install_failure 'checksum computation failed'
   elif command -v shasum >/dev/null 2>&1; then
-    actual_sha=$(shasum -a 256 "$archive" | cut -d ' ' -f 1) || install_failure 'checksum computation failed'
+    actual_sha=$(shasum -a 256 < "$archive" | cut -d ' ' -f 1) || install_failure 'checksum computation failed'
   elif command -v openssl >/dev/null 2>&1; then
-    actual_sha=$(openssl dgst -sha256 "$archive" | sed 's/^.*= //') || install_failure 'checksum computation failed'
+    actual_sha=$(openssl dgst -sha256 < "$archive" | sed 's/^.*= //') || install_failure 'checksum computation failed'
   else
     install_failure 'no SHA-256 utility is available'
   fi


### PR DESCRIPTION
## Summary

- Normalize the native `LOCALAPPDATA` path before the generated hooks bootstrap passes it to Git Bash/MSYS utilities.
- Hash downloaded hook archives through stdin so GNU-compatible checksum tools cannot prefix the digest with a filename-escaping marker.
- Add regression coverage for the Windows path and checksum command shape, and advance the hooks generator version so corrected observability plugins can be republished.

## Motivation

Claude Code runs plugin shell hooks through Git Bash on Windows. Native backslashes in `LOCALAPPDATA` caused GNU `sha256sum` to emit an escaped digest beginning with `\`, so a valid archive deterministically failed comparison with its pinned checksum and the hooks binary was never installed. Reading archive bytes from stdin avoids filename-dependent output while preserving checksum verification.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hook installation from Git Bash on Windows, where backslashes in `LOCALAPPDATA` made GNU checksum utilities emit escaped digests that never matched the pinned checksum.

**Bug Fixes**
- Normalizes the cache root from native Windows form before MSYS utilities consume it.
- Hashes archive bytes from stdin so checksum output never depends on the filename.
- Bumps the hooks generator version so corrected plugins can be republished.
- Adds regression tests for the path normalization and stdin checksum commands.

<sup>Written for commit 58012aee92c3c0bb22d6f7dbcd79f18f641f039b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

