### PR TITLE
chore: add opencode to the CIMD admission preset catalog

### DIFF
--- a/server/internal/usersessions/cimd/admission/catalog.go
+++ b/server/internal/usersessions/cimd/admission/catalog.go
@@ -276,6 +276,19 @@ var catalog = []Preset{
 		DisplayOnly: false,
 		Enabled:     true,
 	},
+
+	// Verified 2026-09-10, after a production CIMD admission denial for
+	// this client_id. The extra "opencode" path segment does NOT mark a
+	// per-server namespace the way OpenAI's does: the shorter
+	// /oauth/client.json form and any other segment both 404, so there is
+	// exactly one document to admit and an exact entry is the right rule.
+	{
+		VendorKey:   "opencode",
+		DisplayName: "opencode",
+		URL:         "https://opencode.ai/oauth/opencode/client.json",
+		DisplayOnly: false,
+		Enabled:     true,
+	},
 }
 
 // catalogURLs and catalogPatterns index the enabled catalog entries for the


### PR DESCRIPTION
[AIM-267](https://linear.app/speakeasy/issue/AIM-267/feat-add-opencode-to-cimd-known-clients)

## Summary

Adds an exact (non-pattern) preset for `https://opencode.ai/oauth/opencode/client.json` to the CIMD admission catalog in `server/internal/usersessions/cimd/admission/catalog.go`, with the verification date and the reasoning for exact matching recorded in the comment above the entry, per the existing convention.

An exact entry rather than a pattern is the right rule here. The URL carries an `opencode` segment between `/oauth/` and `/client.json`, which is the shape OpenAI uses for its per-connector and per-server template endpoints, but it is not one: the shorter `/oauth/client.json` form returns 404, and so does an invented segment, so there is a single fixed document and nothing to enumerate. A pattern would widen admission across the host for no benefit.

No test changes. `catalog_test.go` asserts invariants over `Catalog()` rather than naming individual vendors, so the new entry is covered automatically.

## Motivation

The production CIMD admission denial monitor caught a `denied_not_listed` decision for this client_id, which is the catalog gap that the shadow measurement exists to surface. With the unconfigured default now `ModeOpen`, issuers that never chose a policy still admit opencode today, but any issuer whose operator has opted into `ModePresets` refuses it at `/authorize`, and that refusal is unrecoverable: MCP clients pick CIMD over dynamic client registration once, at metadata-discovery time, and do not fall back when the client_id is rejected.

The document was verified live on 2026-09-10 before landing, as the catalog contract requires: HTTP 200, valid JSON, `client_id` byte-equal to the URL, `token_endpoint_auth_method` of `none`, `application_type: native`, and loopback-only `redirect_uris`. It publishes `client_name`, `client_uri`, and `logo_uri`, all pointing at `opencode.ai`, so the consent screen has complete metadata to show.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opencode to the CIMD admission preset catalog so presets-mode issuers no longer refuse its client ID at `/authorize`, fixing the denial that the production monitor flagged (AIM-267).

- Records the exact URL `https://opencode.ai/oauth/opencode/client.json` rather than a pattern because the shorter `/oauth/client.json` form and any other path segment both 404.
- Verified live on 2026-09-10: HTTP 200, `client_id` byte-equal to the URL, `token_endpoint_auth_method` of `none`, and loopback-only `redirect_uris`.
- Existing catalog tests cover the new entry automatically, so no test changes are needed.

<sup>Written for commit 23347e883a1a2ba80b69dc6617e02421998a01d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

