### PR TITLE
feat: add admin issuer queries and logo loading

### DIFF
--- a/.changeset/admin-issuer-query-cache.md
+++ b/.changeset/admin-issuer-query-cache.md
@@ -1,0 +1,5 @@
+---
+"admin": patch
+---
+
+Prepare shared issuer queries and logo loading, evicting deleted issuer cache entries before refreshing lists.

--- a/client/admin/src/lib/gramAdminClient.test.ts
+++ b/client/admin/src/lib/gramAdminClient.test.ts
@@ -3,6 +3,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
 
 const useMutation = vi.hoisted(() => vi.fn());
 
@@ -269,9 +270,13 @@ it("serves issuer logos through the generated same-origin image operation", asyn
   );
   vi.stubGlobal("fetch", fetch);
   const query = boundary.adminIssuerImageQuery("image-placeholder");
-  const blob = await query.queryFn?.({
-    signal: new AbortController().signal,
-  } as never);
+  const cache = new QueryClient();
+  const blob = await cache.fetchQuery(query);
+  const cached = await cache.ensureQueryData(query);
+  expect(cached).toBe(blob);
+  expect(await cached.arrayBuffer()).toEqual(await blob.arrayBuffer());
+  expect(fetch).toHaveBeenCalledTimes(1);
+  cache.clear();
   expect(blob).toBeInstanceOf(Blob);
   expect((blob as Blob).size).toBe(3);
   expect((blob as Blob).type).toBe("image/png");

