### PR TITLE
mig: add agent role assignments table

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -4234,6 +4234,11 @@ CREATE INDEX IF NOT EXISTS agent_role_assignments_org_role_idx
 ON agent_role_assignments (organization_id, role_urn)
 WHERE deleted_at IS NULL;
 
+-- Supports foreign-key cascade checks, which see every row including the
+-- soft-deleted ones the partial indexes above exclude.
+CREATE INDEX IF NOT EXISTS agent_role_assignments_org_agent_all_idx
+ON agent_role_assignments (organization_id, agent_id);
+
 
 CREATE TABLE IF NOT EXISTS oauth_proxy_client_info (
   mcp_slug TEXT NOT NULL CHECK (mcp_slug <> '' AND CHAR_LENGTH(mcp_slug) <= 60),

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -4205,6 +4205,35 @@ CREATE INDEX IF NOT EXISTS organization_role_assignments_org_user_idx
 ON organization_role_assignments (organization_id, user_id)
 WHERE user_id IS NOT NULL;
 
+-- agent_role_assignments stores which roles each agent principal holds within an org.
+-- It is the agent counterpart to organization_role_assignments. Agents have no WorkOS
+-- identity, so membership here is local only and is never reconciled outward.
+-- role_urn encodes both the role type and ID: "role:global:<uuid>" or "role:organization:<uuid>".
+-- No FK on role_urn — role deletions are handled in app logic, as for member assignments.
+CREATE TABLE IF NOT EXISTS agent_role_assignments (
+  id UUID NOT NULL DEFAULT generate_uuidv7(),
+  organization_id TEXT NOT NULL,
+  agent_id UUID NOT NULL,
+  role_urn TEXT NOT NULL,
+
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  deleted_at timestamptz,
+
+  CONSTRAINT agent_role_assignments_pkey PRIMARY KEY (id),
+  CONSTRAINT agent_role_assignments_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES organization_metadata (id) ON DELETE CASCADE,
+  CONSTRAINT agent_role_assignments_agent_tenant_fkey FOREIGN KEY (organization_id, agent_id) REFERENCES agents (organization_id, id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS agent_role_assignments_org_agent_role_key
+ON agent_role_assignments (organization_id, agent_id, role_urn)
+WHERE deleted_at IS NULL;
+
+-- Supports rendering a role's agent membership without scanning by agent.
+CREATE INDEX IF NOT EXISTS agent_role_assignments_org_role_idx
+ON agent_role_assignments (organization_id, role_urn)
+WHERE deleted_at IS NULL;
+
 
 CREATE TABLE IF NOT EXISTS oauth_proxy_client_info (
   mcp_slug TEXT NOT NULL CHECK (mcp_slug <> '' AND CHAR_LENGTH(mcp_slug) <= 60),

--- a/server/internal/database/models.go
+++ b/server/internal/database/models.go
@@ -40,6 +40,16 @@ type AgentExecution struct {
 	Deleted      bool
 }
 
+type AgentRoleAssignment struct {
+	ID             uuid.UUID
+	OrganizationID string
+	AgentID        uuid.UUID
+	RoleUrn        string
+	CreatedAt      pgtype.Timestamptz
+	UpdatedAt      pgtype.Timestamptz
+	DeletedAt      pgtype.Timestamptz
+}
+
 type AiIntegrationConfig struct {
 	CreatedAt              pgtype.Timestamptz
 	DeletedAt              pgtype.Timestamptz

--- a/server/migrations/20260910165417_aim-268-agent-role-assignments.sql
+++ b/server/migrations/20260910165417_aim-268-agent-role-assignments.sql
@@ -1,0 +1,17 @@
+-- Create "agent_role_assignments" table
+CREATE TABLE "agent_role_assignments" (
+  "id" uuid NOT NULL DEFAULT generate_uuidv7(),
+  "organization_id" text NOT NULL,
+  "agent_id" uuid NOT NULL,
+  "role_urn" text NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "deleted_at" timestamptz NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "agent_role_assignments_agent_tenant_fkey" FOREIGN KEY ("organization_id", "agent_id") REFERENCES "agents" ("organization_id", "id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "agent_role_assignments_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+-- Create index "agent_role_assignments_org_agent_role_key" to table: "agent_role_assignments"
+CREATE UNIQUE INDEX "agent_role_assignments_org_agent_role_key" ON "agent_role_assignments" ("organization_id", "agent_id", "role_urn") WHERE (deleted_at IS NULL);
+-- Create index "agent_role_assignments_org_role_idx" to table: "agent_role_assignments"
+CREATE INDEX "agent_role_assignments_org_role_idx" ON "agent_role_assignments" ("organization_id", "role_urn") WHERE (deleted_at IS NULL);

--- a/server/migrations/20260910171106_aim-268-agent-role-assignments.sql
+++ b/server/migrations/20260910171106_aim-268-agent-role-assignments.sql
@@ -11,6 +11,8 @@ CREATE TABLE "agent_role_assignments" (
   CONSTRAINT "agent_role_assignments_agent_tenant_fkey" FOREIGN KEY ("organization_id", "agent_id") REFERENCES "agents" ("organization_id", "id") ON UPDATE NO ACTION ON DELETE CASCADE,
   CONSTRAINT "agent_role_assignments_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization_metadata" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
 );
+-- Create index "agent_role_assignments_org_agent_all_idx" to table: "agent_role_assignments"
+CREATE INDEX "agent_role_assignments_org_agent_all_idx" ON "agent_role_assignments" ("organization_id", "agent_id");
 -- Create index "agent_role_assignments_org_agent_role_key" to table: "agent_role_assignments"
 CREATE UNIQUE INDEX "agent_role_assignments_org_agent_role_key" ON "agent_role_assignments" ("organization_id", "agent_id", "role_urn") WHERE (deleted_at IS NULL);
 -- Create index "agent_role_assignments_org_role_idx" to table: "agent_role_assignments"

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:vAH7NgOwhz5Ufa6Vx2T1CfoZ9JmIDsWSxuGsT6+QMPc=
+h1:TbO78753AoUIcwuJHs9LgbtGtgZ5Ho5wPAJZdhw2dyA=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -395,4 +395,4 @@ h1:vAH7NgOwhz5Ufa6Vx2T1CfoZ9JmIDsWSxuGsT6+QMPc=
 20260909161418_remote-sessions-upstream-identity-and-validation.sql h1:Ianq/JURh4k1bH7IvSssXtEZZRUqH7jHImfXofwQeIA=
 20260909165020_remote-session-issuers-scope-override-and-resource-indicator.sql h1:ryUGhSzH8d7Xioyo9OBET3MKuoTuqtthej5N89/v3P4=
 20260909195541_repin-issuer-fkeys-to-organization.sql h1:4tWO7vJtVTWtBJK8+WP32Hz0UJzwkig34/p4k5I/4XU=
-20260910165417_aim-268-agent-role-assignments.sql h1:9tc9frnMHK+y8NZNwha8m3ReqPVycDoVPwFMmYVFMN4=
+20260910171106_aim-268-agent-role-assignments.sql h1:rMZ6Z1/nhCL/Cml2TCKg8gVm+Q1eYO+1dpyCrdFPsJs=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:fDRUdQ5oPZObVT0+l0hmmXa4235OAUb4gbzkG8dAJOI=
+h1:vAH7NgOwhz5Ufa6Vx2T1CfoZ9JmIDsWSxuGsT6+QMPc=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -395,3 +395,4 @@ h1:fDRUdQ5oPZObVT0+l0hmmXa4235OAUb4gbzkG8dAJOI=
 20260909161418_remote-sessions-upstream-identity-and-validation.sql h1:Ianq/JURh4k1bH7IvSssXtEZZRUqH7jHImfXofwQeIA=
 20260909165020_remote-session-issuers-scope-override-and-resource-indicator.sql h1:ryUGhSzH8d7Xioyo9OBET3MKuoTuqtthej5N89/v3P4=
 20260909195541_repin-issuer-fkeys-to-organization.sql h1:4tWO7vJtVTWtBJK8+WP32Hz0UJzwkig34/p4k5I/4XU=
+20260910165417_aim-268-agent-role-assignments.sql h1:9tc9frnMHK+y8NZNwha8m3ReqPVycDoVPwFMmYVFMN4=


### PR DESCRIPTION
AIM-268

## Summary

Adds `agent_role_assignments`, the agent counterpart to `organization_role_assignments`. One row per (organization, agent, role), soft-deleted, with a partial unique index on the live rows and a second partial index on `(organization_id, role_urn)` so a role's agent membership can be read without scanning by agent.

`role_urn` carries the same encoding as the member table (`role:global:<uuid>` / `role:organization:<uuid>`) and has no foreign key, matching how role deletion is already handled in application code. Tenancy is pinned by a composite foreign key to `agents (organization_id, id)`.

Migration only — no application code reads or writes the table yet.

## Motivation

`urn.PrincipalTypeAgent` is already a first-class principal, and agent grants are ordinary `principal_grants` rows. Role membership is the one part of RBAC agents cannot reach: `organization_role_assignments` is keyed on `workos_user_id` and has a foreign key to `users`, so there is no row shape an agent fits into.

Extending RBAC role assignment to agent principals needs somewhere to store that membership. Agents have no WorkOS identity, so a separate local table is the right home rather than loosening the member table's linkage to WorkOS — nothing here is ever reconciled outward.

The constraints are declared inside a new `CREATE TABLE`, so there is no full-table validation scan and no PG305/PG306 lint warning.

https://claude.ai/code/session_019YG8JNuytLZADP5Er7Bvgm

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements AIM-268 by adding `agent_role_assignments`, the agent counterpart to `organization_role_assignments`, so RBAC role membership can be extended to agent principals. Agents have no WorkOS identity, so the member table's `workos_user_id` key can't hold them; this table is local only and never reconciled outward. Schema and model only — no application code reads or writes it yet.

**Migration**
- One row per (organization, agent, role), soft-deleted via `deleted_at`.
- Partial unique index on live rows; second partial index on `(organization_id, role_urn)` for role-membership reads.
- Non-partial `(organization_id, agent_id)` index covers FK cascades, which see soft-deleted rows.
- Composite foreign key pins tenancy to `agents (organization_id, id)`; `role_urn` has no FK, matching existing role deletion in app logic.
- Constraints declared inside `CREATE TABLE`, so no full-table validation scan or PG305/PG306 warnings.

<sup>Written for commit 16bfb98f74cf2db85ad3a83ec4865af0c0bcdca6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

