### PR TITLE
feat: preserve admin issuer form payload semantics

### DIFF
--- a/.changeset/admin-issuer-form-payloads.md
+++ b/.changeset/admin-issuer-form-payloads.md
@@ -1,0 +1,5 @@
+---
+"admin": patch
+---
+
+Prepare issuer form payload helpers that preserve discovery metadata and explicit clearing semantics.

--- a/client/admin/src/pages/remote-session-issuers/issuerForm.test.ts
+++ b/client/admin/src/pages/remote-session-issuers/issuerForm.test.ts
@@ -463,3 +463,38 @@ describe("hidden endpoint clearing", () => {
     }
   });
 });
+
+describe("captured-empty versus never-captured discovery arrays", () => {
+  it.each([
+    ["fresh discovery", [], []],
+    ["saved never-captured record", null, undefined],
+  ] as const)(
+    "preserves %s in create and update payloads",
+    (_, value, expected) => {
+      const state = {
+        ...baseState,
+        discoveredSnapshot: {
+          ...snapshot,
+          codeChallengeMethodsSupported: value === null ? null : [...value],
+          introspectionEndpointAuthMethodsSupported:
+            value === null ? null : [...value],
+          idTokenSigningAlgValuesSupported: value === null ? null : [...value],
+          claimsSupported: value === null ? null : [...value],
+        },
+      };
+      for (const form of [
+        buildCreateIssuerForm(state),
+        buildUpdateIssuerForm(state),
+      ]) {
+        for (const field of [
+          "codeChallengeMethodsSupported",
+          "introspectionEndpointAuthMethodsSupported",
+          "idTokenSigningAlgValuesSupported",
+          "claimsSupported",
+        ] as const) {
+          expect(form[field]).toEqual(expected);
+        }
+      }
+    },
+  );
+});

