### PR TITLE
fix: let a category without a recommendation carry a detection scope

### DIFF
--- a/server/internal/risk/detection_scopes_api_test.go
+++ b/server/internal/risk/detection_scopes_api_test.go
@@ -148,9 +148,6 @@ func TestRiskPolicyDetectionScopesValidation(t *testing.T) {
 		{"unknown category", []*types.RiskDetectionScope{
 			{Category: "not_a_category", ScopeInclude: nil, ScopeExempt: nil},
 		}},
-		{"custom self-scopes", []*types.RiskDetectionScope{
-			{Category: string(categories.CategoryCustom), ScopeInclude: nil, ScopeExempt: nil},
-		}},
 		{"session-scoped category", []*types.RiskDetectionScope{
 			{Category: string(categories.CategoryAccountIdentity), ScopeInclude: nil, ScopeExempt: nil},
 		}},
@@ -180,6 +177,53 @@ func TestRiskPolicyDetectionScopesValidation(t *testing.T) {
 		Name: created.Name,
 		DetectionScopes: []*types.RiskDetectionScope{
 			{Category: "not_a_category", ScopeInclude: nil, ScopeExempt: nil},
+		},
+	})
+	requireOopsCode(t, err, oops.CodeInvalid)
+}
+
+// `custom` has no registry recommendation because custom rules usually
+// self-scope through their detection_expr, but a rule written over `content`
+// matches every message kind, so an explicit scope is the only way to narrow
+// it. The scanner honours a specified custom scope, and the legacy-policy-scope
+// fold writes one, so the write path has to accept it.
+func TestRiskPolicyAcceptsCustomDetectionScope(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	ctx = withExactAccessGrants(t, ctx, ti.conn,
+		authz.Grant{Scope: authz.ScopeOrgAdmin, Selector: authz.NewSelector(authz.ScopeOrgAdmin, authCtx.ActiveOrganizationID)},
+	)
+
+	created, err := ti.service.CreateRiskPolicy(ctx, &risk.CreateRiskPolicyPayload{
+		Name: new("Custom Scope"),
+		DetectionScopes: []*types.RiskDetectionScope{
+			{Category: string(categories.CategoryCustom), ScopeInclude: new(`kind in ["tool_request"]`), ScopeExempt: nil},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, created.DetectionScopes, 1)
+	require.Equal(t, string(categories.CategoryCustom), created.DetectionScopes[0].Category)
+	require.NotNil(t, created.DetectionScopes[0].ScopeInclude)
+	require.Equal(t, `kind in ["tool_request"]`, *created.DetectionScopes[0].ScopeInclude)
+
+	// A folded policy round-trips: reading it back and saving it unchanged is
+	// exactly what the dashboard does, and it used to fail here.
+	_, err = ti.service.UpdateRiskPolicy(ctx, &risk.UpdateRiskPolicyPayload{
+		ID:   created.ID,
+		Name: created.Name,
+		DetectionScopes: []*types.RiskDetectionScope{
+			{Category: string(categories.CategoryCustom), ScopeInclude: new(`kind in ["tool_request"]`), ScopeExempt: nil},
+		},
+	})
+	require.NoError(t, err)
+
+	// Session-scoped categories are still refused.
+	_, err = ti.service.CreateRiskPolicy(ctx, &risk.CreateRiskPolicyPayload{
+		Name: new("Session Scoped"),
+		DetectionScopes: []*types.RiskDetectionScope{
+			{Category: string(categories.CategoryAccountIdentity), ScopeInclude: nil, ScopeExempt: nil},
 		},
 	})
 	requireOopsCode(t, err, oops.CodeInvalid)

--- a/server/internal/risk/policycore/validation.go
+++ b/server/internal/risk/policycore/validation.go
@@ -128,6 +128,16 @@ func ValidatePolicyType(policyType string) error {
 	}
 }
 
+// knownCategory reports whether the category is one Gram defines.
+func knownCategory(category categories.Category) bool {
+	for _, def := range categories.All() {
+		if def.Category == category {
+			return true
+		}
+	}
+	return false
+}
+
 // ValidateDetectionScopes validates and normalizes category-level message
 // scopes into the analyzer-config storage shape.
 func ValidateDetectionScopes(eng *celenv.Engine, specs []*DetectionScopeInput) ([]ra.DetectionScopeConfig, error) {
@@ -138,11 +148,19 @@ func ValidateDetectionScopes(eng *celenv.Engine, specs []*DetectionScopeInput) (
 			return nil, fmt.Errorf("detection scope must not be null")
 		}
 		category := categories.Category(spec.Category)
-		recommendation, ok := recommendedscopes.For(category)
-		if !ok {
+		if !knownCategory(category) {
 			return nil, fmt.Errorf("detection scope category %q is not recognized", spec.Category)
 		}
-		if !recommendation.Applicable {
+		// Membership of the registry answers "is there a recommended scope for
+		// this category", not "may this category carry one". `custom` has no
+		// recommendation because custom rules usually self-scope through their
+		// detection_expr, but a rule written over `content` matches every
+		// message kind, so an explicit scope is the only way to narrow it.
+		// The scanner already honours a specified custom scope (a specified
+		// scope wins over any recommendation) and listCategories already
+		// advertises the category as applicable, so gating writes on the
+		// registry only made the two halves disagree.
+		if recommendation, ok := recommendedscopes.For(category); ok && !recommendation.Applicable {
 			return nil, fmt.Errorf("category %q is session-scoped; message detection scopes do not apply", spec.Category)
 		}
 		if seen[category] {

--- a/server/internal/risk/policycore/validation.go
+++ b/server/internal/risk/policycore/validation.go
@@ -130,12 +130,9 @@ func ValidatePolicyType(policyType string) error {
 
 // knownCategory reports whether the category is one Gram defines.
 func knownCategory(category categories.Category) bool {
-	for _, def := range categories.All() {
-		if def.Category == category {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(categories.All(), func(def categories.Definition) bool {
+		return def.Category == category
+	})
 }
 
 // ValidateDetectionScopes validates and normalizes category-level message

--- a/server/internal/risk/policycore/validation.go
+++ b/server/internal/risk/policycore/validation.go
@@ -151,15 +151,9 @@ func ValidateDetectionScopes(eng *celenv.Engine, specs []*DetectionScopeInput) (
 		if !knownCategory(category) {
 			return nil, fmt.Errorf("detection scope category %q is not recognized", spec.Category)
 		}
-		// Membership of the registry answers "is there a recommended scope for
-		// this category", not "may this category carry one". `custom` has no
-		// recommendation because custom rules usually self-scope through their
-		// detection_expr, but a rule written over `content` matches every
-		// message kind, so an explicit scope is the only way to narrow it.
-		// The scanner already honours a specified custom scope (a specified
-		// scope wins over any recommendation) and listCategories already
-		// advertises the category as applicable, so gating writes on the
-		// registry only made the two halves disagree.
+		// The registry says whether a category has a recommended scope, not
+		// whether it may carry one: `custom` has no recommendation but a rule
+		// written over `content` still needs an explicit scope to narrow it.
 		if recommendation, ok := recommendedscopes.For(category); ok && !recommendation.Applicable {
 			return nil, fmt.Errorf("category %q is session-scoped; message detection scopes do not apply", spec.Category)
 		}

--- a/server/internal/risk/policycore/validation_test.go
+++ b/server/internal/risk/policycore/validation_test.go
@@ -7,7 +7,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	ra "github.com/speakeasy-api/gram/server/internal/background/activities/risk_analysis"
+	"github.com/speakeasy-api/gram/server/internal/risk/categories"
 	"github.com/speakeasy-api/gram/server/internal/risk/celenv"
+	"github.com/speakeasy-api/gram/server/internal/risk/recommendedscopes"
 	"github.com/speakeasy-api/gram/server/internal/shadowmcp"
 )
 
@@ -104,4 +106,26 @@ func TestValidateDetectionScopes(t *testing.T) {
 			require.Error(t, err)
 		})
 	}
+}
+
+// The registry answers "is there a recommended scope", not "may this category
+// carry one". `custom` has no recommendation, but the scanner honours a
+// specified scope for it and the legacy-policy-scope fold writes one.
+func TestValidateDetectionScopesAcceptsCategoryWithoutRecommendation(t *testing.T) {
+	t.Parallel()
+
+	eng, err := celenv.New()
+	require.NoError(t, err)
+
+	_, ok := recommendedscopes.For(categories.CategoryCustom)
+	require.False(t, ok, "custom is deliberately absent from the registry")
+
+	include := `kind in ["tool_request"]`
+	got, err := ValidateDetectionScopes(eng, []*DetectionScopeInput{{
+		Category: string(categories.CategoryCustom), ScopeInclude: &include, ScopeExempt: nil,
+	}})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "custom", got[0].Category)
+	require.Equal(t, include, got[0].ScopeInclude)
 }

--- a/server/internal/risk/scanner.go
+++ b/server/internal/risk/scanner.go
@@ -879,7 +879,9 @@ func (s *Scanner) scanPolicy(ctx context.Context, policy repo.RiskPolicy, basePr
 			}
 		}
 	}
-	if denyFindings := filter(customFindings); len(denyFindings) > 0 {
+	// Custom findings pass the category scope like every other source, so a
+	// specified `custom` scope narrows realtime enforcement too.
+	if denyFindings := categoryScope.FilterFindings(view, filter(customFindings)); len(denyFindings) > 0 {
 		return &ScanResult{
 			Action:           policy.Action,
 			PolicyID:         policy.ID.String(),

--- a/server/internal/risk/scanner_test.go
+++ b/server/internal/risk/scanner_test.go
@@ -1470,3 +1470,79 @@ func TestScanner_PresidioDeadLetterBlockStillDenies(t *testing.T) {
 	require.Equal(t, risk_analysis.DeadLetterRuleID, result.RuleID)
 	require.NotEmpty(t, result.DeadLetterReason)
 }
+
+// A specified `custom` detection scope has to narrow realtime enforcement, not
+// just batch analysis: custom findings previously bypassed the category scope,
+// so a scope the API now accepts would have been silently unenforced here.
+func TestScanner_CustomDetectionScopeNarrowsEnforcement(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestRiskService(t)
+	authCtx, _ := contextvalues.GetAuthContext(ctx)
+	require.NotNil(t, authCtx.ProjectID)
+
+	_, err := riskrepo.New(ti.conn).CreateCustomDetectionRule(ctx, riskrepo.CreateCustomDetectionRuleParams{
+		ProjectID:      *authCtx.ProjectID,
+		OrganizationID: authCtx.ActiveOrganizationID,
+		RuleID:         "custom.acme_token",
+		Title:          "ACME token",
+		Description:    "ACME token",
+		// `content` is populated for every message kind, so this rule does not
+		// self-scope and the detection scope is the only thing narrowing it.
+		DetectionExpr: pgtype.Text{String: `content.matchRegex("ACME-[A-Z0-9]{8}")`, Valid: true},
+		Severity:      "high",
+	})
+	require.NoError(t, err)
+
+	analyzerConfig, err := risk_analysis.WithDetectionScopes(nil, []risk_analysis.DetectionScopeConfig{
+		{Category: "custom", ScopeInclude: `kind in ["tool_request"]`, ScopeExempt: ""},
+	})
+	require.NoError(t, err)
+
+	policyID := uuid.New()
+	_, err = riskrepo.New(ti.conn).CreateRiskPolicy(ctx, riskrepo.CreateRiskPolicyParams{
+		ID:                   policyID,
+		ProjectID:            *authCtx.ProjectID,
+		OrganizationID:       authCtx.ActiveOrganizationID,
+		Name:                 "custom scoped",
+		Sources:              []string{},
+		PresidioEntities:     nil,
+		PromptInjectionRules: nil,
+		DisabledRules:        nil,
+		CustomRuleIds:        []string{"custom.acme_token"},
+		MessageTypes:         nil,
+		AnalyzerConfig:       analyzerConfig,
+		Enabled:              true,
+		Action:               "block",
+		AudienceType:         "everyone",
+		AutoName:             false,
+		UserMessage:          pgtype.Text{},
+	})
+	require.NoError(t, err)
+	grantRiskPolicyToAllUsers(t, ti, ctx, authCtx.ActiveOrganizationID, policyID)
+
+	scanner, err := risk.NewScanner(
+		testenv.NewLogger(t),
+		testenv.NewTracerProvider(t),
+		testenv.NewMeterProvider(t),
+		ti.conn,
+		newTestCustomRuleAnalyzer(t, ti.conn),
+		nil,
+		nil,
+		nil,
+		nil,
+		testCELEngine(t), metering.NewRiskRecorder(gcp.NewNoopPublisher[*meteringv1.MeterReading]()))
+	require.NoError(t, err)
+
+	// Out of scope: the rule matches the text, but the scope excludes user messages.
+	result, err := scanner.ScanForEnforcement(ctx, realtimeScanRequest(authCtx.ActiveOrganizationID, *authCtx.ProjectID, authCtx.UserID, "deploy ACME-ABC12345 now", message.User, ""))
+	require.NoError(t, err)
+	require.Nil(t, result, "a custom scope that excludes user messages must not block one")
+
+	// In scope: the same text on the admitted kind still blocks, so the scope
+	// narrows enforcement rather than disabling it.
+	result, err = scanner.ScanForEnforcement(ctx, realtimeScanRequest(authCtx.ActiveOrganizationID, *authCtx.ProjectID, authCtx.UserID, "deploy ACME-ABC12345 now", message.ToolRequest, "Bash"))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, risk_analysis.SourceCustom, result.Source)
+	require.Equal(t, "custom.acme_token", result.RuleID)
+}


### PR DESCRIPTION
`ValidateDetectionScopes` gated writes on membership of the `recommendedscopes`
registry. But registry membership answers "is there a recommended scope for this
category", not "may this category carry one", and `custom` is deliberately
absent from the registry:

> Custom rules are intentionally absent from this registry: they self-scope via
> their CEL `detection_expr`.

So every write of a `custom` detection scope was refused.

That self-scoping reasoning holds for the pre-scoped CEL fields: `prompt` is
empty on anything but a user message, `tool_calls` on anything but a tool
request, and so on (`celenv.go:223-226`), so a rule over those fields cannot
fire on other kinds and a category scope would be redundant. It does not hold
for `content`, which is populated for every message type and which the
rule-authoring assistant offers as its first example
(`content.matchRegex("sk-[A-Za-z0-9]{32}")`). For those rules an explicit scope
is the only way to narrow by message kind once the legacy policy scope is gone.

The rest of the system already agreed. The scanner honours a specified custom
scope (a specified scope wins over any recommendation, and `Masks` copies
specified scopes in regardless of the registry), and `listCategories`
synthesises an `Applicable: true` entry for categories with no recommendation
(`impl.go:1943-1952`). Only the write path disagreed.

## Why now

AIS-678's `legacy-policy-scope` fold (#6096) writes a `custom` detection scope
for an enforcing policy carrying custom rules. Running it locally, two seeded
policies came out with:

```json
[{"category": "custom", "scope_include": "kind in [\"tool_request\"]"}]
```

`policy-form.ts:186` adds `custom` to a policy's selected categories whenever it
has custom rules, so the dashboard round-trips that scope on the next save and
the API rejects it. **After the fold ran, an enforcing policy with custom rules
could not be saved from the dashboard.** This has to be deployed to an
environment before the fold runs there.

It also removes the reason the onboarding wizard still writes the legacy
`message_types` field: `policy-scope.ts:225` mirrors this server rule with a
`key !== "custom"` check, and `configure-policies-step.tsx:371` falls back to
the legacy list because of it. That cleanup is a follow-up.

## Changes

- `ValidateDetectionScopes` checks the category against `categories.All()`
  instead of the registry. Session-scoped categories are still rejected, now
  via the recommendation only where one exists.
- Dropped the `"custom self-scopes"` rejection case, replaced with a positive
  test that creates a policy with a custom scope and saves it back unchanged
  (the dashboard round-trip that was failing).
- Unit coverage in `policycore`.

Unknown categories and session-scoped categories are still refused, both
asserted.

AIS-678.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `ValidateDetectionScopes` so a category without a recommended scope, like `custom`, can carry a detection scope, and applies that scope to custom findings in realtime enforcement.

- Category validity is now checked against `categories.All()`; unknown and session-scoped categories are still refused.
- Custom findings previously bypassed the category scope in realtime enforcement, so an accepted `custom` scope would have been silently ignored there; they now pass through the same filter as other sources.
- Unblocks the legacy-policy-scope fold (AIS-678), which writes a custom detection scope for enforcing policies with custom rules. Without this, such policies could not be saved from the dashboard after the fold ran.

<sup>Written for commit 339141fe84991040d6babee2c4716846b4159d28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