--- a/client/admin/src/lib/gramAdminClient.test.ts
+++ b/client/admin/src/lib/gramAdminClient.test.ts
@@ -34,15 +34,30 @@ afterEach(() => {
 
 describe("generated admin boundary", () => {
   it("does not export generated clients or configurable request controls", () => {
-    expect(Object.keys(boundary).sort()).toEqual([
-      "adminSessionQuery",
-      "isRedirectingToLogin",
-      "organizationActivityQuery",
-      "organizationFeaturesQuery",
-      "redirectOnUnauthorized",
-      "setAdminOrganizationFeature",
-      "useSetAdminOrganizationFeatureMutation",
-    ]);
+    expect(Object.keys(boundary).sort()).toEqual(
+      [
+        "adminSessionQuery",
+        "adminGetGlobalIssuerQuery",
+        "adminListGlobalIssuersQuery",
+        "adminListGlobalIssuerConvergenceCandidatesQuery",
+        "adminGetGlobalIssuerDuplicatePreflightQuery",
+        "adminGetGlobalIssuerMigratePreflightQuery",
+        "adminCreateGlobalIssuer",
+        "adminUpdateGlobalIssuer",
+        "adminDeleteGlobalIssuer",
+        "adminFetchGlobalIssuerMetadata",
+        "adminRefreshGlobalIssuerMetadata",
+        "adminMigrateToGlobalIssuer",
+        "adminUploadPlatformImage",
+        "adminIssuerImageQuery",
+        "isRedirectingToLogin",
+        "organizationActivityQuery",
+        "organizationFeaturesQuery",
+        "redirectOnUnauthorized",
+        "setAdminOrganizationFeature",
+        "useSetAdminOrganizationFeatureMutation",
+      ].sort(),
+    );
 
     expectTypeOf(boundary.adminSessionQuery).parameters.toEqualTypeOf<[]>();
     expectTypeOf(boundary.setAdminOrganizationFeature).parameters.toEqualTypeOf<
@@ -243,4 +258,25 @@ describe("generated admin boundary", () => {
     );
     expect(recordHeader).not.toMatch(/fetch\(|useMutation/);
   });
+});
+
+it("serves issuer logos through the generated same-origin image operation", async () => {
+  const fetch = vi.fn().mockResolvedValue(
+    new Response(new Uint8Array([1, 2, 3]), {
+      status: 200,
+      headers: { "Content-Type": "image/png" },
+    }),
+  );
+  vi.stubGlobal("fetch", fetch);
+  const query = boundary.adminIssuerImageQuery("image-placeholder");
+  const blob = await query.queryFn?.({
+    signal: new AbortController().signal,
+  } as never);
+  expect(blob).toBeInstanceOf(Blob);
+  expect((blob as Blob).size).toBe(3);
+  expect((blob as Blob).type).toBe("image/png");
+  const request = fetch.mock.calls[0]![0] as Request;
+  expect(new URL(request.url).origin).toBe(window.location.origin);
+  expect(request.headers.has("gram-session")).toBe(false);
+  expect(request.headers.has("Authorization")).toBe(false);
 });

--- a/client/admin/src/lib/gramAdminClient.ts
+++ b/client/admin/src/lib/gramAdminClient.ts
@@ -1,4 +1,38 @@
 import {
+  buildAdminUploadPlatformImageMutation,
+  type AdminUploadPlatformImageMutationVariables,
+} from "@gram/admin-client/react-query/adminUploadPlatformImage";
+import {
+  buildAdminMigrateToGlobalIssuerMutation,
+  type AdminMigrateToGlobalIssuerMutationVariables,
+} from "@gram/admin-client/react-query/adminMigrateToGlobalIssuer";
+import {
+  buildAdminRefreshGlobalIssuerMetadataMutation,
+  type AdminRefreshGlobalIssuerMetadataMutationVariables,
+} from "@gram/admin-client/react-query/adminRefreshGlobalIssuerMetadata";
+import {
+  buildAdminFetchGlobalIssuerMetadataMutation,
+  type AdminFetchGlobalIssuerMetadataMutationVariables,
+} from "@gram/admin-client/react-query/adminFetchGlobalIssuerMetadata";
+import {
+  buildAdminDeleteGlobalIssuerMutation,
+  type AdminDeleteGlobalIssuerMutationVariables,
+} from "@gram/admin-client/react-query/adminDeleteGlobalIssuer";
+import {
+  buildAdminUpdateGlobalIssuerMutation,
+  type AdminUpdateGlobalIssuerMutationVariables,
+} from "@gram/admin-client/react-query/adminUpdateGlobalIssuer";
+import {
+  buildAdminCreateGlobalIssuerMutation,
+  type AdminCreateGlobalIssuerMutationVariables,
+} from "@gram/admin-client/react-query/adminCreateGlobalIssuer";
+import { buildAdminServeImageQuery } from "@gram/admin-client/react-query/adminServeImage.core";
+import { buildAdminGetGlobalIssuerMigratePreflightQuery } from "@gram/admin-client/react-query/adminGetGlobalIssuerMigratePreflight.core";
+import { buildAdminGetGlobalIssuerDuplicatePreflightQuery } from "@gram/admin-client/react-query/adminGetGlobalIssuerDuplicatePreflight.core";
+import { buildAdminListGlobalIssuerConvergenceCandidatesQuery } from "@gram/admin-client/react-query/adminListGlobalIssuerConvergenceCandidates.core";
+import { buildAdminListGlobalIssuersQuery } from "@gram/admin-client/react-query/adminListGlobalIssuers.core";
+import { buildAdminGetGlobalIssuerQuery } from "@gram/admin-client/react-query/adminGetGlobalIssuer.core";
+import {
   infiniteQueryOptions,
   queryOptions,
   useMutation,
@@ -155,4 +189,212 @@ export function useSetAdminOrganizationFeatureMutation(
     mutationKey: ["@gram/admin-client", "admin", "adminSetOrganizationFeature"],
     mutationFn: setAdminOrganizationFeature,
   });
+}
+
+function createAdminGetGlobalIssuerQuery(
+  request: Parameters<typeof buildAdminGetGlobalIssuerQuery>[1],
+) {
+  const generated = buildAdminGetGlobalIssuerQuery(redirectingClient, request);
+  return queryOptions({
+    ...generated,
+    queryFn: (context) => redirecting(generated.queryFn(context)),
+  });
+}
+
+function createAdminListGlobalIssuersQuery(
+  request: Parameters<typeof buildAdminListGlobalIssuersQuery>[1],
+) {
+  const generated = buildAdminListGlobalIssuersQuery(
+    redirectingClient,
+    request,
+  );
+  return queryOptions({
+    ...generated,
+    queryFn: (context) => redirecting(generated.queryFn(context)),
+  });
+}
+
+function createAdminListGlobalIssuerConvergenceCandidatesQuery(
+  request: Parameters<
+    typeof buildAdminListGlobalIssuerConvergenceCandidatesQuery
+  >[1],
+) {
+  const generated = buildAdminListGlobalIssuerConvergenceCandidatesQuery(
+    redirectingClient,
+    request,
+  );
+  return queryOptions({
+    ...generated,
+    queryFn: (context) => redirecting(generated.queryFn(context)),
+  });
+}
+
+function createAdminGetGlobalIssuerDuplicatePreflightQuery(
+  request: Parameters<
+    typeof buildAdminGetGlobalIssuerDuplicatePreflightQuery
+  >[1],
+) {
+  const generated = buildAdminGetGlobalIssuerDuplicatePreflightQuery(
+    redirectingClient,
+    request,
+  );
+  return queryOptions({
+    ...generated,
+    queryFn: (context) => redirecting(generated.queryFn(context)),
+  });
+}
+
+function createAdminGetGlobalIssuerMigratePreflightQuery(
+  request: Parameters<typeof buildAdminGetGlobalIssuerMigratePreflightQuery>[1],
+) {
+  const generated = buildAdminGetGlobalIssuerMigratePreflightQuery(
+    redirectingClient,
+    request,
+  );
+  return queryOptions({
+    ...generated,
+    queryFn: (context) => redirecting(generated.queryFn(context)),
+  });
+}
+
+export function adminCreateGlobalIssuer(
+  request: AdminCreateGlobalIssuerMutationVariables["request"],
+): ReturnType<
+  ReturnType<typeof buildAdminCreateGlobalIssuerMutation>["mutationFn"]
+> {
+  return redirecting(
+    buildAdminCreateGlobalIssuerMutation(redirectingClient).mutationFn({
+      request,
+    }),
+  );
+}
+
+export function adminUpdateGlobalIssuer(
+  request: AdminUpdateGlobalIssuerMutationVariables["request"],
+): ReturnType<
+  ReturnType<typeof buildAdminUpdateGlobalIssuerMutation>["mutationFn"]
+> {
+  return redirecting(
+    buildAdminUpdateGlobalIssuerMutation(redirectingClient).mutationFn({
+      request,
+    }),
+  );
+}
+
+export function adminDeleteGlobalIssuer(
+  request: AdminDeleteGlobalIssuerMutationVariables["request"],
+): ReturnType<
+  ReturnType<typeof buildAdminDeleteGlobalIssuerMutation>["mutationFn"]
+> {
+  return redirecting(
+    buildAdminDeleteGlobalIssuerMutation(redirectingClient).mutationFn({
+      request,
+    }),
+  );
+}
+
+export function adminFetchGlobalIssuerMetadata(
+  request: AdminFetchGlobalIssuerMetadataMutationVariables["request"],
+): ReturnType<
+  ReturnType<typeof buildAdminFetchGlobalIssuerMetadataMutation>["mutationFn"]
+> {
+  return redirecting(
+    buildAdminFetchGlobalIssuerMetadataMutation(redirectingClient).mutationFn({
+      request,
+    }),
+  );
+}
+
+export function adminRefreshGlobalIssuerMetadata(
+  request: AdminRefreshGlobalIssuerMetadataMutationVariables["request"],
+): ReturnType<
+  ReturnType<typeof buildAdminRefreshGlobalIssuerMetadataMutation>["mutationFn"]
+> {
+  return redirecting(
+    buildAdminRefreshGlobalIssuerMetadataMutation(redirectingClient).mutationFn(
+      { request },
+    ),
+  );
+}
+
+export function adminMigrateToGlobalIssuer(
+  request: AdminMigrateToGlobalIssuerMutationVariables["request"],
+): ReturnType<
+  ReturnType<typeof buildAdminMigrateToGlobalIssuerMutation>["mutationFn"]
+> {
+  return redirecting(
+    buildAdminMigrateToGlobalIssuerMutation(redirectingClient).mutationFn({
+      request,
+    }),
+  );
+}
+
+export function adminUploadPlatformImage(
+  request: AdminUploadPlatformImageMutationVariables["request"],
+): ReturnType<
+  ReturnType<typeof buildAdminUploadPlatformImageMutation>["mutationFn"]
+> {
+  return redirecting(
+    buildAdminUploadPlatformImageMutation(redirectingClient).mutationFn({
+      request,
+    }),
+  );
+}
+
+function createAdminIssuerImageQuery(id: string) {
+  const generated = buildAdminServeImageQuery(redirectingClient, { id });
+  return queryOptions({
+    queryKey: generated.queryKey,
+    queryFn: async (context) => {
+      const response = await redirecting(generated.queryFn(context));
+      return new Response(response.result, {
+        headers: {
+          "Content-Type":
+            response.headers["Content-Type"]?.[0] ??
+            response.headers["content-type"]?.[0] ??
+            "application/octet-stream",
+        },
+      }).blob();
+    },
+  });
+}
+
+export function adminGetGlobalIssuerQuery(
+  request: Parameters<typeof buildAdminGetGlobalIssuerQuery>[1],
+): ReturnType<typeof createAdminGetGlobalIssuerQuery> {
+  return createAdminGetGlobalIssuerQuery(request);
+}
+
+export function adminListGlobalIssuersQuery(
+  request: Parameters<typeof buildAdminListGlobalIssuersQuery>[1],
+): ReturnType<typeof createAdminListGlobalIssuersQuery> {
+  return createAdminListGlobalIssuersQuery(request);
+}
+
+export function adminListGlobalIssuerConvergenceCandidatesQuery(
+  request: Parameters<
+    typeof buildAdminListGlobalIssuerConvergenceCandidatesQuery
+  >[1],
+): ReturnType<typeof createAdminListGlobalIssuerConvergenceCandidatesQuery> {
+  return createAdminListGlobalIssuerConvergenceCandidatesQuery(request);
+}
+
+export function adminGetGlobalIssuerDuplicatePreflightQuery(
+  request: Parameters<
+    typeof buildAdminGetGlobalIssuerDuplicatePreflightQuery
+  >[1],
+): ReturnType<typeof createAdminGetGlobalIssuerDuplicatePreflightQuery> {
+  return createAdminGetGlobalIssuerDuplicatePreflightQuery(request);
+}
+
+export function adminGetGlobalIssuerMigratePreflightQuery(
+  request: Parameters<typeof buildAdminGetGlobalIssuerMigratePreflightQuery>[1],
+): ReturnType<typeof createAdminGetGlobalIssuerMigratePreflightQuery> {
+  return createAdminGetGlobalIssuerMigratePreflightQuery(request);
+}
+
+export function adminIssuerImageQuery(
+  id: string,
+): ReturnType<typeof createAdminIssuerImageQuery> {
+  return createAdminIssuerImageQuery(id);
 }

--- a/client/admin/src/pages/remote-session-issuers/IssuerLogo.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerLogo.test.tsx
@@ -1,0 +1,35 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { adminIssuerImageQuery } from "@/lib/gramAdminClient";
+import { IssuerLogo } from "./IssuerLogo";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+it("clears and revokes the previous logo while a new image has no data", () => {
+  const cache = new QueryClient({
+    defaultOptions: { queries: { enabled: false } },
+  });
+  cache.setQueryData(
+    adminIssuerImageQuery("first").queryKey,
+    new Blob(["logo"]),
+  );
+  vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:first");
+  const revoke = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+  const view = render(
+    <QueryClientProvider client={cache}>
+      <IssuerLogo id="first" />
+    </QueryClientProvider>,
+  );
+  expect(view.getByRole("img").getAttribute("src")).toBe("blob:first");
+  view.rerender(
+    <QueryClientProvider client={cache}>
+      <IssuerLogo id="second" />
+    </QueryClientProvider>,
+  );
+  expect(revoke).toHaveBeenCalledWith("blob:first");
+  expect(view.queryByRole("img")).toBeNull();
+});

--- a/client/admin/src/pages/remote-session-issuers/IssuerLogo.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerLogo.test.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render } from "@testing-library/react";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, expect, it, vi } from "vitest";
+import * as adminClient from "@/lib/gramAdminClient";
 import { adminIssuerImageQuery } from "@/lib/gramAdminClient";
 import { IssuerLogo } from "./IssuerLogo";
 
@@ -32,4 +33,70 @@ it("clears and revokes the previous logo while a new image has no data", () => {
   );
   expect(revoke).toHaveBeenCalledWith("blob:first");
   expect(view.queryByRole("img")).toBeNull();
+});
+
+// Keep the real query options and React Query observer; only replace transport.
+it("shows an inline fallback even when the client defaults to throwing errors", async () => {
+  const cache = new QueryClient({
+    defaultOptions: { queries: { retry: false, throwOnError: true } },
+  });
+  const options = adminIssuerImageQuery("missing");
+  vi.spyOn(adminClient, "adminIssuerImageQuery").mockReturnValue({
+    ...options,
+    queryFn: async () => {
+      throw new Error("image unavailable");
+    },
+  });
+  const view = render(
+    <QueryClientProvider client={cache}>
+      <IssuerLogo id="missing" />
+    </QueryClientProvider>,
+  );
+  expect((await view.findByRole("alert")).textContent).toBe("Logo unavailable");
+  expect(view.queryByRole("img")).toBeNull();
+  view.unmount();
+  cache.clear();
+});
+
+it("keeps a cached logo after refetch failure and revokes it on unmount", async () => {
+  const cache = new QueryClient({
+    defaultOptions: { queries: { retry: false, throwOnError: true } },
+  });
+  const options = adminIssuerImageQuery("cached");
+  const blob = new Blob(["logo"]);
+  const queryFn = vi
+    .fn()
+    .mockResolvedValueOnce(blob)
+    .mockRejectedValue(new Error("temporary failure"));
+  vi.spyOn(adminClient, "adminIssuerImageQuery").mockReturnValue({
+    ...options,
+    queryFn,
+  });
+  const create = vi
+    .spyOn(URL, "createObjectURL")
+    .mockReturnValue("blob:cached");
+  const revoke = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+  const view = render(
+    <QueryClientProvider client={cache}>
+      <IssuerLogo id="cached" />
+    </QueryClientProvider>,
+  );
+  expect((await view.findByRole("img")).getAttribute("src")).toBe(
+    "blob:cached",
+  );
+  await act(async () => {
+    await cache.refetchQueries({ queryKey: options.queryKey });
+  });
+  await waitFor(() =>
+    expect(cache.getQueryState(options.queryKey)?.status).toBe("error"),
+  );
+  expect(queryFn).toHaveBeenCalledTimes(2);
+  expect(cache.getQueryData(options.queryKey)).toBe(blob);
+  expect(view.getByRole("img").getAttribute("src")).toBe("blob:cached");
+  expect(view.queryByRole("alert")).toBeNull();
+  expect(create).toHaveBeenCalledTimes(1);
+  expect(revoke).not.toHaveBeenCalled();
+  view.unmount();
+  expect(revoke).toHaveBeenCalledExactlyOnceWith("blob:cached");
+  cache.clear();
 });

