### PR TITLE
chore: stop Platform MCP writing the legacy policy-level message_types scope

### DIFF
--- a/.changeset/platform-mcp-drop-policy-message-types.md
+++ b/.changeset/platform-mcp-drop-policy-message-types.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Platform MCP risk policy tools no longer accept or return the policy-level `message_types` field. New policies leave the legacy scope columns empty and scope through `detection_scopes`; a stored policy whose legacy `message_types` still narrows it is reported as `raw_scope` until the legacy scope migration folds it.

--- a/server/internal/platformmcp/risk_policy_create_match_test.go
+++ b/server/internal/platformmcp/risk_policy_create_match_test.go
@@ -1,0 +1,50 @@
+package platformmcp
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/risk/policycatalog"
+	riskrepo "github.com/speakeasy-api/gram/server/internal/risk/repo"
+)
+
+func TestRiskPolicyCreateMatchesRejectsLegacyNarrowedRows(t *testing.T) {
+	t.Parallel()
+
+	catalog, err := policycatalog.Build()
+	require.NoError(t, err)
+	projectID := uuid.New()
+	desired := riskrepo.CreateRiskPolicyParams{
+		ID: uuid.New(), ProjectID: projectID, OrganizationID: "<ORG_ID>", Name: "Policy", PolicyType: "standard",
+		Sources: []string{"gitleaks"}, PresidioEntities: []string{}, AnalyzerConfig: []byte(`{}`), PromptInjectionRules: []string{}, DisabledRules: []string{}, CustomRuleIds: []string{},
+		MessageTypes: nil, ScopeInclude: pgtype.Text{}, ScopeExempt: pgtype.Text{}, Enabled: true, Action: "flag", AudienceType: riskPolicyAudienceEveryone,
+		ShadowMcpDisposition: pgtype.Text{}, AutoName: false, UserMessage: pgtype.Text{}, Prompt: pgtype.Text{}, ModelConfig: nil, Score: pgtype.Float8{Float64: 5, Valid: true},
+	}
+	row := riskrepo.RiskPolicy{
+		ID: uuid.New(), ProjectID: projectID, OrganizationID: "<ORG_ID>", Name: "Policy", PolicyType: "standard",
+		Sources: []string{"gitleaks"}, PresidioEntities: []string{}, AnalyzerConfig: []byte(`{}`), PromptInjectionRules: []string{}, DisabledRules: []string{}, CustomRuleIds: []string{},
+		Enabled: true, Action: "flag", AudienceType: riskPolicyAudienceEveryone, Score: 5,
+	}
+	audience := []string{authz.AllUsersPrincipal().String()}
+
+	cases := map[string]struct {
+		messageTypes []string
+		matches      bool
+	}{
+		"null":         {messageTypes: nil, matches: true},
+		"full catalog": {messageTypes: []string{"user_message", "tool_response", "assistant_message", "tool_request"}, matches: true},
+		"narrowed":     {messageTypes: []string{"tool_request", "tool_response"}, matches: false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			candidate := row
+			candidate.MessageTypes = tc.messageTypes
+			require.Equal(t, tc.matches, riskPolicyCreateMatches(candidate, audience, desired, catalog))
+		})
+	}
+}