--- a/client/admin/src/pages/remote-session-issuers/issuerForm.test.ts
+++ b/client/admin/src/pages/remote-session-issuers/issuerForm.test.ts
@@ -1,0 +1,465 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCreateIssuerForm,
+  buildUpdateIssuerForm,
+  deriveNameFromUrl,
+  deriveSlugFromUrl,
+} from "./issuerForm";
+
+const snapshot = {
+  url: "https://idp.example.com",
+  authorizationEndpoint: "https://idp.example.com/authorize",
+  tokenEndpoint: "https://idp.example.com/token",
+  registrationEndpoint: "",
+  jwksUri: "https://idp.example.com/jwks.json",
+  scopesSupported: ["openid", "profile"],
+  grantTypesSupported: ["authorization_code"],
+  responseTypesSupported: ["code"],
+  tokenEndpointAuthMethodsSupported: ["client_secret_basic"],
+  codeChallengeMethodsSupported: ["S256"],
+  clientIdMetadataDocumentSupported: true,
+  revocationEndpoint: "https://idp.example.com/revoke",
+  serviceDocumentation: "https://docs.example.com",
+  opPolicyUri: "https://example.com/policy",
+  opTosUri: "https://example.com/tos",
+  userinfoEndpoint: "https://idp.example.com/userinfo",
+  introspectionEndpoint: "https://idp.example.com/introspect",
+  introspectionEndpointAuthMethodsSupported: ["client_secret_basic"],
+  idTokenSigningAlgValuesSupported: ["RS256"],
+  claimsSupported: ["sub", "email"],
+  backchannelLogoutSupported: true,
+  authorizationResponseIssParameterSupported: false,
+};
+
+const DISCOVERY_ONLY_CAPABILITY_FIELDS = [
+  "userinfoEndpoint",
+  "introspectionEndpoint",
+  "introspectionEndpointAuthMethodsSupported",
+  "idTokenSigningAlgValuesSupported",
+  "claimsSupported",
+  "backchannelLogoutSupported",
+  "authorizationResponseIssParameterSupported",
+] as const;
+
+const baseState = {
+  id: "issuer-1",
+  name: "  Example IdP  ",
+  logoAssetId: "  11111111-2222-3333-4444-555555555555  ",
+  slug: "  example-idp  ",
+  clientSetupDocumentationUrl: "  https://docs.example.com/oauth  ",
+  issuerUrl: "  https://idp.example.com  ",
+  authorizationEndpoint: "  https://idp.example.com/authorize  ",
+  tokenEndpoint: "  https://idp.example.com/token  ",
+  registrationEndpoint: "  ",
+  jwksUri: "  https://idp.example.com/jwks.json  ",
+  discoveredSnapshot: null,
+};
+
+describe("buildUpdateIssuerForm", () => {
+  it("trims every operator-entered field", () => {
+    const form = buildUpdateIssuerForm(baseState);
+
+    expect(form.name).toBe("Example IdP");
+    expect(form.logoAssetId).toBe("11111111-2222-3333-4444-555555555555");
+    expect(form.slug).toBe("example-idp");
+    expect(form.issuer).toBe("https://idp.example.com");
+    expect(form.authorizationEndpoint).toBe(
+      "https://idp.example.com/authorize",
+    );
+    expect(form.clientSetupDocumentationUrl).toBe(
+      "https://docs.example.com/oauth",
+    );
+  });
+
+  // The server reads "" on these as "clear to NULL", so they must be sent
+  // rather than omitted — omitting would silently keep the old value.
+  it("sends emptied URL fields rather than omitting them", () => {
+    const form = buildUpdateIssuerForm({
+      ...baseState,
+      clientSetupDocumentationUrl: "",
+      registrationEndpoint: "",
+      logoAssetId: "",
+    });
+
+    expect(form).toHaveProperty("clientSetupDocumentationUrl", "");
+    expect(form).toHaveProperty("registrationEndpoint", "");
+    // "" is the explicit "clear the saved logo to NULL" sentinel.
+    expect(form).toHaveProperty("logoAssetId", "");
+  });
+
+  // Without a discovery for the current URL the server must keep the metadata
+  // it already has (COALESCE narg semantics), so the arrays are omitted.
+  it("omits the RFC 8414 arrays when no discovery has run", () => {
+    const form = buildUpdateIssuerForm(baseState);
+
+    expect(form.scopesSupported).toBeUndefined();
+    expect(form.grantTypesSupported).toBeUndefined();
+    expect(form.responseTypesSupported).toBeUndefined();
+    expect(form.tokenEndpointAuthMethodsSupported).toBeUndefined();
+    expect(form.codeChallengeMethodsSupported).toBeUndefined();
+    expect(form.clientIdMetadataDocumentSupported).toBeUndefined();
+    expect(form.revocationEndpoint).toBeUndefined();
+    expect(form.serviceDocumentation).toBeUndefined();
+    expect(form.opPolicyUri).toBeUndefined();
+    expect(form.opTosUri).toBeUndefined();
+  });
+
+  it("forwards the discovered metadata when the snapshot matches the URL", () => {
+    const form = buildUpdateIssuerForm({
+      ...baseState,
+      discoveredSnapshot: snapshot,
+    });
+
+    expect(form.scopesSupported).toEqual(["openid", "profile"]);
+    expect(form.codeChallengeMethodsSupported).toEqual(["S256"]);
+    expect(form.clientIdMetadataDocumentSupported).toBe(true);
+    expect(form.revocationEndpoint).toBe("https://idp.example.com/revoke");
+    expect(form.serviceDocumentation).toBe("https://docs.example.com");
+  });
+
+  // A snapshot seeded from a record whose PKCE methods were never captured
+  // holds null there, and the update must omit the field (keep NULL) rather
+  // than send [], which would record "the issuer advertises no methods".
+  it("omits never-captured PKCE methods from a seeded snapshot", () => {
+    const form = buildUpdateIssuerForm({
+      ...baseState,
+      discoveredSnapshot: { ...snapshot, codeChallengeMethodsSupported: null },
+    });
+
+    expect(form.scopesSupported).toEqual(["openid", "profile"]);
+    expect(form.codeChallengeMethodsSupported).toBeUndefined();
+  });
+
+  // An empty array is a real captured value ("the issuer advertises no
+  // methods") and must be forwarded, not collapsed into the omitted case.
+  it("forwards captured-empty PKCE methods", () => {
+    const form = buildUpdateIssuerForm({
+      ...baseState,
+      discoveredSnapshot: { ...snapshot, codeChallengeMethodsSupported: [] },
+    });
+
+    expect(form.codeChallengeMethodsSupported).toEqual([]);
+  });
+
+  // The operator repointed the provider after discovering the old URL. Sending
+  // the stale snapshot would attribute one authorization server's advertised
+  // capabilities to a different one.
+  it("drops a snapshot discovered against a different URL", () => {
+    const form = buildUpdateIssuerForm({
+      ...baseState,
+      issuerUrl: "https://other-idp.example.com",
+      discoveredSnapshot: snapshot,
+    });
+
+    expect(form.issuer).toBe("https://other-idp.example.com");
+    expect(form.scopesSupported).toBeUndefined();
+    expect(form.clientIdMetadataDocumentSupported).toBeUndefined();
+  });
+
+  // Discover-then-Save on an existing issuer must repoint the capability
+  // columns too, not just the endpoints.
+  it("forwards the discovery-only capabilities from a matching snapshot", () => {
+    const form = buildUpdateIssuerForm({
+      ...baseState,
+      discoveredSnapshot: snapshot,
+    });
+
+    expect(form.userinfoEndpoint).toBe("https://idp.example.com/userinfo");
+    expect(form.introspectionEndpoint).toBe(
+      "https://idp.example.com/introspect",
+    );
+    expect(form.introspectionEndpointAuthMethodsSupported).toEqual([
+      "client_secret_basic",
+    ]);
+    expect(form.idTokenSigningAlgValuesSupported).toEqual(["RS256"]);
+    expect(form.claimsSupported).toEqual(["sub", "email"]);
+    expect(form.backchannelLogoutSupported).toBe(true);
+    expect(form.authorizationResponseIssParameterSupported).toBe(false);
+  });
+
+  // A seeded snapshot holds null for never-captured arrays/booleans; those go
+  // out as undefined so the server keeps NULL rather than recording a value.
+  it("omits never-captured capabilities from a seeded snapshot", () => {
+    const form = buildUpdateIssuerForm({
+      ...baseState,
+      discoveredSnapshot: {
+        ...snapshot,
+        introspectionEndpointAuthMethodsSupported: null,
+        idTokenSigningAlgValuesSupported: null,
+        claimsSupported: null,
+        backchannelLogoutSupported: null,
+        authorizationResponseIssParameterSupported: null,
+      },
+    });
+
+    expect(form.introspectionEndpointAuthMethodsSupported).toBeUndefined();
+    expect(form.idTokenSigningAlgValuesSupported).toBeUndefined();
+    expect(form.claimsSupported).toBeUndefined();
+    expect(form.backchannelLogoutSupported).toBeUndefined();
+    expect(form.authorizationResponseIssParameterSupported).toBeUndefined();
+  });
+
+  // "" is the "clear to NULL" sentinel for a URL the issuer stopped
+  // advertising, so it is sent through verbatim, not collapsed to undefined.
+  it("sends emptied capability endpoints through verbatim", () => {
+    const form = buildUpdateIssuerForm({
+      ...baseState,
+      discoveredSnapshot: {
+        ...snapshot,
+        userinfoEndpoint: "",
+        introspectionEndpoint: "",
+        claimsSupported: [],
+      },
+    });
+
+    expect(form).toHaveProperty("userinfoEndpoint", "");
+    expect(form).toHaveProperty("introspectionEndpoint", "");
+    expect(form.claimsSupported).toEqual([]);
+  });
+
+  it("omits the discovery-only capabilities for a mismatched-URL snapshot", () => {
+    const form = buildUpdateIssuerForm({
+      ...baseState,
+      issuerUrl: "https://other-idp.example.com",
+      discoveredSnapshot: snapshot,
+    });
+
+    for (const field of DISCOVERY_ONLY_CAPABILITY_FIELDS) {
+      expect(form[field]).toBeUndefined();
+    }
+  });
+});
+
+describe("buildCreateIssuerForm", () => {
+  const { id: _id, ...createState } = baseState;
+
+  it("forwards the discovery-only capabilities from a matching snapshot", () => {
+    const form = buildCreateIssuerForm({
+      ...createState,
+      discoveredSnapshot: snapshot,
+    });
+
+    expect(form.codeChallengeMethodsSupported).toEqual(["S256"]);
+    expect(form.userinfoEndpoint).toBe("https://idp.example.com/userinfo");
+    expect(form.introspectionEndpoint).toBe(
+      "https://idp.example.com/introspect",
+    );
+    expect(form.introspectionEndpointAuthMethodsSupported).toEqual([
+      "client_secret_basic",
+    ]);
+    expect(form.idTokenSigningAlgValuesSupported).toEqual(["RS256"]);
+    expect(form.claimsSupported).toEqual(["sub", "email"]);
+    expect(form.backchannelLogoutSupported).toBe(true);
+    expect(form.authorizationResponseIssParameterSupported).toBe(false);
+  });
+
+  // A captured-empty array means "advertises none" and must survive; an
+  // unadvertised endpoint is omitted so the server stores NULL.
+  it("forwards captured-empty arrays and omits unadvertised endpoints", () => {
+    const form = buildCreateIssuerForm({
+      ...createState,
+      discoveredSnapshot: {
+        ...snapshot,
+        userinfoEndpoint: "",
+        introspectionEndpoint: "",
+        claimsSupported: [],
+        idTokenSigningAlgValuesSupported: [],
+        introspectionEndpointAuthMethodsSupported: [],
+      },
+    });
+
+    expect(form.userinfoEndpoint).toBeUndefined();
+    expect(form.introspectionEndpoint).toBeUndefined();
+    expect(form.claimsSupported).toEqual([]);
+    expect(form.idTokenSigningAlgValuesSupported).toEqual([]);
+    expect(form.introspectionEndpointAuthMethodsSupported).toEqual([]);
+  });
+
+  it("omits the discovery-only capabilities when no discovery has run", () => {
+    const form = buildCreateIssuerForm(createState);
+
+    expect(form.codeChallengeMethodsSupported).toBeUndefined();
+    for (const field of DISCOVERY_ONLY_CAPABILITY_FIELDS) {
+      expect(form[field]).toBeUndefined();
+    }
+  });
+
+  it("drops a snapshot discovered against a different URL", () => {
+    const form = buildCreateIssuerForm({
+      ...createState,
+      issuerUrl: "https://other-idp.example.com",
+      discoveredSnapshot: snapshot,
+    });
+
+    for (const field of DISCOVERY_ONLY_CAPABILITY_FIELDS) {
+      expect(form[field]).toBeUndefined();
+    }
+  });
+});
+
+describe("URL derivation", () => {
+  it.each([
+    [
+      "  https://LOGIN.Example.com:8443/tenant?q=1#fragment  ",
+      "login.example.com",
+      "login-example-com",
+    ],
+    ["https://127.0.0.1:8080", "127.0.0.1", "127-0-0-1"],
+    ["https://[::1]/", "[::1]", "1"],
+    [
+      "https://-login-.example.com/",
+      "-login-.example.com",
+      "login-example-com",
+    ],
+    ["custom://Some.Host/path", "Some.Host", "some-host"],
+    ["", null, null],
+    ["   ", null, null],
+    ["example.com", null, null],
+    ["https://", null, null],
+    ["not a url", null, null],
+    ["mailto:person@example.com", null, null],
+    ["file:///tmp/issuer", null, null],
+  ] as const)("derives names and slugs for %j", (url, name, slug) => {
+    expect(deriveNameFromUrl(url)).toBe(name);
+    expect(deriveSlugFromUrl(url)).toBe(slug);
+  });
+
+  it("returns null for a hostname without slug characters", () => {
+    expect(deriveNameFromUrl("custom://---")).toBe("---");
+    expect(deriveSlugFromUrl("custom://---")).toBeNull();
+  });
+});
+
+describe("create payload semantics", () => {
+  const { id: _id, ...createState } = baseState;
+
+  it("trims operator fields and omits empty optional strings", () => {
+    const form = buildCreateIssuerForm(createState);
+    expect(form).toMatchObject({
+      name: "Example IdP",
+      logoAssetId: "11111111-2222-3333-4444-555555555555",
+      slug: "example-idp",
+      issuer: "https://idp.example.com",
+      clientSetupDocumentationUrl: "https://docs.example.com/oauth",
+      authorizationEndpoint: "https://idp.example.com/authorize",
+      tokenEndpoint: "https://idp.example.com/token",
+      jwksUri: "https://idp.example.com/jwks.json",
+      scopesSupported: [],
+      grantTypesSupported: [],
+      responseTypesSupported: [],
+      tokenEndpointAuthMethodsSupported: [],
+      clientIdMetadataDocumentSupported: false,
+    });
+    expect(form.registrationEndpoint).toBeUndefined();
+    expect(form).not.toHaveProperty("id");
+    const empty = buildCreateIssuerForm({
+      ...createState,
+      name: "  ",
+      logoAssetId: "  ",
+      clientSetupDocumentationUrl: "  ",
+      authorizationEndpoint: "  ",
+      tokenEndpoint: "  ",
+      jwksUri: "  ",
+    });
+    for (const field of [
+      "name",
+      "logoAssetId",
+      "clientSetupDocumentationUrl",
+      "authorizationEndpoint",
+      "tokenEndpoint",
+      "jwksUri",
+    ] as const) {
+      expect(empty[field]).toBeUndefined();
+    }
+  });
+
+  it.each([{ methods: null }, { methods: [] }])(
+    "preserves PKCE null versus empty: %j",
+    ({ methods }) => {
+      expect(
+        buildCreateIssuerForm({
+          ...createState,
+          discoveredSnapshot: {
+            ...snapshot,
+            codeChallengeMethodsSupported: methods,
+          },
+        }).codeChallengeMethodsSupported,
+      ).toEqual(methods ?? undefined);
+    },
+  );
+
+  it("omits never-captured nullable arrays and booleans", () => {
+    const form = buildCreateIssuerForm({
+      ...createState,
+      discoveredSnapshot: {
+        ...snapshot,
+        introspectionEndpointAuthMethodsSupported: null,
+        idTokenSigningAlgValuesSupported: null,
+        claimsSupported: null,
+        backchannelLogoutSupported: null,
+        authorizationResponseIssParameterSupported: null,
+      },
+    });
+    for (const field of DISCOVERY_ONLY_CAPABILITY_FIELDS.slice(2)) {
+      expect(form[field]).toBeUndefined();
+    }
+  });
+
+  it("forwards hidden metadata and excludes all stale metadata", () => {
+    const matching = buildCreateIssuerForm({
+      ...createState,
+      discoveredSnapshot: snapshot,
+    });
+    const stale = buildCreateIssuerForm({
+      ...createState,
+      issuerUrl: "https://other.example.com",
+      discoveredSnapshot: snapshot,
+    });
+    const manual = buildCreateIssuerForm({
+      ...createState,
+      issuerUrl: "https://other.example.com",
+    });
+    expect(stale).toEqual(manual);
+    for (const field of [
+      "scopesSupported",
+      "grantTypesSupported",
+      "responseTypesSupported",
+      "tokenEndpointAuthMethodsSupported",
+      "clientIdMetadataDocumentSupported",
+      "revocationEndpoint",
+      "serviceDocumentation",
+      "opPolicyUri",
+      "opTosUri",
+    ] as const) {
+      expect(matching[field]).toEqual(snapshot[field]);
+    }
+  });
+});
+
+describe("hidden endpoint clearing", () => {
+  it("clears discovery-only strings on update but omits them on create", () => {
+    const emptySnapshot = {
+      ...snapshot,
+      revocationEndpoint: "",
+      serviceDocumentation: "",
+      opPolicyUri: "",
+      opTosUri: "",
+      userinfoEndpoint: "",
+      introspectionEndpoint: "",
+    };
+    const state = { ...baseState, discoveredSnapshot: emptySnapshot };
+    const update = buildUpdateIssuerForm(state);
+    const create = buildCreateIssuerForm(state);
+    for (const field of [
+      "revocationEndpoint",
+      "serviceDocumentation",
+      "opPolicyUri",
+      "opTosUri",
+      "userinfoEndpoint",
+      "introspectionEndpoint",
+    ] as const) {
+      expect(update[field]).toBe("");
+      expect(create[field]).toBeUndefined();
+    }
+  });
+});