--- a/client/admin/src/pages/remote-session-issuers/IssuerLogo.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerLogo.test.tsx
@@ -1,3 +1,4 @@
+import { useLayoutEffect } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, expect, it, vi } from "vitest";
@@ -98,5 +99,39 @@ it("keeps a cached logo after refetch failure and revokes it on unmount", async 
   expect(revoke).not.toHaveBeenCalled();
   view.unmount();
   expect(revoke).toHaveBeenCalledExactlyOnceWith("blob:cached");
+  cache.clear();
+});
+
+it("releases the old asset during layout, before passive effects", () => {
+  const cache = new QueryClient({
+    defaultOptions: { queries: { enabled: false } },
+  });
+  cache.setQueryData(
+    adminIssuerImageQuery("first").queryKey,
+    new Blob(["logo"]),
+  );
+  vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:first");
+  const revoke = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+  const observed = vi.fn();
+  function Observer({ id }: { id: string }) {
+    useLayoutEffect(() => {
+      if (id === "second") observed(revoke.mock.calls.length);
+    }, [id]);
+    return <IssuerLogo id={id} />;
+  }
+  const view = render(
+    <QueryClientProvider client={cache}>
+      <Observer id="first" />
+    </QueryClientProvider>,
+  );
+  view.rerender(
+    <QueryClientProvider client={cache}>
+      <Observer id="second" />
+    </QueryClientProvider>,
+  );
+  expect(observed).toHaveBeenCalledExactlyOnceWith(1);
+  expect(view.queryByRole("img")).toBeNull();
+  view.unmount();
+  expect(revoke).toHaveBeenCalledExactlyOnceWith("blob:first");
   cache.clear();
 });

