### PR TITLE
fix: show project names in killswitch MCP server picker

### DIFF
--- a/.changeset/killswitch-mcp-project-names.md
+++ b/.changeset/killswitch-mcp-project-names.md
@@ -1,0 +1,6 @@
+---
+"server": patch
+"dashboard": patch
+---
+
+Show project names instead of project IDs when choosing MCP servers for a killswitch.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -75931,10 +75931,14 @@ components:
         project_id:
           type: string
           format: uuid
+        project_name:
+          type: string
+          description: The project's display name
       required:
         - id
         - name
         - project_id
+        - project_name
     KillswitchMutationReceipt:
       type: object
       properties:

--- a/client/dashboard/src/components/killswitch/KillswitchEditorSheet.test.tsx
+++ b/client/dashboard/src/components/killswitch/KillswitchEditorSheet.test.tsx
@@ -490,8 +490,8 @@ describe("KillswitchEditorSheet", () => {
       screen.getByLabelText("Search MCP servers"),
       "alpha",
     );
-    expect(screen.getByText("Server A")).not.toBeNull();
-    expect(screen.queryByText("Server B")).toBeNull();
+    expect(screen.getByLabelText(/Server A/)).not.toBeNull();
+    expect(screen.queryByLabelText(/Server B/)).toBeNull();
   });
 
   it("keeps picker changes temporary until Apply and discards them on Cancel", async () => {

--- a/client/dashboard/src/components/killswitch/KillswitchEditorSheet.test.tsx
+++ b/client/dashboard/src/components/killswitch/KillswitchEditorSheet.test.tsx
@@ -30,9 +30,24 @@ const members = [
   },
 ];
 const servers = [
-  { id: "server-a", name: "Server A", projectId: "project-1" },
-  { id: "server-b", name: "Server B", projectId: "project-2" },
-  { id: "server-c", name: "Server C", projectId: "project-2" },
+  {
+    id: "server-a",
+    name: "Server A",
+    projectId: "project-1",
+    projectName: "Alpha",
+  },
+  {
+    id: "server-b",
+    name: "Server B",
+    projectId: "project-2",
+    projectName: "Beta",
+  },
+  {
+    id: "server-c",
+    name: "Server C",
+    projectId: "project-2",
+    projectName: "Beta",
+  },
 ];
 const capabilities = [
   { key: "mcp_tool_calls" as const, label: "MCP tool calls" },
@@ -443,6 +458,40 @@ describe("KillswitchEditorSheet", () => {
     expect(
       screen.getByRole("button", { name: "Choose servers (0)" }),
     ).not.toBeNull();
+  });
+
+  it("shows project names instead of project IDs in the MCP server picker", async () => {
+    renderEditor({
+      mode: "edit",
+      initial: {
+        id: "ks-picker-names",
+        userId: "user-1",
+        capabilityKey: "mcp_tool_calls",
+        capabilityLabel: "MCP tool calls",
+        version: 1,
+        status: "active",
+        scope: { type: "selected_servers", serverIds: ["server-a"] },
+        schedule: { start: "now", end: "until_lifted" },
+        externalNote: "Access paused.",
+        internalNote: "Incident response.",
+        history: [],
+        historyTruncated: false,
+      },
+    });
+    await userEvent.click(
+      screen.getByRole("button", { name: /Choose servers/ }),
+    );
+    expect(screen.getByText("Project Alpha")).not.toBeNull();
+    expect(screen.getAllByText("Project Beta")).toHaveLength(2);
+    expect(screen.queryByText(/project-1/)).toBeNull();
+    expect(screen.queryByText(/project-2/)).toBeNull();
+
+    await userEvent.type(
+      screen.getByLabelText("Search MCP servers"),
+      "alpha",
+    );
+    expect(screen.getByText("Server A")).not.toBeNull();
+    expect(screen.queryByText("Server B")).toBeNull();
   });
 
   it("keeps picker changes temporary until Apply and discards them on Cancel", async () => {

--- a/client/dashboard/src/components/killswitch/KillswitchEditorSheet.test.tsx
+++ b/client/dashboard/src/components/killswitch/KillswitchEditorSheet.test.tsx
@@ -486,10 +486,7 @@ describe("KillswitchEditorSheet", () => {
     expect(screen.queryByText(/project-1/)).toBeNull();
     expect(screen.queryByText(/project-2/)).toBeNull();
 
-    await userEvent.type(
-      screen.getByLabelText("Search MCP servers"),
-      "alpha",
-    );
+    await userEvent.type(screen.getByLabelText("Search MCP servers"), "alpha");
     expect(screen.getByLabelText(/Server A/)).not.toBeNull();
     expect(screen.queryByLabelText(/Server B/)).toBeNull();
   });

--- a/client/dashboard/src/components/killswitch/KillswitchEditorSheet.tsx
+++ b/client/dashboard/src/components/killswitch/KillswitchEditorSheet.tsx
@@ -220,7 +220,7 @@ function EditorContents({
     if (!pickerOpen) return [];
     const search = serverSearch.toLowerCase();
     return servers.filter((server) =>
-      `${server.name} ${server.projectId}`.toLowerCase().includes(search),
+      `${server.name} ${server.projectName}`.toLowerCase().includes(search),
     );
   }, [pickerOpen, serverSearch, servers]);
   const deletedSelectedIds = draft.serverIds.filter(
@@ -941,7 +941,7 @@ function EditorContents({
                       <span>
                         {server.name}
                         <span className="text-muted-foreground ml-2 text-xs">
-                          Project {server.projectId}
+                          Project {server.projectName}
                         </span>
                       </span>
                     </label>

--- a/client/dashboard/src/sdk/src/models/components/killswitchmcpserver.ts
+++ b/client/dashboard/src/sdk/src/models/components/killswitchmcpserver.ts
@@ -12,6 +12,10 @@ export type KillswitchMCPServer = {
   id: string;
   name: string;
   projectId: string;
+  /**
+   * The project's display name
+   */
+  projectName: string;
 };
 
 /** @internal */
@@ -23,10 +27,12 @@ export const KillswitchMCPServer$inboundSchema: z.ZodMiniType<
     id: z.string(),
     name: z.string(),
     project_id: z.string(),
+    project_name: z.string(),
   }),
   z.transform((v) => {
     return remap$(v, {
       "project_id": "projectId",
+      "project_name": "projectName",
     });
   }),
 );

--- a/server/design/killswitches/design.go
+++ b/server/design/killswitches/design.go
@@ -28,10 +28,11 @@ var ComingSoonCapability = Type("KillswitchComingSoonCapability", func() {
 })
 
 var MCPServer = Type("KillswitchMCPServer", func() {
-	Required("id", "name", "project_id")
+	Required("id", "name", "project_id", "project_name")
 	Attribute("id", String, func() { Format(FormatUUID) })
 	Attribute("name", String)
 	Attribute("project_id", String, func() { Format(FormatUUID) })
+	Attribute("project_name", String, "The project's display name")
 })
 
 var CustomerScope = Type("KillswitchScope", func() {

--- a/server/gen/http/killswitches/client/encode_decode.go
+++ b/server/gen/http/killswitches/client/encode_decode.go
@@ -2246,9 +2246,10 @@ func unmarshalKillswitchComingSoonCapabilityResponseBodyToKillswitchesKillswitch
 // type *KillswitchMCPServerResponseBody.
 func unmarshalKillswitchMCPServerResponseBodyToKillswitchesKillswitchMCPServer(v *KillswitchMCPServerResponseBody) *killswitches.KillswitchMCPServer {
 	res := &killswitches.KillswitchMCPServer{
-		ID:        *v.ID,
-		Name:      *v.Name,
-		ProjectID: *v.ProjectID,
+		ID:          *v.ID,
+		Name:        *v.Name,
+		ProjectID:   *v.ProjectID,
+		ProjectName: *v.ProjectName,
 	}
 
 	return res

--- a/server/gen/http/killswitches/client/types.go
+++ b/server/gen/http/killswitches/client/types.go
@@ -1846,6 +1846,8 @@ type KillswitchMCPServerResponseBody struct {
 	ID        *string `form:"id,omitempty" json:"id,omitempty" xml:"id,omitempty"`
 	Name      *string `form:"name,omitempty" json:"name,omitempty" xml:"name,omitempty"`
 	ProjectID *string `form:"project_id,omitempty" json:"project_id,omitempty" xml:"project_id,omitempty"`
+	// The project's display name
+	ProjectName *string `form:"project_name,omitempty" json:"project_name,omitempty" xml:"project_name,omitempty"`
 }
 
 // KillswitchSummaryResponseBody is used to define fields on response body
@@ -6087,6 +6089,9 @@ func ValidateKillswitchMCPServerResponseBody(body *KillswitchMCPServerResponseBo
 	}
 	if body.ProjectID == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("project_id", "body"))
+	}
+	if body.ProjectName == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("project_name", "body"))
 	}
 	if body.ID != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.id", *body.ID, goa.FormatUUID))

--- a/server/gen/http/killswitches/server/encode_decode.go
+++ b/server/gen/http/killswitches/server/encode_decode.go
@@ -2022,9 +2022,10 @@ func marshalKillswitchesKillswitchComingSoonCapabilityToKillswitchComingSoonCapa
 // *killswitches.KillswitchMCPServer.
 func marshalKillswitchesKillswitchMCPServerToKillswitchMCPServerResponseBody(v *killswitches.KillswitchMCPServer) *KillswitchMCPServerResponseBody {
 	res := &KillswitchMCPServerResponseBody{
-		ID:        v.ID,
-		Name:      v.Name,
-		ProjectID: v.ProjectID,
+		ID:          v.ID,
+		Name:        v.Name,
+		ProjectID:   v.ProjectID,
+		ProjectName: v.ProjectName,
 	}
 
 	return res

--- a/server/gen/http/killswitches/server/types.go
+++ b/server/gen/http/killswitches/server/types.go
@@ -1848,6 +1848,8 @@ type KillswitchMCPServerResponseBody struct {
 	ID        string `form:"id" json:"id" xml:"id"`
 	Name      string `form:"name" json:"name" xml:"name"`
 	ProjectID string `form:"project_id" json:"project_id" xml:"project_id"`
+	// The project's display name
+	ProjectName string `form:"project_name" json:"project_name" xml:"project_name"`
 }
 
 // KillswitchSummaryResponseBody is used to define fields on response body

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -79135,10 +79135,14 @@ components:
                 project_id:
                     type: string
                     format: uuid
+                project_name:
+                    type: string
+                    description: The project's display name
             required:
                 - id
                 - name
                 - project_id
+                - project_name
         KillswitchMutationReceipt:
             type: object
             properties:

--- a/server/gen/killswitches/service.go
+++ b/server/gen/killswitches/service.go
@@ -182,6 +182,8 @@ type KillswitchMCPServer struct {
 	ID        string
 	Name      string
 	ProjectID string
+	// The project's display name
+	ProjectName string
 }
 
 // KillswitchMutationReceipt is the result type of the killswitches service

--- a/server/internal/killswitchapi/service.go
+++ b/server/internal/killswitchapi/service.go
@@ -33,6 +33,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/management/readmodel"
 	"github.com/speakeasy-api/gram/server/internal/middleware"
 	"github.com/speakeasy-api/gram/server/internal/oops"
+	projectsrepo "github.com/speakeasy-api/gram/server/internal/projects/repo"
 )
 
 const (
@@ -125,9 +126,21 @@ func (s *Service) ListMCPServers(ctx context.Context, _ *gen.ListMCPServersPaylo
 	if err != nil {
 		return nil, mapError(fmt.Errorf("list organization MCP servers: %w", err))
 	}
+	projects, err := projectsrepo.New(s.db).ListProjectsByOrganization(ctx, string(organizationID))
+	if err != nil {
+		return nil, mapError(fmt.Errorf("list organization projects: %w", err))
+	}
+	projectNames := make(map[uuid.UUID]string, len(projects))
+	for _, project := range projects {
+		projectNames[project.ID] = project.Name
+	}
 	servers := make([]*gen.KillswitchMCPServer, len(rows))
 	for i, row := range rows {
-		servers[i] = &gen.KillswitchMCPServer{ID: row.ID.String(), Name: row.Name.String, ProjectID: row.ProjectID.String()}
+		projectName := projectNames[row.ProjectID]
+		if projectName == "" {
+			projectName = row.ProjectID.String()
+		}
+		servers[i] = &gen.KillswitchMCPServer{ID: row.ID.String(), Name: row.Name.String, ProjectID: row.ProjectID.String(), ProjectName: projectName}
 	}
 	return &gen.KillswitchListMCPServersResult{Servers: servers}, nil
 }

--- a/server/internal/killswitchapi/service_test.go
+++ b/server/internal/killswitchapi/service_test.go
@@ -27,6 +27,35 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
+func TestListMCPServersIncludesProjectNames(t *testing.T) {
+	t.Parallel()
+	service, db, orgID, userID, servers := newIntegrationService(t)
+	ctx := customerContext(t, orgID, userID)
+
+	var secondProjectID uuid.UUID
+	require.NoError(t, db.QueryRow(t.Context(), `INSERT INTO projects (name, slug, organization_id) VALUES ('Second Project', $1, $2) RETURNING id`, "p-"+uuid.NewString()[:12], orgID).Scan(&secondProjectID))
+	slug := "ts-" + uuid.NewString()[:12]
+	var toolsetID uuid.UUID
+	require.NoError(t, db.QueryRow(t.Context(), `INSERT INTO toolsets (organization_id, project_id, name, slug) VALUES ($1, $2, $3, $3) RETURNING id`, orgID, secondProjectID, slug).Scan(&toolsetID))
+	var secondServerID uuid.UUID
+	require.NoError(t, db.QueryRow(t.Context(), `INSERT INTO mcp_servers (project_id, name, toolset_id, visibility) VALUES ($1, 'Second Server', $2, 'private') RETURNING id`, secondProjectID, toolsetID).Scan(&secondServerID))
+
+	listed, err := service.ListMCPServers(ctx, &gen.ListMCPServersPayload{})
+	require.NoError(t, err)
+	require.Len(t, listed.Servers, 3)
+
+	byID := make(map[string]*gen.KillswitchMCPServer, len(listed.Servers))
+	for _, server := range listed.Servers {
+		byID[server.ID] = server
+	}
+	require.Equal(t, "project", byID[servers[0].String()].ProjectName)
+	require.Equal(t, "project", byID[servers[1].String()].ProjectName)
+	require.Equal(t, servers[0].String(), byID[servers[0].String()].ProjectID)
+	require.Equal(t, "Second Project", byID[secondServerID.String()].ProjectName)
+	require.Equal(t, secondProjectID.String(), byID[secondServerID.String()].ProjectID)
+	require.Equal(t, "Second Server", byID[secondServerID.String()].Name)
+}
+
 func TestCustomerKillswitchLifecycleAndReadModels(t *testing.T) {
 	t.Parallel()
 	service, db, orgID, userID, servers := newIntegrationService(t)

--- a/server/internal/killswitchapi/service_test.go
+++ b/server/internal/killswitchapi/service_test.go
@@ -50,9 +50,10 @@ func TestListMCPServersIncludesProjectNames(t *testing.T) {
 	}
 	require.Equal(t, "project", byID[servers[0].String()].ProjectName)
 	require.Equal(t, "project", byID[servers[1].String()].ProjectName)
-	require.Equal(t, servers[0].String(), byID[servers[0].String()].ProjectID)
+	require.Equal(t, byID[servers[0].String()].ProjectID, byID[servers[1].String()].ProjectID)
 	require.Equal(t, "Second Project", byID[secondServerID.String()].ProjectName)
 	require.Equal(t, secondProjectID.String(), byID[secondServerID.String()].ProjectID)
+	require.NotEqual(t, byID[servers[0].String()].ProjectID, byID[secondServerID.String()].ProjectID)
 	require.Equal(t, "Second Server", byID[secondServerID.String()].Name)
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Killswitch MCP server selection showed raw project IDs (`Project 0196cbd1-…`) instead of project names, so identical server names across projects were hard to tell apart.

`killswitches.listMCPServers` now includes each server's project display name, and the picker labels/search use that name.

Fixes DNO-1051.

## Changes

- Add required `project_name` to `KillswitchMCPServer`
- Resolve names from organization projects when listing MCP servers
- Render and search `Project {name}` in the killswitch editor picker
- Cover the API mapping and picker labels with tests

## Test plan

- [x] `KillswitchEditorSheet` unit tests — 17 passed, including a new case that the picker shows project names (not IDs) and search matches names
- [x] `killswitchapi` integration tests — 23 passed, including `TestListMCPServersIncludesProjectNames` for servers in two projects
- [ ] Create a killswitch, open **Selected servers**, confirm project names appear next to MCP servers

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DNO-1051](https://linear.app/speakeasy/issue/DNO-1051/bug-project-ids-shown-instead-of-names-when-choosing-mcp-server-in)

<div><a href="https://cursor.com/agents/bc-d248f276-c581-4bf8-8121-0603be658b28?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d248f276-c581-4bf8-8121-0603be658b28&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DNO-1051 by showing project display names instead of raw project IDs in the killswitch MCP server picker, so identical server names across projects are easier to tell apart. `listMCPServers` now supplies the project name for picker labels and search.

- Resolves names from the organization's projects and falls back to the project ID when no matching project exists.
- Adds required `project_name` to the API schema and SDK model.
- Adds integration and picker test coverage.

<sup>Written for commit c9d6d762edc0809589e0c793c789d9bef7ac8f6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

