### PR TITLE
chore: sample successful HTTP response logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,7 @@ require (
 	github.com/robfig/cron v1.2.0
 	github.com/samber/lo v1.53.0
 	github.com/samber/slog-multi v1.8.0
+	github.com/samber/slog-sampling v1.7.0
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/sourcegraph/conc v0.3.0
 	github.com/speakeasy-api/agenthooks v0.7.3
@@ -161,6 +162,7 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect
+	github.com/bluele/gcache v0.0.2 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
 	github.com/bodgit/plumbing v1.3.0 // indirect
 	github.com/bodgit/sevenzip v1.6.0 // indirect
@@ -178,6 +180,7 @@ require (
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
+	github.com/cornelk/hashmap v1.0.8 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -283,7 +286,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
-	github.com/samber/slog-common v0.21.0 // indirect
+	github.com/samber/slog-common v0.22.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLj
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
+github.com/bluele/gcache v0.0.2 h1:WcbfdXICg7G/DGBh1PFfcirkWOQV+v077yF1pSy3DGw=
+github.com/bluele/gcache v0.0.2/go.mod h1:m15KV+ECjptwSPxKhOhQoAFQVtUFjTVkc3H8o0t/fp0=
 github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bodgit/plumbing v1.3.0 h1:pf9Itz1JOQgn7vEOE7v7nlEfBykYqvUYioC61TwWCFU=
@@ -218,6 +220,8 @@ github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7np
 github.com/coreos/go-oidc/v3 v3.18.0 h1:V9orjXynvu5wiC9SemFTWnG4F45v403aIcjWo0d41+A=
 github.com/coreos/go-oidc/v3 v3.18.0/go.mod h1:DYCf24+ncYi+XkIH97GY1+dqoRlbaSI26KVTCI9SrY4=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/cornelk/hashmap v1.0.8 h1:nv0AWgw02n+iDcawr5It4CjQIAcdMMKRrs10HOJYlrc=
+github.com/cornelk/hashmap v1.0.8/go.mod h1:RfZb7JO3RviW/rT6emczVuC/oxpdz4UsSB2LJSclR1k=
 github.com/cpuguy83/dockercfg v0.3.2 h1:DlJTyZGBDlXqUZ2Dk2Q3xHs/FtnooJJVaad2S9GKorA=
 github.com/cpuguy83/dockercfg v0.3.2/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
 github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
@@ -668,10 +672,12 @@ github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6g
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
 github.com/samber/lo v1.53.0 h1:t975lj2py4kJPQ6haz1QMgtId2gtmfktACxIXArw3HM=
 github.com/samber/lo v1.53.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
-github.com/samber/slog-common v0.21.0 h1:Wo2hTly1Br5RjYqX/BTWJJeDnTE85oWk/7vqlpZuAUc=
-github.com/samber/slog-common v0.21.0/go.mod h1:d/6OaSlzdkl9PFpfRLgn8FwY1OW6EFmPtBpsHX4MrU0=
+github.com/samber/slog-common v0.22.0 h1:WyPxYRg/c5xUmxZJbtd0QgysHlLBhRA+MngKdJieHxE=
+github.com/samber/slog-common v0.22.0/go.mod h1:d/6OaSlzdkl9PFpfRLgn8FwY1OW6EFmPtBpsHX4MrU0=
 github.com/samber/slog-multi v1.8.0 h1:E05c1wnQ+8M58oQDBABlJ4TEIJWssNgtckso3zlaLlI=
 github.com/samber/slog-multi v1.8.0/go.mod h1:6+3j/ILxDvAcLD75YdQAm6iKWu6AmwlohLgQxL/2aiI=
+github.com/samber/slog-sampling v1.7.0 h1:IGP4Xq6xEbnTeSEZ9wIFT59Avli8t4jzXOLvVdH2dAw=
+github.com/samber/slog-sampling v1.7.0/go.mod h1:YLXdr2urJxakdEHriRsPyIGHU6aW9KjEvImOzgkVhsM=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=

--- a/mise.toml
+++ b/mise.toml
@@ -228,6 +228,7 @@ LOKI_HTTP_PORT = "13100"
 PROMETHEUS_PORT = "9099"
 LITELLM_PORT = "4001"
 GRAM_LOG_PRETTY = { default = "1" }
+GRAM_LOG_SAMPLING = { default = "false" }
 ## Default Gram API URL baked into the dashboard's inlined Elements code and
 ## used by the CLI to point to the correct Gram API server
 GRAM_API_URL = "{{env.GRAM_SERVER_URL}}"

--- a/server/cmd/gram/root.go
+++ b/server/cmd/gram/root.go
@@ -36,6 +36,12 @@ func newApp() *cli.App {
 				Usage:   "Enable pretty logging",
 				EnvVars: []string{"GRAM_LOG_PRETTY"},
 			},
+			&cli.BoolFlag{
+				Name:    "log-sampling",
+				Value:   true,
+				Usage:   "Sample successful HTTP response logs",
+				EnvVars: []string{"GRAM_LOG_SAMPLING"},
+			},
 		},
 		Commands: []*cli.Command{
 			newStartCommand(),
@@ -56,9 +62,10 @@ func newApp() *cli.App {
 			})
 
 			logger := slog.New(o11y.NewLogHandler(&o11y.LogHandlerOptions{
-				RawLevel:    c.String("log-level"),
-				Pretty:      c.Bool("log-pretty"),
-				DataDogAttr: os.Getenv("DD_SERVICE") != "",
+				RawLevel:        c.String("log-level"),
+				Pretty:          c.Bool("log-pretty"),
+				DataDogAttr:     os.Getenv("DD_SERVICE") != "",
+				SamplingEnabled: c.Bool("log-sampling"),
 			})).With(
 				attr.SlogDataDogGitCommitSHA(GitSHA),
 				attr.SlogDataDogGitRepoURL("github.com/speakeasy-api/gram"),

--- a/server/cmd/workos-backfill/main.go
+++ b/server/cmd/workos-backfill/main.go
@@ -282,9 +282,10 @@ func validateOptions(opts options) error {
 
 func run(ctx context.Context, opts options) error {
 	logger := slog.New(o11y.NewLogHandler(&o11y.LogHandlerOptions{
-		RawLevel:    "info",
-		Pretty:      true,
-		DataDogAttr: false,
+		RawLevel:        "info",
+		Pretty:          true,
+		DataDogAttr:     false,
+		SamplingEnabled: false,
 	}))
 
 	if opts.environment == envProd {

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -21,6 +21,9 @@ const (
 
 	WideEventKey = attribute.Key("gram.wide_event")
 
+	// LogsSamplingBucketKey opts an operational log into a registered sampling policy.
+	LogsSamplingBucketKey = attribute.Key("gram.logs.sampling_bucket")
+
 	ErrorIDKey                       = attribute.Key("error.id")
 	ErrorMessageKey                  = attribute.Key("error.message")
 	ErrorStackKey                    = attribute.Key("error.stack")
@@ -804,10 +807,17 @@ const (
 
 const (
 	VisibilityInternalValue = "internal"
+
+	// LogsSamplingBucketHTTPResponseSuccess samples completed successful HTTP responses.
+	LogsSamplingBucketHTTPResponseSuccess = "http.response.success"
 )
 
 func WideEvent() attribute.KeyValue { return WideEventKey.Bool(true) }
 func SlogWideEvent() slog.Attr      { return slog.Bool(string(WideEventKey), true) }
+
+func SlogLogsSamplingBucket(v string) slog.Attr {
+	return slog.String(string(LogsSamplingBucketKey), v)
+}
 
 func Error(v error) attribute.KeyValue { return ErrorMessageKey.String(v.Error()) }
 func SlogError(v error) slog.Attr      { return slog.String(string(ErrorMessageKey), v.Error()) }

--- a/server/internal/middleware/logging.go
+++ b/server/internal/middleware/logging.go
@@ -323,6 +323,10 @@ func NewHTTPLoggingMiddleware(logger *slog.Logger) func(next http.Handler) http.
 				attr.SlogHTTPServerRequestDuration(time.Since(start).Seconds()),
 			}
 
+			if code >= http.StatusOK && code < http.StatusBadRequest {
+				responseAttrs = append(responseAttrs, attr.SlogLogsSamplingBucket(attr.LogsSamplingBucketHTTPResponseSuccess))
+			}
+
 			if code != rw.statusCode {
 				responseAttrs = append(responseAttrs, attr.SlogHTTPResponseOriginalStatusCode(rw.statusCode))
 			}

--- a/server/internal/o11y/sampling.go
+++ b/server/internal/o11y/sampling.go
@@ -1,0 +1,173 @@
+package o11y
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"slices"
+	"time"
+
+	slogsampling "github.com/samber/slog-sampling"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+)
+
+// samplingHandler routes only explicitly eligible operational events through
+// the sampler. Both branches use the same sink; child handlers share the
+// upstream sampling state but retain independent inherited attribute metadata.
+type samplingHandler struct {
+	next    slog.Handler
+	sampled slog.Handler
+	attrs   samplingAttributes
+}
+
+type samplingAttributes struct {
+	bucket   string
+	invalid  bool
+	hasError bool
+}
+
+var _ slog.Handler = (*samplingHandler)(nil)
+
+func newSamplingHandler(next slog.Handler, rate float64) slog.Handler {
+	// Only the registered HTTP success bucket reaches this sampler. MatchAll
+	// therefore needs one counter regardless of incoming attribute cardinality.
+	// Keep the initial burst, then retain each event with the given probability.
+	options := slogsampling.ThresholdSamplingOption{
+		Tick:                time.Minute,
+		Threshold:           10,
+		Rate:                rate,
+		Matcher:             slogsampling.MatchAll(),
+		Buffer:              nil,
+		OnAccepted:          nil,
+		OnDropped:           nil,
+		IncludeDroppedCount: false,
+	}
+	return &samplingHandler{
+		next:    next,
+		sampled: options.NewMiddleware()(next),
+		attrs:   samplingAttributes{bucket: "", invalid: false, hasError: false},
+	}
+}
+
+func (h *samplingHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.next.Enabled(ctx, level)
+}
+
+func (h *samplingHandler) Handle(ctx context.Context, record slog.Record) error {
+	if record.Level >= slog.LevelWarn || h.attrs.hasError || h.attrs.invalid {
+		if err := h.next.Handle(ctx, record); err != nil {
+			return fmt.Errorf("sampling handler: handle protected record: %w", err)
+		}
+		return nil
+	}
+
+	metadata := h.attrs
+	var resolved []slog.Attr
+	index := 0
+	record.Attrs(func(a slog.Attr) bool {
+		normalized, changed := metadata.inspect(a)
+		if changed && resolved == nil {
+			// Ordinary scalar attributes need no copy. Freeze LogValuer results
+			// only when present, so the sink sees the values used for eligibility.
+			resolved = make([]slog.Attr, 0, record.NumAttrs())
+			record.Attrs(func(original slog.Attr) bool {
+				resolved = append(resolved, original)
+				return true
+			})
+		}
+		if resolved != nil {
+			resolved[index] = normalized
+		}
+		index++
+		return !metadata.hasError && !metadata.invalid
+	})
+
+	if resolved != nil {
+		record = slog.NewRecord(record.Time, record.Level, record.Message, record.PC)
+		record.AddAttrs(resolved...)
+	}
+	handler := h.next
+	if !metadata.hasError && !metadata.invalid && metadata.bucket == attr.LogsSamplingBucketHTTPResponseSuccess {
+		handler = h.sampled
+	}
+	if err := handler.Handle(ctx, record); err != nil {
+		return fmt.Errorf("sampling handler: handle record: %w", err)
+	}
+	return nil
+}
+
+func (h *samplingHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	metadata := h.attrs
+	normalized := attrs
+	copied := false
+	for i, a := range attrs {
+		resolved, changed := metadata.inspect(a)
+		if changed && !copied {
+			normalized = slices.Clone(attrs)
+			copied = true
+		}
+		if copied {
+			normalized[i] = resolved
+		}
+	}
+	return &samplingHandler{
+		next:    h.next.WithAttrs(normalized),
+		sampled: h.sampled.WithAttrs(normalized),
+		attrs:   metadata,
+	}
+}
+
+func (h *samplingHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	return &samplingHandler{
+		next:    h.next.WithGroup(name),
+		sampled: h.sampled.WithGroup(name),
+		attrs:   h.attrs,
+	}
+}
+
+// inspect recognizes reserved keys at any group depth. Conflicting or malformed
+// markers fail open; an error key always wins, even when its value is empty.
+// Resolved values are returned without modifying caller-owned groups.
+func (m *samplingAttributes) inspect(a slog.Attr) (slog.Attr, bool) {
+	if a.Key == string(attr.ErrorMessageKey) {
+		m.hasError = true
+		return a, false
+	}
+
+	changed := a.Value.Kind() == slog.KindLogValuer
+	if changed {
+		a.Value = a.Value.Resolve()
+	}
+	if a.Key == string(attr.LogsSamplingBucketKey) {
+		if a.Value.Kind() != slog.KindString || a.Value.String() == "" {
+			m.invalid = true
+		} else if m.bucket != "" && m.bucket != a.Value.String() {
+			m.invalid = true
+		} else {
+			m.bucket = a.Value.String()
+		}
+	}
+
+	if a.Value.Kind() == slog.KindGroup {
+		group := a.Value.Group()
+		var normalized []slog.Attr
+		for i, child := range group {
+			resolved, childChanged := m.inspect(child)
+			if childChanged && normalized == nil {
+				normalized = slices.Clone(group)
+			}
+			if normalized != nil {
+				normalized[i] = resolved
+			}
+		}
+		if normalized != nil {
+			a.Value = slog.GroupValue(normalized...)
+			changed = true
+		}
+	}
+	return a, changed
+}

--- a/server/internal/o11y/sampling.go
+++ b/server/internal/o11y/sampling.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"time"
 
+	slogmulti "github.com/samber/slog-multi"
 	slogsampling "github.com/samber/slog-sampling"
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
@@ -17,7 +18,11 @@ import (
 type samplingHandler struct {
 	next    slog.Handler
 	sampled slog.Handler
-	attrs   samplingAttributes
+
+	// middleware owns the shared sampler state and wraps each derived sink once.
+	middleware slogmulti.Middleware
+
+	attrs samplingAttributes
 }
 
 type samplingAttributes struct {
@@ -42,10 +47,12 @@ func newSamplingHandler(next slog.Handler, rate float64) slog.Handler {
 		OnDropped:           nil,
 		IncludeDroppedCount: false,
 	}
+	middleware := options.NewMiddleware()
 	return &samplingHandler{
-		next:    next,
-		sampled: options.NewMiddleware()(next),
-		attrs:   samplingAttributes{bucket: "", invalid: false, hasError: false},
+		next:       next,
+		sampled:    middleware(next),
+		middleware: middleware,
+		attrs:      samplingAttributes{bucket: "", invalid: false, hasError: false},
 	}
 }
 
@@ -85,10 +92,12 @@ func (h *samplingHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 			return h.next.WithAttrs(attrs)
 		}
 	}
+	next := h.next.WithAttrs(attrs)
 	return &samplingHandler{
-		next:    h.next.WithAttrs(attrs),
-		sampled: h.sampled.WithAttrs(attrs),
-		attrs:   metadata,
+		next:       next,
+		sampled:    h.middleware(next),
+		middleware: h.middleware,
+		attrs:      metadata,
 	}
 }
 

--- a/server/internal/o11y/sampling.go
+++ b/server/internal/o11y/sampling.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"slices"
 	"time"
 
 	slogsampling "github.com/samber/slog-sampling"
@@ -55,7 +54,7 @@ func (h *samplingHandler) Enabled(ctx context.Context, level slog.Level) bool {
 }
 
 func (h *samplingHandler) Handle(ctx context.Context, record slog.Record) error {
-	if record.Level >= slog.LevelWarn || h.attrs.hasError || h.attrs.invalid {
+	if record.Level >= slog.LevelWarn {
 		if err := h.next.Handle(ctx, record); err != nil {
 			return fmt.Errorf("sampling handler: handle protected record: %w", err)
 		}
@@ -63,30 +62,11 @@ func (h *samplingHandler) Handle(ctx context.Context, record slog.Record) error 
 	}
 
 	metadata := h.attrs
-	var resolved []slog.Attr
-	index := 0
 	record.Attrs(func(a slog.Attr) bool {
-		normalized, changed := metadata.inspect(a)
-		if changed && resolved == nil {
-			// Ordinary scalar attributes need no copy. Freeze LogValuer results
-			// only when present, so the sink sees the values used for eligibility.
-			resolved = make([]slog.Attr, 0, record.NumAttrs())
-			record.Attrs(func(original slog.Attr) bool {
-				resolved = append(resolved, original)
-				return true
-			})
-		}
-		if resolved != nil {
-			resolved[index] = normalized
-		}
-		index++
+		metadata.inspect(a)
 		return !metadata.hasError && !metadata.invalid
 	})
 
-	if resolved != nil {
-		record = slog.NewRecord(record.Time, record.Level, record.Message, record.PC)
-		record.AddAttrs(resolved...)
-	}
 	handler := h.next
 	if !metadata.hasError && !metadata.invalid && metadata.bucket == attr.LogsSamplingBucketHTTPResponseSuccess {
 		handler = h.sampled
@@ -99,21 +79,15 @@ func (h *samplingHandler) Handle(ctx context.Context, record slog.Record) error 
 
 func (h *samplingHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	metadata := h.attrs
-	normalized := attrs
-	copied := false
-	for i, a := range attrs {
-		resolved, changed := metadata.inspect(a)
-		if changed && !copied {
-			normalized = slices.Clone(attrs)
-			copied = true
-		}
-		if copied {
-			normalized[i] = resolved
+	for _, a := range attrs {
+		metadata.inspect(a)
+		if metadata.hasError || metadata.invalid {
+			return h.next.WithAttrs(attrs)
 		}
 	}
 	return &samplingHandler{
-		next:    h.next.WithAttrs(normalized),
-		sampled: h.sampled.WithAttrs(normalized),
+		next:    h.next.WithAttrs(attrs),
+		sampled: h.sampled.WithAttrs(attrs),
 		attrs:   metadata,
 	}
 }
@@ -122,28 +96,23 @@ func (h *samplingHandler) WithGroup(name string) slog.Handler {
 	if name == "" {
 		return h
 	}
-	return &samplingHandler{
-		next:    h.next.WithGroup(name),
-		sampled: h.sampled.WithGroup(name),
-		attrs:   h.attrs,
-	}
+	return h.next.WithGroup(name)
 }
 
-// inspect recognizes reserved keys at any group depth. Conflicting or malformed
-// markers fail open; an error key always wins, even when its value is empty.
-// Resolved values are returned without modifying caller-owned groups.
-func (m *samplingAttributes) inspect(a slog.Attr) (slog.Attr, bool) {
-	if a.Key == string(attr.ErrorMessageKey) {
+// inspect only examines flat attributes. Groups and LogValuer values bypass
+// sampling without traversal or resolution: they can hide error attributes.
+// Conflicting or malformed markers also retain the event.
+func (m *samplingAttributes) inspect(a slog.Attr) {
+	kind := a.Value.Kind()
+	if kind == slog.KindGroup || kind == slog.KindLogValuer {
+		m.invalid = true
+		return
+	}
+	switch a.Key {
+	case string(attr.ErrorMessageKey):
 		m.hasError = true
-		return a, false
-	}
-
-	changed := a.Value.Kind() == slog.KindLogValuer
-	if changed {
-		a.Value = a.Value.Resolve()
-	}
-	if a.Key == string(attr.LogsSamplingBucketKey) {
-		if a.Value.Kind() != slog.KindString || a.Value.String() == "" {
+	case string(attr.LogsSamplingBucketKey):
+		if kind != slog.KindString || a.Value.String() == "" {
 			m.invalid = true
 		} else if m.bucket != "" && m.bucket != a.Value.String() {
 			m.invalid = true
@@ -151,23 +120,4 @@ func (m *samplingAttributes) inspect(a slog.Attr) (slog.Attr, bool) {
 			m.bucket = a.Value.String()
 		}
 	}
-
-	if a.Value.Kind() == slog.KindGroup {
-		group := a.Value.Group()
-		var normalized []slog.Attr
-		for i, child := range group {
-			resolved, childChanged := m.inspect(child)
-			if childChanged && normalized == nil {
-				normalized = slices.Clone(group)
-			}
-			if normalized != nil {
-				normalized[i] = resolved
-			}
-		}
-		if normalized != nil {
-			a.Value = slog.GroupValue(normalized...)
-			changed = true
-		}
-	}
-	return a, changed
 }

--- a/server/internal/o11y/sampling_test.go
+++ b/server/internal/o11y/sampling_test.go
@@ -1,0 +1,313 @@
+package o11y
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	slogmulti "github.com/samber/slog-multi"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+)
+
+const (
+	samplingBucketKey    = string(attr.LogsSamplingBucketKey)
+	samplingFailureGroup = "failure"
+	samplingHTTPGroup    = "http"
+	samplingInlineGroup  = ""
+	samplingBranchKey    = "branch"
+	samplingInheritedKey = "inherited"
+	samplingRecordKey    = "record"
+	samplingWriterKey    = "writer"
+)
+
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	n, err := b.buf.Write(p)
+	if err != nil {
+		return n, fmt.Errorf("capture log output: %w", err)
+	}
+	return n, nil
+}
+
+func (b *lockedBuffer) Bytes() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return bytes.Clone(b.buf.Bytes())
+}
+
+func newCaptureHandler(buf *lockedBuffer) slog.Handler {
+	return slog.NewJSONHandler(buf, &slog.HandlerOptions{
+		AddSource:   false,
+		Level:       slog.LevelDebug,
+		ReplaceAttr: nil,
+	})
+}
+
+func capturedRecords(t *testing.T, buf *lockedBuffer) []map[string]any {
+	t.Helper()
+
+	lines := bytes.Split(bytes.TrimSpace(buf.Bytes()), []byte("\n"))
+	if len(lines) == 1 && len(lines[0]) == 0 {
+		return nil
+	}
+
+	records := make([]map[string]any, 0, len(lines))
+	for _, line := range lines {
+		var record map[string]any
+		require.NoError(t, json.Unmarshal(line, &record))
+		records = append(records, record)
+	}
+	return records
+}
+
+func capturedMessages(t *testing.T, buf *lockedBuffer) []string {
+	t.Helper()
+
+	records := capturedRecords(t, buf)
+	messages := make([]string, 0, len(records))
+	for _, record := range records {
+		message, ok := record[slog.MessageKey].(string)
+		require.True(t, ok)
+		messages = append(messages, message)
+	}
+	return messages
+}
+
+func TestSamplingHandlerExhaustsBurstAndResetsAfterMinute(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		var output lockedBuffer
+		logger := slog.New(newSamplingHandler(newCaptureHandler(&output), 0))
+
+		for range 11 {
+			logger.InfoContext(t.Context(), "successful response", attr.SlogLogsSamplingBucket(attr.LogsSamplingBucketHTTPResponseSuccess))
+		}
+		require.Len(t, capturedRecords(t, &output), 10)
+
+		time.Sleep(time.Minute) //nolint:forbidigo // Advances the fake clock inside the synctest bubble.
+		logger.InfoContext(t.Context(), "after reset", attr.SlogLogsSamplingBucket(attr.LogsSamplingBucketHTTPResponseSuccess))
+
+		messages := capturedMessages(t, &output)
+		require.Len(t, messages, 11)
+		for _, message := range messages[:10] {
+			require.Equal(t, "successful response", message)
+		}
+		require.Equal(t, "after reset", messages[10])
+	})
+}
+
+func TestSamplingHandlerRetainsRecordsWithoutOneValidKnownMarker(t *testing.T) {
+	t.Parallel()
+
+	var output lockedBuffer
+	logger := slog.New(newSamplingHandler(newCaptureHandler(&output), 0))
+	for range 11 {
+		logger.InfoContext(t.Context(), "sampled", attr.SlogLogsSamplingBucket(attr.LogsSamplingBucketHTTPResponseSuccess))
+	}
+
+	logger.InfoContext(t.Context(), "unmarked")
+	logger.InfoContext(t.Context(), "empty marker", attr.SlogLogsSamplingBucket(""))
+	logger.InfoContext(t.Context(), "unknown marker", attr.SlogLogsSamplingBucket("http.response.redirect"))
+	logger.InfoContext(t.Context(), "invalid marker", slog.Int(samplingBucketKey, 1))
+	logger.InfoContext(t.Context(), "conflicting markers",
+		attr.SlogLogsSamplingBucket(attr.LogsSamplingBucketHTTPResponseSuccess),
+		attr.SlogLogsSamplingBucket("http.response.redirect"),
+	)
+
+	messages := capturedMessages(t, &output)
+	require.Len(t, messages, 15)
+	require.Equal(t, []string{
+		"unmarked", "empty marker", "unknown marker", "invalid marker", "conflicting markers",
+	}, messages[len(messages)-5:])
+}
+
+func TestSamplingHandlerBypassesFailuresAndWarningsWithoutUsingBurst(t *testing.T) {
+	t.Parallel()
+
+	var output lockedBuffer
+	logger := slog.New(newSamplingHandler(newCaptureHandler(&output), 0))
+	marker := attr.SlogLogsSamplingBucket(attr.LogsSamplingBucketHTTPResponseSuccess)
+
+	logger.With(attr.SlogErrorMessage("")).InfoContext(t.Context(), "empty inherited error", marker)
+	logger.InfoContext(t.Context(), "nested error", marker, slog.Group(samplingFailureGroup, attr.SlogError(errors.New("boom"))))
+	logger.WarnContext(t.Context(), "warning", marker)
+	logger.ErrorContext(t.Context(), "error level", marker)
+
+	for range 11 {
+		logger.InfoContext(t.Context(), "clean success", marker)
+	}
+
+	messages := capturedMessages(t, &output)
+	require.Len(t, messages, 14)
+	require.Equal(t, []string{
+		"empty inherited error", "nested error", "warning", "error level",
+	}, messages[:4])
+	require.Equal(t, 10, bytes.Count(output.Bytes(), []byte(`"msg":"clean success"`)))
+}
+
+type samplingBucketValue string
+
+func (v samplingBucketValue) LogValue() slog.Value {
+	return slog.StringValue(string(v))
+}
+
+func TestSamplingHandlerFindsMarkersAcrossLoggerMetadata(t *testing.T) {
+	t.Parallel()
+
+	var output lockedBuffer
+	logger := slog.New(newSamplingHandler(newCaptureHandler(&output), 0))
+	marker := attr.SlogLogsSamplingBucket(attr.LogsSamplingBucketHTTPResponseSuccess)
+
+	logger.With(slog.String(samplingBranchKey, "left")).InfoContext(t.Context(), "left", marker)
+	logger.With(slog.String(samplingBranchKey, "right")).InfoContext(t.Context(), "right", marker)
+	for range 8 {
+		logger.InfoContext(t.Context(), "fill", marker)
+	}
+
+	logger.With(marker).InfoContext(t.Context(), "inherited marker")
+	logger.WithGroup("request").With(marker).InfoContext(t.Context(), "grouped inherited marker")
+	logger.With(marker).WithGroup("request").InfoContext(t.Context(), "inherited marker before group")
+	logger.WithGroup("request").InfoContext(t.Context(), "grouped record marker", marker)
+	logger.InfoContext(t.Context(), "nested marker", slog.Group(samplingHTTPGroup, marker))
+	logger.InfoContext(t.Context(), "inline marker", slog.Group(samplingInlineGroup, marker))
+	logger.InfoContext(t.Context(), "valuer marker", slog.Any(samplingBucketKey, samplingBucketValue(attr.LogsSamplingBucketHTTPResponseSuccess)))
+	logger.With(slog.String(samplingBranchKey, "plain")).InfoContext(t.Context(), "unmarked sibling")
+	logger.InfoContext(t.Context(), "duplicate marker", marker, marker)
+
+	records := capturedRecords(t, &output)
+	require.Len(t, records, 11)
+	require.Equal(t, "left", records[0]["branch"])
+	require.Equal(t, "right", records[1]["branch"])
+	require.Equal(t, "plain", records[10]["branch"])
+	messages := capturedMessages(t, &output)
+	require.Equal(t, []string{"left", "right"}, messages[:2])
+	for _, message := range messages[2:10] {
+		require.Equal(t, "fill", message)
+	}
+	require.Equal(t, "unmarked sibling", messages[10])
+}
+
+type changingSamplingValue struct {
+	calls int
+}
+
+func (v *changingSamplingValue) LogValue() slog.Value {
+	v.calls++
+	if v.calls > 1 {
+		return slog.StringValue("changed")
+	}
+	return slog.GroupValue(attr.SlogLogsSamplingBucket(attr.LogsSamplingBucketHTTPResponseSuccess))
+}
+
+func TestSamplingHandlerUsesResolvedValuesForEligibilityAndOutput(t *testing.T) {
+	t.Parallel()
+
+	var output lockedBuffer
+	logger := slog.New(newSamplingHandler(newCaptureHandler(&output), 0))
+	inherited := &changingSamplingValue{}
+	record := &changingSamplingValue{}
+	logger.With(slog.Any(samplingInheritedKey, inherited)).
+		WithGroup("request").
+		InfoContext(t.Context(), "resolved", slog.Any(samplingRecordKey, record))
+
+	events := capturedRecords(t, &output)
+	require.Len(t, events, 1)
+	require.Equal(t, 1, inherited.calls)
+	require.Equal(t, 1, record.calls)
+	require.Equal(t, map[string]any{
+		samplingBucketKey: attr.LogsSamplingBucketHTTPResponseSuccess,
+	}, events[0]["inherited"])
+	require.Equal(t, map[string]any{
+		"record": map[string]any{samplingBucketKey: attr.LogsSamplingBucketHTTPResponseSuccess},
+	}, events[0]["request"])
+}
+
+type failingHandler struct {
+	err error
+}
+
+func (h *failingHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+func (h *failingHandler) Handle(context.Context, slog.Record) error {
+	return h.err
+}
+
+func (h *failingHandler) WithAttrs([]slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *failingHandler) WithGroup(string) slog.Handler {
+	return h
+}
+
+func TestSamplingHandlerPropagatesUnderlyingHandleError(t *testing.T) {
+	t.Parallel()
+
+	sinkErr := errors.New("sink failed")
+	handler := newSamplingHandler(&failingHandler{err: sinkErr}, 1)
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "successful response", 0)
+	record.AddAttrs(attr.SlogLogsSamplingBucket(attr.LogsSamplingBucketHTTPResponseSuccess))
+
+	require.ErrorIs(t, handler.Handle(t.Context(), record), sinkErr)
+}
+
+func TestSamplingHandlerLeavesIndependentFanoutSinkUnsampled(t *testing.T) {
+	t.Parallel()
+
+	var sampledOutput lockedBuffer
+	var independentOutput lockedBuffer
+	logger := slog.New(slogmulti.Fanout(
+		newSamplingHandler(newCaptureHandler(&sampledOutput), 0),
+		newCaptureHandler(&independentOutput),
+	))
+
+	for range 11 {
+		logger.InfoContext(t.Context(), "successful response", attr.SlogLogsSamplingBucket(attr.LogsSamplingBucketHTTPResponseSuccess))
+	}
+
+	require.Len(t, capturedRecords(t, &sampledOutput), 10)
+	require.Len(t, capturedRecords(t, &independentOutput), 11)
+}
+
+func TestSamplingHandlerHandlesConcurrentRecords(t *testing.T) {
+	t.Parallel()
+
+	const (
+		writers          = 16
+		recordsPerWriter = 64
+	)
+
+	var output lockedBuffer
+	logger := slog.New(newSamplingHandler(newCaptureHandler(&output), 1))
+	marker := attr.SlogLogsSamplingBucket(attr.LogsSamplingBucketHTTPResponseSuccess)
+
+	var wg sync.WaitGroup
+	for writer := range writers {
+		wg.Go(func() {
+			for record := range recordsPerWriter {
+				logger.InfoContext(t.Context(), "concurrent success", marker, slog.Int(samplingWriterKey, writer), slog.Int(samplingRecordKey, record))
+			}
+		})
+	}
+	wg.Wait()
+
+	require.Len(t, capturedRecords(t, &output), writers*recordsPerWriter)
+}

--- a/server/internal/o11y/sampling_test.go
+++ b/server/internal/o11y/sampling_test.go
@@ -145,7 +145,7 @@ func TestSamplingHandlerBypassesFailuresAndWarningsWithoutUsingBurst(t *testing.
 	marker := attr.SlogLogsSamplingBucket(attr.LogsSamplingBucketHTTPResponseSuccess)
 
 	logger.With(attr.SlogErrorMessage("")).InfoContext(t.Context(), "empty inherited error", marker)
-	logger.InfoContext(t.Context(), "nested error", marker, slog.Group(samplingFailureGroup, attr.SlogError(errors.New("boom"))))
+	logger.InfoContext(t.Context(), "record error", marker, attr.SlogError(errors.New("boom")))
 	logger.WarnContext(t.Context(), "warning", marker)
 	logger.ErrorContext(t.Context(), "error level", marker)
 
@@ -156,7 +156,7 @@ func TestSamplingHandlerBypassesFailuresAndWarningsWithoutUsingBurst(t *testing.
 	messages := capturedMessages(t, &output)
 	require.Len(t, messages, 14)
 	require.Equal(t, []string{
-		"empty inherited error", "nested error", "warning", "error level",
+		"empty inherited error", "record error", "warning", "error level",
 	}, messages[:4])
 	require.Equal(t, 10, bytes.Count(output.Bytes(), []byte(`"msg":"clean success"`)))
 }
@@ -181,12 +181,7 @@ func TestSamplingHandlerFindsMarkersAcrossLoggerMetadata(t *testing.T) {
 	}
 
 	logger.With(marker).InfoContext(t.Context(), "inherited marker")
-	logger.WithGroup("request").With(marker).InfoContext(t.Context(), "grouped inherited marker")
-	logger.With(marker).WithGroup("request").InfoContext(t.Context(), "inherited marker before group")
-	logger.WithGroup("request").InfoContext(t.Context(), "grouped record marker", marker)
-	logger.InfoContext(t.Context(), "nested marker", slog.Group(samplingHTTPGroup, marker))
-	logger.InfoContext(t.Context(), "inline marker", slog.Group(samplingInlineGroup, marker))
-	logger.InfoContext(t.Context(), "valuer marker", slog.Any(samplingBucketKey, samplingBucketValue(attr.LogsSamplingBucketHTTPResponseSuccess)))
+	logger.WithGroup("").With(marker).InfoContext(t.Context(), "empty group")
 	logger.With(slog.String(samplingBranchKey, "plain")).InfoContext(t.Context(), "unmarked sibling")
 	logger.InfoContext(t.Context(), "duplicate marker", marker, marker)
 
@@ -203,6 +198,33 @@ func TestSamplingHandlerFindsMarkersAcrossLoggerMetadata(t *testing.T) {
 	require.Equal(t, "unmarked sibling", messages[10])
 }
 
+func TestSamplingHandlerRetainsGroupsWithoutInspectingThem(t *testing.T) {
+	t.Parallel()
+
+	var output lockedBuffer
+	logger := slog.New(newSamplingHandler(newCaptureHandler(&output), 0))
+	marker := attr.SlogLogsSamplingBucket(attr.LogsSamplingBucketHTTPResponseSuccess)
+	for range 11 {
+		logger.InfoContext(t.Context(), "fill", marker)
+	}
+
+	logger.InfoContext(t.Context(), "nested marker", slog.Group(samplingHTTPGroup, marker))
+	logger.InfoContext(t.Context(), "inline marker", slog.Group(samplingInlineGroup, marker))
+	logger.InfoContext(t.Context(), "grouped error", marker, slog.Group(samplingFailureGroup, attr.SlogError(errors.New("boom"))))
+	logger.With(slog.Group(samplingHTTPGroup, marker)).InfoContext(t.Context(), "inherited group")
+	logger.WithGroup("request").With(marker).InfoContext(t.Context(), "group before marker")
+	logger.With(marker).WithGroup("request").InfoContext(t.Context(), "group after marker")
+	logger.WithGroup("request").InfoContext(t.Context(), "grouped record", marker)
+	logger.InfoContext(t.Context(), "valuer marker", slog.Any(samplingBucketKey, samplingBucketValue(attr.LogsSamplingBucketHTTPResponseSuccess)))
+
+	messages := capturedMessages(t, &output)
+	require.Len(t, messages, 18)
+	require.Equal(t, []string{
+		"nested marker", "inline marker", "grouped error", "inherited group",
+		"group before marker", "group after marker", "grouped record", "valuer marker",
+	}, messages[10:])
+}
+
 type changingSamplingValue struct {
 	calls int
 }
@@ -215,27 +237,38 @@ func (v *changingSamplingValue) LogValue() slog.Value {
 	return slog.GroupValue(attr.SlogLogsSamplingBucket(attr.LogsSamplingBucketHTTPResponseSuccess))
 }
 
-func TestSamplingHandlerUsesResolvedValuesForEligibilityAndOutput(t *testing.T) {
+func TestSamplingHandlerRetainsValuersWithoutDoubleEvaluation(t *testing.T) {
 	t.Parallel()
 
 	var output lockedBuffer
 	logger := slog.New(newSamplingHandler(newCaptureHandler(&output), 0))
+	for range 11 {
+		logger.InfoContext(t.Context(), "fill", attr.SlogLogsSamplingBucket(attr.LogsSamplingBucketHTTPResponseSuccess))
+	}
 	inherited := &changingSamplingValue{}
 	record := &changingSamplingValue{}
 	logger.With(slog.Any(samplingInheritedKey, inherited)).
-		WithGroup("request").
 		InfoContext(t.Context(), "resolved", slog.Any(samplingRecordKey, record))
+	direct := &changingSamplingValue{}
+	logger.InfoContext(t.Context(), "direct valuer",
+		attr.SlogLogsSamplingBucket(attr.LogsSamplingBucketHTTPResponseSuccess),
+		slog.Any(samplingRecordKey, direct),
+	)
 
 	events := capturedRecords(t, &output)
-	require.Len(t, events, 1)
+	require.Len(t, events, 12)
 	require.Equal(t, 1, inherited.calls)
 	require.Equal(t, 1, record.calls)
+	require.Equal(t, 1, direct.calls)
 	require.Equal(t, map[string]any{
 		samplingBucketKey: attr.LogsSamplingBucketHTTPResponseSuccess,
-	}, events[0]["inherited"])
+	}, events[10]["inherited"])
 	require.Equal(t, map[string]any{
-		"record": map[string]any{samplingBucketKey: attr.LogsSamplingBucketHTTPResponseSuccess},
-	}, events[0]["request"])
+		samplingBucketKey: attr.LogsSamplingBucketHTTPResponseSuccess,
+	}, events[10]["record"])
+	require.Equal(t, map[string]any{
+		samplingBucketKey: attr.LogsSamplingBucketHTTPResponseSuccess,
+	}, events[11]["record"])
 }
 
 type failingHandler struct {

--- a/server/internal/o11y/slog.go
+++ b/server/internal/o11y/slog.go
@@ -54,9 +54,9 @@ type LogHandlerOptions struct {
 	// instead of vendor-agnostic equivalents.
 	DataDogAttr bool
 
-	// SamplingEnabled retains the first 10 eligible events per minute and 1%
-	// thereafter. Errors and warnings bypass sampling. False retains every
-	// event enabled by RawLevel.
+	// SamplingEnabled retains the first 10 eligible flat events per minute and
+	// 1% thereafter. Errors, warnings, groups and LogValuer values bypass
+	// sampling. False retains every event enabled by RawLevel.
 	SamplingEnabled bool
 }
 

--- a/server/internal/o11y/slog.go
+++ b/server/internal/o11y/slog.go
@@ -53,6 +53,11 @@ type LogHandlerOptions struct {
 	// DataDogAttr indicates whether to add DataDog specific attributes to logs
 	// instead of vendor-agnostic equivalents.
 	DataDogAttr bool
+
+	// SamplingEnabled retains the first 10 eligible events per minute and 1%
+	// thereafter. Errors and warnings bypass sampling. False retains every
+	// event enabled by RawLevel.
+	SamplingEnabled bool
 }
 
 func NewLogHandler(opts *LogHandlerOptions) slog.Handler {
@@ -63,8 +68,9 @@ func NewLogHandler(opts *LogHandlerOptions) slog.Handler {
 
 	temporalKeys := getTemporalKeyRemaps(opts.DataDogAttr)
 
+	var handler slog.Handler
 	if opts.Pretty {
-		return &ContextHandler{
+		handler = &ContextHandler{
 			DataDogAttr: opts.DataDogAttr,
 			Handler: plog.NewHandler(
 				plog.WithAddSource(true),
@@ -78,7 +84,7 @@ func NewLogHandler(opts *LogHandlerOptions) slog.Handler {
 			),
 		}
 	} else {
-		return &ContextHandler{
+		handler = &ContextHandler{
 			DataDogAttr: opts.DataDogAttr,
 			Handler: slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
 				AddSource: true,
@@ -105,6 +111,11 @@ func NewLogHandler(opts *LogHandlerOptions) slog.Handler {
 			}),
 		}
 	}
+
+	if opts.SamplingEnabled {
+		return newSamplingHandler(handler, 0.01)
+	}
+	return handler
 }
 
 type ContextHandler struct {

--- a/server/internal/testenv/testcontainers.go
+++ b/server/internal/testenv/testcontainers.go
@@ -35,9 +35,10 @@ func (t *testcontainersLogger) Printf(format string, v ...any) {
 func NewTestcontainersLogger() log.Logger {
 	return &testcontainersLogger{
 		logger: slog.New(o11y.NewLogHandler(&o11y.LogHandlerOptions{
-			RawLevel:    os.Getenv("LOG_LEVEL"),
-			Pretty:      true,
-			DataDogAttr: false,
+			RawLevel:        os.Getenv("LOG_LEVEL"),
+			Pretty:          true,
+			DataDogAttr:     false,
+			SamplingEnabled: false,
 		})),
 	}
 }

--- a/server/internal/testenv/testing.go
+++ b/server/internal/testenv/testing.go
@@ -51,9 +51,10 @@ func NewEncryptionClient(t *testing.T) *encryption.Client {
 func NewLogger(*testing.T) *slog.Logger {
 	if isTestingVerbose() {
 		return slog.New(o11y.NewLogHandler(&o11y.LogHandlerOptions{
-			RawLevel:    os.Getenv("LOG_LEVEL"),
-			Pretty:      true,
-			DataDogAttr: false,
+			RawLevel:        os.Getenv("LOG_LEVEL"),
+			Pretty:          true,
+			DataDogAttr:     false,
+			SamplingEnabled: false,
 		}))
 	}
 	return slog.New(slog.DiscardHandler)


### PR DESCRIPTION
## Summary

- Add opt-in slog sampling via `gram.logs.sampling_bucket`, backed by `samber/slog-sampling` v1.7.0. The initial `http.response.success` bucket retains the first 10 events per minute per process, then retains each additional event with 1% probability.
- Mark only completed HTTP 2xx/3xx responses. Sampling inspects flat scalar attributes only, including inherited attributes. Unmarked events, unknown or invalid buckets, `error.message` attributes, and WARN+ events bypass sampling. Grouped loggers and records containing groups or `LogValuer` values are retained without sampling, avoiding recursive inspection, value resolution, and record rebuilding.
- Enable sampling in the server CLI, with `--log-sampling=false` or `GRAM_LOG_SAMPLING=false` restoring full logging after restart. Local development defaults to unsampled logging through `mise.toml`, while explicit environment overrides remain supported. Preserve existing behavior for test helpers and the backfill command.
- Add deterministic regression coverage for burst reset, failure bypass, child loggers, resolved attributes, concurrent logging, and independent event sinks.

## Motivation

Successful response logs generate repetitive application log volume. Centralizing the sampling policy keeps call sites explicit while avoiding a bespoke sampler and preserving failure visibility. Sampling is confined to the operational logging sink; deployment event sinks and Nginx ingress logging are unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in sampling for successful HTTP response logs to cut repetitive operational log volume. The first 10 eligible events per minute per process are kept, then each additional event is kept with 1% probability; errors, warnings, unmarked events, and events with groups, LogValuer values, or invalid buckets bypass sampling entirely.

- Sampling applies only to completed HTTP 2xx/3xx responses with flat attributes, marked with `gram.logs.sampling_bucket`.
- Events with groups or LogValuer values bypass sampling without inspection or resolution, so they can hide error attributes.
- Server CLI enables sampling by default; `mise.toml` sets `GRAM_LOG_SAMPLING=false` for local development, and `--log-sampling=false` restores full logging after restart.
- Test helpers and the backfill command keep sampling disabled.
- Adds `samber/slog-sampling` v1.7.0 and regression coverage for burst reset, failure bypass, shared child-logger sampling state, resolved attributes, concurrency, and independent sinks.

<sup>Written for commit e666e7f3e07c6662716f75f22f20df2ece2f906f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