--- a/client/admin/src/pages/remote-session-issuers/issuerForm.ts
+++ b/client/admin/src/pages/remote-session-issuers/issuerForm.ts
@@ -1,0 +1,216 @@
+import type { CreateRemoteSessionIssuerForm } from "@gram/admin-client/models/components/createremotesessionissuerform";
+import type { UpdateRemoteSessionIssuerForm } from "@gram/admin-client/models/components/updateremotesessionissuerform";
+
+// Snapshot of the issuer + RFC 8414 metadata for a given Issuer URL. Created
+// fresh on every successful discovery and seeded from saved records in the
+// Modify sheet. Drives the Discover/Reset slot and the URL-change reset.
+export type DiscoveredEndpoints = {
+  url: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  registrationEndpoint: string;
+  jwksUri: string;
+  scopesSupported: string[];
+  grantTypesSupported: string[];
+  responseTypesSupported: string[];
+  tokenEndpointAuthMethodsSupported: string[];
+  // PKCE methods (RFC 8414 code_challenge_methods_supported). Unlike the
+  // arrays above this is tri-state, mirroring the nullable column: null means
+  // the saved record was never captured, and it must round-trip as null so a
+  // settings save does not turn "never captured" into "advertises no methods"
+  // (an empty array — a refusal state under future PKCE enforcement). A
+  // fresh-discovery snapshot is never null: an omitted field captures as [].
+  codeChallengeMethodsSupported: string[] | null;
+  // OAuth CIMD draft capability parsed from the discovery document: whether the
+  // issuer accepts a Client ID Metadata Document URL as client_id. Persisted on
+  // create/update so the CIMD client type can be offered for this issuer.
+  clientIdMetadataDocumentSupported: boolean;
+  // RFC 7009 revocation endpoint parsed from the discovery document. Carried
+  // through create/update but not rendered as an input, like the capability
+  // arrays above and the documentation URLs below: an operator never needs to
+  // hand-write it, and re-running discovery is the way to correct a stale one.
+  // An empty string means the issuer advertised none, which is common — the
+  // sessions minted against such an issuer simply revoke locally.
+  revocationEndpoint: string;
+  // RFC 8414 documentation URLs parsed from the discovery document. An empty
+  // string means the issuer advertised nothing usable — the update payload sends
+  // it through verbatim, which the server reads as "clear to NULL", so a URL the
+  // issuer stopped advertising does not linger.
+  serviceDocumentation: string;
+  opPolicyUri: string;
+  opTosUri: string;
+  // OIDC userinfo / RFC 7662 introspection endpoints; "" = not advertised.
+  userinfoEndpoint: string;
+  introspectionEndpoint: string;
+  // Tri-state like codeChallengeMethodsSupported: null = never captured.
+  introspectionEndpointAuthMethodsSupported: string[] | null;
+  idTokenSigningAlgValuesSupported: string[] | null;
+  claimsSupported: string[] | null;
+  backchannelLogoutSupported: boolean | null;
+  authorizationResponseIssParameterSupported: boolean | null;
+};
+
+export type IssuerSettingsFormState = {
+  id: string;
+  name: string;
+  // The logo's asset id, empty when the issuer has no logo. Like the other
+  // optional strings, "" on update is the explicit "clear to NULL" sentinel.
+  logoAssetId: string;
+  slug: string;
+  clientSetupDocumentationUrl: string;
+  issuerUrl: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  registrationEndpoint: string;
+  jwksUri: string;
+  discoveredSnapshot: DiscoveredEndpoints | null;
+};
+
+// Updates send empty strings to clear saved values. Only matching discovery
+// metadata is sent; omission preserves the stored value.
+export function buildUpdateIssuerForm(
+  state: IssuerSettingsFormState,
+): UpdateRemoteSessionIssuerForm {
+  const issuer = state.issuerUrl.trim();
+  const snapshot = state.discoveredSnapshot;
+  const fromDiscovery = snapshot && snapshot.url === issuer ? snapshot : null;
+
+  return {
+    id: state.id,
+    name: state.name.trim(),
+    logoAssetId: state.logoAssetId.trim(),
+    slug: state.slug.trim(),
+    clientSetupDocumentationUrl: state.clientSetupDocumentationUrl.trim(),
+    issuer,
+    authorizationEndpoint: state.authorizationEndpoint.trim(),
+    tokenEndpoint: state.tokenEndpoint.trim(),
+    registrationEndpoint: state.registrationEndpoint.trim(),
+    jwksUri: state.jwksUri.trim(),
+    scopesSupported: fromDiscovery?.scopesSupported,
+    grantTypesSupported: fromDiscovery?.grantTypesSupported,
+    responseTypesSupported: fromDiscovery?.responseTypesSupported,
+    tokenEndpointAuthMethodsSupported:
+      fromDiscovery?.tokenEndpointAuthMethodsSupported,
+    // Tri-state: a seeded snapshot of a never-captured record holds null,
+    // which must go out as undefined (omit; the server keeps its stored
+    // value) — sending [] instead would record "the issuer advertises no
+    // methods", a refusal state under future PKCE enforcement.
+    codeChallengeMethodsSupported:
+      fromDiscovery?.codeChallengeMethodsSupported ?? undefined,
+    clientIdMetadataDocumentSupported:
+      fromDiscovery?.clientIdMetadataDocumentSupported,
+    revocationEndpoint: fromDiscovery?.revocationEndpoint,
+    serviceDocumentation: fromDiscovery?.serviceDocumentation,
+    opPolicyUri: fromDiscovery?.opPolicyUri,
+    opTosUri: fromDiscovery?.opTosUri,
+    // Endpoints verbatim ("" clears a dropped URL); null seeded = keep stored.
+    userinfoEndpoint: fromDiscovery?.userinfoEndpoint,
+    introspectionEndpoint: fromDiscovery?.introspectionEndpoint,
+    introspectionEndpointAuthMethodsSupported:
+      fromDiscovery?.introspectionEndpointAuthMethodsSupported ?? undefined,
+    idTokenSigningAlgValuesSupported:
+      fromDiscovery?.idTokenSigningAlgValuesSupported ?? undefined,
+    claimsSupported: fromDiscovery?.claimsSupported ?? undefined,
+    backchannelLogoutSupported:
+      fromDiscovery?.backchannelLogoutSupported ?? undefined,
+    authorizationResponseIssParameterSupported:
+      fromDiscovery?.authorizationResponseIssParameterSupported ?? undefined,
+  };
+}
+
+// Creation omits empty optional strings and defaults non-null metadata arrays
+// to empty. Nullable capabilities retain never-captured versus captured-empty.
+export function buildCreateIssuerForm(
+  state: Omit<IssuerSettingsFormState, "id">,
+): CreateRemoteSessionIssuerForm {
+  const issuer = state.issuerUrl.trim();
+  const snapshot = state.discoveredSnapshot;
+  const fromDiscovery = snapshot && snapshot.url === issuer ? snapshot : null;
+
+  return {
+    slug: state.slug.trim(),
+    issuer,
+    name: state.name.trim() || undefined,
+    logoAssetId: state.logoAssetId.trim() || undefined,
+    clientSetupDocumentationUrl:
+      state.clientSetupDocumentationUrl.trim() || undefined,
+    authorizationEndpoint: state.authorizationEndpoint.trim() || undefined,
+    tokenEndpoint: state.tokenEndpoint.trim() || undefined,
+    registrationEndpoint: state.registrationEndpoint.trim() || undefined,
+    jwksUri: state.jwksUri.trim() || undefined,
+    scopesSupported: fromDiscovery?.scopesSupported ?? [],
+    grantTypesSupported: fromDiscovery?.grantTypesSupported ?? [],
+    responseTypesSupported: fromDiscovery?.responseTypesSupported ?? [],
+    tokenEndpointAuthMethodsSupported:
+      fromDiscovery?.tokenEndpointAuthMethodsSupported ?? [],
+    // No `?? []` default, unlike the NOT NULL arrays above: the column is
+    // nullable, and an operator who typed endpoints by hand has not captured
+    // the field — omitting it stores NULL ("not captured"), while [] would
+    // claim the issuer advertises no methods. A fresh discovery snapshot is
+    // never null, so a discovered create records what the document said.
+    codeChallengeMethodsSupported:
+      fromDiscovery?.codeChallengeMethodsSupported ?? undefined,
+    // CIMD support is parsed during discovery and persisted here so the issuer
+    // can offer the CIMD client type. Defaults false when the operator skipped
+    // Discover and typed the endpoints by hand.
+    clientIdMetadataDocumentSupported:
+      fromDiscovery?.clientIdMetadataDocumentSupported ?? false,
+    // The RFC 7009 revocation endpoint is discovery-only too, and undefined is
+    // the ordinary case: plenty of issuers advertise none, and sessions minted
+    // against those revoke locally with no upstream call.
+    revocationEndpoint: fromDiscovery?.revocationEndpoint || undefined,
+    // RFC 8414 documentation URLs are discovery-only — there are no form
+    // inputs for them. Undefined when the operator skipped Discover or the
+    // issuer advertised nothing usable.
+    serviceDocumentation: fromDiscovery?.serviceDocumentation || undefined,
+    opPolicyUri: fromDiscovery?.opPolicyUri || undefined,
+    opTosUri: fromDiscovery?.opTosUri || undefined,
+    // Discovery-only capabilities; omitted (NULL) unless discovery ran.
+    userinfoEndpoint: fromDiscovery?.userinfoEndpoint || undefined,
+    introspectionEndpoint: fromDiscovery?.introspectionEndpoint || undefined,
+    introspectionEndpointAuthMethodsSupported:
+      fromDiscovery?.introspectionEndpointAuthMethodsSupported ?? undefined,
+    idTokenSigningAlgValuesSupported:
+      fromDiscovery?.idTokenSigningAlgValuesSupported ?? undefined,
+    claimsSupported: fromDiscovery?.claimsSupported ?? undefined,
+    backchannelLogoutSupported:
+      fromDiscovery?.backchannelLogoutSupported ?? undefined,
+    authorizationResponseIssParameterSupported:
+      fromDiscovery?.authorizationResponseIssParameterSupported ?? undefined,
+  };
+}
+
+// Derive a unique slug from the Issuer URL's hostname. Mirrors the hyphen-style
+// transform an operator would reasonably hand-write so the auto-filled value
+// looks natural. Returns null for unparseable URLs — callers keep the prior slug
+// in that case so partial typing doesn't blow it away.
+export function deriveSlugFromUrl(url: string): string | null {
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+  try {
+    const host = new URL(trimmed).hostname;
+    if (!host) return null;
+    const slug = host
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+    return slug || null;
+  } catch {
+    return null;
+  }
+}
+
+// Derive a default Display name from the Issuer URL's hostname. Unlike the slug
+// transform this keeps the hostname human-readable (no hyphenation/lowercasing).
+// Returns null for unparseable URLs so callers leave the prior value intact while
+// a partial URL is being typed.
+export function deriveNameFromUrl(url: string): string | null {
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+  try {
+    const host = new URL(trimmed).hostname;
+    return host || null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Stack context

The standalone issuer API is now available through [#6273](https://github.com/speakeasy-api/gram/pull/6273). This PR begins the frontend portion of the migration by defining how the upcoming editor represents issuer state and translates it into create and update requests.

The important work here is preserving meaning: saved values, discovery results, explicit clearing, and never-captured metadata must not collapse into the same payload. Keeping those rules in shared helpers lets the editor in [#6280](https://github.com/speakeasy-api/gram/pull/6280) focus on interaction while using consistent request semantics. This is a preparatory layer, not a newly reachable management page.

## Summary

Add reusable issuer form state and payload helpers that preserve discovery values, explicit clearing, and nullable PKCE metadata. This preparatory slice adds no reachable routes.

## Motivation

Keep create and edit payload behavior consistent before connecting the standalone admin issuer editor.
