### PR TITLE
feat: share admin issuer refresh and delete actions

### DIFF
--- a/.changeset/admin-issuer-shared-actions.md
+++ b/.changeset/admin-issuer-shared-actions.md
@@ -1,0 +1,5 @@
+---
+"admin": patch
+---
+
+Prepare shared metadata refresh and confirmed deletion actions with deletion-aware cache invalidation.

--- a/client/admin/src/pages/remote-session-issuers/IssuerActions.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerActions.test.tsx
@@ -22,7 +22,46 @@ vi.mock("@/lib/gramAdminClient", () => ({
   adminDeleteGlobalIssuer: api.remove,
   adminRefreshGlobalIssuerMetadata: api.refresh,
 }));
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+it("clears previous refresh warnings while retrying and after failure", async () => {
+  const warning = "Previous discovery warning";
+  let rejectRefresh!: (reason: Error) => void;
+  const pendingRefresh = new Promise<never>((_, reject) => {
+    rejectRefresh = reject;
+  });
+  api.refresh
+    .mockResolvedValueOnce({ discoveryWarnings: [warning] })
+    .mockReturnValueOnce(pendingRefresh);
+  const record = {
+    issuer: { id: "target", name: "Example provider" },
+    globalClientCount: 0,
+    tenantClientCount: 0,
+  } as GlobalRemoteSessionIssuer;
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <IssuerActions record={record} />
+    </QueryClientProvider>,
+  );
+  const refresh = screen.getByRole("button", { name: "Refresh metadata" });
+  fireEvent.click(refresh);
+  expect(await screen.findByText(warning)).toBeTruthy();
+  await waitFor(() =>
+    expect((refresh as HTMLButtonElement).disabled).toBe(false),
+  );
+  fireEvent.click(refresh);
+  expect(api.refresh).toHaveBeenCalledTimes(2);
+  expect((refresh as HTMLButtonElement).disabled).toBe(true);
+  expect(screen.queryByText(warning)).toBeNull();
+  rejectRefresh(new Error("New refresh failure"));
+  expect((await screen.findByRole("alert")).textContent).toContain(
+    "New refresh failure",
+  );
+  expect(screen.queryByText(warning)).toBeNull();
+});
 it("retains deletion errors and identity inside the retryable dialog", async () => {
   api.remove.mockRejectedValue(new Error("Clients appeared"));
   const record = {

--- a/client/admin/src/pages/remote-session-issuers/IssuerActions.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerActions.test.tsx
@@ -1,0 +1,107 @@
+import { queryKeyAdminGetGlobalIssuer } from "@gram/admin-client/react-query/adminGetGlobalIssuer.core";
+import { queryKeyAdminListGlobalIssuerConvergenceCandidates } from "@gram/admin-client/react-query/adminListGlobalIssuerConvergenceCandidates.core";
+import { queryKeyAdminListGlobalIssuers } from "@gram/admin-client/react-query/adminListGlobalIssuers.core";
+import {
+  cleanup,
+  render,
+  screen,
+  fireEvent,
+  within,
+  waitFor,
+} from "@testing-library/react";
+import {
+  QueryClient,
+  QueryClientProvider,
+  QueryObserver,
+} from "@tanstack/react-query";
+import { afterEach, expect, it, vi } from "vitest";
+import { IssuerActions } from "./IssuerActions";
+import type { GlobalRemoteSessionIssuer } from "@gram/admin-client/models/components/globalremotesessionissuer";
+const api = vi.hoisted(() => ({ remove: vi.fn(), refresh: vi.fn() }));
+vi.mock("@/lib/gramAdminClient", () => ({
+  adminDeleteGlobalIssuer: api.remove,
+  adminRefreshGlobalIssuerMetadata: api.refresh,
+}));
+afterEach(cleanup);
+it("retains deletion errors and identity inside the retryable dialog", async () => {
+  api.remove.mockRejectedValue(new Error("Clients appeared"));
+  const record = {
+    issuer: { id: "target", name: "Example provider" },
+    globalClientCount: 0,
+    tenantClientCount: 0,
+  } as GlobalRemoteSessionIssuer;
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <IssuerActions record={record} />
+    </QueryClientProvider>,
+  );
+  fireEvent.click(screen.getByRole("button", { name: "Delete issuer" }));
+  const dialog = screen.getByRole("dialog");
+  fireEvent.click(
+    within(dialog).getByRole("button", { name: "Delete issuer" }),
+  );
+  expect((await within(dialog).findByRole("alert")).textContent).toContain(
+    "Clients appeared",
+  );
+  expect(within(dialog).getByText(/Example provider/)).toBeTruthy();
+  expect(screen.getByRole("dialog")).toBeTruthy();
+  api.remove.mockResolvedValueOnce(undefined);
+  fireEvent.click(
+    within(dialog).getByRole("button", { name: "Delete issuer" }),
+  );
+  await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+});
+
+it.each([false, true])(
+  "refreshes the list without requesting the deleted issuer (detail navigation: %s)",
+  async (navigate) => {
+    api.remove.mockResolvedValue(undefined);
+    const cache = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    const keys = [
+      queryKeyAdminGetGlobalIssuer({ id: "target" }),
+      queryKeyAdminListGlobalIssuerConvergenceCandidates({
+        targetId: "target",
+      }),
+      queryKeyAdminListGlobalIssuers({}),
+    ];
+    const rows = keys.map((queryKey) => {
+      cache.setQueryData(queryKey, {});
+      const queryFn = vi.fn(async () => ({}));
+      const observer = new QueryObserver(cache, { queryKey, queryFn });
+      return { queryFn, unsubscribe: observer.subscribe(() => {}) };
+    });
+    const onDeleted = vi.fn(async () => {});
+    const record = {
+      issuer: { id: "target", name: "Example provider" },
+      globalClientCount: 0,
+      tenantClientCount: 0,
+    } as GlobalRemoteSessionIssuer;
+    try {
+      render(
+        <QueryClientProvider client={cache}>
+          <IssuerActions
+            record={record}
+            onDeleted={navigate ? onDeleted : undefined}
+          />
+        </QueryClientProvider>,
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Delete issuer" }));
+      fireEvent.click(
+        within(screen.getByRole("dialog")).getByRole("button", {
+          name: "Delete issuer",
+        }),
+      );
+      await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+      expect(rows[0]!.queryFn).not.toHaveBeenCalled();
+      expect(rows[1]!.queryFn).not.toHaveBeenCalled();
+      expect(rows[2]!.queryFn).toHaveBeenCalledTimes(1);
+      expect(onDeleted).toHaveBeenCalledTimes(navigate ? 1 : 0);
+    } finally {
+      cleanup();
+      rows.forEach((row) => row.unsubscribe());
+      cache.clear();
+    }
+  },
+);

--- a/client/admin/src/pages/remote-session-issuers/IssuerActions.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerActions.tsx
@@ -1,0 +1,142 @@
+import { useRef, useState, type JSX } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import type { GlobalRemoteSessionIssuer } from "@gram/admin-client/models/components/globalremotesessionissuer";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  adminDeleteGlobalIssuer,
+  adminRefreshGlobalIssuerMetadata,
+} from "@/lib/gramAdminClient";
+import { invalidateIssuerQueries } from "./issuerQueries";
+export function IssuerActions({
+  record,
+  showRefresh = true,
+  disabled = false,
+  onDeleted,
+}: {
+  record: GlobalRemoteSessionIssuer;
+  showRefresh?: boolean;
+  disabled?: boolean;
+  onDeleted?: () => Promise<void>;
+}): JSX.Element {
+  const cache = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const [pending, setPending] = useState(false);
+  const busy = useRef(false);
+  const [error, setError] = useState("");
+  const [refreshWarnings, setRefreshWarnings] = useState<string[]>([]);
+  const run = async (remove: boolean) => {
+    if (busy.current || disabled) return;
+    busy.current = true;
+    setPending(true);
+    setError("");
+    try {
+      if (remove) {
+        await adminDeleteGlobalIssuer({ id: record.issuer.id });
+        await invalidateIssuerQueries(cache, record.issuer.id);
+        toast.success("Issuer deleted");
+        setOpen(false);
+        await onDeleted?.();
+      } else {
+        const result = await adminRefreshGlobalIssuerMetadata({
+          id: record.issuer.id,
+        });
+        setRefreshWarnings(result.discoveryWarnings);
+        await invalidateIssuerQueries(cache);
+        toast.success("Issuer metadata refreshed");
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Request failed");
+    } finally {
+      busy.current = false;
+      setPending(false);
+    }
+  };
+  return (
+    <div className="grid gap-2">
+      <div className="flex flex-wrap gap-2">
+        {showRefresh && (
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={pending || disabled}
+            onClick={() => void run(false)}
+          >
+            Refresh metadata
+          </Button>
+        )}
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={pending || disabled}
+          onClick={() => {
+            setError("");
+            setOpen(true);
+          }}
+        >
+          Delete issuer
+        </Button>
+      </div>
+      {!open && error && (
+        <p role="alert" className="text-destructive text-sm">
+          {error}
+        </p>
+      )}
+      {refreshWarnings.map((warning, i) => (
+        <p key={i} className="text-muted-foreground text-sm">
+          {warning}
+        </p>
+      ))}
+      <Dialog
+        open={open}
+        onOpenChange={(value) => {
+          if (!pending) setOpen(value);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              Delete {record.issuer.name || record.issuer.issuer}?
+            </DialogTitle>
+            <DialogDescription>
+              {record.globalClientCount} platform clients and{" "}
+              {record.tenantClientCount} tenant-owned clients currently
+              reference this issuer. Tenant clients can only be removed by their
+              owning organizations. Counts are advisory; the server refuses
+              deletion while dependencies exist.
+            </DialogDescription>
+          </DialogHeader>
+          {error && (
+            <p role="alert" className="text-destructive text-sm">
+              {error}
+            </p>
+          )}
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              disabled={pending || disabled}
+              onClick={() => setOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={pending || disabled}
+              onClick={() => void run(true)}
+            >
+              {pending ? "Deleting…" : "Delete issuer"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/client/admin/src/pages/remote-session-issuers/IssuerActions.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerActions.tsx
@@ -46,6 +46,7 @@ export function IssuerActions({
         setOpen(false);
         await onDeleted?.();
       } else {
+        setRefreshWarnings([]);
         const result = await adminRefreshGlobalIssuerMetadata({
           id: record.issuer.id,
         });


### PR DESCRIPTION
## Stack context

After establishing issuer inspection and shared data access, this PR adds the reusable actions needed to maintain platform issuers: refreshing discovery metadata and deleting an issuer with confirmation. It applies the API operations from [#6273](https://github.com/speakeasy-api/gram/pull/6273) through the query and cache conventions introduced in [#6276](https://github.com/speakeasy-api/gram/pull/6276).

Keeping conflict feedback, confirmation, and deletion-aware invalidation together avoids duplicating that behavior across the catalog and detail views. This remains a preparatory component layer; [#6280](https://github.com/speakeasy-api/gram/pull/6280) makes the actions reachable as part of the standalone issuer-management flow.

## Summary

Add reusable metadata-refresh and confirmed-delete actions with conflict feedback and deletion-aware cache invalidation. This preparatory component adds no reachable routes.

## Motivation

Share safe mutation behavior across the upcoming issuer catalog and detail views, avoiding requests for records that were just deleted.
