### PR TITLE
feat: improve agent key creation controls

### DIFF
--- a/client/dashboard/src/pages/agents/AgentAPIKeys.test.tsx
+++ b/client/dashboard/src/pages/agents/AgentAPIKeys.test.tsx
@@ -697,10 +697,14 @@ describe("Agent API keys", () => {
       await screen.findByText("secret_example_once");
       const expiry =
         mocks.create.mock.calls[0]?.[0].request.createKeyForm.expiresAt;
-      expect(expiry.getTime()).toBeGreaterThanOrEqual(before + days * 86400000);
-      expect(expiry.getTime()).toBeLessThanOrEqual(
-        Date.now() + days * 86400000,
-      );
+      const lifetime = days * 86400000 - (days === 365 ? 5 * 60_000 : 0);
+      expect(expiry.getTime()).toBeGreaterThanOrEqual(before + lifetime);
+      expect(expiry.getTime()).toBeLessThanOrEqual(Date.now() + lifetime);
+      if (days === 365) {
+        // A server clock four minutes behind still accepts the one-year preset.
+        const serverNow = before - 4 * 60_000;
+        expect(expiry.getTime()).toBeLessThan(serverNow + 365 * 86400000);
+      }
     },
   );
   it("submits a custom expiry at local midnight", async () => {

--- a/client/dashboard/src/pages/agents/AgentAPIKeys.test.tsx
+++ b/client/dashboard/src/pages/agents/AgentAPIKeys.test.tsx
@@ -154,11 +154,9 @@ async function openCreate() {
     expect(screen.queryByText("Loading delegable permissions…")).toBeNull(),
   );
 }
-async function emptyCreate() {
+async function selectedCreate() {
   await openCreate();
-  fireEvent.click(
-    screen.getByRole("checkbox", { name: /Create without permissions/ }),
-  );
+  fireEvent.click(await screen.findByRole("checkbox", { name: /mcp:connect/ }));
   fireEvent.click(screen.getByRole("button", { name: "Create key" }));
 }
 beforeEach(() => {
@@ -172,7 +170,7 @@ beforeEach(() => {
   mocks.list.mockResolvedValue({ keys: [key] });
   mocks.create.mockResolvedValue({ ...key, key: "secret_example_once" });
   mocks.revoke.mockResolvedValue(undefined);
-  mocks.listDelegableGrants.mockResolvedValue([]);
+  mocks.listDelegableGrants.mockResolvedValue([grant]);
   mocks.toolsets.mockResolvedValue({
     toolsets: [
       {
@@ -251,41 +249,25 @@ describe("Agent API keys", () => {
       { sessionHeaderGramSession: "" },
     );
   });
-  it("discovers delegable grants for authorize-only users and requires explicit empty approval", async () => {
+  it("requires at least one permission without an empty-key bypass", async () => {
+    mocks.listDelegableGrants.mockResolvedValue([]);
     setup();
     await openCreate();
-    expect(mocks.listDelegableGrants).toHaveBeenCalledWith(
-      { agentId: agent.id },
-      undefined,
-      expect.anything(),
-    );
+    await screen.findByText(/No permissions can be delegated to this agent/);
     expect(
-      screen.getByText(/No permissions can be delegated to this agent/),
-    ).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Create key" }));
+      screen.queryByRole("checkbox", { name: /Create without permissions/ }),
+    ).toBeNull();
+    expect(
+      (screen.getByRole("button", { name: "Create key" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    fireEvent.submit(screen.getByLabelText("Key name").closest("form")!);
     expect(mocks.create).not.toHaveBeenCalled();
-    fireEvent.click(
-      screen.getByRole("checkbox", { name: /Create without permissions/ }),
-    );
-    fireEvent.click(screen.getByRole("button", { name: "Create key" }));
-    await screen.findByText("secret_example_once");
-    expect(mocks.create.mock.calls[0]?.[0]).toEqual({
-      security: { sessionHeaderGramSession: "" },
-      request: {
-        createKeyForm: {
-          agentId: agent.id,
-          name: "New key",
-          delegatedGrantsVersion: 1,
-          requestedGrants: [],
-          scopes: [],
-        },
-      },
-    });
   });
   it("reveals secrets once without copying them to query cache or storage", async () => {
     const storage = vi.spyOn(Storage.prototype, "setItem");
     const { client } = setup();
-    await emptyCreate();
+    await selectedCreate();
     await screen.findByText("secret_example_once");
     expect(
       JSON.stringify(
@@ -309,7 +291,7 @@ describe("Agent API keys", () => {
     "clears a revealed secret on %s change",
     async (kind) => {
       const { change } = setup();
-      await emptyCreate();
+      await selectedCreate();
       await screen.findByText("secret_example_once");
       if (kind === "organization") mocks.org = "org_other";
       change(kind === "agent" ? { ...agent, id: "agent_other" } : agent);
@@ -325,7 +307,7 @@ describe("Agent API keys", () => {
         }),
     );
     const { change } = setup();
-    await emptyCreate();
+    await selectedCreate();
     await waitFor(() => expect(mocks.create).toHaveBeenCalled());
     change({ ...agent, id: "agent_other" });
     resolve({ ...key, key: "secret_example_once" });
@@ -356,7 +338,7 @@ describe("Agent API keys", () => {
   });
   it("closes creation and clears the secret on rollout loss", async () => {
     const { change } = setup();
-    await emptyCreate();
+    await selectedCreate();
     await screen.findByText("secret_example_once");
     mocks.flag = "disabled";
     change();
@@ -375,7 +357,7 @@ describe("Agent API keys", () => {
         }),
     );
     const { change } = setup();
-    await emptyCreate();
+    await selectedCreate();
     await waitFor(() => expect(mocks.create).toHaveBeenCalled());
     mocks.flag = "disabled";
     change();
@@ -417,6 +399,7 @@ describe("Agent API keys", () => {
     },
   );
   it("stops discovery refetch and creation on rollout loss", async () => {
+    mocks.listDelegableGrants.mockResolvedValue([]);
     const { change, client } = setup();
     await openCreate();
     await screen.findByText(/No permissions can be delegated to this agent/);
@@ -492,7 +475,7 @@ describe("Agent API keys", () => {
   it("explains issuance validation failures without displaying server secrets", async () => {
     mocks.create.mockRejectedValue(new Error("secret_server_error"));
     setup();
-    await emptyCreate();
+    await selectedCreate();
     expect(await screen.findByRole("alert")).toHaveProperty(
       "textContent",
       expect.stringContaining("owner's live permissions"),
@@ -547,12 +530,12 @@ describe("Agent API keys", () => {
       target: { value: name },
     });
     fireEvent.click(
-      screen.getByRole("checkbox", { name: /Create without permissions/ }),
+      await screen.findByRole("checkbox", { name: /mcp:connect/ }),
     );
     fireEvent.click(screen.getByRole("button", { name: "Create key" }));
-    expect(screen.getByRole("alert").textContent).toMatch(
-      /reserved|255 Unicode characters/,
-    );
+    expect(
+      screen.getByLabelText(/reserved|255 Unicode characters/),
+    ).toBeTruthy();
     expect(mocks.create).not.toHaveBeenCalled();
   });
   it("submits a trimmed name at the Unicode codepoint limit", async () => {
@@ -562,7 +545,7 @@ describe("Agent API keys", () => {
       target: { value: `  ${"😀".repeat(255)}  ` },
     });
     fireEvent.click(
-      screen.getByRole("checkbox", { name: /Create without permissions/ }),
+      await screen.findByRole("checkbox", { name: /mcp:connect/ }),
     );
     fireEvent.click(screen.getByRole("button", { name: "Create key" }));
     await screen.findByText("secret_example_once");
@@ -608,9 +591,9 @@ describe("Agent API keys", () => {
     ).toBe(true);
     fireEvent.submit(screen.getByLabelText("Key name").closest("form")!);
     expect(mocks.create).not.toHaveBeenCalled();
-    expect(screen.getByRole("alert").textContent).toMatch(
-      /still loading. Wait for them to finish/,
-    );
+    expect(
+      screen.getByLabelText(/Delegable permissions are still loading/),
+    ).toBeTruthy();
 
     resolveRefetch([grant]);
     const restored = await screen.findByRole("checkbox", {
@@ -641,9 +624,9 @@ describe("Agent API keys", () => {
     expect(screen.queryByRole("checkbox", { name: /mcp:connect/ })).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Create key" }));
     expect(mocks.create).not.toHaveBeenCalled();
-    expect(screen.getByRole("alert").textContent).toMatch(
-      /Select permissions or explicitly confirm/,
-    );
+    expect(
+      screen.getByLabelText(/Select at least one valid permission/),
+    ).toBeTruthy();
     fireEvent.click(await screen.findByRole("checkbox", { name: /mcp:read/ }));
     fireEvent.click(screen.getByRole("button", { name: "Create key" }));
     await screen.findByText("secret_example_once");
@@ -651,25 +634,142 @@ describe("Agent API keys", () => {
       mocks.create.mock.calls[0]?.[0].request.createKeyForm.requestedGrants,
     ).toEqual([narrowed]);
   });
-  it("still issues an explicitly empty key while candidates are loading", async () => {
+  it("accumulates loading, name and permission reasons on the accessible wrapper", async () => {
     mocks.listDelegableGrants.mockImplementation(() => new Promise(() => {}));
     setup();
     fireEvent.click(
       await screen.findByRole("button", { name: "Create API key" }),
     );
-    fireEvent.change(screen.getByLabelText("Key name"), {
-      target: { value: "New key" },
-    });
     await screen.findByText("Loading delegable permissions…");
-    fireEvent.click(
-      screen.getByRole("checkbox", { name: /Create without permissions/ }),
+    const wrapper = screen.getByLabelText(
+      /Delegable permissions are still loading/,
     );
+    expect(wrapper.getAttribute("aria-label")).toMatch(/Enter a key name/);
+    expect(wrapper.getAttribute("aria-label")).toMatch(
+      /Select at least one valid permission/,
+    );
+    expect(wrapper.tabIndex).toBe(0);
+    fireEvent.submit(screen.getByLabelText("Key name").closest("form")!);
+    expect(mocks.create).not.toHaveBeenCalled();
+  });
+  it("explains pending creation and loss of issuance eligibility together", async () => {
+    mocks.create.mockImplementation(() => new Promise(() => {}));
+    const { change } = setup();
+    await selectedCreate();
+    await screen.findByRole("button", { name: "Creating…" });
+    change({ ...agent, lifecycle: "suspended" });
+    const wrapper = screen.getByLabelText(/An API key is being created/);
+    expect(wrapper.getAttribute("aria-label")).toMatch(
+      /Issuance requires an active agent/,
+    );
+    fireEvent.focus(wrapper);
+    expect((await screen.findByRole("tooltip")).textContent).toMatch(
+      /An API key is being created/,
+    );
+    expect(screen.getByRole("tooltip").textContent).toMatch(
+      /Issuance requires an active agent/,
+    );
+  });
+  it("defaults expiry to 90 days", async () => {
+    setup();
+    const before = Date.now();
+    await selectedCreate();
+    await screen.findByText("secret_example_once");
+    const expiry =
+      mocks.create.mock.calls[0]?.[0].request.createKeyForm.expiresAt;
+    expect(expiry.getTime()).toBeGreaterThanOrEqual(before + 90 * 86400000);
+    expect(expiry.getTime()).toBeLessThanOrEqual(Date.now() + 90 * 86400000);
+  });
+  it.each([7, 30, 90, 180, 365])(
+    "submits a selected %i-day expiry",
+    async (days) => {
+      setup();
+      await openCreate();
+      fireEvent.click(
+        await screen.findByRole("checkbox", { name: /mcp:connect/ }),
+      );
+      fireEvent.keyDown(screen.getByLabelText("Expiration"), { key: "Enter" });
+      fireEvent.click(
+        await screen.findByRole("option", { name: `${days} days` }),
+      );
+      const before = Date.now();
+      fireEvent.click(screen.getByRole("button", { name: "Create key" }));
+      await screen.findByText("secret_example_once");
+      const expiry =
+        mocks.create.mock.calls[0]?.[0].request.createKeyForm.expiresAt;
+      expect(expiry.getTime()).toBeGreaterThanOrEqual(before + days * 86400000);
+      expect(expiry.getTime()).toBeLessThanOrEqual(
+        Date.now() + days * 86400000,
+      );
+    },
+  );
+  it("submits a custom expiry at local midnight", async () => {
+    setup();
+    await openCreate();
+    fireEvent.click(
+      await screen.findByRole("checkbox", { name: /mcp:connect/ }),
+    );
+    fireEvent.keyDown(screen.getByLabelText("Expiration"), { key: "Enter" });
+    fireEvent.click(await screen.findByRole("option", { name: "Custom date" }));
+    const date = new Date(Date.now() + 10 * 86_400_000);
+    const value = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+    fireEvent.change(screen.getByLabelText("Expiration date"), {
+      target: { value },
+    });
     fireEvent.click(screen.getByRole("button", { name: "Create key" }));
     await screen.findByText("secret_example_once");
     expect(
-      mocks.create.mock.calls[0]?.[0].request.createKeyForm.requestedGrants,
-    ).toEqual([]);
+      mocks.create.mock.calls[0]?.[0].request.createKeyForm.expiresAt,
+    ).toEqual(new Date(`${value}T00:00:00`));
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+    await openCreate();
+    expect(screen.getByLabelText("Expiration").textContent).toBe("90 days");
+    expect(screen.queryByLabelText("Expiration date")).toBeNull();
+    fireEvent.keyDown(screen.getByLabelText("Expiration"), { key: "Enter" });
+    fireEvent.click(await screen.findByRole("option", { name: "Custom date" }));
+    expect(
+      (screen.getByLabelText("Expiration date") as HTMLInputElement).value,
+    ).toBe("");
   });
+  it.each([
+    ["missing", "", "Choose a valid expiration date."],
+    ["invalid", "not-a-date", "Choose a valid expiration date."],
+    ["past", "2000-01-01", "Expiration date must be in the future."],
+    ["out-of-range", "2999-01-01", "Expiration date must be within 365 days."],
+  ])(
+    "blocks %s custom expiry and accumulates tooltip reasons",
+    async (_label, value, reason) => {
+      setup();
+      await openCreate();
+      fireEvent.keyDown(screen.getByLabelText("Expiration"), { key: "Enter" });
+      fireEvent.click(
+        await screen.findByRole("option", { name: "Custom date" }),
+      );
+      fireEvent.change(screen.getByLabelText("Expiration date"), {
+        target: { value },
+      });
+      const button = screen.getByRole("button", { name: "Create key" });
+      expect((button as HTMLButtonElement).disabled).toBe(true);
+      const wrapper = button.parentElement!;
+      expect(wrapper.getAttribute("aria-label")).toContain(reason);
+      expect(wrapper.getAttribute("aria-label")).toContain(
+        "Select at least one valid permission.",
+      );
+      fireEvent.focus(wrapper);
+      expect((await screen.findByRole("tooltip")).textContent).toContain(
+        reason,
+      );
+      fireEvent.submit(screen.getByLabelText("Key name").closest("form")!);
+      expect(mocks.create).not.toHaveBeenCalled();
+      // An invalid custom date must not prevent switching back to a preset.
+      fireEvent.click(
+        await screen.findByRole("checkbox", { name: /mcp:connect/ }),
+      );
+      fireEvent.keyDown(screen.getByLabelText("Expiration"), { key: "Enter" });
+      fireEvent.click(await screen.findByRole("option", { name: "90 days" }));
+      expect((button as HTMLButtonElement).disabled).toBe(false);
+    },
+  );
   it("drops a retained selection and blocks issuance after a discovery refetch failure", async () => {
     mocks.listDelegableGrants.mockResolvedValue([
       {
@@ -696,16 +796,8 @@ describe("Agent API keys", () => {
     expect(screen.queryByRole("checkbox", { name: /mcp:connect/ })).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Create key" }));
     expect(mocks.create).not.toHaveBeenCalled();
-    fireEvent.click(
-      screen.getByRole("checkbox", { name: /Create without permissions/ }),
-    );
-    fireEvent.click(screen.getByRole("button", { name: "Create key" }));
-    await screen.findByText("secret_example_once");
-    expect(
-      mocks.create.mock.calls[0]?.[0].request.createKeyForm.requestedGrants,
-    ).toEqual([]);
   });
-  it("lets writers narrow a broad grant to one server, tool and disposition", async () => {
+  it("lets writers narrow a broad grant to one server and tool", async () => {
     mocks.listDelegableGrants.mockResolvedValue([
       {
         ...grant,
@@ -723,15 +815,8 @@ describe("Agent API keys", () => {
     fireEvent.click(selectedGrant);
     const server = await screen.findByLabelText("Server for mcp:connect");
     fireEvent.change(server, { target: { value: "server_one" } });
-    fireEvent.change(await screen.findByLabelText("Tool for mcp:connect"), {
-      target: { value: "search" },
-    });
-    fireEvent.change(
-      screen.getByLabelText("Tool disposition for mcp:connect"),
-      {
-        target: { value: "read_only" },
-      },
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Specific tools" }));
+    fireEvent.click(await screen.findByRole("button", { name: "search" }));
     fireEvent.click(screen.getByRole("button", { name: "Create key" }));
     await screen.findByText("secret_example_once");
     expect(
@@ -744,7 +829,6 @@ describe("Agent API keys", () => {
           resourceKind: "mcp",
           resourceId: "server_one",
           tool: "search",
-          disposition: "read_only",
         },
       },
     ]);
@@ -810,9 +894,10 @@ describe("Agent API keys", () => {
     fireEvent.change(await screen.findByLabelText("Server for mcp:connect"), {
       target: { value: "server_remote" },
     });
-    fireEvent.change(await screen.findByLabelText("Tool for mcp:connect"), {
-      target: { value: "remote_search" },
-    });
+    fireEvent.click(screen.getByRole("button", { name: "Specific tools" }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: "remote_search" }),
+    );
     expect(mocks.toolMetadata).toHaveBeenCalledWith({
       mcpServerId: "server_remote",
       gramProject: "project-one",
@@ -858,15 +943,15 @@ describe("Agent API keys", () => {
     fireEvent.click(
       await screen.findByRole("checkbox", { name: /mcp:connect/ }),
     );
-    await screen.findByText(/Could not load tools for this server/);
+    await screen.findByText(/Couldn't load this server/);
     expect(screen.queryByLabelText("Tool for mcp:connect")).toBeNull();
     mocks.toolMetadata.mockResolvedValue({
       tools: [{ toolName: "remote_search" }],
     });
-    fireEvent.click(screen.getByRole("button", { name: "Retry tools" }));
-    fireEvent.change(await screen.findByLabelText("Tool for mcp:connect"), {
-      target: { value: "remote_search" },
-    });
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: "remote_search" }),
+    );
     fireEvent.click(screen.getByRole("button", { name: "Create key" }));
     await screen.findByText("secret_example_once");
     expect(
@@ -906,7 +991,7 @@ describe("Agent API keys", () => {
     fireEvent.click(
       await screen.findByRole("checkbox", { name: /mcp:connect/ }),
     );
-    await screen.findByText(/resolves its tools at call time/);
+    await screen.findByText(/Tools are discovered at runtime/);
     expect(screen.queryByLabelText("Tool for mcp:connect")).toBeNull();
     expect(mocks.toolMetadata).not.toHaveBeenCalled();
   });
@@ -937,9 +1022,7 @@ describe("Agent API keys", () => {
       // Server and tool choices come from the withheld inventory.
       expect(screen.queryByLabelText("Server for mcp:connect")).toBeNull();
       expect(screen.queryByLabelText("Tool for mcp:connect")).toBeNull();
-      // The project list comes from the session, not the inventory, so it
-      // stays: narrowing to a project needs no server to be known.
-      expect(screen.getByLabelText("Project for mcp:connect")).toBeTruthy();
+      expect(screen.queryByLabelText("Project for mcp:connect")).toBeNull();
       // The candidate is still delegable exactly as discovered.
       fireEvent.click(screen.getByRole("button", { name: "Create key" }));
       await screen.findByText("secret_example_once");
@@ -1213,7 +1296,7 @@ describe("Agent API keys", () => {
       },
     ]);
   });
-  it("keeps server and project choices within one project", async () => {
+  it("does not offer project narrowing after selecting a server", async () => {
     mocks.listDelegableGrants.mockResolvedValue([
       { ...grant, selector: { resourceKind: "mcp", resourceId: "*" } },
     ]);
@@ -1227,15 +1310,7 @@ describe("Agent API keys", () => {
     fireEvent.change(await screen.findByLabelText("Server for mcp:connect"), {
       target: { value: "server_two" },
     });
-    // The chosen server fixes the project, so the other one is not offered.
-    const project = screen.getByLabelText("Project for mcp:connect");
-    expect(optionText(project)).toContain("Project two");
-    expect(optionText(project)).not.toContain("Project one");
-    fireEvent.change(project, { target: { value: "project_two" } });
-    // ...and the project now limits the servers to that project.
-    expect(
-      optionText(screen.getByLabelText("Server for mcp:connect")),
-    ).not.toContain("Server one");
+    expect(screen.queryByLabelText("Project for mcp:connect")).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Create key" }));
     await screen.findByText("secret_example_once");
     expect(
@@ -1247,7 +1322,6 @@ describe("Agent API keys", () => {
         selector: {
           resourceKind: "mcp",
           resourceId: "server_two",
-          projectId: "project_two",
         },
       },
     ]);

--- a/client/dashboard/src/pages/agents/AgentAPIKeys.test.tsx
+++ b/client/dashboard/src/pages/agents/AgentAPIKeys.test.tsx
@@ -739,7 +739,11 @@ describe("Agent API keys", () => {
     ["missing", "", "Choose a valid expiration date."],
     ["invalid", "not-a-date", "Choose a valid expiration date."],
     ["past", "2000-01-01", "Expiration date must be in the future."],
-    ["out-of-range", "2999-01-01", "Expiration date must be within 365 days."],
+    [
+      "out-of-range",
+      "2999-01-01",
+      "Expiration date must be within 365 days minus a 5-minute clock-skew margin.",
+    ],
   ])(
     "blocks %s custom expiry and accumulates tooltip reasons",
     async (_label, value, reason) => {

--- a/client/dashboard/src/pages/agents/AgentAPIKeys.tsx
+++ b/client/dashboard/src/pages/agents/AgentAPIKeys.tsx
@@ -191,17 +191,21 @@ function AgentAPIKeysContent({
   if (!requestedGrants.length)
     disablingReasons.push("Select at least one valid permission.");
   const expiryValidation = (now: number) => {
+    // Leave five minutes below the server limit for modest browser clock skew.
+    const maxLifetime = 365 * 86_400_000 - 5 * 60_000;
     // Date-only selections expire at local midnight, not UTC midnight.
     const expiresAt =
       expiryDays === "custom"
         ? new Date(`${customExpiry}T00:00:00`)
-        : new Date(now + Number(expiryDays) * 86_400_000);
+        : new Date(
+            now + Math.min(Number(expiryDays) * 86_400_000, maxLifetime),
+          );
     let reason: string | undefined;
     if (!Number.isFinite(expiresAt.getTime()))
       reason = "Choose a valid expiration date.";
     else if (expiresAt.getTime() <= now)
       reason = "Expiration date must be in the future.";
-    else if (expiresAt.getTime() > now + 365 * 86_400_000)
+    else if (expiresAt.getTime() > now + maxLifetime)
       reason = "Expiration date must be within 365 days.";
     return { expiresAt, reason };
   };

--- a/client/dashboard/src/pages/agents/AgentAPIKeys.tsx
+++ b/client/dashboard/src/pages/agents/AgentAPIKeys.tsx
@@ -6,7 +6,14 @@ import { useFeatureFlag, type FeatureFlagResult } from "@/hooks/useFeatureFlag";
 import { FEATURE_FLAGS } from "@/lib/featureFlags";
 import { SettingsSection } from "@/components/page-templates";
 import { Button } from "@/components/ui/Button";
-import { Checkbox } from "@/components/ui/Checkbox";
+import { SimpleTooltip, TooltipProvider } from "@/components/ui/Tooltip";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/Select";
 import { Dialog } from "@/components/ui/Dialog";
 import { Input } from "@/components/ui/Input";
 import { Text } from "@/components/ui/Text";
@@ -80,7 +87,8 @@ function AgentAPIKeysContent({
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
   const [narrowings, setNarrowings] = useState<GrantNarrowings>({});
-  const [withoutPermissions, setWithoutPermissions] = useState(false);
+  const [expiryDays, setExpiryDays] = useState("90");
+  const [customExpiry, setCustomExpiry] = useState("");
   const [secret, setSecret] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -106,13 +114,12 @@ function AgentAPIKeysContent({
   // A cached candidate set keeps `isSuccess` and its stale `data` while a
   // refetch is in flight, so reopening the dialog or a background refresh
   // would otherwise offer grants the current read has not confirmed. Editing
-  // and non-empty issuance wait for the in-flight read to finish; failed
+  // and issuance wait for the in-flight read to finish; failed
   // refetches can likewise retain stale data.
   const discoveryComplete =
     delegable.isSuccess &&
     !delegable.isFetching &&
     Array.isArray(delegable.data);
-  const hasSelections = Object.keys(narrowings).length > 0;
   const create = useCreateAPIKeyMutation({ gcTime: 0, retry: false });
   const resetCreation = create.reset;
   useEffect(() => {
@@ -144,49 +151,68 @@ function AgentAPIKeysContent({
     setCopied(false);
     setName("");
     setNarrowings({});
-    setWithoutPermissions(false);
+    setExpiryDays("90");
+    setCustomExpiry("");
     setError(null);
     create.reset();
   };
+  const disablingReasons: string[] = [];
+  if (!canIssue)
+    disablingReasons.push(
+      "Issuance requires an active agent with a valid owner and credential authorization.",
+    );
+  if (create.isPending) disablingReasons.push("An API key is being created.");
+  if (delegable.isFetching)
+    disablingReasons.push("Delegable permissions are still loading.");
+  else if (!discoveryComplete)
+    disablingReasons.push(
+      "Delegable permissions could not be loaded. Retry permissions.",
+    );
+  let validatedName = "";
+  try {
+    validatedName = validateAgentAPIKeyName(name);
+  } catch (error) {
+    disablingReasons.push(
+      error instanceof Error ? error.message : "Enter a valid key name.",
+    );
+  }
+  let requestedGrants: AgentPolicyGrantForm[] = [];
+  try {
+    const selections = (discoveryComplete ? (delegable.data ?? []) : [])
+      .map((grant) => ({ grant, key: delegableGrantKey(grant) }))
+      .filter(({ key }) => narrowings[key] !== undefined)
+      .map(({ grant, key }) => ({ grant, narrowing: narrowings[key] ?? {} }));
+    requestedGrants = buildRequestedGrants(selections);
+  } catch (error) {
+    disablingReasons.push(
+      error instanceof Error ? error.message : "Select valid permissions.",
+    );
+  }
+  if (!requestedGrants.length)
+    disablingReasons.push("Select at least one valid permission.");
+  const expiryValidation = (now: number) => {
+    // Date-only selections expire at local midnight, not UTC midnight.
+    const expiresAt =
+      expiryDays === "custom"
+        ? new Date(`${customExpiry}T00:00:00`)
+        : new Date(now + Number(expiryDays) * 86_400_000);
+    let reason: string | undefined;
+    if (!Number.isFinite(expiresAt.getTime()))
+      reason = "Choose a valid expiration date.";
+    else if (expiresAt.getTime() <= now)
+      reason = "Expiration date must be in the future.";
+    else if (expiresAt.getTime() > now + 365 * 86_400_000)
+      reason = "Expiration date must be within 365 days.";
+    return { expiresAt, reason };
+  };
+  const expiryReason = expiryValidation(Date.now()).reason;
+  if (expiryReason) disablingReasons.push(expiryReason);
   const issue = () => {
-    if (!canIssue || create.isPending) return;
-    let validatedName: string;
-    try {
-      validatedName = validateAgentAPIKeyName(name);
-    } catch (error) {
-      setError(
-        error instanceof Error ? error.message : "Enter a valid key name.",
-      );
-      return;
-    }
-    // Only a read that is still in flight blocks: a failed one already drops
-    // its candidates below, leaving the explicit empty path as the stated
-    // recovery.
-    if (delegable.isFetching && hasSelections) {
-      setError(
-        "Delegable permissions are still loading. Wait for them to finish before issuing a key with permissions.",
-      );
-      return;
-    }
-    let requestedGrants;
-    try {
-      // Only candidates discovery actually returned can be requested, so a
-      // failed read yields no permissions rather than a hand-written request.
-      const selections = (discoveryComplete ? (delegable.data ?? []) : [])
-        .map((grant) => ({ grant, key: delegableGrantKey(grant) }))
-        .filter(({ key }) => narrowings[key] !== undefined)
-        .map(({ grant, key }) => ({ grant, narrowing: narrowings[key] ?? {} }));
-      requestedGrants = buildRequestedGrants(selections);
-      if (!requestedGrants.length && !withoutPermissions)
-        throw new Error(
-          "Select permissions or explicitly confirm Create without permissions.",
-        );
-    } catch (error) {
-      setError(
-        error instanceof Error
-          ? error.message
-          : "Select permissions or explicitly confirm Create without permissions.",
-      );
+    if (disablingReasons.length) return;
+    // Recheck at submission in case the form stayed open past midnight.
+    const { expiresAt, reason } = expiryValidation(Date.now());
+    if (reason) {
+      setError(reason);
       return;
     }
     setError(null);
@@ -197,6 +223,7 @@ function AgentAPIKeysContent({
           createKeyForm: {
             agentId: agent.id,
             name: validatedName,
+            expiresAt,
             delegatedGrantsVersion: 1,
             requestedGrants,
             scopes: [],
@@ -323,7 +350,7 @@ function AgentAPIKeysContent({
             <Dialog.Description>
               {secret
                 ? "This key is shown only once. Copy it now and store it securely."
-                : "Keys expire after 90 days. Effective access remains limited by the agent policy, the owner's live permissions and your own; validation can reject grants outside that ceiling."}
+                : "Choose an expiry for this key. Effective access remains limited by the agent policy, the owner's live permissions and your own; validation can reject grants outside that ceiling."}
             </Dialog.Description>
           </Dialog.Header>
           {secret ? (
@@ -364,34 +391,78 @@ function AgentAPIKeysContent({
                 disabled={create.isPending}
                 onRetry={() => void delegable.refetch()}
               />
-              <label className="flex items-start gap-2">
-                <Checkbox
-                  checked={withoutPermissions}
-                  onCheckedChange={(value) => setWithoutPermissions(!!value)}
+              <div className="space-y-2">
+                <label
+                  htmlFor="agent-key-expiry"
+                  className="text-sm font-medium"
+                >
+                  Expiration
+                </label>
+                <Select
+                  value={expiryDays}
+                  onValueChange={setExpiryDays}
                   disabled={create.isPending}
-                  className="mt-0.5"
-                />
-                <span className="min-w-0 flex-1">
-                  <span className="block text-sm font-medium">
-                    Create without permissions
+                >
+                  <SelectTrigger id="agent-key-expiry">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {[7, 30, 90, 180, 365].map((days) => (
+                      <SelectItem key={days} value={String(days)}>
+                        {days} days
+                      </SelectItem>
+                    ))}
+                    <SelectItem value="custom">Custom date</SelectItem>
+                  </SelectContent>
+                </Select>
+                {expiryDays === "custom" && (
+                  <label className="block space-y-2 text-sm font-medium">
+                    Expiration date
+                    <Input
+                      type="date"
+                      value={customExpiry}
+                      onChange={setCustomExpiry}
+                      disabled={create.isPending}
+                    />
+                  </label>
+                )}
+                <Text small muted>
+                  Keys expire within 365 days. Custom dates use midnight in your
+                  local time zone.
+                </Text>
+              </div>
+              <TooltipProvider>
+                <SimpleTooltip
+                  tooltip={
+                    disablingReasons.length ? (
+                      <ul className="list-disc pl-4">
+                        {disablingReasons.map((reason) => (
+                          <li key={reason}>{reason}</li>
+                        ))}
+                      </ul>
+                    ) : (
+                      "Create this API key"
+                    )
+                  }
+                >
+                  <span
+                    className="inline-flex"
+                    tabIndex={disablingReasons.length ? 0 : undefined}
+                    aria-label={
+                      disablingReasons.length
+                        ? disablingReasons.join(" ")
+                        : undefined
+                    }
+                  >
+                    <Button
+                      type="submit"
+                      disabled={disablingReasons.length > 0}
+                    >
+                      {create.isPending ? "Creating…" : "Create key"}
+                    </Button>
                   </span>
-                  <Text as="span" small muted className="block">
-                    If no grants are selected, this key will not authorize any
-                    actions.
-                  </Text>
-                </span>
-              </label>
-              <Button
-                type="submit"
-                disabled={
-                  !canIssue ||
-                  create.isPending ||
-                  !name.trim() ||
-                  (delegable.isFetching && hasSelections)
-                }
-              >
-                {create.isPending ? "Creating…" : "Create key"}
-              </Button>
+                </SimpleTooltip>
+              </TooltipProvider>
             </form>
           )}
           {error && <p role="alert">{error}</p>}
@@ -488,7 +559,7 @@ function DelegableGrantSection({
     <div className="space-y-2">
       <Text muted>
         Delegable permissions could not be loaded, so none can be delegated.
-        Retry, or create a key without permissions.
+        Retry to select permissions before creating a key.
       </Text>
       <Button type="button" variant="secondary" onClick={onRetry}>
         Retry permissions

--- a/client/dashboard/src/pages/agents/AgentAPIKeys.tsx
+++ b/client/dashboard/src/pages/agents/AgentAPIKeys.tsx
@@ -206,7 +206,8 @@ function AgentAPIKeysContent({
     else if (expiresAt.getTime() <= now)
       reason = "Expiration date must be in the future.";
     else if (expiresAt.getTime() > now + maxLifetime)
-      reason = "Expiration date must be within 365 days.";
+      reason =
+        "Expiration date must be within 365 days minus a 5-minute clock-skew margin.";
     return { expiresAt, reason };
   };
   const expiryReason = expiryValidation(Date.now()).reason;

--- a/client/dashboard/src/pages/agents/AgentGrantSelector.test.tsx
+++ b/client/dashboard/src/pages/agents/AgentGrantSelector.test.tsx
@@ -15,7 +15,7 @@ vi.mock("@/contexts/Auth", () => ({
 }));
 vi.mock("@/pages/access/useOrgMcpServers", () => ({
   useOrgMcpServers: () => ({
-    isSettled: true,
+    settled: true,
     isError: false,
     refetch: vi.fn(),
     groups: [
@@ -76,6 +76,17 @@ function selection() {
 }
 
 describe("AgentGrantSelector fine-tuning", () => {
+  it("offers server narrowing from the settled inventory", () => {
+    render(
+      <Editor
+        candidate={{
+          ...grant,
+          selector: { resourceKind: "mcp", resourceId: "*" },
+        }}
+      />,
+    );
+    expect(screen.getByRole("combobox", { name: /Server/ })).toBeTruthy();
+  });
   it("reuses multi-tool selection and preserves the project ceiling without a project picker", () => {
     render(<Editor />);
     expect(screen.queryByRole("combobox", { name: /Project/ })).toBeNull();

--- a/client/dashboard/src/pages/agents/AgentGrantSelector.test.tsx
+++ b/client/dashboard/src/pages/agents/AgentGrantSelector.test.tsx
@@ -1,0 +1,128 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+import { AgentGrantSelector, type GrantNarrowings } from "./AgentGrantSelector";
+import {
+  buildRequestedGrants,
+  delegableGrantKey,
+} from "./agent-api-key-grants";
+import type { AgentPolicyGrantForm } from "@gram/client/models/components/agentpolicygrantform.js";
+
+vi.mock("@/contexts/Auth", () => ({
+  useOrganization: () => ({
+    projects: [{ id: "project_one", name: "Project one", slug: "project-one" }],
+  }),
+}));
+vi.mock("@/pages/access/useOrgMcpServers", () => ({
+  useOrgMcpServers: () => ({
+    isSettled: true,
+    isError: false,
+    refetch: vi.fn(),
+    groups: [
+      {
+        projectId: "project_one",
+        projectName: "Project one",
+        servers: [
+          {
+            id: "server_one",
+            name: "Example server",
+            slug: "example",
+            dynamicTools: false,
+            remoteBacked: false,
+            tools: [
+              { id: "search", name: "search", type: "http" },
+              { id: "fetch", name: "fetch", type: "http" },
+            ],
+          },
+        ],
+      },
+    ],
+  }),
+}));
+vi.mock("@/hooks/useToolMetadata", () => ({
+  useToolMetadata: () => ({
+    metadataByTool: {},
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  }),
+}));
+afterEach(cleanup);
+const grant: AgentPolicyGrantForm = {
+  effect: "allow",
+  scope: "mcp:connect",
+  selector: {
+    resourceKind: "mcp",
+    resourceId: "server_one",
+    projectId: "project_one",
+  },
+};
+function Editor({ candidate = grant }: { candidate?: AgentPolicyGrantForm }) {
+  const key = delegableGrantKey(candidate);
+  const [narrowings, setNarrowings] = useState<GrantNarrowings>({ [key]: {} });
+  return (
+    <>
+      <AgentGrantSelector
+        grants={[candidate]}
+        narrowings={narrowings}
+        onChange={setNarrowings}
+      />
+      <output data-testid="selection">{JSON.stringify(narrowings[key])}</output>
+    </>
+  );
+}
+function selection() {
+  return JSON.parse(screen.getByTestId("selection").textContent!);
+}
+
+describe("AgentGrantSelector fine-tuning", () => {
+  it("reuses multi-tool selection and preserves the project ceiling without a project picker", () => {
+    render(<Editor />);
+    expect(screen.queryByRole("combobox", { name: /Project/ })).toBeNull();
+    fireEvent.click(screen.getByText("search", { exact: true }));
+    fireEvent.click(screen.getByText("fetch", { exact: true }));
+    expect(selection().tools).toEqual(["search", "fetch"]);
+    expect(
+      buildRequestedGrants([{ grant, narrowing: selection() }]).map(
+        ({ selector }) => selector.projectId,
+      ),
+    ).toEqual(["project_one", "project_one"]);
+  });
+  it("selects multiple dispositions and switches away from manual tools", () => {
+    render(<Editor />);
+    fireEvent.click(screen.getByText("search", { exact: true }));
+    fireEvent.click(screen.getByRole("button", { name: /By annotation/ }));
+    fireEvent.click(screen.getByRole("checkbox", { name: /Read-only/ }));
+    fireEvent.click(screen.getByRole("checkbox", { name: /Idempotent/ }));
+    expect(selection()).toMatchObject({
+      dispositions: ["read_only", "idempotent"],
+    });
+    expect(selection().tools).toBeUndefined();
+    fireEvent.click(
+      screen.getByRole("button", { name: /Reset tool restrictions/ }),
+    );
+    expect(selection()).toEqual({});
+  });
+  it("keeps an explicit empty selection until the user resets it", () => {
+    render(<Editor />);
+    fireEvent.click(screen.getByText("search", { exact: true }));
+    fireEvent.click(screen.getByText("search", { exact: true }));
+    expect(selection().tools).toEqual([]);
+    expect(() =>
+      buildRequestedGrants([{ grant, narrowing: selection() }]),
+    ).toThrow(/at least one/);
+  });
+  it("does not offer replacing a disposition pinned by the candidate", () => {
+    render(
+      <Editor
+        candidate={{
+          ...grant,
+          selector: { ...grant.selector, disposition: "read_only" },
+        }}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /By annotation/ })).toBeNull();
+    fireEvent.click(screen.getByText("search", { exact: true }));
+    expect(selection().tools).toEqual(["search"]);
+  });
+});

--- a/client/dashboard/src/pages/agents/AgentGrantSelector.tsx
+++ b/client/dashboard/src/pages/agents/AgentGrantSelector.tsx
@@ -1,3 +1,8 @@
+import {
+  ToolSelectionPanel,
+  type ToolSelectionServer,
+} from "@/components/tool-selection/ToolSelectionPanel";
+import type { ToolAnnotation } from "@/components/tool-selection/annotations";
 import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
 import { Text } from "@/components/ui/Text";
@@ -7,7 +12,6 @@ import { useOrgMcpServers } from "@/pages/access/useOrgMcpServers";
 import { toolMetadataToServerTools } from "@/pages/access/remoteToolMetadata";
 import type { Server } from "@/pages/access/serverMerge";
 import type { AgentPolicyGrantForm } from "@gram/client/models/components/agentpolicygrantform.js";
-import type { AgentPolicySelectorDisposition } from "@gram/client/models/components/agentpolicyselector.js";
 import { useMemo, type JSX } from "react";
 
 import {
@@ -186,26 +190,13 @@ function GrantRow({
   const selected = narrowing !== undefined;
   const resolvedResourceId = narrowing?.resourceId ?? selector.resourceId;
   const entry = serverIndex.get(resolvedResourceId);
-  // A server and a project filter that name different projects produce a grant
-  // that matches nothing, so each choice constrains the other: a pinned or
-  // chosen project limits the servers, and a chosen server limits the projects.
+  // Existing project ceilings constrain inventory, but this editor never adds one.
   const projectFilter =
-    selector.projectId !== ANY_RESOURCE
-      ? (selector.projectId ?? narrowing?.projectId)
-      : narrowing?.projectId;
+    selector.projectId !== ANY_RESOURCE ? selector.projectId : undefined;
   const serversInProject = projectFilter
     ? mcpOptions.filter((option) => option.projectId === projectFilter)
     : mcpOptions;
   const resourceOptions = isMcp ? serversInProject : projectOptions;
-  // A concrete server whose inventory entry is unknown must not offer projects:
-  // any choice could contradict the server and issue a credential that matches
-  // nothing. Withhold the choice rather than guess at the server's project.
-  const serverUnknown = isMcp && resolvedResourceId !== ANY_RESOURCE && !entry;
-  const projectsForServer = serverUnknown
-    ? []
-    : entry
-      ? projectOptions.filter((option) => option.id === entry.projectId)
-      : projectOptions;
 
   const update = (patch: GrantNarrowing) =>
     onNarrow({ ...narrowing, ...patch });
@@ -232,9 +223,9 @@ function GrantRow({
           {isMcp && serversFailed && (
             <div className="space-y-1">
               <Text small muted>
-                Could not load this organization&rsquo;s MCP servers, so this
-                permission cannot be narrowed. It can still be delegated exactly
-                as listed.
+                Could not load this organization&rsquo;s MCP servers. Server and
+                specific-tool choices are unavailable. Existing policy
+                restrictions still apply.
               </Text>
               <Button
                 type="button"
@@ -257,54 +248,21 @@ function GrantRow({
               // A different server has different tools, so a tool pinned for
               // the previous one would silently stop matching.
               onChange={(value) =>
-                update({ resourceId: value || undefined, tool: undefined })
+                update({
+                  resourceId: value || undefined,
+                  tool: undefined,
+                  tools: undefined,
+                })
               }
             />
           )}
-          {open.has("tool") && isMcp && (
+          {isMcp && (open.has("tool") || open.has("disposition")) && (
             <ToolNarrowing
               entry={entry}
-              scope={grant.scope}
-              value={narrowing?.tool ?? ""}
+              grant={grant}
+              narrowing={narrowing}
               disabled={disabled}
-              onChange={(value) => update({ tool: value || undefined })}
-            />
-          )}
-          {open.has("disposition") && (
-            <NarrowingSelect
-              label="Tool disposition"
-              scope={grant.scope}
-              anyLabel="Any disposition"
-              value={narrowing?.disposition ?? ""}
-              options={Object.entries(DISPOSITION_LABELS).map(([id, name]) => ({
-                id,
-                name,
-              }))}
-              disabled={disabled}
-              onChange={(value) =>
-                update({
-                  disposition:
-                    (value as AgentPolicySelectorDisposition) || undefined,
-                })
-              }
-            />
-          )}
-          {open.has("projectId") && projectsForServer.length > 0 && (
-            <NarrowingSelect
-              label="Project"
-              scope={grant.scope}
-              anyLabel="Any project"
-              value={narrowing?.projectId ?? ""}
-              options={projectsForServer}
-              disabled={disabled}
-              onChange={(value) =>
-                update({
-                  projectId: value || undefined,
-                  ...(entry && value && entry.projectId !== value
-                    ? { resourceId: undefined, tool: undefined }
-                    : {}),
-                })
-              }
+              onChange={update}
             />
           )}
         </div>
@@ -322,17 +280,17 @@ function GrantRow({
  */
 function ToolNarrowing({
   entry,
-  scope,
-  value,
+  grant,
+  narrowing,
   disabled,
   onChange,
 }: {
   entry: ServerEntry | undefined;
-  scope: string;
-  value: string;
+  grant: AgentPolicyGrantForm;
+  narrowing: GrantNarrowing;
   disabled?: boolean;
-  onChange: (value: string) => void;
-}): JSX.Element | null {
+  onChange: (value: GrantNarrowing) => void;
+}): JSX.Element {
   const server = entry?.server;
   const remoteBacked = server?.dynamicTools === true && server.remoteBacked;
   const metadata = useToolMetadata(remoteBacked ? server.id : undefined, {
@@ -347,59 +305,115 @@ function ToolNarrowing({
       ),
     [server?.id, metadata.metadataByTool],
   );
-
-  // Without a resolved server there is no tool list to pick from; the caller
-  // narrows the server first.
-  if (!server) return null;
-  if (server.dynamicTools && !server.remoteBacked)
-    return (
+  const open = new Set(openDimensions(grant));
+  const tools = remoteBacked ? remoteTools : (server?.tools ?? []);
+  const panelServers: ToolSelectionServer[] =
+    server && open.has("tool")
+      ? [
+          {
+            id: server.id,
+            name: server.name,
+            tools: tools.map((tool) => {
+              const annotations: ToolAnnotation[] = [];
+              if (tool.annotations?.readOnlyHint) annotations.push("read_only");
+              if (tool.annotations?.destructiveHint)
+                annotations.push("destructive");
+              if (tool.annotations?.idempotentHint)
+                annotations.push("idempotent");
+              if (tool.annotations?.openWorldHint)
+                annotations.push("open_world");
+              return { name: tool.name, annotations };
+            }),
+            status: remoteBacked
+              ? metadata.isLoading
+                ? "loading"
+                : metadata.isError
+                  ? "error"
+                  : "ready"
+              : server.dynamicTools
+                ? "unavailable"
+                : "ready",
+            unavailableLabel: "Tools are discovered at runtime",
+            emptyLabel: "No tools recorded",
+            emptyContent:
+              "No tools are recorded for this server. You can still restrict tool dispositions.",
+            onRetry: metadata.refetch,
+          },
+        ]
+      : [];
+  const selectedTools =
+    narrowing.tools ?? (narrowing.tool ? [narrowing.tool] : []);
+  const selectedAnnotations =
+    narrowing.dispositions ??
+    (narrowing.disposition ? [narrowing.disposition] : []);
+  return (
+    <fieldset
+      disabled={disabled}
+      className="min-w-0 space-y-2 sm:col-span-2"
+      aria-label={`Fine-tune ${grant.scope}`}
+    >
       <Text small muted>
-        This server resolves its tools at call time, so the credential cannot be
-        narrowed to one tool.
+        Optional: select tool dispositions or specific tools. Existing policy
+        restrictions always apply.
       </Text>
-    );
-  if (remoteBacked && metadata.isLoading)
-    return (
-      <Text small muted>
-        Loading tools for this server…
-      </Text>
-    );
-  if (remoteBacked && metadata.isError)
-    return (
-      <div className="space-y-1">
+      {!server && open.has("tool") && (
         <Text small muted>
-          Could not load tools for this server, so the credential cannot be
-          narrowed to one tool.
+          Select a server to choose specific tools.
         </Text>
+      )}
+      <ToolSelectionPanel
+        servers={panelServers}
+        mode={
+          narrowing.dispositions !== undefined ||
+          narrowing.disposition ||
+          !open.has("tool") ||
+          !server
+            ? "annotations"
+            : "tools"
+        }
+        selectedAnnotations={selectedAnnotations}
+        selectedTools={selectedTools.map((toolName) => ({
+          serverId: server?.id ?? "",
+          toolName,
+        }))}
+        annotationSelectionSupported={open.has("disposition")}
+        flattenSingleServer
+        toolsTabLabel="Specific tools"
+        onSelectionChange={(change) => {
+          if (disabled) return;
+          onChange({
+            tool: undefined,
+            disposition: undefined,
+            tools:
+              change.mode === "tools"
+                ? change.tools.map((tool) => tool.toolName)
+                : undefined,
+            dispositions:
+              change.mode === "annotations" ? change.annotations : undefined,
+          });
+        }}
+      />
+      {(narrowing.tools !== undefined ||
+        narrowing.dispositions !== undefined ||
+        narrowing.tool ||
+        narrowing.disposition) && (
         <Button
           type="button"
+          variant="tertiary"
           size="sm"
-          variant="secondary"
-          onClick={metadata.refetch}
+          onClick={() =>
+            onChange({
+              tools: undefined,
+              dispositions: undefined,
+              tool: undefined,
+              disposition: undefined,
+            })
+          }
         >
-          Retry tools
+          Reset tool restrictions
         </Button>
-      </div>
-    );
-
-  const tools = remoteBacked ? remoteTools : server.tools;
-  if (tools.length === 0)
-    return (
-      <Text small muted>
-        No tools are recorded for this server, so the credential cannot be
-        narrowed to one tool.
-      </Text>
-    );
-  return (
-    <NarrowingSelect
-      label="Tool"
-      scope={scope}
-      anyLabel="Any tool"
-      value={value}
-      options={tools.map((tool) => ({ id: tool.name, name: tool.name }))}
-      disabled={disabled}
-      onChange={onChange}
-    />
+      )}
+    </fieldset>
   );
 }
 

--- a/client/dashboard/src/pages/agents/AgentPolicy.test.tsx
+++ b/client/dashboard/src/pages/agents/AgentPolicy.test.tsx
@@ -369,20 +369,15 @@ describe("Creating an agent with permissions", () => {
     ).toBeNull();
   });
 
-  it("refuses a permissionless agent until it is confirmed, then sends no grants", async () => {
+  it("creates a permissionless agent without confirmation", async () => {
     setup();
     fireEvent.change(screen.getByLabelText("Agent name"), {
       target: { value: "Bare" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Create agent" }));
-    expect(mocks.createAgent).not.toHaveBeenCalled();
-    expect(screen.getByRole("alert").textContent).toMatch(
-      /Add permissions or explicitly confirm/,
-    );
-    fireEvent.click(
-      screen.getByRole("checkbox", { name: /Create without permissions/ }),
-    );
-    fireEvent.click(screen.getByRole("button", { name: "Create agent" }));
+    expect(
+      screen.queryByRole("checkbox", { name: /Create without permissions/ }),
+    ).toBeNull();
     await waitFor(() => expect(mocks.createAgent).toHaveBeenCalledTimes(1));
     expect(createdAgentForm()).toEqual({ name: "Bare" });
   });

--- a/client/dashboard/src/pages/agents/Agents.tsx
+++ b/client/dashboard/src/pages/agents/Agents.tsx
@@ -10,7 +10,6 @@ import { Table, type Column } from "@/components/ui/Table";
 import { useSdkClient } from "@/contexts/Sdk";
 import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
-import { Checkbox } from "@/components/ui/Checkbox";
 import { Input } from "@/components/ui/Input";
 import { Label } from "@/components/ui/Label";
 import { getRBACScopeOverrideHeader } from "@/components/dev-toolbar-utils";
@@ -216,7 +215,6 @@ function CreateAgent({
 }) {
   const [name, setName] = useState("");
   const [draft, setDraft] = useState<AgentPolicyDraft>({});
-  const [withoutPermissions, setWithoutPermissions] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const organization = useOrganization();
   const { user } = useSession();
@@ -246,12 +244,6 @@ function CreateAgent({
     const trimmedName = name.trim();
     if (!trimmedName) return;
     const policyGrants = agentPolicyGrantsFromDraft(draft);
-    if (policyGrants.length === 0 && !withoutPermissions) {
-      setError(
-        "Add permissions or explicitly confirm Create without permissions.",
-      );
-      return;
-    }
     setError(null);
     create.mutate({
       request: {
@@ -308,23 +300,6 @@ function CreateAgent({
             disabled={disabled || create.isPending}
           />
         </div>
-        <label className="mt-4 flex items-start gap-2">
-          <Checkbox
-            checked={withoutPermissions}
-            onCheckedChange={(value) => setWithoutPermissions(!!value)}
-            disabled={disabled || create.isPending}
-            className="mt-0.5"
-          />
-          <span className="min-w-0 flex-1">
-            <span className="block text-sm font-medium">
-              Create without permissions
-            </span>
-            <Text as="span" small muted className="block">
-              Only needed if you leave the list above empty. You can add
-              permissions later.
-            </Text>
-          </span>
-        </label>
         {error && (
           <p role="alert" className="mt-4 text-sm">
             {error}

--- a/client/dashboard/src/pages/agents/agent-api-key-grants.test.ts
+++ b/client/dashboard/src/pages/agents/agent-api-key-grants.test.ts
@@ -36,11 +36,7 @@ const pinnedTool = policyGrant("grant_tool", "mcp:write", {
 
 describe("delegated grant narrowing", () => {
   it("offers only the dimensions the server accepts for the resource kind", () => {
-    expect(openDimensions(anyServer)).toEqual([
-      "projectId",
-      "disposition",
-      "tool",
-    ]);
+    expect(openDimensions(anyServer)).toEqual(["disposition", "tool"]);
     expect(
       openDimensions(
         policyGrant("grant_env", "environment:read", {
@@ -48,7 +44,7 @@ describe("delegated grant narrowing", () => {
           resourceId: "env_one",
         }),
       ),
-    ).toEqual(["projectId"]);
+    ).toEqual([]);
     expect(
       openDimensions(
         policyGrant("grant_project", "project:read", {
@@ -59,7 +55,7 @@ describe("delegated grant narrowing", () => {
     ).toEqual([]);
   });
   it("never offers a dimension the candidate pins to a concrete value", () => {
-    expect(openDimensions(pinnedTool)).toEqual(["projectId", "disposition"]);
+    expect(openDimensions(pinnedTool)).toEqual(["disposition"]);
   });
   it("treats a wildcard dimension as narrowable, not as pinned", () => {
     const wildcardDimensions = policyGrant("grant_wild", "mcp:connect", {
@@ -68,11 +64,7 @@ describe("delegated grant narrowing", () => {
       tool: "*",
       projectId: "*",
     });
-    expect(openDimensions(wildcardDimensions)).toEqual([
-      "projectId",
-      "disposition",
-      "tool",
-    ]);
+    expect(openDimensions(wildcardDimensions)).toEqual(["disposition", "tool"]);
     const [form] = buildRequestedGrants([
       {
         grant: wildcardDimensions,
@@ -83,7 +75,7 @@ describe("delegated grant narrowing", () => {
       resourceKind: "mcp",
       resourceId: "server_one",
       tool: "search",
-      projectId: "project_one",
+      projectId: "*",
     });
     expect(
       requestNarrowsPolicy(wildcardDimensions.selector, form!.selector),
@@ -123,7 +115,6 @@ describe("delegated grant narrowing", () => {
             resourceId: "server_one",
             tool: "search",
             disposition: "read_only",
-            projectId: "project_one",
           },
         },
       ]),
@@ -136,7 +127,6 @@ describe("delegated grant narrowing", () => {
           resourceId: "server_one",
           tool: "search",
           disposition: "read_only",
-          projectId: "project_one",
         },
       },
     ]);
@@ -153,6 +143,84 @@ describe("delegated grant narrowing", () => {
       resourceId: "server_one",
       tool: "search",
     });
+  });
+  it("expands multiple tools and dispositions as intersecting unions", () => {
+    const forms = buildRequestedGrants([
+      {
+        grant: anyServer,
+        narrowing: {
+          tools: ["search", "fetch"],
+          dispositions: ["read_only", "idempotent"],
+        },
+      },
+    ]);
+    expect(
+      forms.map(({ selector }) => [selector.tool, selector.disposition]),
+    ).toEqual([
+      ["search", "read_only"],
+      ["search", "idempotent"],
+      ["fetch", "read_only"],
+      ["fetch", "idempotent"],
+    ]);
+  });
+  it("preserves every candidate ceiling while expanding and ignores new project narrowing", () => {
+    const grant = policyGrant("restricted", "mcp:connect", {
+      resourceKind: "mcp",
+      resourceId: "server_one",
+      projectId: "project_one",
+      tool: "search",
+      serverIdentity: "identity",
+      serverUrl: "https://example.com/mcp",
+    });
+    const forms = buildRequestedGrants([
+      {
+        grant,
+        narrowing: {
+          resourceId: "other",
+          projectId: "other",
+          tools: ["delete", "fetch"],
+          dispositions: ["read_only", "idempotent"],
+        },
+      },
+    ]);
+    expect(forms).toHaveLength(2);
+    for (const form of forms) {
+      expect(form.selector).toMatchObject(grant.selector);
+      expect(requestNarrowsPolicy(grant.selector, form.selector)).toBe(true);
+    }
+    expect(
+      buildRequestedGrants([
+        { grant: anyServer, narrowing: { projectId: "other" } },
+      ])[0]?.selector.projectId,
+    ).toBeUndefined();
+  });
+  it("does not turn empty selections or deny grants into unrestricted allows", () => {
+    expect(() =>
+      buildRequestedGrants([{ grant: anyServer, narrowing: { tools: [] } }]),
+    ).toThrow(/at least one/);
+    expect(() =>
+      buildRequestedGrants([
+        { grant: anyServer, narrowing: { dispositions: [] } },
+      ]),
+    ).toThrow(/at least one/);
+    expect(() =>
+      buildRequestedGrants([
+        {
+          grant: {
+            ...anyServer,
+            effect: "deny",
+          } as unknown as typeof anyServer,
+          narrowing: {},
+        },
+      ]),
+    ).toThrow(/Only allowed/);
+  });
+  it("deduplicates repeated values within one multi-selection", () => {
+    expect(
+      buildRequestedGrants([
+        { grant: anyServer, narrowing: { tools: ["search", "search"] } },
+      ]),
+    ).toHaveLength(1);
   });
   it("rejects a request the live policy grant would not cover", () => {
     expect(

--- a/client/dashboard/src/pages/agents/agent-api-key-grants.ts
+++ b/client/dashboard/src/pages/agents/agent-api-key-grants.ts
@@ -8,23 +8,25 @@ import type {
 export const ANY_RESOURCE = "*";
 
 /**
- * The dimensions a delegated request may pin on top of a policy grant.
- * Mirrors allowedSelectorKeys in server/internal/authz/selector.go — the
- * server rejects any other key, so the editor never offers one.
+ * The dimensions API keys may add on top of a policy grant. This is a subset
+ * of allowedSelectorKeys in server/internal/authz/selector.go: keys never add
+ * project narrowing, but must preserve any project restriction already present.
  */
 const NARROWABLE_BY_KIND: Record<string, NarrowingDimension[]> = {
-  mcp: ["projectId", "disposition", "tool"],
-  environment: ["projectId"],
+  mcp: ["disposition", "tool"],
 };
 
-export type NarrowingDimension = "projectId" | "disposition" | "tool";
+export type NarrowingDimension = "disposition" | "tool";
 
 /** Which inventory names the resources a selector of this kind identifies. */
 export type ResourceInventory = "mcp" | "project";
 
 export interface GrantNarrowing {
   resourceId?: string;
+  /** Legacy editor state: ignored; candidate project restrictions are preserved. */
   projectId?: string;
+  tools?: string[];
+  dispositions?: AgentPolicySelectorDisposition[];
   disposition?: AgentPolicySelectorDisposition;
   tool?: string;
 }
@@ -105,23 +107,49 @@ export function requestNarrowsPolicy(
   );
 }
 
-function buildRequestedGrant(selection: GrantSelection): AgentPolicyGrantForm {
+function expandRequestedGrants(
+  selection: GrantSelection,
+): AgentPolicyGrantForm[] {
   const { grant, narrowing } = selection;
+  if (grant.effect !== "allow") {
+    throw new Error("Only allowed permissions can be delegated.");
+  }
   const selector: AgentPolicySelector = { ...grant.selector };
   if (narrowing.resourceId && canNarrowResource(grant)) {
     selector.resourceId = narrowing.resourceId;
   }
   const open = new Set(openDimensions(grant));
-  if (open.has("projectId") && narrowing.projectId) {
-    selector.projectId = narrowing.projectId;
+  // Each axis is a union; combining axes intersects them. Always clone the
+  // complete candidate so project, tool, server identity and other ceilings
+  // survive expansion. Legacy scalar state remains supported.
+  const tools = open.has("tool")
+    ? (narrowing.tools ?? (narrowing.tool ? [narrowing.tool] : undefined))
+    : undefined;
+  const dispositions = open.has("disposition")
+    ? (narrowing.dispositions ??
+      (narrowing.disposition ? [narrowing.disposition] : undefined))
+    : undefined;
+  // An explicit empty selection must not silently become unrestricted.
+  if (
+    tools?.length === 0 ||
+    dispositions?.length === 0 ||
+    tools?.some((tool) => !tool)
+  ) {
+    throw new Error(
+      "Select at least one tool or disposition, or reset the permission.",
+    );
   }
-  if (open.has("disposition") && narrowing.disposition) {
-    selector.disposition = narrowing.disposition;
-  }
-  if (open.has("tool") && narrowing.tool) {
-    selector.tool = narrowing.tool;
-  }
-  return { effect: "allow", scope: grant.scope, selector };
+  return [...new Set(tools ?? [undefined])].flatMap((tool) =>
+    [...new Set(dispositions ?? [undefined])].map((disposition) => ({
+      effect: grant.effect,
+      scope: grant.scope,
+      selector: {
+        ...selector,
+        ...(tool ? { tool } : {}),
+        ...(disposition ? { disposition } : {}),
+      },
+    })),
+  );
 }
 
 /**
@@ -157,20 +185,21 @@ export function buildRequestedGrants(
   const forms: AgentPolicyGrantForm[] = [];
   const seen = new Set<string>();
   for (const selection of selections) {
-    const form = buildRequestedGrant(selection);
-    if (!requestNarrowsPolicy(selection.grant.selector, form.selector)) {
-      throw new Error(
-        "A requested permission is broader than the agent policy allows. Reset it and try again.",
-      );
+    for (const form of expandRequestedGrants(selection)) {
+      if (!requestNarrowsPolicy(selection.grant.selector, form.selector)) {
+        throw new Error(
+          "A requested permission is broader than the agent policy allows. Reset it and try again.",
+        );
+      }
+      const identity = delegableGrantKey(form);
+      if (seen.has(identity)) {
+        throw new Error(
+          "Two requested permissions are identical. Narrow or remove one of them.",
+        );
+      }
+      seen.add(identity);
+      forms.push(form);
     }
-    const identity = delegableGrantKey(form);
-    if (seen.has(identity)) {
-      throw new Error(
-        "Two requested permissions are identical. Narrow or remove one of them.",
-      );
-    }
-    seen.add(identity);
-    forms.push(form);
   }
   return forms;
 }


### PR DESCRIPTION
## Summary
Simplify agent creation and require a valid name plus at least one permission when issuing agent API keys, with a tooltip that lists all blocking reasons. Add expiry presets and a custom date option, defaulting to 90 days and respecting the existing one-year backend limit. Reuse the access-rule tool selection panel for multi-tool and annotation selection, and remove additional project narrowing from the key form.

## Motivation
The empty-permissions confirmation is unnecessary for agents that can be configured immediately after creation, while permissionless keys are not useful in the creation UI. Single-choice tool controls and independent project narrowing make it too easy to create unusable credentials.

## Technical details
Selected tools and dispositions expand into delegated grants without broadening the candidate permissions; inherited project restrictions remain intact. Custom dates expire at local midnight. Backend behavior and regular API key creation remain unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Agent API key creation now requires at least one permission and a valid name, with a tooltip explaining every blocking reason. Adds expiry presets plus a custom date option (defaulting to 90 days, capped at 365), and reuses the multi-tool selection panel for tool and annotation choices instead of single-choice dropdowns.

**Behavior changes**
- Removes the "Create without permissions" bypass from both key issuance and agent creation.
- Drops project narrowing from the key form; inherited project restrictions still apply.
- Custom expiry dates use local midnight and must fall within 365 days minus a 5-minute clock-skew margin.

**Grant expansion**
- Selected tools and dispositions expand into intersecting union grants without broadening candidate permissions.
- Empty tool or disposition selections now throw instead of silently becoming unrestricted allows; deny grants are rejected outright.

<sup>Written for commit 03ffc55a9f48781213a85f413095b7a44848888a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

