### PR TITLE
fix: stop server access lines naming their own principal

### DIFF
--- a/client/dashboard/src/pages/mcp/access/ManageAccess.test.tsx
+++ b/client/dashboard/src/pages/mcp/access/ManageAccess.test.tsx
@@ -248,12 +248,14 @@ describe("the access list", () => {
     // the role's own connect line, since this block covers every server and
     // so is not the role row's to lift either. A collapsed row keeps its
     // panel in the DOM — inert, so the disclosure can animate — so the
-    // role's line is rendered without being expanded. The note is split
-    // around a link to the role, hence matching on whole text.
+    // role's line is rendered without being expanded. The person's note is
+    // split around a link to the role, hence matching on whole text; the
+    // role's own line just reads "No access", since naming itself says
+    // nothing.
     const notes = screen
       .getAllByText(/blocked by/)
       .filter((el) => el.textContent === "blocked by Engineering");
-    expect(notes).toHaveLength(2);
+    expect(notes).toHaveLength(1);
     expect(screen.queryByText("Search")).toBeNull();
   });
 

--- a/client/dashboard/src/pages/mcp/access/ManageAccess.tsx
+++ b/client/dashboard/src/pages/mcp/access/ManageAccess.tsx
@@ -659,6 +659,11 @@ function ScopeLine({
           )}
         </Text>
       )}
+      {state.note && (
+        <Text muted small>
+          {state.granted ? state.note : `blocked ${state.note}`}
+        </Text>
+      )}
     </div>
   );
 }

--- a/client/dashboard/src/pages/mcp/access/accessRows.test.ts
+++ b/client/dashboard/src/pages/mcp/access/accessRows.test.ts
@@ -199,6 +199,47 @@ describe("a person and the roles they are in", () => {
     expect(state.subtracts).toBe(true);
   });
 
