### PR TITLE
feat: display admin issuer configuration fields

### DIFF
--- a/.changeset/admin-issuer-overview-fields.md
+++ b/.changeset/admin-issuer-overview-fields.md
@@ -1,0 +1,5 @@
+---
+"admin": patch
+---
+
+Prepare issuer configuration rendering with safe documentation links and preserved stored metadata.

--- a/client/admin/src/pages/remote-session-issuers/IssuerConfiguration.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerConfiguration.test.tsx
@@ -33,6 +33,10 @@ it("renders stable explicit labels and nullable capability semantics", () => {
     screen.queryByText("client Id Metadata Document Supported"),
   ).toBeNull();
 });
+it("omits project ownership for global issuers", () => {
+  render(<IssuerConfiguration issuer={issuer} />);
+  expect(screen.queryByText("Project", { selector: "dt" })).toBeNull();
+});
 it("distinguishes explicitly empty PKCE and safely links documentation", () => {
   render(
     <IssuerConfiguration

--- a/client/admin/src/pages/remote-session-issuers/IssuerConfiguration.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerConfiguration.test.tsx
@@ -33,7 +33,7 @@ it("renders stable explicit labels and nullable capability semantics", () => {
     screen.queryByText("client Id Metadata Document Supported"),
   ).toBeNull();
 });
-it("omits project ownership for global issuers", () => {
+it("omits project ownership", () => {
   render(<IssuerConfiguration issuer={issuer} />);
   expect(screen.queryByText("Project", { selector: "dt" })).toBeNull();
 });

--- a/client/admin/src/pages/remote-session-issuers/IssuerConfiguration.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerConfiguration.test.tsx
@@ -1,0 +1,57 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, expect, it } from "vitest";
+import type { RemoteSessionIssuer } from "@gram/admin-client/models/components/remotesessionissuer";
+import { IssuerConfiguration } from "./IssuerConfiguration";
+const issuer = {
+  id: "example",
+  name: "",
+  slug: "example",
+  issuer: "https://issuer.example",
+  organizationId: "",
+  projectId: "",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  oidc: false,
+  passthrough: false,
+  clientIdMetadataDocumentSupported: false,
+} satisfies RemoteSessionIssuer;
+afterEach(cleanup);
+function value(label: string) {
+  return screen.getByText(label, { selector: "dt" }).parentElement!;
+}
+it("renders stable explicit labels and nullable capability semantics", () => {
+  render(<IssuerConfiguration issuer={issuer} />);
+  expect(within(value("Name")).getByText("—")).toBeTruthy();
+  expect(within(value("Authorization")).getByText("—")).toBeTruthy();
+  expect(
+    within(value("PKCE Code Challenge Methods")).getByText("Not captured"),
+  ).toBeTruthy();
+  expect(
+    within(value("Client ID Metadata Document")).getByText("Not supported"),
+  ).toBeTruthy();
+  expect(
+    screen.queryByText("client Id Metadata Document Supported"),
+  ).toBeNull();
+});
+it("distinguishes explicitly empty PKCE and safely links documentation", () => {
+  render(
+    <IssuerConfiguration
+      issuer={{
+        ...issuer,
+        codeChallengeMethodsSupported: [],
+        clientSetupDocumentationUrl: "https://docs.example/setup",
+        serviceDocumentation: "javascript:alert(1)",
+      }}
+    />,
+  );
+  expect(
+    within(value("PKCE Code Challenge Methods")).getByText("None advertised"),
+  ).toBeTruthy();
+  const link = screen.getByRole("link", { name: "https://docs.example/setup" });
+  expect(link.getAttribute("target")).toBe("_blank");
+  expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  expect(
+    screen.queryByRole("link", { name: "javascript:alert(1)" }),
+  ).toBeNull();
+  expect(screen.getByText("javascript:alert(1)")).toBeTruthy();
+});

--- a/client/admin/src/pages/remote-session-issuers/IssuerConfiguration.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerConfiguration.test.tsx
@@ -29,9 +29,6 @@ it("renders stable explicit labels and nullable capability semantics", () => {
   expect(
     within(value("Client ID Metadata Document")).getByText("Not supported"),
   ).toBeTruthy();
-  expect(
-    screen.queryByText("client Id Metadata Document Supported"),
-  ).toBeNull();
 });
 it("omits project ownership", () => {
   render(<IssuerConfiguration issuer={issuer} />);

--- a/client/admin/src/pages/remote-session-issuers/IssuerConfiguration.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerConfiguration.tsx
@@ -1,0 +1,155 @@
+import type { JSX, ReactNode } from "react";
+import type { RemoteSessionIssuer } from "@gram/admin-client/models/components/remotesessionissuer";
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}): JSX.Element {
+  return (
+    <div>
+      <dt className="text-muted-foreground text-sm">{label}</dt>
+      <dd className="break-all text-sm">{children}</dd>
+    </div>
+  );
+}
+function Documentation({ value }: { value?: string }): JSX.Element {
+  const url = value?.trim();
+  let safe = false;
+  try {
+    safe = !!url && ["http:", "https:"].includes(new URL(url).protocol);
+  } catch {
+    /* Stored invalid values remain visible, never executable links. */
+  }
+  return safe ? (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="underline underline-offset-4"
+    >
+      {url}
+    </a>
+  ) : (
+    <>{url || "—"}</>
+  );
+}
+const ordinary = (v?: string | null): string => v?.trim() || "—";
+const list = (v?: string[] | null): string => (v?.length ? v.join(", ") : "—");
+const captured = (v?: string[] | null): string =>
+  v == null ? "Not captured" : v.length ? v.join(", ") : "None advertised";
+const supported = (v?: boolean): string =>
+  v === undefined ? "Not captured" : v ? "Supported" : "Not supported";
+export function IssuerConfiguration({
+  issuer,
+}: {
+  issuer: RemoteSessionIssuer;
+}): JSX.Element {
+  const sections: [string, [string, ReactNode][]][] = [
+    [
+      "Essentials",
+      [
+        ["Name", ordinary(issuer.name)],
+        ["Slug", ordinary(issuer.slug)],
+        ["Issuer", ordinary(issuer.issuer)],
+        ["Project", "—"],
+        ["Issuer ID", issuer.id],
+      ],
+    ],
+    [
+      "Endpoints",
+      [
+        ["Authorization", ordinary(issuer.authorizationEndpoint)],
+        ["Token", ordinary(issuer.tokenEndpoint)],
+        ["Registration", ordinary(issuer.registrationEndpoint)],
+        ["JWKS", ordinary(issuer.jwksUri)],
+        ["Revocation", ordinary(issuer.revocationEndpoint)],
+        ["Userinfo", ordinary(issuer.userinfoEndpoint)],
+        ["Introspection", ordinary(issuer.introspectionEndpoint)],
+      ],
+    ],
+    [
+      "Identity Provider Details",
+      [
+        ["Scopes", list(issuer.scopesSupported)],
+        ["Grant Types", list(issuer.grantTypesSupported)],
+        ["Response Types", list(issuer.responseTypesSupported)],
+        [
+          "Token Endpoint Authentication Methods",
+          list(issuer.tokenEndpointAuthMethodsSupported),
+        ],
+        [
+          "PKCE Code Challenge Methods",
+          captured(issuer.codeChallengeMethodsSupported),
+        ],
+        [
+          "Client ID Metadata Document",
+          supported(issuer.clientIdMetadataDocumentSupported),
+        ],
+        [
+          "Introspection Authentication Methods",
+          captured(issuer.introspectionEndpointAuthMethodsSupported),
+        ],
+        [
+          "ID Token Signing Algorithms",
+          captured(issuer.idTokenSigningAlgValuesSupported),
+        ],
+        ["Claims", captured(issuer.claimsSupported)],
+        ["Back-Channel Logout", supported(issuer.backchannelLogoutSupported)],
+        [
+          "Authorization Response Issuer Parameter",
+          supported(issuer.authorizationResponseIssParameterSupported),
+        ],
+        ["OpenID Connect", supported(issuer.oidc)],
+        ["Passthrough", supported(issuer.passthrough)],
+        ["Resource Indicator", supported(issuer.resourceIndicatorSupported)],
+        ["Scope Override", list(issuer.scopeOverride)],
+      ],
+    ],
+    [
+      "Documentation",
+      [
+        [
+          "Client Setup Documentation",
+          <Documentation
+            key="setup"
+            value={issuer.clientSetupDocumentationUrl}
+          />,
+        ],
+        [
+          "Service Documentation",
+          <Documentation key="service" value={issuer.serviceDocumentation} />,
+        ],
+        ["Policy", <Documentation key="policy" value={issuer.opPolicyUri} />],
+        [
+          "Terms of Service",
+          <Documentation key="terms" value={issuer.opTosUri} />,
+        ],
+      ],
+    ],
+    [
+      "Record",
+      [
+        ["Created", issuer.createdAt?.toLocaleString() || "—"],
+        ["Updated", issuer.updatedAt?.toLocaleString() || "—"],
+      ],
+    ],
+  ];
+  return (
+    <div className="grid gap-6 sm:grid-cols-2">
+      {sections.map(([title, fields]) => (
+        <section key={title} className="grid content-start gap-3">
+          <h2 className="text-base font-semibold">{title}</h2>
+          <dl className="grid gap-3">
+            {fields.map(([label, value]) => (
+              <Field key={label} label={label}>
+                {value}
+              </Field>
+            ))}
+          </dl>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/client/admin/src/pages/remote-session-issuers/IssuerConfiguration.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerConfiguration.tsx
@@ -53,7 +53,6 @@ export function IssuerConfiguration({
         ["Name", ordinary(issuer.name)],
         ["Slug", ordinary(issuer.slug)],
         ["Issuer", ordinary(issuer.issuer)],
-        ["Project", "—"],
         ["Issuer ID", issuer.id],
       ],
     ],


### PR DESCRIPTION
## Stack context

Moving platform issuer management into standalone admin requires an inspection view as well as an editor. Building on the issuer data contract exposed in [#6273](https://github.com/speakeasy-api/gram/pull/6273), this PR adds a reusable renderer for an issuer’s configuration, discovered capabilities, and documentation links.

This layer makes the read-only presentation independently reviewable: labels are explicit, nullable metadata retains its meaning, and invalid stored links remain visible without becoming executable links. It does not introduce navigation or routes. The detail page in [#6280](https://github.com/speakeasy-api/gram/pull/6280) combines this renderer with the data-access layer and management actions.

## Summary

Add an issuer configuration renderer for metadata, capabilities, and documentation links, preserving invalid stored values as non-executable text. This preparatory component is not yet connected to a route.

## Motivation

Make issuer configuration inspectable in the upcoming standalone admin detail page.
