### PR TITLE
feat: authorize standalone admin global operations

### DIFF
--- a/.changeset/admin-global-authorization.md
+++ b/.changeset/admin-global-authorization.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Support trusted standalone admin authorization for existing global operations while retaining tenant authorization boundaries.

--- a/server/internal/assets/adminhandlers.go
+++ b/server/internal/assets/adminhandlers.go
@@ -35,7 +35,7 @@ func (s *Service) UploadPlatformImage(ctx context.Context, payload *admingen.Upl
 
 	operatorEmail, logger, err := auth.RequireGlobalAdmin(ctx, s.logger)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("authorize global operation: %w", err)
 	}
 
 	result, err := s.downloadAuthorizedAsset(ctx, reader, &downloadPendingAssetParams{

--- a/server/internal/assets/adminhandlers.go
+++ b/server/internal/assets/adminhandlers.go
@@ -3,7 +3,12 @@ package assets
 import (
 	"context"
 	"fmt"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"go.opentelemetry.io/otel/trace"
 	"io"
+	"log/slog"
 	"mime"
 	"time"
 
@@ -30,12 +35,12 @@ func (s *Service) UploadPlatformImage(ctx context.Context, payload *admingen.Upl
 		return reader.Close()
 	})
 
-	authCtx, logger, err := auth.RequirePlatformAdmin(ctx, s.logger)
+	operatorEmail, logger, err := authorizePlatformImage(ctx, s.logger)
 	if err != nil {
 		return nil, err
 	}
 
-	result, err := s.downloadPendingAsset(ctx, reader, &downloadPendingAssetParams{
+	result, err := s.downloadAuthorizedAsset(ctx, reader, &downloadPendingAssetParams{
 		maxLength:     MaxFileSizeImage,
 		contentLength: payload.ContentLength,
 		contentType:   payload.ContentType,
@@ -116,7 +121,7 @@ func (s *Service) UploadPlatformImage(ctx context.Context, payload *admingen.Upl
 		attr.SlogAuditSubject("asset"),
 		attr.SlogAuditSubjectID(urn.NewAsset(urn.AssetKindImage, asset.ID).String()),
 		attr.SlogAssetID(asset.ID.String()),
-		attr.SlogAuthUserEmail(conv.PtrValOrEmpty(authCtx.Email, "")),
+		attr.SlogAuthUserEmail(operatorEmail),
 	)
 
 	return &admingen.UploadImageResult{
@@ -130,4 +135,23 @@ func (s *Service) UploadPlatformImage(ctx context.Context, payload *admingen.Upl
 			UpdatedAt:     asset.UpdatedAt.Time.Format(time.RFC3339),
 		},
 	}, nil
+}
+
+// NewPlatformService supplies only dependencies needed by public image serving and global uploads.
+func NewPlatformService(logger *slog.Logger, tp trace.TracerProvider, policy *guardian.Policy, db *pgxpool.Pool, storage BlobStore) *Service {
+	return &Service{auth: nil, authz: nil, jwtSecret: "", chatSessions: nil, projects: nil, audit: nil, logger: logger, tracer: tp.Tracer("github.com/speakeasy-api/gram/server/internal/assets"), guardianPolicy: policy, db: db, storage: storage, repo: repo.New(db)}
+}
+
+func authorizePlatformImage(ctx context.Context, logger *slog.Logger) (string, *slog.Logger, error) {
+	if a, ok := contextvalues.GetAdminAuthContext(ctx); ok {
+		if a == nil || a.SessionID == "" || a.OIDCSubject == "" {
+			return "", logger, oops.C(oops.CodeUnauthorized)
+		}
+		return a.Email, logger.With(attr.SlogAdminOIDCSubject(a.OIDCSubject), attr.SlogAuthSource("gram_admin")), nil
+	}
+	a, logger, err := auth.RequirePlatformAdmin(ctx, logger)
+	if err != nil {
+		return "", logger, err
+	}
+	return conv.PtrValOrEmpty(a.Email, ""), logger, nil
 }

--- a/server/internal/assets/adminhandlers.go
+++ b/server/internal/assets/adminhandlers.go
@@ -3,22 +3,20 @@ package assets
 import (
 	"context"
 	"fmt"
-	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/speakeasy-api/gram/server/internal/contextvalues"
-	"github.com/speakeasy-api/gram/server/internal/guardian"
-	"go.opentelemetry.io/otel/trace"
 	"io"
 	"log/slog"
 	"mime"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel/trace"
 
 	admingen "github.com/speakeasy-api/gram/server/gen/admin_assets"
 	"github.com/speakeasy-api/gram/server/internal/assets/repo"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/auth"
-	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
 	"github.com/speakeasy-api/gram/server/internal/o11y"
 	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/urn"
@@ -35,7 +33,7 @@ func (s *Service) UploadPlatformImage(ctx context.Context, payload *admingen.Upl
 		return reader.Close()
 	})
 
-	operatorEmail, logger, err := authorizePlatformImage(ctx, s.logger)
+	operatorEmail, logger, err := auth.RequireGlobalAdmin(ctx, s.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -139,19 +137,19 @@ func (s *Service) UploadPlatformImage(ctx context.Context, payload *admingen.Upl
 
 // NewPlatformService supplies only dependencies needed by public image serving and global uploads.
 func NewPlatformService(logger *slog.Logger, tp trace.TracerProvider, policy *guardian.Policy, db *pgxpool.Pool, storage BlobStore) *Service {
-	return &Service{auth: nil, authz: nil, jwtSecret: "", chatSessions: nil, projects: nil, audit: nil, logger: logger, tracer: tp.Tracer("github.com/speakeasy-api/gram/server/internal/assets"), guardianPolicy: policy, db: db, storage: storage, repo: repo.New(db)}
-}
-
-func authorizePlatformImage(ctx context.Context, logger *slog.Logger) (string, *slog.Logger, error) {
-	if a, ok := contextvalues.GetAdminAuthContext(ctx); ok {
-		if a == nil || a.SessionID == "" || a.OIDCSubject == "" {
-			return "", logger, oops.C(oops.CodeUnauthorized)
-		}
-		return a.Email, logger.With(attr.SlogAdminOIDCSubject(a.OIDCSubject), attr.SlogAuthSource("gram_admin")), nil
+	logger = logger.With(attr.SlogComponent("assets"))
+	return &Service{
+		auth:           nil,
+		authz:          nil,
+		jwtSecret:      "",
+		chatSessions:   nil,
+		projects:       nil,
+		audit:          nil,
+		logger:         logger,
+		tracer:         tp.Tracer("github.com/speakeasy-api/gram/server/internal/assets"),
+		guardianPolicy: policy,
+		db:             db,
+		storage:        storage,
+		repo:           repo.New(db),
 	}
-	a, logger, err := auth.RequirePlatformAdmin(ctx, logger)
-	if err != nil {
-		return "", logger, err
-	}
-	return conv.PtrValOrEmpty(a.Email, ""), logger, nil
 }

--- a/server/internal/assets/adminhandlers.go
+++ b/server/internal/assets/adminhandlers.go
@@ -38,7 +38,7 @@ func (s *Service) UploadPlatformImage(ctx context.Context, payload *admingen.Upl
 		return nil, fmt.Errorf("authorize global operation: %w", err)
 	}
 
-	result, err := s.downloadAuthorizedAsset(ctx, reader, &downloadPendingAssetParams{
+	result, err := s.downloadAuthorizedAsset(ctx, reader, &downloadAuthorizedAssetParams{
 		maxLength:     MaxFileSizeImage,
 		contentLength: payload.ContentLength,
 		contentType:   payload.ContentType,

--- a/server/internal/assets/impl.go
+++ b/server/internal/assets/impl.go
@@ -596,6 +596,11 @@ func (s *Service) downloadPendingAsset(ctx context.Context, reader io.Reader, pa
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
+	return s.downloadAuthorizedAsset(ctx, reader, params)
+}
+
+// downloadAuthorizedAsset is called only after the owning handler authenticates.
+func (s *Service) downloadAuthorizedAsset(ctx context.Context, reader io.Reader, params *downloadPendingAssetParams) (*downloadPendingAssetResult, error) {
 	if params.contentLength == 0 {
 		return nil, oops.E(oops.CodeBadRequest, nil, "no content")
 	}

--- a/server/internal/assets/impl.go
+++ b/server/internal/assets/impl.go
@@ -228,7 +228,7 @@ func (s *Service) UploadImage(ctx context.Context, payload *gen.UploadImageForm,
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
-	result, err := s.downloadPendingAsset(ctx, reader, &downloadPendingAssetParams{
+	result, err := s.downloadPendingAsset(ctx, reader, &downloadAuthorizedAssetParams{
 		maxLength:     MaxFileSizeImage,
 		contentLength: payload.ContentLength,
 		contentType:   payload.ContentType,
@@ -348,7 +348,7 @@ func (s *Service) UploadFunctions(ctx context.Context, payload *gen.UploadFuncti
 
 	logger := s.logger
 
-	result, err := s.downloadPendingAsset(ctx, reader, &downloadPendingAssetParams{
+	result, err := s.downloadPendingAsset(ctx, reader, &downloadAuthorizedAssetParams{
 		maxLength:     MaxFileSizeFunctions,
 		contentLength: payload.ContentLength,
 		contentType:   payload.ContentType,
@@ -470,7 +470,7 @@ func (s *Service) UploadOpenAPIv3(ctx context.Context, payload *gen.UploadOpenAP
 
 	logger := s.logger
 
-	result, err := s.downloadPendingAsset(ctx, reader, &downloadPendingAssetParams{
+	result, err := s.downloadPendingAsset(ctx, reader, &downloadAuthorizedAssetParams{
 		maxLength:     MaxFileSizeOpenAPI,
 		contentLength: payload.ContentLength,
 		contentType:   payload.ContentType,
@@ -576,7 +576,7 @@ func (s *Service) UploadOpenAPIv3(ctx context.Context, payload *gen.UploadOpenAP
 	}, nil
 }
 
-type downloadPendingAssetParams struct {
+type downloadAuthorizedAssetParams struct {
 	maxLength     int64
 	contentLength int64
 	contentType   string
@@ -587,7 +587,7 @@ type downloadPendingAssetResult struct {
 	cleanup func() error
 }
 
-func (s *Service) downloadPendingAsset(ctx context.Context, reader io.Reader, params *downloadPendingAssetParams) (*downloadPendingAssetResult, error) {
+func (s *Service) downloadPendingAsset(ctx context.Context, reader io.Reader, params *downloadAuthorizedAssetParams) (*downloadPendingAssetResult, error) {
 	// Handlers authenticate and resolve their asset owner before calling this,
 	// so the check here is tier-agnostic defense-in-depth: no anonymous path
 	// may buffer request bytes to disk.
@@ -600,7 +600,7 @@ func (s *Service) downloadPendingAsset(ctx context.Context, reader io.Reader, pa
 }
 
 // downloadAuthorizedAsset is called only after the owning handler authenticates.
-func (s *Service) downloadAuthorizedAsset(ctx context.Context, reader io.Reader, params *downloadPendingAssetParams) (*downloadPendingAssetResult, error) {
+func (s *Service) downloadAuthorizedAsset(ctx context.Context, reader io.Reader, params *downloadAuthorizedAssetParams) (*downloadPendingAssetResult, error) {
 	if params.contentLength == 0 {
 		return nil, oops.E(oops.CodeBadRequest, nil, "no content")
 	}
@@ -967,7 +967,7 @@ func (s *Service) FetchOpenAPIv3FromURL(ctx context.Context, payload *gen.FetchO
 		return nil, oops.E(oops.CodeBadRequest, nil, "content length exceeds 10 MiB limit")
 	}
 
-	result, err := s.downloadPendingAsset(ctx, resp.Body, &downloadPendingAssetParams{
+	result, err := s.downloadPendingAsset(ctx, resp.Body, &downloadAuthorizedAssetParams{
 		maxLength:     MaxFileSizeOpenAPI,
 		contentLength: contentLength,
 		contentType:   mediaType,
@@ -1123,7 +1123,7 @@ func (s *Service) FetchImageAssetFromURL(ctx context.Context, imageURL string) (
 		return nil, oops.E(oops.CodeBadRequest, nil, "content length exceeds 4 MiB limit")
 	}
 
-	result, err := s.downloadPendingAsset(ctx, resp.Body, &downloadPendingAssetParams{
+	result, err := s.downloadPendingAsset(ctx, resp.Body, &downloadAuthorizedAssetParams{
 		maxLength:     MaxFileSizeImage,
 		contentLength: contentLength,
 		contentType:   resp.Header.Get("Content-Type"),
@@ -1359,7 +1359,7 @@ func (s *Service) UploadChatAttachment(ctx context.Context, payload *gen.UploadC
 		return nil, oops.C(oops.CodeUnauthorized)
 	}
 
-	result, err := s.downloadPendingAsset(ctx, reader, &downloadPendingAssetParams{
+	result, err := s.downloadPendingAsset(ctx, reader, &downloadAuthorizedAssetParams{
 		maxLength:     MaxFileSizeChatAttachment,
 		contentLength: payload.ContentLength,
 		contentType:   payload.ContentType,

--- a/server/internal/assets/organizationhandlers.go
+++ b/server/internal/assets/organizationhandlers.go
@@ -46,7 +46,7 @@ func (s *Service) UploadOrganizationImage(ctx context.Context, payload *orggen.U
 
 	logger := s.logger.With(attr.SlogOrganizationID(authCtx.ActiveOrganizationID))
 
-	result, err := s.downloadPendingAsset(ctx, reader, &downloadPendingAssetParams{
+	result, err := s.downloadPendingAsset(ctx, reader, &downloadAuthorizedAssetParams{
 		maxLength:     MaxFileSizeImage,
 		contentLength: payload.ContentLength,
 		contentType:   payload.ContentType,

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -12,6 +12,8 @@ import (
 type Key = attribute.Key
 
 const (
+	AdminOIDCSubjectKey              = attribute.Key("admin_oidc_subject")
+	AuthSourceKey                    = attribute.Key("auth_source")
 	AuthorizationOrganizationIDKey   = attribute.Key("gram.authorization.organization_id")
 	AuthorizationActorTypeKey        = attribute.Key("gram.authorization.actor.type")
 	AuthorizationActorIDKey          = attribute.Key("gram.authorization.actor.id")
@@ -2881,3 +2883,6 @@ func SlogAuthorizationAuthorizerUserID(v string) slog.Attr {
 func SlogAuthorizationOwnerUserID(v string) slog.Attr {
 	return slog.String(string(AuthorizationOwnerUserIDKey), v)
 }
+
+func SlogAdminOIDCSubject(v string) slog.Attr { return slog.String(string(AdminOIDCSubjectKey), v) }
+func SlogAuthSource(v string) slog.Attr       { return slog.String(string(AuthSourceKey), v) }

--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -12,8 +12,8 @@ import (
 type Key = attribute.Key
 
 const (
-	AdminOIDCSubjectKey              = attribute.Key("admin_oidc_subject")
-	AuthSourceKey                    = attribute.Key("auth_source")
+	AdminOIDCSubjectKey              = attribute.Key("gram.admin.oidc_subject")
+	AuthSourceKey                    = attribute.Key("gram.auth.source")
 	AuthorizationOrganizationIDKey   = attribute.Key("gram.authorization.organization_id")
 	AuthorizationActorTypeKey        = attribute.Key("gram.authorization.actor.type")
 	AuthorizationActorIDKey          = attribute.Key("gram.authorization.actor.id")

--- a/server/internal/auth/globaladmin.go
+++ b/server/internal/auth/globaladmin.go
@@ -1,0 +1,28 @@
+package auth
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+)
+
+// RequireGlobalAdmin authorizes global operations using either a standalone admin
+// context verified by the admin transport or the legacy dashboard platform-admin
+// entitlement. It returns audit metadata, not a tenant credential.
+func RequireGlobalAdmin(ctx context.Context, logger *slog.Logger) (string, *slog.Logger, error) {
+	if a, ok := contextvalues.GetAdminAuthContext(ctx); ok {
+		if a == nil || a.SessionID == "" || a.OIDCSubject == "" {
+			return "", logger, oops.C(oops.CodeUnauthorized)
+		}
+		return a.Email, logger.With(attr.SlogAdminOIDCSubject(a.OIDCSubject), attr.SlogAuthSource("gram_admin")), nil
+	}
+	a, logger, err := RequirePlatformAdmin(ctx, logger)
+	if err != nil {
+		return "", logger, err
+	}
+	return conv.PtrValOrEmpty(a.Email, ""), logger, nil
+}

--- a/server/internal/auth/globaladmin.go
+++ b/server/internal/auth/globaladmin.go
@@ -14,6 +14,9 @@ import (
 // context verified by the admin transport or the legacy dashboard platform-admin
 // entitlement. It returns audit metadata, not a tenant credential.
 func RequireGlobalAdmin(ctx context.Context, logger *slog.Logger) (string, *slog.Logger, error) {
+	if logger == nil {
+		return "", nil, oops.E(oops.CodeUnavailable, nil, "platform authorization logger is unavailable")
+	}
 	if a, ok := contextvalues.GetAdminAuthContext(ctx); ok {
 		if a == nil || a.SessionID == "" || a.OIDCSubject == "" {
 			return "", logger, oops.C(oops.CodeUnauthorized)

--- a/server/internal/auth/globaladmin_test.go
+++ b/server/internal/auth/globaladmin_test.go
@@ -1,0 +1,37 @@
+package auth
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+)
+
+func TestRequireGlobalAdmin(t *testing.T) {
+	email := "admin@example.com"
+	dashboard := contextvalues.SetAuthContext(context.Background(), &contextvalues.AuthContext{IsAdmin: true, Email: &email})
+	for _, tt := range []struct {
+		name    string
+		ctx     context.Context
+		allowed bool
+	}{
+		{"missing", context.Background(), false},
+		{"dashboard admin", dashboard, true},
+		{"dashboard non-admin", contextvalues.SetAuthContext(context.Background(), &contextvalues.AuthContext{}), false},
+		{"standalone admin", contextvalues.SetAdminAuthContext(context.Background(), &contextvalues.AdminAuthContext{SessionID: "session", OIDCSubject: "subject", Email: email}), true},
+		{"nil admin is absent", contextvalues.SetAdminAuthContext(context.Background(), nil), false},
+		{"missing session blocks fallback", contextvalues.SetAdminAuthContext(dashboard, &contextvalues.AdminAuthContext{OIDCSubject: "subject"}), false},
+		{"missing subject blocks fallback", contextvalues.SetAdminAuthContext(dashboard, &contextvalues.AdminAuthContext{SessionID: "session"}), false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _, err := RequireGlobalAdmin(tt.ctx, slog.Default())
+			if (err == nil) != tt.allowed {
+				t.Fatalf("allowed=%v, err=%v", tt.allowed, err)
+			}
+			if tt.allowed && got != email {
+				t.Fatalf("email=%q", got)
+			}
+		})
+	}
+}

--- a/server/internal/auth/globaladmin_test.go
+++ b/server/internal/auth/globaladmin_test.go
@@ -18,7 +18,7 @@ func TestRequireGlobalAdmin(t *testing.T) {
 		ctx     func() context.Context
 		allowed bool
 	}{
-		{"missing", func() context.Context { return context.Background() }, false},
+		{"missing", context.Background, false},
 		{"dashboard admin", func() context.Context { return dashboard }, true},
 		{"dashboard non-admin", func() context.Context {
 			return contextvalues.SetAuthContext(context.Background(), &contextvalues.AuthContext{})

--- a/server/internal/auth/globaladmin_test.go
+++ b/server/internal/auth/globaladmin_test.go
@@ -1,31 +1,42 @@
-package auth
+package auth_test
 
 import (
 	"context"
-	"log/slog"
 	"testing"
 
+	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
 func TestRequireGlobalAdmin(t *testing.T) {
+	t.Parallel()
 	email := "admin@example.com"
 	dashboard := contextvalues.SetAuthContext(context.Background(), &contextvalues.AuthContext{IsAdmin: true, Email: &email})
 	for _, tt := range []struct {
 		name    string
-		ctx     context.Context
+		ctx     func() context.Context
 		allowed bool
 	}{
-		{"missing", context.Background(), false},
-		{"dashboard admin", dashboard, true},
-		{"dashboard non-admin", contextvalues.SetAuthContext(context.Background(), &contextvalues.AuthContext{}), false},
-		{"standalone admin", contextvalues.SetAdminAuthContext(context.Background(), &contextvalues.AdminAuthContext{SessionID: "session", OIDCSubject: "subject", Email: email}), true},
-		{"nil admin is absent", contextvalues.SetAdminAuthContext(context.Background(), nil), false},
-		{"missing session blocks fallback", contextvalues.SetAdminAuthContext(dashboard, &contextvalues.AdminAuthContext{OIDCSubject: "subject"}), false},
-		{"missing subject blocks fallback", contextvalues.SetAdminAuthContext(dashboard, &contextvalues.AdminAuthContext{SessionID: "session"}), false},
+		{"missing", func() context.Context { return context.Background() }, false},
+		{"dashboard admin", func() context.Context { return dashboard }, true},
+		{"dashboard non-admin", func() context.Context {
+			return contextvalues.SetAuthContext(context.Background(), &contextvalues.AuthContext{})
+		}, false},
+		{"standalone admin", func() context.Context {
+			return contextvalues.SetAdminAuthContext(context.Background(), &contextvalues.AdminAuthContext{SessionID: "session", OIDCSubject: "subject", Email: email})
+		}, true},
+		{"nil admin is absent", func() context.Context { return contextvalues.SetAdminAuthContext(context.Background(), nil) }, false},
+		{"missing session blocks fallback", func() context.Context {
+			return contextvalues.SetAdminAuthContext(dashboard, &contextvalues.AdminAuthContext{OIDCSubject: "subject"})
+		}, false},
+		{"missing subject blocks fallback", func() context.Context {
+			return contextvalues.SetAdminAuthContext(dashboard, &contextvalues.AdminAuthContext{SessionID: "session"})
+		}, false},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _, err := RequireGlobalAdmin(tt.ctx, slog.Default())
+			t.Parallel()
+			got, _, err := auth.RequireGlobalAdmin(tt.ctx(), testenv.NewLogger(t))
 			if (err == nil) != tt.allowed {
 				t.Fatalf("allowed=%v, err=%v", tt.allowed, err)
 			}

--- a/server/internal/auth/globaladmin_test.go
+++ b/server/internal/auth/globaladmin_test.go
@@ -2,10 +2,12 @@ package auth_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/speakeasy-api/gram/server/internal/auth"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/oops"
 	"github.com/speakeasy-api/gram/server/internal/testenv"
 )
 
@@ -44,5 +46,20 @@ func TestRequireGlobalAdmin(t *testing.T) {
 				t.Fatalf("email=%q", got)
 			}
 		})
+	}
+}
+
+func TestRequireGlobalAdmin_NilLogger(t *testing.T) {
+	t.Parallel()
+	ctx := contextvalues.SetAdminAuthContext(t.Context(), &contextvalues.AdminAuthContext{
+		SessionID: "session", OIDCSubject: "subject", Email: "admin@example.com",
+	})
+	email, logger, err := auth.RequireGlobalAdmin(ctx, nil)
+	var shareable *oops.ShareableError
+	if !errors.As(err, &shareable) || shareable.Code != oops.CodeUnavailable {
+		t.Fatalf("expected unavailable, got %v", err)
+	}
+	if email != "" || logger != nil {
+		t.Fatal("expected no actor or logger")
 	}
 }

--- a/server/internal/background/openrouter_admin_mutation_generation_test.go
+++ b/server/internal/background/openrouter_admin_mutation_generation_test.go
@@ -139,6 +139,8 @@ func TestOpenRouterAdminTokenMismatchAndCompleteRetryAreIdempotent(t *testing.T)
 		reconciles.Add(1)
 		return cursor.Load(), nil
 	}, activity.RegisterOptions{Name: OpenRouterAdminReconcileActivityName})
+	var begun int
+	var afterBegins func()
 	updateBegin := func(id string, token *int64) {
 		env.UpdateWorkflow(OpenRouterAdminBeginUpdate, id, &testsuite.TestUpdateCallback{
 			OnReject: func(err error) { require.NoError(t, err) },
@@ -148,6 +150,12 @@ func TestOpenRouterAdminTokenMismatchAndCompleteRetryAreIdempotent(t *testing.T)
 				var ok bool
 				*token, ok = result.(int64)
 				require.True(t, ok)
+				begun++
+				if begun == 2 {
+					// Capture activities are asynchronous: elapsed time does not
+					// guarantee both Begin tokens are ready for Complete/Abort.
+					env.RegisterDelayedCallback(afterBegins, 0)
+				}
 			},
 		})
 	}
@@ -168,11 +176,11 @@ func TestOpenRouterAdminTokenMismatchAndCompleteRetryAreIdempotent(t *testing.T)
 	}
 	env.RegisterDelayedCallback(func() { updateBegin("a", &tokenA) }, time.Millisecond)
 	env.RegisterDelayedCallback(func() { updateBegin("b", &tokenB) }, 2*time.Millisecond)
-	env.RegisterDelayedCallback(func() { env.SignalWorkflow(OpenRouterAdminAbortSignal, tokenA+1000) }, 3*time.Millisecond)
-	env.RegisterDelayedCallback(func() {
+	afterBegins = func() {
+		env.SignalWorkflow(OpenRouterAdminAbortSignal, tokenA+1000)
 		cursor.Store(1)
 		complete("complete")
-	}, 4*time.Millisecond)
+	}
 
 	env.ExecuteWorkflow(testOpenRouterAdminWorkflow, openrouterkeys.AdminReconciliationScope{OrganizationID: "organization_placeholder", KeyType: "chat"})
 	require.NoError(t, env.GetWorkflowError())

--- a/server/internal/remotesessions/adminhandlers.go
+++ b/server/internal/remotesessions/adminhandlers.go
@@ -14,8 +14,6 @@ import (
 	adminrsgen "github.com/speakeasy-api/gram/server/gen/admin_remote_sessions"
 	"github.com/speakeasy-api/gram/server/gen/types"
 	"github.com/speakeasy-api/gram/server/internal/attr"
-	"github.com/speakeasy-api/gram/server/internal/auth"
-	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/issuerurl"
 	"github.com/speakeasy-api/gram/server/internal/mv"
@@ -59,12 +57,12 @@ func scopeOverride(s []string) []string {
 // subject) for a global mutation, standing in for the auditlogs rows globals
 // can't have. Call it only after the transaction commits so the log never
 // claims a mutation that rolled back.
-func logGlobalMutation(ctx context.Context, logger *slog.Logger, authCtx *contextvalues.AuthContext, action, subject, subjectID string) {
+func logGlobalMutation(ctx context.Context, logger *slog.Logger, authCtx globalActor, action, subject, subjectID string) {
 	logger.InfoContext(ctx, "global remote session "+subject+" "+action,
 		attr.SlogAuditAction(action),
 		attr.SlogAuditSubject(subject),
 		attr.SlogAuditSubjectID(subjectID),
-		attr.SlogAuthUserEmail(conv.PtrValOrEmpty(authCtx.Email, "")),
+		attr.SlogAuthUserEmail(authCtx.email),
 	)
 }
 
@@ -73,7 +71,7 @@ func logGlobalMutation(ctx context.Context, logger *slog.Logger, authCtx *contex
 // CreateGlobalIssuer creates a global remote_session_issuer (project_id NULL,
 // organization_id NULL), reusing CreateRemoteSessionIssuer with NULL scoping.
 func (s *Service) CreateGlobalIssuer(ctx context.Context, payload *adminrsgen.CreateGlobalIssuerPayload) (*types.RemoteSessionIssuer, error) {
-	authCtx, logger, err := auth.RequirePlatformAdmin(ctx, s.logger)
+	authCtx, logger, err := authorizeGlobalOperation(ctx, s.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +198,7 @@ func (s *Service) CreateGlobalIssuer(ctx context.Context, payload *adminrsgen.Cr
 // answering that question here would put another organization's configuration
 // in front of a form that is only asking about the shared catalog.
 func (s *Service) GetGlobalIssuerDuplicatePreflight(ctx context.Context, payload *adminrsgen.GetGlobalIssuerDuplicatePreflightPayload) (*types.RemoteSessionIssuerDuplicatePreflight, error) {
-	_, logger, err := auth.RequirePlatformAdmin(ctx, s.logger)
+	_, logger, err := authorizeGlobalOperation(ctx, s.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +227,7 @@ func (s *Service) GetGlobalIssuerDuplicatePreflight(ctx context.Context, payload
 // ListGlobalIssuers lists the global remote_session_issuers, each with the
 // global and tenant-owned client counts that decide whether it can be deleted.
 func (s *Service) ListGlobalIssuers(ctx context.Context, payload *adminrsgen.ListGlobalIssuersPayload) (*adminrsgen.ListGlobalRemoteSessionIssuersResult, error) {
-	_, logger, err := auth.RequirePlatformAdmin(ctx, s.logger)
+	_, logger, err := authorizeGlobalOperation(ctx, s.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +271,7 @@ func (s *Service) ListGlobalIssuers(ctx context.Context, payload *adminrsgen.Lis
 // client counts the listing carries so the detail view can describe a delete
 // without a second round trip.
 func (s *Service) GetGlobalIssuer(ctx context.Context, payload *adminrsgen.GetGlobalIssuerPayload) (*adminrsgen.GlobalRemoteSessionIssuer, error) {
-	_, logger, err := auth.RequirePlatformAdmin(ctx, s.logger)
+	_, logger, err := authorizeGlobalOperation(ctx, s.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -300,7 +298,7 @@ func (s *Service) GetGlobalIssuer(ctx context.Context, payload *adminrsgen.GetGl
 
 // UpdateGlobalIssuer patches a global remote_session_issuer.
 func (s *Service) UpdateGlobalIssuer(ctx context.Context, payload *adminrsgen.UpdateGlobalIssuerPayload) (*types.RemoteSessionIssuer, error) {
-	authCtx, logger, err := auth.RequirePlatformAdmin(ctx, s.logger)
+	authCtx, logger, err := authorizeGlobalOperation(ctx, s.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -426,7 +424,7 @@ func (s *Service) UpdateGlobalIssuer(ctx context.Context, payload *adminrsgen.Up
 // any global clients still reference it (the operator deletes the clients
 // first). Mirrors the org-scoped DeleteIssuer.
 func (s *Service) DeleteGlobalIssuer(ctx context.Context, payload *adminrsgen.DeleteGlobalIssuerPayload) error {
-	authCtx, logger, err := auth.RequirePlatformAdmin(ctx, s.logger)
+	authCtx, logger, err := authorizeGlobalOperation(ctx, s.logger)
 	if err != nil {
 		return err
 	}
@@ -520,7 +518,7 @@ func (s *Service) DeleteGlobalIssuer(ctx context.Context, payload *adminrsgen.De
 // document and returns a draft suitable for CreateGlobalIssuer. Keyed by issuer
 // URL, so no record need exist and nothing is persisted.
 func (s *Service) FetchGlobalIssuerMetadata(ctx context.Context, payload *adminrsgen.FetchGlobalIssuerMetadataPayload) (*types.RemoteSessionIssuerDraft, error) {
-	_, logger, err := auth.RequirePlatformAdmin(ctx, s.logger)
+	_, logger, err := authorizeGlobalOperation(ctx, s.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -550,7 +548,7 @@ func (s *Service) FetchGlobalIssuerMetadata(ctx context.Context, payload *adminr
 // than an auditlogs row, since audit_log.organization_id is NOT NULL and a
 // global issuer belongs to no organization.
 func (s *Service) RefreshGlobalIssuerMetadata(ctx context.Context, payload *adminrsgen.RefreshGlobalIssuerMetadataPayload) (*types.RemoteSessionIssuerRefresh, error) {
-	authCtx, logger, err := auth.RequirePlatformAdmin(ctx, s.logger)
+	authCtx, logger, err := authorizeGlobalOperation(ctx, s.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -681,7 +679,7 @@ func loadPlatformMigrationPair(ctx context.Context, r *repo.Queries, logger *slo
 // upstream authorization server as a given global issuer, so a platform admin
 // can see who could be consolidated onto the shared catalog entry.
 func (s *Service) ListGlobalIssuerConvergenceCandidates(ctx context.Context, payload *adminrsgen.ListGlobalIssuerConvergenceCandidatesPayload) (*adminrsgen.ListIssuerConvergenceCandidatesResult, error) {
-	_, logger, err := auth.RequirePlatformAdmin(ctx, s.logger)
+	_, logger, err := authorizeGlobalOperation(ctx, s.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -760,7 +758,7 @@ func (s *Service) ListGlobalIssuerConvergenceCandidates(ctx context.Context, pay
 // onto a global one would do, and every blocker that would make it fail, so the
 // confirmation dialog is authoritative before the mutation runs.
 func (s *Service) GetGlobalIssuerMigratePreflight(ctx context.Context, payload *adminrsgen.GetGlobalIssuerMigratePreflightPayload) (*adminrsgen.IssuerMigratePreflight, error) {
-	_, logger, err := auth.RequirePlatformAdmin(ctx, s.logger)
+	_, logger, err := authorizeGlobalOperation(ctx, s.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -810,7 +808,7 @@ func (s *Service) GetGlobalIssuerMigratePreflight(ctx context.Context, payload *
 // Like every other platform-admin mutation this records a structured-log line
 // rather than an auditlogs row.
 func (s *Service) MigrateToGlobalIssuer(ctx context.Context, payload *adminrsgen.MigrateToGlobalIssuerPayload) (*adminrsgen.MigrateRemoteSessionIssuerResult, error) {
-	authCtx, logger, err := auth.RequirePlatformAdmin(ctx, s.logger)
+	authCtx, logger, err := authorizeGlobalOperation(ctx, s.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -916,7 +914,7 @@ func (s *Service) MigrateToGlobalIssuer(ctx context.Context, payload *adminrsgen
 // global issuer, reusing CreateRemoteSessionClient with NULL scoping. Global
 // clients carry no user_session_issuer attachments.
 func (s *Service) CreateGlobalClient(ctx context.Context, payload *adminrsgen.CreateGlobalClientPayload) (*types.RemoteSessionClient, error) {
-	authCtx, logger, err := auth.RequirePlatformAdmin(ctx, s.logger)
+	authCtx, logger, err := authorizeGlobalOperation(ctx, s.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -993,7 +991,7 @@ func (s *Service) CreateGlobalClient(ctx context.Context, payload *adminrsgen.Cr
 
 // ListGlobalClients lists the global clients registered with a global issuer.
 func (s *Service) ListGlobalClients(ctx context.Context, payload *adminrsgen.ListGlobalClientsPayload) (*adminrsgen.ListRemoteSessionClientsResult, error) {
-	_, logger, err := auth.RequirePlatformAdmin(ctx, s.logger)
+	_, logger, err := authorizeGlobalOperation(ctx, s.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -1037,7 +1035,7 @@ func (s *Service) ListGlobalClients(ctx context.Context, payload *adminrsgen.Lis
 
 // GetGlobalClient resolves a global client by id.
 func (s *Service) GetGlobalClient(ctx context.Context, payload *adminrsgen.GetGlobalClientPayload) (*types.RemoteSessionClient, error) {
-	_, logger, err := auth.RequirePlatformAdmin(ctx, s.logger)
+	_, logger, err := authorizeGlobalOperation(ctx, s.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -1061,7 +1059,7 @@ func (s *Service) GetGlobalClient(ctx context.Context, payload *adminrsgen.GetGl
 // UpdateGlobalClient patches a global client's non-issuer fields, rotating the
 // client secret when supplied.
 func (s *Service) UpdateGlobalClient(ctx context.Context, payload *adminrsgen.UpdateGlobalClientPayload) (*types.RemoteSessionClient, error) {
-	authCtx, logger, err := auth.RequirePlatformAdmin(ctx, s.logger)
+	authCtx, logger, err := authorizeGlobalOperation(ctx, s.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -1121,7 +1119,7 @@ func (s *Service) UpdateGlobalClient(ctx context.Context, payload *adminrsgen.Up
 // DeleteGlobalClient soft-deletes a global client and cascades the
 // remote_sessions minted against it.
 func (s *Service) DeleteGlobalClient(ctx context.Context, payload *adminrsgen.DeleteGlobalClientPayload) error {
-	authCtx, logger, err := auth.RequirePlatformAdmin(ctx, s.logger)
+	authCtx, logger, err := authorizeGlobalOperation(ctx, s.logger)
 	if err != nil {
 		return err
 	}

--- a/server/internal/remotesessions/globalauth.go
+++ b/server/internal/remotesessions/globalauth.go
@@ -2,17 +2,15 @@ package remotesessions
 
 import (
 	"context"
+	"log/slog"
+
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/auth"
-	"github.com/speakeasy-api/gram/server/internal/contextvalues"
-	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/encryption"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
-	"github.com/speakeasy-api/gram/server/internal/oops"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
-	"log/slog"
 )
 
 // globalActor is audit metadata, never a dashboard credential.
@@ -21,20 +19,27 @@ type globalActor struct{ email string }
 // authorizeGlobalOperation accepts trusted transport context only for global operations.
 // Tenant handlers continue to require their existing AuthContext and RBAC grants.
 func authorizeGlobalOperation(ctx context.Context, logger *slog.Logger) (globalActor, *slog.Logger, error) {
-	if a, ok := contextvalues.GetAdminAuthContext(ctx); ok {
-		if a == nil || a.SessionID == "" || a.OIDCSubject == "" {
-			return globalActor{}, logger, oops.C(oops.CodeUnauthorized)
-		}
-		return globalActor{email: a.Email}, logger.With(attr.SlogAdminOIDCSubject(a.OIDCSubject), attr.SlogAuthSource("gram_admin")), nil
-	}
-	a, logger, err := auth.RequirePlatformAdmin(ctx, logger)
-	if err != nil {
-		return globalActor{}, logger, err
-	}
-	return globalActor{email: conv.PtrValOrEmpty(a.Email, "")}, logger, nil
+	email, logger, err := auth.RequireGlobalAdmin(ctx, logger)
+	return globalActor{email: email}, logger, err
 }
 
 // NewGlobalService deliberately omits tenant authentication and mounts no routes.
 func NewGlobalService(logger *slog.Logger, tp trace.TracerProvider, mp metric.MeterProvider, db *pgxpool.Pool, enc *encryption.Client, policy *guardian.Policy) *Service {
-	return &Service{auth: nil, sessions: nil, authz: nil, environments: nil, auditLogger: nil, serverURL: nil, refresher: nil, productFeatures: nil, logger: logger, tracer: tp.Tracer("github.com/speakeasy-api/gram/server/internal/remotesessions"), db: db, enc: enc, policy: policy, revoker: NewUpstreamRevoker(logger, tp, mp, db, enc, policy)}
+	logger = logger.With(attr.SlogComponent("remotesessions"))
+	return &Service{
+		auth:            nil,
+		sessions:        nil,
+		authz:           nil,
+		environments:    nil,
+		auditLogger:     nil,
+		serverURL:       nil,
+		refresher:       nil,
+		productFeatures: nil,
+		logger:          logger,
+		tracer:          tp.Tracer("github.com/speakeasy-api/gram/server/internal/remotesessions"),
+		db:              db,
+		enc:             enc,
+		policy:          policy,
+		revoker:         NewUpstreamRevoker(logger, tp, mp, db, enc, policy),
+	}
 }

--- a/server/internal/remotesessions/globalauth.go
+++ b/server/internal/remotesessions/globalauth.go
@@ -1,0 +1,40 @@
+package remotesessions
+
+import (
+	"context"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/auth"
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/encryption"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+	"log/slog"
+)
+
+// globalActor is audit metadata, never a dashboard credential.
+type globalActor struct{ email string }
+
+// authorizeGlobalOperation accepts trusted transport context only for global operations.
+// Tenant handlers continue to require their existing AuthContext and RBAC grants.
+func authorizeGlobalOperation(ctx context.Context, logger *slog.Logger) (globalActor, *slog.Logger, error) {
+	if a, ok := contextvalues.GetAdminAuthContext(ctx); ok {
+		if a == nil || a.SessionID == "" || a.OIDCSubject == "" {
+			return globalActor{}, logger, oops.C(oops.CodeUnauthorized)
+		}
+		return globalActor{email: a.Email}, logger.With(attr.SlogAdminOIDCSubject(a.OIDCSubject), attr.SlogAuthSource("gram_admin")), nil
+	}
+	a, logger, err := auth.RequirePlatformAdmin(ctx, logger)
+	if err != nil {
+		return globalActor{}, logger, err
+	}
+	return globalActor{email: conv.PtrValOrEmpty(a.Email, "")}, logger, nil
+}
+
+// NewGlobalService deliberately omits tenant authentication and mounts no routes.
+func NewGlobalService(logger *slog.Logger, tp trace.TracerProvider, mp metric.MeterProvider, db *pgxpool.Pool, enc *encryption.Client, policy *guardian.Policy) *Service {
+	return &Service{auth: nil, sessions: nil, authz: nil, environments: nil, auditLogger: nil, serverURL: nil, refresher: nil, productFeatures: nil, logger: logger, tracer: tp.Tracer("github.com/speakeasy-api/gram/server/internal/remotesessions"), db: db, enc: enc, policy: policy, revoker: NewUpstreamRevoker(logger, tp, mp, db, enc, policy)}
+}

--- a/server/internal/remotesessions/globalauth.go
+++ b/server/internal/remotesessions/globalauth.go
@@ -2,6 +2,7 @@ package remotesessions
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -20,7 +21,10 @@ type globalActor struct{ email string }
 // Tenant handlers continue to require their existing AuthContext and RBAC grants.
 func authorizeGlobalOperation(ctx context.Context, logger *slog.Logger) (globalActor, *slog.Logger, error) {
 	email, logger, err := auth.RequireGlobalAdmin(ctx, logger)
-	return globalActor{email: email}, logger, err
+	if err != nil {
+		return globalActor{email: email}, logger, fmt.Errorf("authorize global operation: %w", err)
+	}
+	return globalActor{email: email}, logger, nil
 }
 
 // NewGlobalService deliberately omits tenant authentication and mounts no routes.

--- a/server/internal/telemetry/get_tool_usage_summary_test.go
+++ b/server/internal/telemetry/get_tool_usage_summary_test.go
@@ -512,7 +512,8 @@ func insertHostedToolEvent(t *testing.T, ctx context.Context, ti *testInstance, 
 	// UUID hyphens to get 32 hex chars. This is what lands the event in the
 	// trace_summaries materialized view that now backs the tool-usage queries.
 	traceID := strings.ReplaceAll(uuid.New().String(), "-", "")
-	err = ti.chClient.InsertTelemetryLog(ctx, telemetryRepo.InsertTelemetryLogParams{
+	// Query fixtures must be committed before reading; do not depend on the shared async queue.
+	err = ti.chClient.InsertTelemetryLogsSync(ctx, []telemetryRepo.InsertTelemetryLogParams{{
 		ID:                   uuid.New().String(),
 		TimeUnixNano:         p.timestamp.UnixNano(),
 		ObservedTimeUnixNano: p.timestamp.UnixNano(),
@@ -529,7 +530,7 @@ func insertHostedToolEvent(t *testing.T, ctx context.Context, ti *testInstance, 
 		ServiceName:          "gram-http-gateway",
 		ServiceVersion:       nil,
 		GramChatID:           nil,
-	})
+	}})
 	require.NoError(t, err)
 }
 
@@ -622,7 +623,8 @@ func insertDirectMCPToolEvent(t *testing.T, ctx context.Context, ti *testInstanc
 
 	spanID := uuid.New().String()[:16]
 	traceID := strings.ReplaceAll(uuid.New().String(), "-", "")
-	err = ti.chClient.InsertTelemetryLog(ctx, telemetryRepo.InsertTelemetryLogParams{
+	// Query fixtures must be committed before reading; do not depend on the shared async queue.
+	err = ti.chClient.InsertTelemetryLogsSync(ctx, []telemetryRepo.InsertTelemetryLogParams{{
 		ID:                   uuid.New().String(),
 		TimeUnixNano:         p.timestamp.UnixNano(),
 		ObservedTimeUnixNano: p.timestamp.UnixNano(),
@@ -639,7 +641,7 @@ func insertDirectMCPToolEvent(t *testing.T, ctx context.Context, ti *testInstanc
 		ServiceName:          "gram-remote-mcp",
 		ServiceVersion:       nil,
 		GramChatID:           nil,
-	})
+	}})
 	require.NoError(t, err)
 }
 
@@ -678,7 +680,8 @@ func insertHostedToolEventRow(t *testing.T, ctx context.Context, ti *testInstanc
 	require.NoError(t, err)
 
 	spanID := uuid.New().String()[:16]
-	err = ti.chClient.InsertTelemetryLog(ctx, telemetryRepo.InsertTelemetryLogParams{
+	// Query fixtures must be committed before reading; do not depend on the shared async queue.
+	err = ti.chClient.InsertTelemetryLogsSync(ctx, []telemetryRepo.InsertTelemetryLogParams{{
 		ID:                   uuid.New().String(),
 		TimeUnixNano:         timestamp.UnixNano(),
 		ObservedTimeUnixNano: timestamp.UnixNano(),
@@ -695,7 +698,7 @@ func insertHostedToolEventRow(t *testing.T, ctx context.Context, ti *testInstanc
 		ServiceName:          "gram-http-gateway",
 		ServiceVersion:       nil,
 		GramChatID:           nil,
-	})
+	}})
 	require.NoError(t, err)
 }
 
@@ -842,4 +845,17 @@ func TestGetToolUsageGranularEndpoints_MatchSummary(t *testing.T) {
 	breakdown, err := ti.service.GetToolUsageTargetToolBreakdown(ctx, &gen.GetToolUsageTargetToolBreakdownPayload{From: from, To: to})
 	require.NoError(t, err, "cause: %v", errors.Unwrap(err))
 	require.Equal(t, summary.TargetToolBreakdown, breakdown.TargetToolBreakdown)
+}
+
+// Fixture writes must be visible without polling or a server-wide async flush.
+func TestToolUsageFixturesAreQueryReady(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestLogsService(t)
+	now := time.Now().UTC()
+	insertHostedToolEvent(t, ctx, ti, hostedToolEventParams{projectID: ti.projectID, timestamp: now, toolsetSlug: "fixture", toolName: "query", statusCode: 200})
+	insertDirectMCPToolEvent(t, ctx, ti, directMCPToolEventParams{projectID: ti.projectID, timestamp: now, sourceID: uuid.NewString(), mcpServerID: uuid.NewString(), toolName: "query", statusCode: 200})
+	insertHostedToolEventRow(t, ctx, ti, strings.ReplaceAll(uuid.NewString(), "-", ""), now, "fixture", "query", "")
+	var count uint64
+	require.NoError(t, ti.chConn.QueryRow(ctx, "SELECT count() FROM telemetry_logs WHERE gram_project_id = ?", ti.projectID).Scan(&count))
+	require.Equal(t, uint64(3), count, "fixture helpers must commit every row before returning")
 }


### PR DESCRIPTION
## Stack context

This stack moves platform-wide remote-session issuer management from the dashboard into the standalone admin application. The complete flow covers browsing and configuring issuers, discovering and refreshing their metadata, managing logos, and migrating tenant-owned issuers to platform ownership.

This first PR establishes the authorization foundation. It lets the existing global issuer operations and platform image-upload logic accept a verified standalone-admin identity without fabricating a dashboard session or weakening tenant authorization. Later PRs wire that business logic into the standalone admin API and build the management UI on top.

## Summary

Accept trusted standalone-admin identities for global remote-session operations and platform image uploads. Keep tenant authorization separate and record stable operator audit attributes.

## Motivation

Allow the standalone admin service to reuse existing global-operation business logic without fabricating dashboard credentials.