--- a/client/admin/src/pages/remote-session-issuers/IssuerLogo.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerLogo.tsx
@@ -1,0 +1,24 @@
+import type { JSX } from "react";
+// oxlint-disable-next-line no-restricted-imports -- object URLs are external resources requiring cleanup
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { adminIssuerImageQuery } from "@/lib/gramAdminClient";
+export function IssuerLogo({ id }: { id: string }): JSX.Element | null {
+  const query = useQuery(adminIssuerImageQuery(id));
+  const [url, setUrl] = useState("");
+  useEffect(() => {
+    if (!query.data) return;
+    const next = URL.createObjectURL(query.data);
+    setUrl(next);
+    return () => URL.revokeObjectURL(next);
+  }, [query.data]);
+  if (query.error)
+    return (
+      <span role="alert" className="text-muted-foreground text-xs">
+        Logo unavailable
+      </span>
+    );
+  return url ? (
+    <img src={url} alt="Issuer logo" className="size-10 object-contain" />
+  ) : null;
+}

--- a/client/admin/src/pages/remote-session-issuers/IssuerLogo.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerLogo.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { adminIssuerImageQuery } from "@/lib/gramAdminClient";
 export function IssuerLogo({ id }: { id: string }): JSX.Element | null {
-  const query = useQuery(adminIssuerImageQuery(id));
+  const query = useQuery({ ...adminIssuerImageQuery(id), throwOnError: false });
   const [url, setUrl] = useState("");
   useEffect(() => {
     if (!query.data) {
@@ -15,7 +15,7 @@ export function IssuerLogo({ id }: { id: string }): JSX.Element | null {
     setUrl(next);
     return () => URL.revokeObjectURL(next);
   }, [query.data]);
-  if (query.error)
+  if (query.error && !url)
     return (
       <span role="alert" className="text-muted-foreground text-xs">
         Logo unavailable

--- a/client/admin/src/pages/remote-session-issuers/IssuerLogo.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerLogo.tsx
@@ -7,7 +7,10 @@ export function IssuerLogo({ id }: { id: string }): JSX.Element | null {
   const query = useQuery(adminIssuerImageQuery(id));
   const [url, setUrl] = useState("");
   useEffect(() => {
-    if (!query.data) return;
+    if (!query.data) {
+      setUrl("");
+      return;
+    }
     const next = URL.createObjectURL(query.data);
     setUrl(next);
     return () => URL.revokeObjectURL(next);

--- a/client/admin/src/pages/remote-session-issuers/IssuerLogo.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerLogo.tsx
@@ -1,12 +1,12 @@
 import type { JSX } from "react";
 // oxlint-disable-next-line no-restricted-imports -- object URLs are external resources requiring cleanup
-import { useEffect, useState } from "react";
+import { useLayoutEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { adminIssuerImageQuery } from "@/lib/gramAdminClient";
 export function IssuerLogo({ id }: { id: string }): JSX.Element | null {
   const query = useQuery({ ...adminIssuerImageQuery(id), throwOnError: false });
   const [url, setUrl] = useState("");
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!query.data) {
       setUrl("");
       return;

--- a/client/admin/src/pages/remote-session-issuers/issuerQueries.test.ts
+++ b/client/admin/src/pages/remote-session-issuers/issuerQueries.test.ts
@@ -1,0 +1,96 @@
+import { queryKeyAdminGetGlobalIssuer } from "@gram/admin-client/react-query/adminGetGlobalIssuer.core";
+import {
+  queryKeyAdminListGlobalIssuerConvergenceCandidates,
+  queryKeyAdminListGlobalIssuerConvergenceCandidatesInfinite,
+} from "@gram/admin-client/react-query/adminListGlobalIssuerConvergenceCandidates.core";
+import { queryKeyAdminGetGlobalIssuerMigratePreflight } from "@gram/admin-client/react-query/adminGetGlobalIssuerMigratePreflight.core";
+import {
+  queryKeyAdminListGlobalIssuers,
+  queryKeyAdminListGlobalIssuersInfinite,
+} from "@gram/admin-client/react-query/adminListGlobalIssuers.core";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
+import { expect, it, vi } from "vitest";
+import { invalidateIssuerQueries } from "./issuerQueries";
+it("invalidates issuer pages and preflight without invalidating unrelated admin data", async () => {
+  const cache = new QueryClient();
+  const issuer = [
+    "@gram/admin-client",
+    "admin",
+    "listGlobalIssuers",
+    { cursor: "next" },
+  ];
+  const preflight = [
+    "@gram/admin-client",
+    "admin",
+    "getGlobalIssuerMigratePreflight",
+    { sourceId: "source" },
+  ];
+  const session = ["@gram/admin-client", "admin", "getSession"];
+  for (const key of [issuer, preflight, session]) cache.setQueryData(key, {});
+  await invalidateIssuerQueries(cache);
+  expect(cache.getQueryState(issuer)?.isInvalidated).toBe(true);
+  expect(cache.getQueryState(preflight)?.isInvalidated).toBe(true);
+  expect(cache.getQueryState(session)?.isInvalidated).toBe(false);
+});
+
+it.each([undefined, "deleted"])(
+  "refreshes active issuer queries, evicting only an explicitly deleted ID (%s)",
+  async (deletedId) => {
+    const cache = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    const deleted = [
+      queryKeyAdminGetGlobalIssuer({ id: "deleted" }),
+      queryKeyAdminListGlobalIssuerConvergenceCandidates({
+        targetId: "deleted",
+      }),
+      queryKeyAdminListGlobalIssuerConvergenceCandidates({
+        targetId: "deleted",
+        cursor: "next",
+      }),
+      queryKeyAdminListGlobalIssuerConvergenceCandidatesInfinite({
+        targetId: "deleted",
+      }),
+      queryKeyAdminGetGlobalIssuerMigratePreflight({
+        sourceId: "local",
+        targetId: "deleted",
+      }),
+    ];
+    const surviving = [
+      queryKeyAdminListGlobalIssuers({}),
+      queryKeyAdminListGlobalIssuers({ cursor: "next" }),
+      queryKeyAdminListGlobalIssuersInfinite({}),
+      queryKeyAdminGetGlobalIssuer({ id: "surviving" }),
+      queryKeyAdminListGlobalIssuerConvergenceCandidates({
+        targetId: "surviving",
+      }),
+      queryKeyAdminGetGlobalIssuerMigratePreflight({
+        sourceId: "local",
+        targetId: "surviving",
+      }),
+    ];
+    const rows = [...deleted, ...surviving].map((queryKey) => {
+      cache.setQueryData(queryKey, { cached: true });
+      const queryFn = vi.fn(async () => ({ cached: false }));
+      const observer = new QueryObserver(cache, { queryKey, queryFn });
+      return { queryKey, queryFn, unsubscribe: observer.subscribe(() => {}) };
+    });
+    try {
+      await invalidateIssuerQueries(cache, deletedId);
+      for (const row of rows.slice(0, deleted.length)) {
+        if (deletedId) {
+          expect(row.queryFn).not.toHaveBeenCalled();
+          expect(cache.getQueryState(row.queryKey)).toBeUndefined();
+        } else {
+          expect(row.queryFn).toHaveBeenCalledTimes(1);
+        }
+      }
+      for (const row of rows.slice(deleted.length)) {
+        expect(row.queryFn).toHaveBeenCalledTimes(1);
+      }
+    } finally {
+      rows.forEach((row) => row.unsubscribe());
+      cache.clear();
+    }
+  },
+);

--- a/client/admin/src/pages/remote-session-issuers/issuerQueries.test.ts
+++ b/client/admin/src/pages/remote-session-issuers/issuerQueries.test.ts
@@ -1,3 +1,4 @@
+import { queryKeyAdminGetSession } from "@gram/admin-client/react-query/adminGetSession.core";
 import { queryKeyAdminGetGlobalIssuer } from "@gram/admin-client/react-query/adminGetGlobalIssuer.core";
 import {
   queryKeyAdminListGlobalIssuerConvergenceCandidates,
@@ -13,19 +14,12 @@ import { expect, it, vi } from "vitest";
 import { invalidateIssuerQueries } from "./issuerQueries";
 it("invalidates issuer pages and preflight without invalidating unrelated admin data", async () => {
   const cache = new QueryClient();
-  const issuer = [
-    "@gram/admin-client",
-    "admin",
-    "listGlobalIssuers",
-    { cursor: "next" },
-  ];
-  const preflight = [
-    "@gram/admin-client",
-    "admin",
-    "getGlobalIssuerMigratePreflight",
-    { sourceId: "source" },
-  ];
-  const session = ["@gram/admin-client", "admin", "getSession"];
+  const issuer = queryKeyAdminListGlobalIssuers({ cursor: "next" });
+  const preflight = queryKeyAdminGetGlobalIssuerMigratePreflight({
+    sourceId: "source",
+    targetId: "target",
+  });
+  const session = queryKeyAdminGetSession();
   for (const key of [issuer, preflight, session]) cache.setQueryData(key, {});
   await invalidateIssuerQueries(cache);
   expect(cache.getQueryState(issuer)?.isInvalidated).toBe(true);

--- a/client/admin/src/pages/remote-session-issuers/issuerQueries.ts
+++ b/client/admin/src/pages/remote-session-issuers/issuerQueries.ts
@@ -1,0 +1,32 @@
+import type { Query, QueryClient } from "@tanstack/react-query";
+
+function isIssuerQuery(query: Query): boolean {
+  return (
+    query.queryKey[0] === "@gram/admin-client" &&
+    query.queryKey[1] === "admin" &&
+    typeof query.queryKey[2] === "string" &&
+    query.queryKey[2].toLowerCase().includes("globalissuer")
+  );
+}
+
+export function invalidateIssuerQueries(
+  cache: QueryClient,
+  deletedId?: string,
+): Promise<void> {
+  if (deletedId !== undefined) {
+    // Evict before invalidating: detail observers can remain mounted until navigation.
+    // Generated infinite keys insert "infinite" before the request parameters.
+    cache.removeQueries({
+      predicate: (query) =>
+        isIssuerQuery(query) &&
+        query.queryKey.some(
+          (part) =>
+            typeof part === "object" &&
+            part !== null &&
+            (("id" in part && part.id === deletedId) ||
+              ("targetId" in part && part.targetId === deletedId)),
+        ),
+    });
+  }
+  return cache.invalidateQueries({ predicate: isIssuerQuery });
+}


### PR DESCRIPTION
## Stack context

The preceding PRs provide the standalone issuer and image APIs; this PR adds the shared frontend data-access layer for them. It uses the issuer operations from [#6273](https://github.com/speakeasy-api/gram/pull/6273) and the image endpoints from [#6272](https://github.com/speakeasy-api/gram/pull/6272) to support cached issuer queries, mutations, and logo loading without the dashboard client.

Scoped invalidation and deletion-aware cache cleanup give the later action and convergence components a consistent way to keep the UI current. Blob-backed logo loading handles the image lifecycle separately from form payload semantics introduced in [#6275](https://github.com/speakeasy-api/gram/pull/6275). These helpers are connected to user-facing pages in [#6280](https://github.com/speakeasy-api/gram/pull/6280).

## Summary

Add standalone admin issuer query and mutation helpers, scoped cache invalidation, and blob-backed logo loading. Deleted issuer detail and convergence entries are evicted before list invalidation. This preparatory slice adds no reachable routes.

## Motivation

Provide shared data access and image handling for the upcoming issuer pages without relying on the dashboard client.