+  it("says nothing extra when a row's own rule for every server decides it", () => {
+    // "via Collaborator" on the Collaborator row says nothing, and this page
+    // answers for one server, so where else the rule reaches is not the note.
+    const row = rowFor([role("Collaborator", { level: "view" })]);
+    const state = scopeState(row, "view", catalog);
+
+    expect(state.value).toBe("Allowed");
+    expect(state.via).toBeUndefined();
+    expect(state.note).toBeUndefined();
+  });
+
+  it("says which scope on this server a weaker line is included in", () => {
+    const row = rowFor([
+      role("Collaborator", { appliesTo: "resource", level: "manage" }),
+    ]);
+
+    expect(scopeState(row, "view", catalog).note).toBe("included in Manage");
+  });
+
+  it("reads a row's own block for every server as plain no access", () => {
+    const row = rowFor([role("Collaborator", { level: "blocked_manage" })]);
+    const state = scopeState(row, "manage", catalog);
+
+    expect(state.value).toBe("No access");
+    expect(state.granted).toBe(false);
+    expect(state.via).toBeUndefined();
+    expect(state.note).toBeUndefined();
+    expect(state.capped).toBe(true);
+  });
+
+  it("names another principal over the row's own wider rule", () => {
+    const person = personIn([
+      role("Admin", { level: "manage" }),
+      entry({ principalUrn: "user:u1", appliesTo: "all_resources" }),
+    ]);
+    const state = scopeState(person, "use", catalog);
+
+    expect(state.via).toBe("Admin");
+    expect(state.note).toBeUndefined();
+  });
+
   it("still resolves a role's grant when the person has a rule of their own", () => {
     // The person's own connect rule must not hide the role's manage grant:
     // the write paths need it to know a block is required.

--- a/client/dashboard/src/pages/mcp/access/accessRows.ts
+++ b/client/dashboard/src/pages/mcp/access/accessRows.ts
@@ -208,10 +208,16 @@ export interface ScopeState {
   subtracts: boolean;
   /** True when the line can be turned off here at all. */
   canRevoke: boolean;
-  /** The principal this line comes from, when it is not this row's own rule. */
+  /** Another principal this line comes from, when one decides it. */
   via?: string;
   /** That principal's URN, so the name can link to it. */
   viaPrincipalUrn?: string;
+  /**
+   * Where the line comes from when a stronger scope on this server, held by
+   * this row's own principal, decides it. Naming the principal there reads as
+   * "via itself", which says nothing.
+   */
+  note?: string;
   /** True when a block this row cannot lift caps how far the line reaches. */
   capped?: boolean;
 }
@@ -254,13 +260,15 @@ export function scopeState(
     // this row's to reopen.
     const foreign = foreignBlocks(row, cell);
     const cancelling = foreign.find(isUnnarrowed) ?? foreign[0];
+    const cancellingSelf = cancelling?.principalUrn === row.principalUrn;
     return {
       value: "No access",
       granted: false,
       subtracts: false,
       canRevoke: false,
-      via: cancelling?.displayName,
-      viaPrincipalUrn: cancelling?.principalUrn,
+      via: cancellingSelf ? undefined : cancelling?.displayName,
+      viaPrincipalUrn: cancellingSelf ? undefined : cancelling?.principalUrn,
+      note: cancellingSelf ? sourceNote(cancelling) : undefined,
       // Any block this row cannot lift caps it, whether it closed the line
       // outright or trimmed the last tool away.
       capped: foreign.length > 0,
@@ -270,16 +278,36 @@ export function scopeState(
   // Anything granting this line other than the rule this page owns. It is
   // what a revoke has to subtract from, and what the line comes "via".
   const foreign = cell.grants.filter((grant) => grant !== cell.own);
+  // Another principal granting the line is what an administrator wants named,
+  // so it wins over this row's own wider rule when both reach it.
+  const granting =
+    foreign.find((grant) => grant.principalUrn !== row.principalUrn) ??
+    foreign[0];
+  const grantingSelf = granting?.principalUrn === row.principalUrn;
 
   return {
     value: scope === "use" ? connectLabel(cell, catalog, reachable) : "Allowed",
     granted: true,
     subtracts: foreign.length > 0,
     canRevoke: true,
-    via: cell.own ? undefined : foreign[0]?.displayName,
-    viaPrincipalUrn: cell.own ? undefined : foreign[0]?.principalUrn,
+    via: cell.own || grantingSelf ? undefined : granting?.displayName,
+    viaPrincipalUrn:
+      cell.own || grantingSelf ? undefined : granting?.principalUrn,
+    note: cell.own || !grantingSelf ? undefined : sourceNote(granting),
     capped: foreignBlocks(row, cell).length > 0,
   };
+}
+
+/**
+ * How to say where a rule of this row's own principal comes from, when it is
+ * not the rule this page owns for this line. A rule covering every server
+ * gets no note: this page answers for one server, and where else the rule
+ * reaches is not what an administrator is reading here.
+ */
+function sourceNote(entry: ResourceAudienceEntry): string | undefined {
+  if (entry.appliesTo === "all_resources") return undefined;
+  const label = SCOPE_ROWS.find((row) => row.key === entry.level)?.label;
+  return label ? `included in ${label}` : undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

On a server's "Manage access to this server" panel, each scope line names where its answer comes from when the rule is not the one the panel owns. That attribution was resolved by picking the first contributing rule, so a row whose own wider rule decided the line named itself: the Collaborator row read `Allowed via Collaborator` and `No access blocked by Collaborator`.

`scopeState` now decides attribution by who holds the rule, not by position:

- Another principal deciding the line still reads `via X` / `blocked by X`, and is now preferred over the row's own wider rule when both reach the line, so the informative name wins.
- The row's own rule covering every server contributes no note. This panel answers for one server, so `Allowed` and `No access` stand alone.
- A stronger scope on *this* server carrying a weaker line reads `included in Manage`, which is the one self-attribution a reviewer can act on here.

## Motivation

"via itself" is noise that reads like a second principal is involved, and on the blocked line it implied an external rule an administrator would go looking for. The distinction that matters on this page is whether some *other* principal decides the line — that is what an administrator has to go and change — so the label now says exactly that and stays quiet otherwise.

https://claude.ai/code/session_011arBjiP4QfkLogW37zU8RC


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the server access panel so scope lines no longer name the row's own principal as the source. Attribution now prefers another principal's rule, and a row's own wider rule is only noted when it includes a weaker scope on this server.

- Scope lines now resolve attribution by which principal's rule decides the line, not by which rule appears first.
- Another principal's rule is still named with `via X` or `blocked by X` and takes precedence over the row's own wider rule.
- A row's own rule covering every server no longer adds a note; the line reads plain `Allowed` or `No access`.
- A stronger scope on this server that carries a weaker line now reads `included in Manage` (or the appropriate scope label).
- Added tests covering these cases, including interaction with collapsed rows.

<sup>Written for commit 4872e04747fb83bbbc0308fe9004fabdc8e75ae7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

