### PR TITLE
fix: show registered agents in the identities roster

### DIFF
--- a/client/dashboard/src/components/observe/insightsEmployeesData.ts
+++ b/client/dashboard/src/components/observe/insightsEmployeesData.ts
@@ -19,6 +19,8 @@ export type EmployeeAccount = {
 };
 
 export type Employee = {
+  // Set only for identities returned by the registered-agent inventory.
+  registeredAgentId?: string;
   id: string;
   name: string;
   email: string;

--- a/client/dashboard/src/pages/identities/IdentitiesIndex.tsx
+++ b/client/dashboard/src/pages/identities/IdentitiesIndex.tsx
@@ -70,6 +70,8 @@ import {
   identityRosterQueryKey,
   fetchRegisteredAgents,
   registeredAgentIdentity,
+  registeredAgentHref,
+  matchesIdentityTelemetryFilters,
 } from "./identityRoster";
 
 export function IdentitiesRoot(): JSX.Element {
@@ -191,8 +193,6 @@ const ENROLLMENT_OPTIONS = [
   { value: "not_enrolled", label: "Not enrolled" },
 ];
 
-const DAY_MS = 24 * 60 * 60 * 1000;
-
 /**
  * Activity buckets, each the window it names — "Last 30 days" includes the
  * last week rather than excluding it, because a reader narrowing to a month
@@ -204,17 +204,6 @@ const ACTIVITY_OPTIONS = [
   { value: "older", label: "Over 30 days ago" },
   { value: "never", label: "Never active" },
 ];
-
-function matchesActivity(identity: Employee, bucket: string): boolean {
-  const timestamp = identity.lastActivityTimestamp;
-  if (bucket === "never") return timestamp === null;
-  if (timestamp === null) return false;
-  const age = Date.now() - timestamp;
-  if (bucket === "7d") return age <= 7 * DAY_MS;
-  if (bucket === "30d") return age <= 30 * DAY_MS;
-  if (bucket === "older") return age > 30 * DAY_MS;
-  return true;
-}
 
 /** How each device-coverage bucket reads in the filter. */
 const DEVICE_STATUS_LABELS: Record<string, string> = {
@@ -587,8 +576,8 @@ function IdentitiesIndexContent(): JSX.Element {
       ) {
         return false;
       }
-      if (enrollment && identity.status !== enrollment) return false;
-      if (activity && !matchesActivity(identity, activity)) return false;
+      if (!matchesIdentityTelemetryFilters(identity, enrollment, activity))
+        return false;
       if (
         selectedDeviceStatuses.length > 0 &&
         !selectedDeviceStatuses.includes(
@@ -778,7 +767,11 @@ function IdentitiesIndexContent(): JSX.Element {
             onRowClick={(row) =>
               void navigate(
                 row.registeredAgentId
-                  ? `${orgRoutes.agents.href()}?id=${encodeURIComponent(row.registeredAgentId)}`
+                  ? registeredAgentHref(
+                      orgRoutes.agents.href(),
+                      location.search,
+                      row.registeredAgentId,
+                    )
                   : routes.identities.detail.overview.href(
                       encodeIdentityUrn(identityUrnForEmployee(row)),
                     ),
@@ -919,6 +912,7 @@ function personInitials(name: string): string {
  * and quietly.
  */
 function IdentityCell({ identity }: { identity: Employee }): JSX.Element {
+  const location = useLocation();
   const orgRoutes = useOrgRoutes();
   const isAgent = identityKindOf(identity) === "agent";
   // A person with no member row has only their address, which is already the
@@ -946,7 +940,11 @@ function IdentityCell({ identity }: { identity: Employee }): JSX.Element {
           <Text className="line-clamp-2 min-w-0 font-medium wrap-anywhere">
             {identity.registeredAgentId ? (
               <Link
-                to={`${orgRoutes.agents.href()}?id=${encodeURIComponent(identity.registeredAgentId)}`}
+                to={registeredAgentHref(
+                  orgRoutes.agents.href(),
+                  location.search,
+                  identity.registeredAgentId,
+                )}
                 onClick={(event) => event.stopPropagation()}
                 className="decoration-foreground/30 hover:decoration-foreground underline underline-offset-4"
               >

--- a/client/dashboard/src/pages/identities/IdentitiesIndex.tsx
+++ b/client/dashboard/src/pages/identities/IdentitiesIndex.tsx
@@ -19,8 +19,14 @@ import {
   StatTileSkeleton,
 } from "@/components/chart/stat-tile";
 import { defineFilters, useFilterState } from "@/components/filters";
-import { useOrganization } from "@/contexts/Auth";
-import { useProjectSlugForRequests } from "@/contexts/Sdk";
+import {
+  useOrganization,
+  useSession,
+  useIsPlatformAdmin,
+} from "@/contexts/Auth";
+import { getRBACScopeOverrideHeader } from "@/components/dev-toolbar-utils";
+import { DEMO_ORG_SLUG } from "@/lib/demo";
+import { useSdkClient, useProjectSlugForRequests } from "@/contexts/Sdk";
 import { Page } from "@/components/page-layout";
 import { RequireScope } from "@/components/require-scope";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/Avatar";
@@ -31,7 +37,7 @@ import { Text } from "@/components/ui/Text";
 import { IdentityLink } from "@/components/identity-link";
 import { getInitials } from "@/lib/initials";
 import { encodeIdentityUrn } from "@/lib/identity-urn";
-import { useRoutes } from "@/routes";
+import { useOrgRoutes, useRoutes } from "@/routes";
 import { useGramContext } from "@gram/client/react-query/_context.js";
 import { useMembers } from "@gram/client/react-query/members.js";
 import { useRoles } from "@gram/client/react-query/roles.js";
@@ -39,6 +45,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Bot } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import {
+  Link,
   Navigate,
   Outlet,
   useLocation,
@@ -58,7 +65,12 @@ import {
   fetchDeviceCoverage,
   NO_DEVICE_BUCKET,
 } from "./identityDeviceCoverage";
-import { fetchIdentityRoster, identityRosterQueryKey } from "./identityRoster";
+import {
+  fetchIdentityRoster,
+  identityRosterQueryKey,
+  fetchRegisteredAgents,
+  registeredAgentIdentity,
+} from "./identityRoster";
 
 export function IdentitiesRoot(): JSX.Element {
   return <Outlet />;
@@ -216,10 +228,12 @@ const DEVICE_STATUS_LABELS: Record<string, string> = {
   [NO_DEVICE_BUCKET]: "No managed device",
 };
 
-const KIND_OPTIONS = (["person", "agent"] as IdentityKind[]).map((kind) => ({
-  value: kind,
-  label: IDENTITY_KIND_LABELS[kind],
-}));
+const KIND_OPTIONS = (["person", "agent", "unknown"] as IdentityKind[]).map(
+  (kind) => ({
+    value: kind,
+    label: IDENTITY_KIND_LABELS[kind],
+  }),
+);
 
 // One em dash for every kind of "no role": an agent has none by definition, a
 // person with no account has none yet, and the roster reports an absent role
@@ -259,7 +273,7 @@ const IDENTITY_COLUMNS: Column<Employee>[] = [
     render: (identity) => {
       const kind = identityKindOf(identity);
       return (
-        <Badge variant={kind === "person" ? "neutral" : "information"}>
+        <Badge variant={kind === "agent" ? "information" : "neutral"}>
           {IDENTITY_KIND_LABELS[kind]}
         </Badge>
       );
@@ -273,7 +287,11 @@ const IDENTITY_COLUMNS: Column<Employee>[] = [
     sortValue: (identity) => identity.status,
     render: (identity) => (
       <Text muted small className="truncate">
-        {identity.status === "enrolled" ? "Enrolled" : "Not enrolled"}
+        {identity.registeredAgentId
+          ? "—"
+          : identity.status === "enrolled"
+            ? "Enrolled"
+            : "Not enrolled"}
       </Text>
     ),
   },
@@ -348,10 +366,32 @@ export default function IdentitiesIndex(): JSX.Element {
 function IdentitiesIndexContent(): JSX.Element {
   const location = useLocation();
   const routes = useRoutes();
+  const orgRoutes = useOrgRoutes();
   const organization = useOrganization();
   const projectSlug = useProjectSlugForRequests();
   const navigate = useNavigate();
   const client = useGramContext();
+  const sdk = useSdkClient();
+  const session = useSession();
+  const isPlatformAdmin = useIsPlatformAdmin();
+  // Match the existing agent screen's supported sessions, without changing scope.
+  const agentsEnabled =
+    organization.slug !== DEMO_ORG_SLUG &&
+    !session.organizationOverride &&
+    !session.impersonatorEmail &&
+    getRBACScopeOverrideHeader(import.meta.env.DEV || isPlatformAdmin) === null;
+  const agentsQuery = useQuery({
+    queryKey: [
+      "identities",
+      "registered-agents",
+      organization.id,
+      session.user.id,
+    ],
+    queryFn: ({ signal }) => fetchRegisteredAgents(sdk, signal),
+    enabled: agentsEnabled,
+    throwOnError: false,
+    retry: false,
+  });
   const [search, setSearch] = useState("");
   // Honours `?sort=<column>:<asc|desc>` so a handoff can open the list on the
   // order it was talking about — the dashboard's Top Users "View all" means
@@ -394,14 +434,20 @@ function IdentitiesIndexContent(): JSX.Element {
   });
   const deviceCoverage = deviceCoverageQuery.data;
 
-  // The list is the join of all three reads, so until they land there is no
+  // The list is the join of the roster reads, so until they land there is no
   // roster to report on — and "0 identities" or "No identities match these
   // filters" is a statement about the organization, not about a request still
   // in flight or one that never came back.
   const rosterLoading =
-    membersQuery.isLoading || rolesQuery.isLoading || usageQuery.isLoading;
+    membersQuery.isLoading ||
+    rolesQuery.isLoading ||
+    usageQuery.isLoading ||
+    (agentsEnabled && agentsQuery.isLoading);
   const rosterFailed =
-    membersQuery.isError || rolesQuery.isError || usageQuery.isError;
+    membersQuery.isError ||
+    rolesQuery.isError ||
+    usageQuery.isError ||
+    (agentsEnabled && agentsQuery.isError);
   const rosterUnavailable = rosterFailed ? "—" : undefined;
   const rosterTooltip = rosterFailed
     ? "The identity roster could not be loaded."
@@ -410,16 +456,27 @@ function IdentitiesIndexContent(): JSX.Element {
     if (membersQuery.isError) void membersQuery.refetch();
     if (rolesQuery.isError) void rolesQuery.refetch();
     if (usageQuery.isError) void usageQuery.refetch();
+    if (agentsEnabled && agentsQuery.isError) void agentsQuery.refetch();
   };
 
   const identities = useMemo(
-    () =>
-      buildEmployees(
+    () => [
+      ...buildEmployees(
         membersQuery.data?.members ?? [],
         rolesQuery.data?.roles ?? [],
         usageQuery.data ?? [],
       ),
-    [membersQuery.data, rolesQuery.data, usageQuery.data],
+      ...(agentsEnabled ? (agentsQuery.data ?? []) : []).map(
+        registeredAgentIdentity,
+      ),
+    ],
+    [
+      membersQuery.data,
+      rolesQuery.data,
+      usageQuery.data,
+      agentsEnabled,
+      agentsQuery.data,
+    ],
   );
 
   const counts = useMemo(() => {
@@ -720,9 +777,11 @@ function IdentitiesIndexContent(): JSX.Element {
             rowKey={(row) => row.id}
             onRowClick={(row) =>
               void navigate(
-                routes.identities.detail.overview.href(
-                  encodeIdentityUrn(identityUrnForEmployee(row)),
-                ),
+                row.registeredAgentId
+                  ? `${orgRoutes.agents.href()}?id=${encodeURIComponent(row.registeredAgentId)}`
+                  : routes.identities.detail.overview.href(
+                      encodeIdentityUrn(identityUrnForEmployee(row)),
+                    ),
               )
             }
             noResultsMessage={
@@ -855,11 +914,12 @@ function personInitials(name: string): string {
 
 /**
  * The leading cell. Every person reads as a person — photo or initials, name in
- * the same weight — and only an agent gets a different face, because a bare id
- * it chose for itself may name no one. Whether they hold a linked account is
- * the Accounts column's job, which says it once and quietly.
+ * the same weight — and only a registered agent gets a different face. Whether
+ * they hold a linked account is the Accounts column's job, which says it once
+ * and quietly.
  */
 function IdentityCell({ identity }: { identity: Employee }): JSX.Element {
+  const orgRoutes = useOrgRoutes();
   const isAgent = identityKindOf(identity) === "agent";
   // A person with no member row has only their address, which is already the
   // name; repeating it underneath would be noise.
@@ -884,11 +944,21 @@ function IdentityCell({ identity }: { identity: Employee }): JSX.Element {
           {/* An agent's name may be a long unbroken id, so it wraps anywhere
               and stops at two lines rather than running past the row. */}
           <Text className="line-clamp-2 min-w-0 font-medium wrap-anywhere">
-            <IdentityLink
-              identifier={{ urn: identityUrnForEmployee(identity) }}
-            >
-              {identity.name}
-            </IdentityLink>
+            {identity.registeredAgentId ? (
+              <Link
+                to={`${orgRoutes.agents.href()}?id=${encodeURIComponent(identity.registeredAgentId)}`}
+                onClick={(event) => event.stopPropagation()}
+                className="decoration-foreground/30 hover:decoration-foreground underline underline-offset-4"
+              >
+                {identity.name}
+              </Link>
+            ) : (
+              <IdentityLink
+                identifier={{ urn: identityUrnForEmployee(identity) }}
+              >
+                {identity.name}
+              </IdentityLink>
+            )}
           </Text>
         </div>
         {secondary && (

--- a/client/dashboard/src/pages/identities/identityKind.test.ts
+++ b/client/dashboard/src/pages/identities/identityKind.test.ts
@@ -1,0 +1,60 @@
+import type { Employee } from "@/components/observe/insightsEmployeesData";
+import { describe, expect, it } from "vitest";
+import { identityHasAccount, identityKindOf } from "./identityKind";
+
+const telemetryIdentity: Employee = {
+  id: "usage:external_example",
+  name: "external_example",
+  email: "",
+  role: "",
+  status: "not_enrolled",
+  tokenCount: 10,
+  lastActivity: "—",
+  lastActivityTimestamp: null,
+  accounts: [],
+  mostRecentAccount: null,
+  hasPersonalAccount: false,
+  roleIds: [],
+  department: "",
+  teams: [],
+};
+
+describe("identityKindOf", () => {
+  it("does not infer an agent from an unmatched bare telemetry identifier", () => {
+    expect(identityKindOf(telemetryIdentity)).toBe("unknown");
+    expect(identityHasAccount(telemetryIdentity)).toBe(false);
+  });
+
+  it.each([
+    { email: "person@example.com", name: "External person" },
+    { email: "", name: "person@example.com" },
+  ])("recognizes an unmatched person from $email / $name", (fields) => {
+    const identity = { ...telemetryIdentity, ...fields };
+
+    expect(identityKindOf(identity)).toBe("person");
+    expect(identityHasAccount(identity)).toBe(false);
+  });
+
+  it("recognizes a directory member without requiring an email address", () => {
+    const identity = { ...telemetryIdentity, id: "user_example" };
+
+    expect(identityKindOf(identity)).toBe("person");
+    expect(identityHasAccount(identity)).toBe(true);
+  });
+
+  it.each(["usage:external_example", "agent:agent_example", "user_example"])(
+    "gives explicit registration precedence over person-like fields for %s",
+    (id) => {
+      const identity: Employee = {
+        ...telemetryIdentity,
+        id,
+        registeredAgentId: "agent_example",
+        email: "automation@example.com",
+        name: "Automation@example.com",
+      };
+
+      expect(identityKindOf(identity)).toBe("agent");
+      expect(identityHasAccount(identity)).toBe(false);
+    },
+  );
+});

--- a/client/dashboard/src/pages/identities/identityKind.ts
+++ b/client/dashboard/src/pages/identities/identityKind.ts
@@ -12,18 +12,19 @@ import {
  * gap in our records. Whether they hold an account is a separate fact — see
  * {@link identityHasAccount} — shown as its own affordance.
  */
-export type IdentityKind = "person" | "agent";
+export type IdentityKind = "person" | "agent" | "unknown";
 
 export const IDENTITY_KIND_LABELS: Record<IdentityKind, string> = {
   person: "Person",
   agent: "Agent",
+  unknown: "Unknown",
 };
 
 export function identityKindOf(employee: Employee): IdentityKind {
+  if (employee.registeredAgentId) return "agent";
   if (!isUnattributedEmployee(employee)) return "person";
-  // An address belongs to a person; a bare identifier is the name an agent
-  // gave itself and may name no one at all.
-  return employee.email || employee.name.includes("@") ? "person" : "agent";
+  // A bare telemetry identifier is not evidence of a registered agent.
+  return employee.email || employee.name.includes("@") ? "person" : "unknown";
 }
 
 /**
@@ -33,7 +34,7 @@ export function identityKindOf(employee: Employee): IdentityKind {
  * record.
  */
 export function identityHasAccount(employee: Employee): boolean {
-  return !isUnattributedEmployee(employee);
+  return !employee.registeredAgentId && !isUnattributedEmployee(employee);
 }
 
 /** The URN the resolver expects for a row, by what the row actually holds. */

--- a/client/dashboard/src/pages/identities/identityRoster.test.ts
+++ b/client/dashboard/src/pages/identities/identityRoster.test.ts
@@ -1,0 +1,105 @@
+import { Gram } from "@gram/client";
+import type { ManagedAgent } from "@gram/client/models/components/managedagent.js";
+import { GramError } from "@gram/client/models/errors/gramerror.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { identityHasAccount, identityKindOf } from "./identityKind";
+import {
+  fetchRegisteredAgents,
+  registeredAgentIdentity,
+} from "./identityRoster";
+
+const agent: ManagedAgent = {
+  id: "agent_example",
+  name: "Automation@example.com",
+  ownerUserId: "user_owner",
+  lifecycle: "active",
+  permissions: { read: true, write: false, authorize: true, transfer: false },
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  updatedAt: new Date("2026-01-01T00:00:00Z"),
+};
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("registeredAgentIdentity", () => {
+  it("maps inventory without inventing human enrollment, accounts, or activity", () => {
+    const identity = registeredAgentIdentity(agent);
+
+    expect(identity).toEqual({
+      id: "agent:agent_example",
+      registeredAgentId: agent.id,
+      name: agent.name,
+      email: "",
+      role: "",
+      status: "not_enrolled",
+      tokenCount: 0,
+      lastActivity: "—",
+      lastActivityTimestamp: null,
+      accounts: [],
+      mostRecentAccount: null,
+      hasPersonalAccount: false,
+      roleIds: [],
+      department: "",
+      teams: [],
+    });
+    expect(identityKindOf(identity)).toBe("agent");
+    expect(identityHasAccount(identity)).toBe(false);
+  });
+});
+
+describe("fetchRegisteredAgents", () => {
+  it("returns the org-scoped inventory and forwards the abort signal", async () => {
+    const client = new Gram();
+    const list = vi.spyOn(client.agents, "list").mockResolvedValue([agent]);
+    const signal = new AbortController().signal;
+
+    await expect(fetchRegisteredAgents(client, signal)).resolves.toEqual([
+      agent,
+    ]);
+    expect(list).toHaveBeenCalledExactlyOnceWith(undefined, undefined, {
+      signal,
+    });
+  });
+
+  it("allows callers to omit the abort signal", async () => {
+    const client = new Gram();
+    const list = vi.spyOn(client.agents, "list").mockResolvedValue([]);
+
+    await expect(fetchRegisteredAgents(client)).resolves.toEqual([]);
+    expect(list).toHaveBeenCalledExactlyOnceWith(undefined, undefined, {
+      signal: undefined,
+    });
+  });
+
+  it("treats the backend rollout gate's SDK 404 as an empty inventory", async () => {
+    const client = new Gram();
+    vi.spyOn(client.agents, "list").mockRejectedValue(httpError(404));
+
+    await expect(fetchRegisteredAgents(client)).resolves.toEqual([]);
+  });
+
+  it.each([403, 500])("propagates genuine SDK %i failures", async (status) => {
+    const client = new Gram();
+    const error = httpError(status);
+    vi.spyOn(client.agents, "list").mockRejectedValue(error);
+
+    await expect(fetchRegisteredAgents(client)).rejects.toBe(error);
+  });
+
+  it("does not mistake a non-SDK error for the rollout gate", async () => {
+    const client = new Gram();
+    const error = Object.assign(new Error("Failed to list agents"), {
+      statusCode: 404,
+    });
+    vi.spyOn(client.agents, "list").mockRejectedValue(error);
+
+    await expect(fetchRegisteredAgents(client)).rejects.toBe(error);
+  });
+});
+
+function httpError(status: number): GramError {
+  return new GramError("Failed to list agents", {
+    response: new Response(null, { status }),
+    request: new Request("https://example.com/rpc/agents.list"),
+    body: "",
+  });
+}

--- a/client/dashboard/src/pages/identities/identityRoster.test.ts
+++ b/client/dashboard/src/pages/identities/identityRoster.test.ts
@@ -6,6 +6,8 @@ import { identityHasAccount, identityKindOf } from "./identityKind";
 import {
   fetchRegisteredAgents,
   registeredAgentIdentity,
+  registeredAgentHref,
+  matchesIdentityTelemetryFilters,
 } from "./identityRoster";
 
 const agent: ManagedAgent = {
@@ -103,3 +105,69 @@ function httpError(status: number): GramError {
     body: "",
   });
 }
+
+describe("registeredAgentHref", () => {
+  it("preserves the time window and repeated filters while replacing only id", () => {
+    const href = registeredAgentHref(
+      "/org/agents",
+      "?from=2026-01-01&to=2026-02-01&kind=agent&kind=unknown&id=old",
+      "agent/a b",
+    );
+    const url = new URL(href, "https://example.com");
+    expect(url.pathname).toBe("/org/agents");
+    expect([...url.searchParams.entries()]).toEqual([
+      ["from", "2026-01-01"],
+      ["to", "2026-02-01"],
+      ["kind", "agent"],
+      ["kind", "unknown"],
+      ["id", "agent/a b"],
+    ]);
+  });
+  it("handles an empty query", () => {
+    expect(registeredAgentHref("/org/agents", "", "agent/a")).toBe(
+      "/org/agents?id=agent%2Fa",
+    );
+  });
+});
+
+describe("matchesIdentityTelemetryFilters", () => {
+  const inventory = registeredAgentIdentity(agent);
+  it("keeps inventory visible without telemetry filters", () => {
+    expect(
+      matchesIdentityTelemetryFilters(inventory, undefined, undefined),
+    ).toBe(true);
+  });
+  it.each(["not_enrolled", "enrolled"])(
+    "excludes inventory from %s enrollment",
+    (enrollment) => {
+      expect(
+        matchesIdentityTelemetryFilters(inventory, enrollment, undefined),
+      ).toBe(false);
+    },
+  );
+  it.each(["never", "7d", "30d", "older"])(
+    "excludes inventory from %s activity",
+    (activity) => {
+      expect(
+        matchesIdentityTelemetryFilters(inventory, undefined, activity),
+      ).toBe(false);
+    },
+  );
+  it("preserves known non-inventory enrollment and activity filtering", () => {
+    const person = { ...inventory, registeredAgentId: undefined };
+    expect(
+      matchesIdentityTelemetryFilters(person, "not_enrolled", "never"),
+    ).toBe(true);
+    expect(matchesIdentityTelemetryFilters(person, "enrolled", undefined)).toBe(
+      false,
+    );
+    expect(matchesIdentityTelemetryFilters(person, undefined, "7d")).toBe(
+      false,
+    );
+    const active = { ...person, lastActivityTimestamp: Date.now() };
+    expect(matchesIdentityTelemetryFilters(active, undefined, "7d")).toBe(true);
+    expect(matchesIdentityTelemetryFilters(active, undefined, "never")).toBe(
+      false,
+    );
+  });
+});

--- a/client/dashboard/src/pages/identities/identityRoster.ts
+++ b/client/dashboard/src/pages/identities/identityRoster.ts
@@ -94,3 +94,38 @@ export function registeredAgentIdentity(agent: ManagedAgent): Employee {
     teams: [],
   };
 }
+
+/** Preserve roster context while selecting the agent at the org-level destination. */
+export function registeredAgentHref(
+  path: string,
+  search: string,
+  id: string,
+): string {
+  const params = new URLSearchParams(search);
+  params.set("id", id);
+  return `${path}?${params.toString()}`;
+}
+
+/** Inventory-only agents have no known enrollment or activity classification. */
+export function matchesIdentityTelemetryFilters(
+  identity: Employee,
+  enrollment: string | undefined,
+  activity: string | undefined,
+): boolean {
+  if (identity.registeredAgentId && (enrollment || activity)) return false;
+  if (enrollment && identity.status !== enrollment) return false;
+  return !activity || matchesActivity(identity, activity);
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function matchesActivity(identity: Employee, bucket: string): boolean {
+  const timestamp = identity.lastActivityTimestamp;
+  if (bucket === "never") return timestamp === null;
+  if (timestamp === null) return false;
+  const age = Date.now() - timestamp;
+  if (bucket === "7d") return age <= 7 * DAY_MS;
+  if (bucket === "30d") return age <= 30 * DAY_MS;
+  if (bucket === "older") return age > 30 * DAY_MS;
+  return true;
+}

--- a/client/dashboard/src/pages/identities/identityRoster.ts
+++ b/client/dashboard/src/pages/identities/identityRoster.ts
@@ -1,3 +1,7 @@
+import type { Employee } from "@/components/observe/insightsEmployeesData";
+import type { Gram } from "@gram/client";
+import type { ManagedAgent } from "@gram/client/models/components/managedagent.js";
+import { GramError } from "@gram/client/models/errors/gramerror.js";
 import { telemetrySearchUsers } from "@gram/client/funcs/telemetrySearchUsers";
 import { Source } from "@gram/client/models/components/searchuserspayload.js";
 import type { UserSummary } from "@gram/client/models/components/usersummary.js";
@@ -55,4 +59,38 @@ export async function fetchIdentityRoster(
   } while (cursor);
 
   return users;
+}
+
+/** Agent management is org-scoped and returns 404 when its rollout is off. */
+export async function fetchRegisteredAgents(
+  client: Gram,
+  signal?: AbortSignal,
+): Promise<ManagedAgent[]> {
+  try {
+    return await client.agents.list(undefined, undefined, { signal });
+  } catch (error) {
+    if (error instanceof GramError && error.statusCode === 404) return [];
+    throw error;
+  }
+}
+
+/** Inventory rows do not imply human enrollment or telemetry activity. */
+export function registeredAgentIdentity(agent: ManagedAgent): Employee {
+  return {
+    id: `agent:${agent.id}`,
+    registeredAgentId: agent.id,
+    name: agent.name,
+    email: "",
+    role: "",
+    status: "not_enrolled",
+    tokenCount: 0,
+    lastActivity: "—",
+    lastActivityTimestamp: null,
+    accounts: [],
+    mostRecentAccount: null,
+    hasPersonalAccount: false,
+    roleIds: [],
+    department: "",
+    teams: [],
+  };
 }

--- a/seed/demo/PAGES.md
+++ b/seed/demo/PAGES.md
@@ -52,6 +52,11 @@ connection.
 
 ### Managed agents
 
+The Identities roster also reads these three existing registered-agent fixtures
+in an ordinary local session. Agent names open the existing agent-management
+screen; unmatched telemetry identifiers without an email are Unknown, not Agent.
+The shared demo skips the restricted inventory read and keeps its people roster.
+
 Verify in the local rewritten seed with an ordinary human session: shared demo
 impersonation remains intentionally restricted by agent management authorization.
 `agent-management` enables inventory; `agent-identity-credentials` enables API key


### PR DESCRIPTION
## Summary
Include actual registered agents in the Identities roster alongside members and project telemetry. Unmatched telemetry without an email address or `@` in its name is now **Unknown**, rather than inferred to be an agent.

## Motivation
The roster previously counted bare telemetry identifiers as agents while omitting registered agents. Read the existing organization-scoped inventory, treat its disabled-rollout 404 as an empty agent list, and skip inventory reads for sessions unsupported by agent management. Existing organization/project scope is unchanged.

Agent row clicks and name links open the existing agent-management screen. **Moving agents into the identity page, including the agent detail experience, is a follow-up.** Existing seeded agents cover the added roster source; the shared demo continues to skip the restricted inventory read.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The identities roster now includes registered agents alongside members and telemetry, and unmatched telemetry without an email or `@` in its name is now **Unknown** instead of **Agent**.

- Reads the org-scoped agent inventory and treats the disabled-rollout 404 as an empty agent list.
- Skips the inventory read for sessions unsupported by agent management (demo org, impersonation, scope overrides).
- Agent rows and name links open the existing agent-management screen, preserving the roster's time window and filters; the agent detail experience is a follow-up.
- Registered agents are excluded from enrollment and activity filters and show an em dash for enrollment status since inventory rows don't imply human enrollment.

<sup>Written for commit 1f0e2b4a29ec8f0034ad3028f58022c3ec7895b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

