### PR TITLE
fix: stop the dashboard writing the legacy policy scope

### DIFF
--- a/client/dashboard/src/pages/security/policy-scope.test.ts
+++ b/client/dashboard/src/pages/security/policy-scope.test.ts
@@ -465,8 +465,9 @@ describe("policyScopeUpdateForCategoryEdit", () => {
   });
 
   it("never puts a scope the API rejects on the wire", () => {
-    // `custom` and session-scoped categories have no recommendation to
-    // replace; a scope for either fails the whole update.
+    // Session-scoped categories reject message scoping outright and a scope
+    // for one fails the whole update. `custom` is not one of them: it has no
+    // recommendation, but the API accepts a specified scope for it.
     const update = policyScopeUpdateForCategoryEdit({
       category: "secrets",
       kinds: ["user_message"],
@@ -476,20 +477,39 @@ describe("policyScopeUpdateForCategoryEdit", () => {
     });
 
     expect(update.detectionScopes.map((scope) => scope.category)).toEqual([
+      "custom",
       "secrets",
     ]);
-    expect(acceptsDetectionScope(categoryDefinitions[3])).toBe(false);
+    expect(acceptsDetectionScope(categoryDefinitions[3])).toBe(true);
     expect(acceptsDetectionScope(categoryDefinitions[4])).toBe(false);
   });
 
-  it("keeps the legacy list when a covered category cannot be pinned", () => {
-    // Custom rules cannot carry a category scope, so clearing message_types
-    // would widen them; the list survives, gaining only the edited kinds.
+  it("clears the legacy list once every covered category can be pinned", () => {
+    // `custom` accepts a scope now, so its share of the legacy narrowing is
+    // pinned onto it and the legacy list goes away entirely.
+    const update = policyScopeUpdateForCategoryEdit({
+      category: "secrets",
+      kinds: ["user_message"],
+      policyCategories: ["secrets", "custom"],
+      categoryDefinitions,
+      messageTypes: ["tool_request"],
+    });
+
+    expect(update.messageTypes).toEqual([]);
+    expect(update.detectionScopes).toContainEqual({
+      category: "custom",
+      scopeInclude: 'kind in ["tool_request"]',
+    });
+  });
+
+  it("keeps the legacy list for a category it has no definition for", () => {
+    // An unrecognized category cannot be pinned, so clearing message_types
+    // would widen it; the list survives, gaining only the edited kinds.
     expect(
       policyScopeUpdateForCategoryEdit({
         category: "secrets",
         kinds: ["user_message"],
-        policyCategories: ["secrets", "custom"],
+        policyCategories: ["secrets", "not_a_category"],
         categoryDefinitions,
         messageTypes: ["tool_request"],
       }).messageTypes,

--- a/client/dashboard/src/pages/security/policy-scope.ts
+++ b/client/dashboard/src/pages/security/policy-scope.ts
@@ -211,19 +211,15 @@ export function categoryRecommendationScope(
     : undefined;
 }
 
-/** The API rejects a detection scope for a category its recommendation
- *  registry does not carry: session-scoped categories reject message scoping
- *  outright, and `custom` is deliberately absent — custom rules scope
- *  themselves through their detection CEL. Writing either fails the whole
- *  update, so never put one on the wire. */
+/** Session-scoped categories reject message scoping outright, and writing one
+ *  fails the whole update, so never put one on the wire. Categories with no
+ *  recommendation (`custom`) do accept a specified scope: a custom rule written
+ *  over `content` matches every message kind, so its scope is the only thing
+ *  narrowing it. */
 export function acceptsDetectionScope(
   definition: CategoryScopeRecommendation | undefined,
 ): boolean {
-  return (
-    definition !== undefined &&
-    definition.recommendedScopeApplicable &&
-    definition.key !== "custom"
-  );
+  return definition !== undefined && definition.recommendedScopeApplicable;
 }
 
 function definitionsByKey(

--- a/client/dashboard/src/pages/setup/components/steps/configure-policies-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/configure-policies-step.tsx
@@ -368,17 +368,21 @@ export function ConfigurePoliciesStep({
             categoryDefinitions,
             messageTypes: existing.messageTypes,
           })
-        : // Recommendations have not loaded, so there is nothing to compose
-          // with; scope to the selected kinds alone. The legacy list is no
-          // longer accepted on the wire.
-          {
-            detectionScopes: [
-              {
-                category: cat,
-                ...narrowScopeToKinds(undefined, [...nextCfg.messageTypes]),
-              },
-            ],
-          };
+        : categoryDefinitions === undefined
+          ? // Recommendations have not loaded, so there is nothing to compose
+            // with; scope to the selected kinds alone. The legacy list is no
+            // longer accepted on the wire.
+            {
+              detectionScopes: [
+                {
+                  category: cat,
+                  ...narrowScopeToKinds(undefined, [...nextCfg.messageTypes]),
+                },
+              ],
+            }
+          : // Loaded, and the category takes no message scope (session-scoped).
+            // Sending one would fail the whole update, so send none.
+            {};
     updatePolicyMutation.mutate({
       request: {
         updateRiskPolicyRequestBody: {

--- a/client/dashboard/src/pages/setup/components/steps/configure-policies-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/configure-policies-step.tsx
@@ -473,9 +473,17 @@ export function ConfigurePoliciesStep({
                       },
                     ],
                   }
-                : // Recommendations have not loaded: fall back to the legacy
-                  // list, which the server intersects with them.
-                  { messageTypes: [...cfg.messageTypes] }),
+                : // Recommendations have not loaded, so there is nothing to
+                  // compose with; scope to the selected kinds alone rather
+                  // than writing the legacy list.
+                  {
+                    detectionScopes: [
+                      {
+                        category: cat,
+                        ...narrowScopeToKinds(undefined, [...cfg.messageTypes]),
+                      },
+                    ],
+                  }),
               action: cfg.action,
               autoName: true,
             },

--- a/client/dashboard/src/pages/setup/components/steps/configure-policies-step.tsx
+++ b/client/dashboard/src/pages/setup/components/steps/configure-policies-step.tsx
@@ -368,9 +368,17 @@ export function ConfigurePoliciesStep({
             categoryDefinitions,
             messageTypes: existing.messageTypes,
           })
-        : // The API rejects a category scope it has no recommendation for;
-          // fall back to the legacy list, which it intersects with them.
-          { messageTypes: [...nextCfg.messageTypes] };
+        : // Recommendations have not loaded, so there is nothing to compose
+          // with; scope to the selected kinds alone. The legacy list is no
+          // longer accepted on the wire.
+          {
+            detectionScopes: [
+              {
+                category: cat,
+                ...narrowScopeToKinds(undefined, [...nextCfg.messageTypes]),
+              },
+            ],
+          };
     updatePolicyMutation.mutate({
       request: {
         updateRiskPolicyRequestBody: {


### PR DESCRIPTION
Stacked on #6255. **Do not merge before #6255 is deployed**: the wizard starts
sending `custom` detection scopes, which the current server rejects.

`acceptsDetectionScope` mirrored the server's registry gate client-side,
including its `custom` exclusion:

```ts
definition.recommendedScopeApplicable && definition.key !== "custom"
```

With #6255 letting a category that has no recommendation carry a scope, that
exclusion was the only thing keeping the wizard on the legacy field.
`policyScopeUpdateForCategoryEdit` pins a policy's legacy narrowing onto its
other categories before clearing `message_types`; a category it cannot pin
(`unpinnable`) forces the legacy list to survive. `custom` was always in that
set, so any policy with custom rules kept writing `message_types` forever.

Dropping the exclusion makes `unpinnable` empty for every recognized category,
the narrowing pins onto `custom` like any other, and the legacy list clears
itself. That is the bulk of this change: one condition.

## The other two writers

- `configure-policies-step.tsx` fell back to `messageTypes` when the category
  recommendations had not loaded yet. It now scopes to the selected kinds
  directly, which is what the legacy list resolved to anyway once the server
  intersected it.
- `useSecretGuideOperations.ts` hardcoded
  `messageTypes: ["tool_request", "tool_response"]` on create. Now writes the
  equivalent `secrets` detection scope via `kindScopeForMessageTypes`.

## Behavior

Unchanged for the user. Every path that used to narrow through the legacy list
now narrows through a detection scope that resolves to the same message kinds.

An unrecognized category (one with no definition in the recommendations
response) still cannot be pinned, so the legacy list survives there. That is
deliberate and now has its own test, since it is the only remaining branch that
writes the field.

## Tests

Two existing tests asserted the old behavior and are inverted:

- `never puts a scope the API rejects on the wire` now expects `custom` on the
  wire and only session-scoped categories rejected.
- `keeps the legacy list when a covered category cannot be pinned` became
  `clears the legacy list once every covered category can be pinned`, with the
  legacy-list-survives case re-tested against an unrecognized category instead.

459 tests pass across `src/pages/security`, `src/components/project-guide` and
`src/pages/setup`; `tsc --noEmit` clean.

AIS-678.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the dashboard writing the legacy `message_types` policy scope. The wizard, secrets guide, and policy edits now write `detectionScopes`; edits pin the legacy narrowing onto `custom` and clear the list. The wizard's pre-hydration fallback scopes to the selected kinds directly, and when a category accepts no message scope it sends none rather than one the API rejects. The secrets guide's status check recognizes its policy in the new scoped or legacy shape and stops creating a duplicate policy after the switch.

Behavior is unchanged for users; the legacy list still survives for unrecognized categories, which can't be pinned. Requires the server accepting `custom` detection scopes and rejecting `message_types` to be deployed first.

<sup>Written for commit 0478f582e95a40a151108efbf996a9d6ef57ef13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

