### PR TITLE
fix: keep MCP routes serving without Temporal

### DIFF
--- a/server/internal/background/index_toolset.go
+++ b/server/internal/background/index_toolset.go
@@ -31,6 +31,10 @@ func ExecuteIndexToolset(
 	env *tenv.Environment,
 	params IndexToolsetParams,
 ) (client.WorkflowRun, error) {
+	if env == nil {
+		return nil, ErrTemporalUnavailable
+	}
+
 	id := fmt.Sprintf(
 		"v1:index-toolset:%s:%s",
 		params.ProjectID,

--- a/server/internal/background/index_toolset_test.go
+++ b/server/internal/background/index_toolset_test.go
@@ -1,0 +1,21 @@
+package background
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/gen/types"
+)
+
+func TestExecuteIndexToolsetWithoutTemporal(t *testing.T) {
+	t.Parallel()
+
+	run, err := ExecuteIndexToolset(t.Context(), nil, IndexToolsetParams{
+		ProjectID:   uuid.New(),
+		ToolsetSlug: types.Slug("unavailable-index"),
+	})
+	require.ErrorIs(t, err, ErrTemporalUnavailable)
+	require.Nil(t, run)
+}

--- a/server/internal/background/skill_efficacy.go
+++ b/server/internal/background/skill_efficacy.go
@@ -370,6 +370,10 @@ var _ efficacy.Signaler = (*TemporalSkillEfficacySignaler)(nil)
 // run is live. The workflow id is the project's, so a signal raised while a run
 // is in flight joins that run instead of starting a second one.
 func (s *TemporalSkillEfficacySignaler) Signal(ctx context.Context, projectID uuid.UUID) error {
+	if s == nil || s.TemporalEnv == nil {
+		return ErrTemporalUnavailable
+	}
+
 	workflowID := skillEfficacyCoordinatorWorkflowID(projectID)
 
 	_, err := s.TemporalEnv.Client().SignalWithStartWorkflow(

--- a/server/internal/background/skill_efficacy_test.go
+++ b/server/internal/background/skill_efficacy_test.go
@@ -57,6 +57,20 @@ func TestSkillEfficacyCoordinatorWorkflowIDIsPerProject(t *testing.T) {
 	require.NotEqual(t, skillEfficacyCoordinatorWorkflowID(uuid.New()), skillEfficacyCoordinatorWorkflowID(projectID))
 }
 
+func TestTemporalSkillEfficacySignalerWithoutTemporal(t *testing.T) {
+	t.Parallel()
+
+	signaler := &TemporalSkillEfficacySignaler{}
+	require.ErrorIs(t, signaler.Signal(t.Context(), uuid.New()), ErrTemporalUnavailable)
+}
+
+func TestNilTemporalSkillEfficacySignaler(t *testing.T) {
+	t.Parallel()
+
+	var signaler *TemporalSkillEfficacySignaler
+	require.ErrorIs(t, signaler.Signal(t.Context(), uuid.New()), ErrTemporalUnavailable)
+}
+
 func TestSkillEfficacyCoordinatorWorkflowCompletesWhenThereIsNoWork(t *testing.T) {
 	t.Parallel()
 	var suite testsuite.WorkflowTestSuite

--- a/server/internal/background/temporal_errors.go
+++ b/server/internal/background/temporal_errors.go
@@ -1,0 +1,7 @@
+package background
+
+import "errors"
+
+// ErrTemporalUnavailable reports that a Temporal-backed operation cannot run
+// because no Temporal environment is configured in this process.
+var ErrTemporalUnavailable = errors.New("temporal environment is not configured")

--- a/server/internal/mcp/dynamic_tool_calling.go
+++ b/server/internal/mcp/dynamic_tool_calling.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -21,8 +22,11 @@ import (
 )
 
 const (
-	searchToolsToolName = "search_tools"
+	searchToolsToolName        = "search_tools"
+	toolSearchIndexWaitTimeout = 10 * time.Second
 )
+
+var errToolSearchIndexUnavailable = errors.New("tool search index is unavailable")
 
 func buildDynamicSearchToolsSchema(availableTags []string) json.RawMessage {
 	return json.RawMessage(fmt.Sprintf(`{
@@ -66,7 +70,7 @@ func buildDynamicSessionTools(
 	temporalEnv *temporal.Environment,
 ) ([]*toolListEntry, error) {
 	if err := waitForIndexing(ctx, logger, toolset, vectorToolStore, temporalEnv); err != nil {
-		return nil, fmt.Errorf("failed to index toolset: %w", err)
+		return nil, fmt.Errorf("index toolset: %w", err)
 	}
 
 	findDescription := "Search through the available tools in this MCP server using a search query. The result will be a list of tools that could help you complete your task."
@@ -149,6 +153,10 @@ type searchToolsArguments struct {
 	NumResults int           `json:"num_results"`
 }
 
+type workflowResult interface {
+	Get(context.Context, any) error
+}
+
 func handleSearchToolsCall(
 	ctx context.Context,
 	logger *slog.Logger,
@@ -159,6 +167,9 @@ func handleSearchToolsCall(
 	temporalEnv *temporal.Environment,
 ) (json.RawMessage, error) {
 	if err := waitForIndexing(ctx, logger, toolset, vectorToolStore, temporalEnv); err != nil {
+		if errors.Is(err, errToolSearchIndexUnavailable) {
+			return nil, oops.E(oops.CodeUnavailable, err, "tool search is temporarily unavailable; try again later").LogError(ctx, logger)
+		}
 		return nil, oops.E(oops.CodeUnexpected, err, "failed to index toolset").LogError(ctx, logger)
 	}
 
@@ -289,14 +300,29 @@ func waitForIndexing(ctx context.Context, logger *slog.Logger, toolset *types.To
 		)
 
 		if indexErr != nil {
+			if errors.Is(indexErr, background.ErrTemporalUnavailable) {
+				return fmt.Errorf("%w: prepare tool search index: %w", errToolSearchIndexUnavailable, indexErr)
+			}
 			return fmt.Errorf("failed to prepare tool search index: %w", indexErr)
 		}
 
-		wrError := wr.Get(ctx, nil)
-		if wrError != nil {
-			return fmt.Errorf("failed to build tool search index: %w", wrError)
-
+		if err := waitForToolSearchIndex(ctx, wr, toolSearchIndexWaitTimeout); err != nil {
+			return err
 		}
+	}
+
+	return nil
+}
+
+func waitForToolSearchIndex(ctx context.Context, result workflowResult, timeout time.Duration) error {
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	if err := result.Get(waitCtx, nil); err != nil {
+		if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+			return fmt.Errorf("%w: wait for tool search index: %w", errToolSearchIndexUnavailable, err)
+		}
+		return fmt.Errorf("build tool search index: %w", err)
 	}
 
 	return nil

--- a/server/internal/mcp/dynamic_tool_calling_test.go
+++ b/server/internal/mcp/dynamic_tool_calling_test.go
@@ -1,8 +1,11 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -11,6 +14,31 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/rag"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
+
+type blockingWorkflowResult struct{}
+
+func (blockingWorkflowResult) Get(ctx context.Context, _ any) error {
+	<-ctx.Done()
+	return fmt.Errorf("wait for workflow result: %w", ctx.Err())
+}
+
+func TestWaitForToolSearchIndexBoundsTheWait(t *testing.T) {
+	t.Parallel()
+
+	err := waitForToolSearchIndex(t.Context(), blockingWorkflowResult{}, time.Millisecond)
+	require.ErrorIs(t, err, errToolSearchIndexUnavailable)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestWaitForToolSearchIndexPreservesParentCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	err := waitForToolSearchIndex(ctx, blockingWorkflowResult{}, time.Hour)
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotErrorIs(t, err, errToolSearchIndexUnavailable)
+}
 
 func TestBuildDynamicSearchToolsSchema(t *testing.T) {
 	t.Parallel()

--- a/server/internal/mcp/no_temporal_test.go
+++ b/server/internal/mcp/no_temporal_test.go
@@ -1,0 +1,165 @@
+package mcp_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oauthtest"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/platformtools"
+	skillsrepo "github.com/speakeasy-api/gram/server/internal/skills/repo"
+	toolsetsrepo "github.com/speakeasy-api/gram/server/internal/toolsets/repo"
+)
+
+const toolSearchUnavailableMessage = "tool search is temporarily unavailable; try again later"
+
+func TestMCPWithoutTemporalServesStaticRequestsAndRejectsDynamicIndexing(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPServiceWithoutTemporal(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	toolset := createPublicMCPToolset(t, ctx, toolsetsrepo.New(ti.conn), authCtx, "no-temporal-"+uuid.NewString()[:8])
+	addHTTPTools(t, ctx, ti, toolset.ID, toolset.ProjectID, authCtx.ActiveOrganizationID, "static_tool")
+
+	initialize, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeInitializeBody(), "", nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, initialize.Code)
+
+	staticList, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeToolsListBody(), "", nil)
+	require.NoError(t, err)
+	require.Equal(t, []string{"static_tool"}, toolNames(parseToolsListResponse(t, staticList.Body.Bytes())))
+
+	dynamicList, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeToolsListBody(), "", map[string]string{"Gram-Mode": "dynamic"})
+	require.NoError(t, err)
+	requireMCPToolSearchUnavailable(t, dynamicList)
+
+	dynamicSearch, err := servePublicHTTP(t, ctx, ti, toolset.McpSlug.String, makeToolsCallBody("search_tools"), "", map[string]string{"Gram-Mode": "dynamic"})
+	require.NoError(t, err)
+	requireMCPToolSearchUnavailable(t, dynamicSearch)
+}
+
+func TestOAuthWithoutTemporalServesAuthorizationMetadata(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPServiceWithoutTemporal(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	external := oauthtest.CreateExternalOAuthToolset(t, ctx, ti.conn, authCtx, oauthtest.ExternalOAuthToolsetOpts{
+		Slug:     "no-temporal-oauth-" + uuid.NewString()[:8],
+		IsPublic: true,
+		Metadata: nil,
+	})
+	w, err := runMCPWellKnown(t, ctx, ti.service.HandleGetAuthorizationServer, external.Toolset.McpSlug.String)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestSkillsLoadWithoutTemporalRemainsSuccessfulAcrossTrailingSignal(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestMCPServiceWithoutTemporal(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	assistantID := createAssistant(t, ti, authCtx, "No Temporal")
+	token := mintAssistantToken(t, ti, authCtx, assistantID)
+	skillName := "no-temporal-skill-" + uuid.NewString()[:8]
+	queries := skillsrepo.New(ti.conn)
+	skill, err := queries.CreateSkill(ctx, skillsrepo.CreateSkillParams{
+		ProjectID:   *authCtx.ProjectID,
+		Name:        skillName,
+		DisplayName: skillName,
+		Summary:     pgtype.Text{},
+	})
+	require.NoError(t, err)
+	content := "---\nname: " + skillName + "\ndescription: nil Temporal coverage\n---\n\nbody\n"
+	_, err = queries.CreateSkillVersion(ctx, skillsrepo.CreateSkillVersionParams{
+		Content:          content,
+		CanonicalSha256:  uuid.NewString(),
+		RawSha256:        uuid.NewString(),
+		Description:      pgtype.Text{String: "nil Temporal coverage", Valid: true},
+		Metadata:         []byte(`{}`),
+		SpecValid:        true,
+		ValidationErrors: []byte(`[]`),
+		CreatedByUserID:  authCtx.UserID,
+		ProjectID:        *authCtx.ProjectID,
+		SkillID:          skill.ID,
+	})
+	require.NoError(t, err)
+	_, err = queries.CreateSkillDistribution(ctx, skillsrepo.CreateSkillDistributionParams{
+		PluginID:        uuid.NullUUID{},
+		AssistantID:     uuid.NullUUID{UUID: assistantID, Valid: true},
+		PinnedVersionID: uuid.NullUUID{},
+		Channel:         "assistant",
+		CreatedByUserID: authCtx.UserID,
+		ProjectID:       *authCtx.ProjectID,
+		SkillID:         skill.ID,
+	})
+	require.NoError(t, err)
+
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      platformtools.ToolNameSkillsLoad,
+			"arguments": map[string]any{"name": skillName},
+		},
+	})
+	require.NoError(t, err)
+	callLoad := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/platform/mcp/"+platformtools.AssistantsPlatformToolsetSlug, bytes.NewReader(body))
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Gram-Chat-ID", uuid.NewString())
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("toolsetSlug", platformtools.AssistantsPlatformToolsetSlug)
+		req = req.WithContext(context.WithValue(t.Context(), chi.RouteCtxKey, rctx))
+
+		w := httptest.NewRecorder()
+		require.NoError(t, ti.service.ServePlatformToolset(w, req))
+		return w
+	}
+
+	first := callLoad()
+	require.Equal(t, http.StatusOK, first.Code)
+	require.Contains(t, first.Body.String(), "body")
+	second := callLoad()
+	require.Equal(t, http.StatusOK, second.Code)
+	require.Contains(t, second.Body.String(), "body")
+
+	// The second call is coalesced into a trailing signal. Flushing exercises
+	// that callback synchronously so a nil Temporal environment cannot leave a
+	// process-crashing timer behind.
+	require.NoError(t, ti.efficacySignaler.Shutdown(t.Context()))
+}
+
+func requireMCPToolSearchUnavailable(t *testing.T, w *httptest.ResponseRecorder) {
+	t.Helper()
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var response struct {
+		Error struct {
+			Code    oops.MCPCode `json:"code"`
+			Message string       `json:"message"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.Equal(t, oops.MCPCodeInternalError, response.Error.Code)
+	require.Equal(t, toolSearchUnavailableMessage, response.Error.Message)
+}

--- a/server/internal/mcp/rpc_tools_list.go
+++ b/server/internal/mcp/rpc_tools_list.go
@@ -138,6 +138,9 @@ func handleToolsList(
 	case ToolModeDynamic:
 		tools, err = buildDynamicSessionTools(ctx, logger, toolset, vectorToolStore, temporalEnv)
 		if err != nil {
+			if errors.Is(err, errToolSearchIndexUnavailable) {
+				return nil, oops.E(oops.CodeUnavailable, err, "tool search is temporarily unavailable; try again later").LogError(ctx, logger)
+			}
 			return nil, oops.E(oops.CodeUnexpected, err, "failed to build dynamic session tools").LogError(ctx, logger)
 		}
 	case ToolModeStatic:

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -2,7 +2,6 @@ package mcp_test
 
 import (
 	"context"
-	"github.com/speakeasy-api/gram/server/internal/agents/runtimepolicy"
 	"log"
 	"log/slog"
 	"net/url"
@@ -16,9 +15,12 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/speakeasy-api/gram/dev-idp/pkg/devidptest"
+	"github.com/speakeasy-api/gram/server/internal/agents/runtimepolicy"
+	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/auth/identity"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
+	"github.com/speakeasy-api/gram/server/internal/background"
 	"github.com/speakeasy-api/gram/server/internal/mcpservers"
 	"github.com/speakeasy-api/gram/server/internal/productfeatures"
 	productfeatures_repo "github.com/speakeasy-api/gram/server/internal/productfeatures/repo"
@@ -27,6 +29,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/remotemcp"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 	"github.com/speakeasy-api/gram/server/internal/telemetry"
+	"github.com/speakeasy-api/gram/server/internal/temporal"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/openrouter"
 	"github.com/speakeasy-api/gram/server/internal/toolcallobserver"
 	"github.com/stretchr/testify/require"
@@ -56,6 +59,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/platformmcp"
 	"github.com/speakeasy-api/gram/server/internal/platformtools"
 	platformtoolsruntime "github.com/speakeasy-api/gram/server/internal/platformtools/runtime"
+	platformskills "github.com/speakeasy-api/gram/server/internal/platformtools/skills"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 	"github.com/speakeasy-api/gram/server/internal/thirdparty/posthog"
@@ -109,7 +113,8 @@ type testInstance struct {
 	// features is the injectable flag provider wired into the service; tests
 	// enable flag-gated behavior (e.g. the Platform MCP assistant toolset
 	// variant) with SetFlagVariant.
-	features *feature.InMemory
+	features         *feature.InMemory
+	efficacySignaler *background.ThrottledSignaler
 }
 
 // newTestMCPService wires a permissive identity resolver. Tests asserting
@@ -118,6 +123,26 @@ type testInstance struct {
 func newTestMCPService(t *testing.T) (context.Context, *testInstance) {
 	t.Helper()
 	return newTestMCPServiceWithIdentityResolver(t, &mockIdentityResolver{hasAccessOK: true})
+}
+
+func newTestMCPServiceWithoutTemporal(t *testing.T) (context.Context, *testInstance) {
+	t.Helper()
+	return newTestMCPServiceWithPoolConfigAndTemporal(
+		t,
+		testenv.NewLogger(t),
+		testenv.NewMeterProvider(t),
+		&mockIdentityResolver{hasAccessOK: true},
+		mcp.TunnelPublicConfig{
+			SessionTTL:         0,
+			LiveSessionCap:     0,
+			InitializeRate:     ratelimit.Rate{Tokens: 0, Interval: 0, Burst: 0},
+			RequestRate:        ratelimit.Rate{Tokens: 0, Interval: 0, Burst: 0},
+			MaxRequestLifetime: 0,
+		},
+		nil,
+		nil,
+		false,
+	)
 }
 
 // errorLogRecorder is a slog.Handler that keeps the messages of ERROR-level
@@ -282,6 +307,21 @@ func newTestMCPServiceWithPoolConfig(
 	guardianOpts ...func(*guardian.Policy),
 ) (context.Context, *testInstance) {
 	t.Helper()
+	return newTestMCPServiceWithPoolConfigAndTemporal(t, logger, meterProvider, identityResolver, tunnelPublicConfig, wrapCache, configurePool, true, guardianOpts...)
+}
+
+func newTestMCPServiceWithPoolConfigAndTemporal(
+	t *testing.T,
+	logger *slog.Logger,
+	meterProvider metric.MeterProvider,
+	identityResolver mcp.IdentityResolver,
+	tunnelPublicConfig mcp.TunnelPublicConfig,
+	wrapCache func(cache.Cache) cache.Cache,
+	configurePool func(*pgxpool.Config),
+	withTemporal bool,
+	guardianOpts ...func(*guardian.Policy),
+) (context.Context, *testInstance) {
+	t.Helper()
 
 	ctx := t.Context()
 
@@ -361,7 +401,10 @@ func newTestMCPServiceWithPoolConfig(
 		nil,
 	)
 
-	temporalEnv, _ := infra.NewTemporalEnv(t)
+	var temporalEnv *temporal.Environment
+	if withTemporal {
+		temporalEnv, _ = infra.NewTemporalEnv(t)
+	}
 
 	redisClient, err2 := infra.NewRedisClient(t, 0)
 	require.NoError(t, err2)
@@ -375,7 +418,15 @@ func newTestMCPServiceWithPoolConfig(
 	require.NoError(t, err)
 	remoteProxyManager := remotemcp.NewProxyManager(logger, tracerProvider, meterProvider, conn, guardianPolicy, authzEngine, posthog, telemLogger, billingStub, billingStub, mcpservers.NewToolDispositionCache(logger, conn, cacheAdapter), toolcallobserver.NoopSuccessRecorder{}, toolfilter.NewSessionToolWitnessStore(testenv.NewLogger(t), testenv.NewMemoryCache()), mcpToolExecutionCheckpoint)
 	managedLogsTools := platformtoolsruntime.ManagedAssistantLogsTools(telemService)
-	assistantSkillTools := platformtoolsruntime.AssistantSkillTools(logger, conn)
+	efficacySignaler := background.NewThrottledSignaler(
+		&background.TemporalSkillEfficacySignaler{TemporalEnv: temporalEnv, Logger: logger},
+		background.SkillEfficacySignalCooldown,
+		logger.With(attr.SlogComponent("skill-efficacy")),
+	)
+	t.Cleanup(func() {
+		require.NoError(t, efficacySignaler.Shutdown(context.Background()))
+	})
+	assistantSkillTools := platformtoolsruntime.AssistantSkillTools(logger, conn, platformskills.WithEfficacySignaler(efficacySignaler))
 	platformToolsets := platformtools.BuildToolsets(platformtools.ToolsetDependencies{
 		AssistantMemoryTools:          nil,
 		AssistantSkillTools:           assistantSkillTools,
@@ -394,7 +445,7 @@ func newTestMCPServiceWithPoolConfig(
 	})
 	tunnelRoutes := route.NewRouteTable()
 	features := &feature.InMemory{}
-	svc, err := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthog, features, serverURL, siteURL, enc, mcpCache, guardianPolicy, funcs, billingStub, billingStub, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger, nil, featClient.PlatformFeatureCheck, platformToolsets, identityResolver, userSessionSigner, remoteChallengeMgr, remoteProxyManager, tunnelRoutes, "", nil, redisClient, tunnelPublicConfig, mcp.MetaRuntimeConfig{MemberCallTimeout: 0})
+	svc, err := mcp.NewService(logger, tracerProvider, meterProvider, conn, sessionManager, chatSessionsManager, env, posthog, features, serverURL, siteURL, enc, mcpCache, guardianPolicy, funcs, billingStub, billingStub, telemLogger, telemService, vectorToolStore, nil, temporalEnv, authzEngine, assistantTokens, shadowMCPClient, auditLogger, assistantSkillTools, featClient.PlatformFeatureCheck, platformToolsets, identityResolver, userSessionSigner, remoteChallengeMgr, remoteProxyManager, tunnelRoutes, "", nil, redisClient, tunnelPublicConfig, mcp.MetaRuntimeConfig{MemberCallTimeout: 0})
 	require.NoError(t, err)
 
 	authnCache := cache.NewTypedObjectCache[mcp.AuthnChallengeState](logger, cacheAdapter, cache.SuffixNone)
@@ -415,6 +466,7 @@ func newTestMCPServiceWithPoolConfig(
 		audit:               auditLogger,
 		tunnelRoutes:        tunnelRoutes,
 		features:            features,
+		efficacySignaler:    efficacySignaler,
 	}
 }
 


### PR DESCRIPTION
AIM-263

## Summary

- Guard Temporal-backed toolset indexing and skill-efficacy signaling when the server has no Temporal environment.
- Keep static MCP discovery, OAuth metadata, and skill loading available; return a stable temporary-unavailable response only when dynamic tool search requires indexing.
- Bound request-side index waits to 10 seconds while allowing an already-started workflow to continue, and add nil-Temporal regression coverage across the affected routes.

## Motivation

Temporal is an optional server dependency, but MCP route construction still includes features that use it opportunistically. A dynamic tool request or a trailing skill-efficacy signal could therefore dereference a nil Temporal environment and crash the process, taking unrelated static and OAuth routes down with it.

The failure is handled at the Temporal-backed operation boundary so callers can distinguish an unavailable optional dependency from an unexpected indexing failure. Dynamic search returns unavailable instead of incomplete results, while routes that do not require background work continue serving. The bounded wait also prevents an MCP request from hanging indefinitely without canceling durable work that has already started.

Temporal actions/month ≈ 0 additional, scales with tool calls and skill loads only through existing indexing workflows and efficacy signals when Temporal is configured.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP and OAuth routes panicking when the server runs without a Temporal environment. Dynamic tool search now returns a temporary-unavailable response, static tool listing, initialization, and OAuth metadata keep serving, and a repeated `skills_load` no longer arms a process-crashing timer.

Resolves AIM-263.

- Adds `ErrTemporalUnavailable` so callers can distinguish an unconfigured optional dependency from a real indexing failure.
- Bounds request-side index waits to 10 seconds without canceling an already-started index workflow.
- Adds nil-Temporal regression coverage across dynamic tool listing, search, and skill load routes.

<sup>Written for commit b7677f621b8e3bc6fb3263ac15804825eee80a45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