--- a/server/internal/platformmcp/risk_policy_mutations.go
+++ b/server/internal/platformmcp/risk_policy_mutations.go
@@ -773,7 +773,7 @@ func (s *riskPolicyMutationService) matchExistingCreate(ctx context.Context, tx 
 		if err != nil {
 			return nil, fmt.Errorf("load risk policy audience for create convergence: %w", err)
 		}
-		if riskPolicyCreateMatches(row, audience, prepared.params) {
+		if riskPolicyCreateMatches(row, audience, prepared.params, s.catalog) {
 			matches = append(matches, policycore.MutationResult{Row: row, AudiencePrincipalURNs: audience})
 		}
 	}
@@ -786,8 +786,12 @@ func (s *riskPolicyMutationService) matchExistingCreate(ctx context.Context, tx 
 	return nil, nil
 }
 
-func riskPolicyCreateMatches(row riskrepo.RiskPolicy, audience []string, desired riskrepo.CreateRiskPolicyParams) bool {
-	return row.OrganizationID == desired.OrganizationID && row.Name == desired.Name && row.PolicyType == desired.PolicyType && row.Enabled == desired.Enabled && row.Action == desired.Action && row.AudienceType == desired.AudienceType && row.AutoName == desired.AutoName && row.Score == desired.Score.Float64 &&
+// riskPolicyCreateMatches decides whether an existing row is the same policy a
+// create describes. Platform MCP creates carry no legacy scope, so a row still
+// narrowed by the legacy message_types column is a different, narrower policy
+// and must not satisfy the create.
+func riskPolicyCreateMatches(row riskrepo.RiskPolicy, audience []string, desired riskrepo.CreateRiskPolicyParams, catalog policycatalog.Catalog) bool {
+	return !legacyMessageTypesNarrow(row.MessageTypes, catalog) && row.OrganizationID == desired.OrganizationID && row.Name == desired.Name && row.PolicyType == desired.PolicyType && row.Enabled == desired.Enabled && row.Action == desired.Action && row.AudienceType == desired.AudienceType && row.AutoName == desired.AutoName && row.Score == desired.Score.Float64 &&
 		reflect.DeepEqual(canonicalStrings(row.Sources), canonicalStrings(desired.Sources)) && reflect.DeepEqual(canonicalStrings(row.PresidioEntities), canonicalStrings(desired.PresidioEntities)) && reflect.DeepEqual(canonicalStrings(row.PromptInjectionRules), canonicalStrings(desired.PromptInjectionRules)) && reflect.DeepEqual(canonicalStrings(row.DisabledRules), canonicalStrings(desired.DisabledRules)) && len(row.CustomRuleIds) == 0 &&
 		canonicalJSONEqual(row.AnalyzerConfig, desired.AnalyzerConfig) && row.ScopeInclude == desired.ScopeInclude && row.ScopeExempt == desired.ScopeExempt && row.ShadowMcpDisposition == desired.ShadowMcpDisposition && row.UserMessage == desired.UserMessage && row.Prompt == desired.Prompt && len(row.ModelConfig) == 0 && reflect.DeepEqual(canonicalStrings(audience), []string{authz.AllUsersPrincipal().String()})
 }

--- a/server/internal/platformmcp/risk_policy_mutations.go
+++ b/server/internal/platformmcp/risk_policy_mutations.go
@@ -55,7 +55,6 @@ type createRiskPolicyInput struct {
 	Enabled                bool                 `json:"enabled"`
 	Action                 string               `json:"action,omitempty"`
 	Score                  *float64             `json:"score,omitempty"`
-	MessageTypes           []string             `json:"message_types,omitempty"`
 	UserMessage            *string              `json:"user_message,omitempty"`
 	Sources                []string             `json:"sources,omitempty"`
 	PresidioEntities       []string             `json:"presidio_entities,omitempty"`
@@ -88,7 +87,6 @@ type normalizedCreateRiskPolicy struct {
 	Enabled                bool                 `json:"enabled"`
 	Action                 string               `json:"action"`
 	Score                  float64              `json:"score"`
-	MessageTypes           []string             `json:"message_types"`
 	UserMessage            *string              `json:"user_message,omitempty"`
 	Sources                []string             `json:"sources"`
 	PresidioEntities       []string             `json:"presidio_entities"`
@@ -319,7 +317,7 @@ func normalizeRiskPolicyPatchForReceipt(patch map[string]json.RawMessage) (map[s
 				return nil, invalidRiskPolicyRequest()
 			}
 			normalized[field] = value
-		case "message_types", "sources", "presidio_entities", "prompt_injection_rules", "disabled_rules", "approved_email_domains":
+		case "sources", "presidio_entities", "prompt_injection_rules", "disabled_rules", "approved_email_domains":
 			var value []string
 			if json.Unmarshal(raw, &value) != nil {
 				return nil, invalidRiskPolicyRequest()
@@ -380,24 +378,21 @@ func (s *riskPolicyMutationService) prepareCreate(ctx context.Context, principal
 	if !slices.Contains(s.catalog.Actions, action) || score < 0.1 || score > 10 || !utf8.ValidString(input.Name) {
 		return preparedRiskPolicyCreate{}, invalidRiskPolicyRequest()
 	}
-	messageTypes := canonicalStrings(input.MessageTypes)
-	if input.MessageTypes == nil {
-		messageTypes = slices.Clone(s.catalog.PolicyMessageTypes)
-	}
-	if !allIn(messageTypes, s.catalog.PolicyMessageTypes) || len(messageTypes) == 0 || invalidUserMessage(input.UserMessage) {
+	if invalidUserMessage(input.UserMessage) {
 		return preparedRiskPolicyCreate{}, invalidRiskPolicyRequest()
 	}
 
 	normalized := normalizedCreateRiskPolicy{
 		ProjectSlug: project.Slug, PolicyType: input.PolicyType, Name: input.Name, Enabled: input.Enabled,
-		Action: action, Score: score, MessageTypes: messageTypes, UserMessage: input.UserMessage,
+		Action: action, Score: score, UserMessage: input.UserMessage,
 		Sources: []string{}, PresidioEntities: []string{}, PresidioScoreThreshold: nil, PromptInjectionRules: []string{}, DisabledRules: []string{}, ApprovedEmailDomains: []string{}, DetectionScopes: []riskDetectionScope{}, PromptDigest: "",
 	}
 	params := riskrepo.CreateRiskPolicyParams{
 		ID: uuid.Nil, ProjectID: project.ID, OrganizationID: principal.OrganizationID, Name: input.Name,
 		PolicyType: input.PolicyType, Sources: []string{}, PresidioEntities: []string{}, AnalyzerConfig: nil,
-		PromptInjectionRules: []string{}, DisabledRules: []string{}, CustomRuleIds: []string{}, MessageTypes: messageTypes,
-		ScopeInclude: pgtype.Text{String: "", Valid: false}, ScopeExempt: pgtype.Text{String: "", Valid: false}, Enabled: input.Enabled, Action: action,
+		PromptInjectionRules: []string{}, DisabledRules: []string{}, CustomRuleIds: []string{},
+		// Legacy policy-level scope columns stay NULL; detection_scopes carry scope.
+		MessageTypes: nil, ScopeInclude: pgtype.Text{String: "", Valid: false}, ScopeExempt: pgtype.Text{String: "", Valid: false}, Enabled: input.Enabled, Action: action,
 		AudienceType: riskPolicyAudienceEveryone, ShadowMcpDisposition: pgtype.Text{String: "", Valid: false}, AutoName: false,
 		UserMessage: conv.PtrToPGTextEmpty(input.UserMessage), Prompt: pgtype.Text{String: "", Valid: false}, ModelConfig: nil,
 		Score: pgtype.Float8{Float64: score, Valid: true},
@@ -484,7 +479,7 @@ func (s *riskPolicyMutationService) prepareUpdate(ctx context.Context, principal
 	// depend on randomized Go map order.
 	for _, field := range []string{
 		"sources", "presidio_entities", "action", "name", "enabled", "score", "prompt", "user_message",
-		"message_types", "presidio_score_threshold", "approved_email_domains", "prompt_injection_rules", "disabled_rules", "detection_scopes",
+		"presidio_score_threshold", "approved_email_domains", "prompt_injection_rules", "disabled_rules", "detection_scopes",
 	} {
 		raw, ok := input.Patch[field]
 		if !ok {
@@ -537,17 +532,6 @@ func (s *riskPolicyMutationService) prepareUpdate(ctx context.Context, principal
 				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
 			}
 			params.UserMessage = conv.ToPGTextEmpty(value)
-			normalized[field] = value
-		case "message_types":
-			var value []string
-			if json.Unmarshal(raw, &value) != nil {
-				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
-			}
-			value = canonicalStrings(value)
-			if len(value) == 0 || !allIn(value, s.catalog.PolicyMessageTypes) {
-				return policycore.UpdateMutation{}, nil, invalidRiskPolicyRequest()
-			}
-			params.MessageTypes = value
 			normalized[field] = value
 		case "sources":
 			if current.PolicyType != "standard" {
@@ -804,7 +788,7 @@ func (s *riskPolicyMutationService) matchExistingCreate(ctx context.Context, tx 
 
 func riskPolicyCreateMatches(row riskrepo.RiskPolicy, audience []string, desired riskrepo.CreateRiskPolicyParams) bool {
 	return row.OrganizationID == desired.OrganizationID && row.Name == desired.Name && row.PolicyType == desired.PolicyType && row.Enabled == desired.Enabled && row.Action == desired.Action && row.AudienceType == desired.AudienceType && row.AutoName == desired.AutoName && row.Score == desired.Score.Float64 &&
-		reflect.DeepEqual(canonicalStrings(row.Sources), canonicalStrings(desired.Sources)) && reflect.DeepEqual(canonicalStrings(row.PresidioEntities), canonicalStrings(desired.PresidioEntities)) && reflect.DeepEqual(canonicalStrings(row.PromptInjectionRules), canonicalStrings(desired.PromptInjectionRules)) && reflect.DeepEqual(canonicalStrings(row.DisabledRules), canonicalStrings(desired.DisabledRules)) && len(row.CustomRuleIds) == 0 && reflect.DeepEqual(canonicalStrings(row.MessageTypes), canonicalStrings(desired.MessageTypes)) &&
+		reflect.DeepEqual(canonicalStrings(row.Sources), canonicalStrings(desired.Sources)) && reflect.DeepEqual(canonicalStrings(row.PresidioEntities), canonicalStrings(desired.PresidioEntities)) && reflect.DeepEqual(canonicalStrings(row.PromptInjectionRules), canonicalStrings(desired.PromptInjectionRules)) && reflect.DeepEqual(canonicalStrings(row.DisabledRules), canonicalStrings(desired.DisabledRules)) && len(row.CustomRuleIds) == 0 &&
 		canonicalJSONEqual(row.AnalyzerConfig, desired.AnalyzerConfig) && row.ScopeInclude == desired.ScopeInclude && row.ScopeExempt == desired.ScopeExempt && row.ShadowMcpDisposition == desired.ShadowMcpDisposition && row.UserMessage == desired.UserMessage && row.Prompt == desired.Prompt && len(row.ModelConfig) == 0 && reflect.DeepEqual(canonicalStrings(audience), []string{authz.AllUsersPrincipal().String()})
 }
 

--- a/server/internal/platformmcp/risk_policy_mutations_integration_test.go
+++ b/server/internal/platformmcp/risk_policy_mutations_integration_test.go
@@ -70,7 +70,9 @@ func TestRiskPolicyMutationHandlersCreateUpdateReplayAndRedact(t *testing.T) {
 	require.Equal(t, "flag", stored.Action)
 	require.InDelta(t, 5.0, stored.Score, 0)
 	require.ElementsMatch(t, []string{"gitleaks"}, stored.Sources)
-	require.ElementsMatch(t, []string{"assistant_message", "tool_request", "tool_response", "user_message"}, stored.MessageTypes)
+	require.Empty(t, stored.MessageTypes)
+	require.False(t, stored.ScopeInclude.Valid)
+	require.False(t, stored.ScopeExempt.Valid)
 
 	createAudit, err := audittest.LatestAuditLogByAction(ctx, conn, audit.ActionRiskPolicyCreate)
 	require.NoError(t, err)

--- a/server/internal/platformmcp/risk_reads.go
+++ b/server/internal/platformmcp/risk_reads.go
@@ -473,12 +473,18 @@ func (s *RiskReadService) policyUnsupported(policy policycore.Policy) []string {
 // legacyMessageTypesRestrict reports whether the policy-level message_types
 // column still narrows the policy. Platform MCP no longer exposes that column,
 // so a narrowing value is hidden scope until the legacy-policy-scope migration
-// folds it into detection scopes. NULL or the full catalog restricts nothing.
+// folds it into detection scopes.
 func (s *RiskReadService) legacyMessageTypesRestrict(policy policycore.Policy) bool {
-	if len(policy.MessageTypes) == 0 {
+	return legacyMessageTypesNarrow(policy.MessageTypes, s.catalog)
+}
+
+// legacyMessageTypesNarrow is true when a stored message_types value scans
+// fewer kinds than an unscoped policy. NULL or the full catalog narrows nothing.
+func legacyMessageTypesNarrow(messageTypes []string, catalog policycatalog.Catalog) bool {
+	if len(messageTypes) == 0 {
 		return false
 	}
-	return !slices.Equal(canonicalStrings(policy.MessageTypes), canonicalStrings(s.catalog.PolicyMessageTypes))
+	return !slices.Equal(canonicalStrings(messageTypes), canonicalStrings(catalog.PolicyMessageTypes))
 }
 
 func (s *RiskReadService) policyActionSupported(policy policycore.Policy) bool {

--- a/server/internal/platformmcp/risk_reads.go
+++ b/server/internal/platformmcp/risk_reads.go
@@ -207,7 +207,6 @@ type RiskPolicyDetail struct {
 	PresidioScoreThreshold *float64             `json:"presidio_score_threshold,omitempty"`
 	ApprovedEmailDomains   []string             `json:"approved_email_domains"`
 	DisabledRules          []string             `json:"disabled_rules"`
-	MessageTypes           []string             `json:"message_types"`
 	DetectionScopes        []RiskDetectionScope `json:"detection_scopes"`
 	UserMessage            *string              `json:"user_message,omitempty"`
 	Prompt                 *string              `json:"prompt,omitempty"`
@@ -428,7 +427,6 @@ func (s *RiskReadService) policyDetail(policy policycore.Policy, shadowDecisions
 		PresidioScoreThreshold: policy.PresidioScoreThreshold,
 		ApprovedEmailDomains:   append([]string{}, policy.ApprovedEmailDomains...),
 		DisabledRules:          allowlisted(policy.DisabledRules, s.catalog.DisabledRules),
-		MessageTypes:           allowlisted(policy.MessageTypes, s.catalog.PolicyMessageTypes),
 		DetectionScopes:        detectionScopes,
 		UserMessage:            policy.UserMessage,
 		Prompt:                 nil,
@@ -459,17 +457,28 @@ func (s *RiskReadService) policyUnsupported(policy policycore.Policy) []string {
 		unsupported = append(unsupported, "shadow_mcp_url_decisions")
 	}
 	_, scopesSupported := s.projectDetectionScopes(policy)
-	if policy.ScopeInclude != nil || policy.ScopeExempt != nil || !scopesSupported {
+	if policy.ScopeInclude != nil || policy.ScopeExempt != nil || s.legacyMessageTypesRestrict(policy) || !scopesSupported {
 		unsupported = append(unsupported, "raw_scope")
 	}
 	if policy.Prompt != nil && utf8.RuneCountInString(*policy.Prompt) > 4000 {
 		unsupported = append(unsupported, "prompt_too_long")
 	}
-	if hasUnknown(policy.Sources, s.catalog.Sources) || hasUnknown(policy.PresidioEntities, s.catalog.PresidioEntities) || hasUnknown(policy.DisabledRules, s.catalog.DisabledRules) || hasUnknown(policy.MessageTypes, s.catalog.PolicyMessageTypes) || len(policy.PromptInjectionRules) > 0 {
+	if hasUnknown(policy.Sources, s.catalog.Sources) || hasUnknown(policy.PresidioEntities, s.catalog.PresidioEntities) || hasUnknown(policy.DisabledRules, s.catalog.DisabledRules) || len(policy.PromptInjectionRules) > 0 {
 		unsupported = append(unsupported, "unknown_detector_value")
 	}
 	slices.Sort(unsupported)
 	return slices.Compact(unsupported)
+}
+
+// legacyMessageTypesRestrict reports whether the policy-level message_types
+// column still narrows the policy. Platform MCP no longer exposes that column,
+// so a narrowing value is hidden scope until the legacy-policy-scope migration
+// folds it into detection scopes. NULL or the full catalog restricts nothing.
+func (s *RiskReadService) legacyMessageTypesRestrict(policy policycore.Policy) bool {
+	if len(policy.MessageTypes) == 0 {
+		return false
+	}
+	return !slices.Equal(canonicalStrings(policy.MessageTypes), canonicalStrings(s.catalog.PolicyMessageTypes))
 }
 
 func (s *RiskReadService) policyActionSupported(policy policycore.Policy) bool {

--- a/server/internal/platformmcp/risk_reads_test.go
+++ b/server/internal/platformmcp/risk_reads_test.go
@@ -292,6 +292,43 @@ func TestRiskPolicyProjectionRecognizesOnlyCanonicalD3ScopesAndActions(t *testin
 	require.Contains(t, output.Policy.Compatibility.UnsupportedFields, "raw_scope")
 }
 
+func TestRiskPolicyLegacyMessageTypesAreHiddenScope(t *testing.T) {
+	t.Parallel()
+
+	project := ResolvedProject{ID: uuid.New(), Name: "Project", Slug: "project"}
+	base := policycore.Policy{
+		ID: uuid.New(), ProjectID: project.ID, OrganizationID: "<ORG_ID>", Name: "legacy", PolicyType: "standard",
+		Sources: []string{"gitleaks"}, Enabled: true, Action: "flag", AudienceType: "everyone", Score: 5, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	cases := map[string]struct {
+		messageTypes []string
+		rawScope     bool
+	}{
+		"null":         {messageTypes: nil, rawScope: false},
+		"full catalog": {messageTypes: []string{"user_message", "tool_response", "assistant_message", "tool_request"}, rawScope: false},
+		"narrowed":     {messageTypes: []string{"user_message"}, rawScope: true},
+		"unknown kind": {messageTypes: []string{"assistant_message", "tool_request", "tool_response", "user_message", "prompt_attachment"}, rawScope: true},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			policy := base
+			policy.MessageTypes = tc.messageTypes
+			service := testRiskReadService(t, &stubRiskProjects{project: project, expected: []riskProjectCall{{organizationID: "<ORG_ID>", projectSlug: "project"}}}, &stubRiskPolicies{policy: policy}, &stubRiskExclusions{})
+			output, err := service.GetPolicy(t.Context(), testRiskPrincipal("user"), GetRiskPolicyInput{ProjectSlug: "project", PolicyID: policy.ID.String()})
+			require.NoError(t, err)
+			encoded, err := json.Marshal(output)
+			require.NoError(t, err)
+			require.NotContains(t, string(encoded), `"message_types"`)
+			if tc.rawScope {
+				require.Contains(t, output.Policy.Compatibility.UnsupportedFields, "raw_scope")
+			} else {
+				require.Equal(t, "fully_supported", output.Policy.Compatibility.State)
+			}
+		})
+	}
+}
+
 func TestRiskPolicyGetDistinguishesNotFoundFromInfrastructureFailure(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/platformmcp/tool_risk_reads.go
+++ b/server/internal/platformmcp/tool_risk_reads.go
@@ -331,7 +331,6 @@ func updateRiskPolicySchema(catalog policycatalog.Catalog) *jsonschema.Schema {
 		"action":                   catalogEnumSchema(catalog, catalog.Actions),
 		"score":                    {Type: "number", Minimum: new(0.1), Maximum: new(float64(10))},
 		"prompt":                   stringSchema("Replacement prompt-policy instruction.", 1, 4000),
-		"message_types":            arraySchema(catalogEnumSchema(catalog, catalog.PolicyMessageTypes), 0, true),
 		"sources":                  arraySchema(catalogEnumSchema(catalog, catalog.Sources), 0, true),
 		"presidio_entities":        arraySchema(catalogEnumSchema(catalog, catalog.PresidioEntities), 0, true),
 		"presidio_score_threshold": {Type: "number", Minimum: new(float64(0)), Maximum: new(float64(1))},
@@ -390,7 +389,6 @@ func riskPolicyCreateCommonProperties(catalog policycatalog.Catalog) map[string]
 		"enabled":         {Type: "boolean"},
 		"action":          catalogEnumSchema(catalog, catalog.Actions),
 		"score":           {Type: "number", Minimum: new(0.1), Maximum: new(float64(10))},
-		"message_types":   arraySchema(catalogEnumSchema(catalog, catalog.PolicyMessageTypes), 1, true),
 		"user_message":    stringSchema("Optional user-facing enforcement message.", 0, 500),
 		"idempotency_key": stringSchema("Caller key retained for 24-hour replay safety.", 1, 128),
 	}


### PR DESCRIPTION
AIS-678

## Summary

- `create_risk_policy` and `update_risk_policy` no longer accept `message_types`, and `get_risk_policy` no longer returns it. The per-category `detection_scopes[].message_types` is untouched.
- New policies created through Platform MCP leave `message_types`, `scope_include`, and `scope_exempt` NULL. Updates still carry the stored values forward unchanged.
- A stored policy whose legacy `message_types` still narrows it (not NULL and not the full catalog) is reported as `raw_scope`, the same as a raw `scope_include`, since agents can no longer see that scope. NULL and the full catalog restrict nothing and stay `fully_supported`.
- Create convergence uses the same predicate: a same-name policy still narrowed by legacy `message_types` is not treated as the policy an unscoped create describes.

## Motivation

The policy-level `message_types`, `scope_include`, and `scope_exempt` columns are being retired in favour of per-category detection scopes. Platform MCP was the last writer of `message_types` besides the management API, defaulting it to the full catalog on every create. Stopping the writes here lets the legacy-policy-scope migration fold existing rows without new ones appearing behind it.

Notes for reviewers:

- **Tool contract change.** Callers that omitted `message_types` see no behaviour change, because the old default was the full catalog and the scanner treats NULL the same way. Callers that passed it now get the transport's schema-validation error, the same as any other unknown key on these closed schemas, and should use `detection_scopes` instead.
- **Version tokens are unchanged.** `message_types` still contributes to the policy version HMAC, because it is still persisted and still read by the scanner. When the migration NULLs a policy's column, holders of that policy's version get a conflict and re-read, which is the intended stale-write protection. The hash will change once, for every policy, when the field leaves `policycore.Policy` in the management API PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Platform MCP from writing the legacy policy-level `message_types` scope, unblocking the legacy-scope migration for AIS-678.

**Behavior**
- `create_risk_policy` and `update_risk_policy` reject `message_types` with an invalid-request error; callers that omitted it see no change, since NULL behaves like the old full-catalog default.
- `get_risk_policy` no longer returns `message_types`; per-category `detection_scopes[].message_types` is unaffected.
- New policies leave `message_types`, `scope_include`, and `scope_exempt` NULL; updates preserve stored values.
- A stored policy whose `message_types` still narrows it is reported as `raw_scope`, same as a raw `scope_include`.
- Create convergence won't match a same-name policy still narrowed by legacy `message_types`, since an unscoped create describes a broader policy.
- Version tokens are unchanged; `message_types` still feeds the policy version HMAC until the migration NULLs it.

<sup>Written for commit 7ff460b5005ee55ab005dccf0358dd24a0ad8c3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

