### PR TITLE
feat: add admin issuer convergence controls

### DIFF
--- a/.changeset/admin-issuer-convergence-panel.md
+++ b/.changeset/admin-issuer-convergence-panel.md
@@ -1,0 +1,5 @@
+---
+"admin": patch
+---
+
+Prepare issuer convergence controls with candidate preflights and migration feedback.

--- a/client/admin/src/pages/remote-session-issuers/Convergence.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/Convergence.test.tsx
@@ -1,0 +1,267 @@
+import {
+  cleanup,
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { Convergence, ConvergenceHelp, MigrationReview } from "./Convergence";
+const api = vi.hoisted(() => ({
+  preflight: vi.fn(),
+  migrate: vi.fn(),
+  candidates: vi.fn(),
+}));
+vi.mock("@/lib/gramAdminClient", () => ({
+  adminListGlobalIssuerConvergenceCandidatesQuery: (request: unknown) => ({
+    queryKey: ["candidates", request],
+    queryFn: () => api.candidates(request),
+  }),
+  adminGetGlobalIssuerMigratePreflightQuery: (r: unknown) => ({
+    queryKey: ["preflight", r],
+    queryFn: () => api.preflight(),
+  }),
+  adminMigrateToGlobalIssuer: api.migrate,
+}));
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+function mount() {
+  render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <MigrationReview
+        sourceId="source"
+        targetId="target"
+        onClose={vi.fn<() => void>()}
+      />
+    </QueryClientProvider>,
+  );
+}
+it("blocks confirmation after failed authoritative preflight", async () => {
+  api.preflight.mockRejectedValue(new Error("Preflight unavailable"));
+  mount();
+  expect((await screen.findByRole("alert")).textContent).toContain(
+    "Preflight unavailable",
+  );
+  expect(
+    (screen.getByRole("button", { name: "Consolidate" }) as HTMLButtonElement)
+      .disabled,
+  ).toBe(true);
+});
+it("shows conflicting bindings and refuses unsafe migration", async () => {
+  api.preflight.mockResolvedValue({
+    canMigrate: false,
+    clientCount: 1,
+    targetTenantClientCount: 2,
+    mcpServerNames: ["Example MCP"],
+    conflictingMcpServerNames: ["Conflicting MCP"],
+    endpointMismatches: [],
+    warnings: [],
+  });
+  mount();
+  expect(await screen.findByText("Conflicting MCP")).toBeTruthy();
+  fireEvent.click(screen.getByRole("button", { name: "Consolidate" }));
+  expect(api.migrate).not.toHaveBeenCalled();
+});
+
+it("allows warnings only after preflight and reports migration races", async () => {
+  api.preflight.mockResolvedValue({
+    canMigrate: true,
+    clientCount: 1,
+    targetTenantClientCount: 0,
+    mcpServerNames: [],
+    conflictingMcpServerNames: [],
+    endpointMismatches: [],
+    warnings: [
+      {
+        field: "scopes_supported",
+        sourceValues: ["old"],
+        targetValues: ["new"],
+      },
+    ],
+  });
+  api.migrate.mockRejectedValue(new Error("Binding changed during migration"));
+  mount();
+  expect(await screen.findByText("Scopes")).toBeTruthy();
+  await waitFor(() =>
+    expect(
+      (screen.getByRole("button", { name: "Consolidate" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false),
+  );
+  fireEvent.click(screen.getByRole("button", { name: "Consolidate" }));
+  expect((await screen.findByRole("alert")).textContent).toContain(
+    "Binding changed during migration",
+  );
+  expect(api.migrate).toHaveBeenCalledWith({
+    sourceId: "source",
+    targetId: "target",
+  });
+  await waitFor(() => expect(api.preflight).toHaveBeenCalledTimes(2));
+});
+
+it("explains convergence on keyboard focus and dismisses on Escape", async () => {
+  render(
+    <TooltipProvider>
+      <ConvergenceHelp />
+    </TooltipProvider>,
+  );
+  const trigger = screen.getByRole("button", { name: "About convergence" });
+  trigger.focus();
+  expect((await screen.findByRole("tooltip")).textContent).toContain(
+    "Organization or project issuers that use the same upstream identity provider",
+  );
+  fireEvent.keyDown(trigger, { key: "Escape" });
+  await waitFor(() => expect(screen.queryByRole("tooltip")).toBeNull());
+});
+it("discloses named target, fallback owner, scope deltas and scalar empty values", async () => {
+  api.preflight.mockResolvedValue({
+    canMigrate: false,
+    clientCount: 2,
+    targetTenantClientCount: 1,
+    mcpServerNames: ["Affected server"],
+    conflictingMcpServerNames: ["Conflicting binding"],
+    endpointMismatches: [
+      { field: "token_endpoint", sourceValue: "", targetValue: undefined },
+    ],
+    warnings: [
+      {
+        field: "scopes_supported",
+        sourceValues: ["old", "kept"],
+        targetValues: ["new", "kept"],
+      },
+    ],
+  });
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <MigrationReview
+        sourceId="source"
+        sourceOwner="organization-fallback"
+        targetId="target"
+        targetName="Named platform provider"
+        onClose={() => {}}
+      />
+    </QueryClientProvider>,
+  );
+  expect(await screen.findByText("Added: new")).toBeTruthy();
+  expect(screen.getByText("Dropped: old")).toBeTruthy();
+  expect(screen.getByText(/owned by organization-fallback/)).toBeTruthy();
+  expect(screen.getByText(/Named platform provider/)).toBeTruthy();
+  expect(screen.getByText("Affected server")).toBeTruthy();
+  expect(screen.getByText("Conflicting binding")).toBeTruthy();
+  expect(screen.getByText(/Source: empty/)).toBeTruthy();
+});
+it("carries an unsynced organization ID fallback from candidate row into review", async () => {
+  api.candidates.mockResolvedValue({
+    result: {
+      items: [
+        {
+          issuer: {
+            id: "source",
+            name: "Source provider",
+            issuer: "https://source.example",
+            projectId: "",
+          },
+          organizationName: "",
+          organizationId: "owner-fallback",
+          clientCount: 1,
+          endpointMismatches: [],
+          warnings: [],
+        },
+      ],
+    },
+  });
+  api.preflight.mockResolvedValue({
+    canMigrate: true,
+    clientCount: 1,
+    targetTenantClientCount: 0,
+    mcpServerNames: [],
+    conflictingMcpServerNames: [],
+    endpointMismatches: [],
+    warnings: [],
+  });
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <TooltipProvider>
+        <Convergence issuerId="target" targetName="Named target" />
+      </TooltipProvider>
+    </QueryClientProvider>,
+  );
+  fireEvent.click(await screen.findByRole("button", { name: "Review" }));
+  expect(await screen.findByText(/owned by owner-fallback/)).toBeTruthy();
+  expect(screen.getByText(/platform issuer Named target/)).toBeTruthy();
+});
+
+it.each([undefined, "", "   "])(
+  "identifies a nameless source (%j) by issuer URL while preserving migration IDs",
+  async (name) => {
+    api.candidates.mockResolvedValue({
+      result: {
+        items: [
+          {
+            issuer: {
+              id: "source-id",
+              name,
+              issuer: "https://source.example",
+              projectId: "",
+            },
+            organizationName: "Source owner",
+            organizationId: "owner-id",
+            clientCount: 1,
+            endpointMismatches: [],
+            warnings: [],
+          },
+        ],
+      },
+    });
+    api.preflight.mockResolvedValue({
+      canMigrate: true,
+      clientCount: 1,
+      targetTenantClientCount: 0,
+      mcpServerNames: [],
+      conflictingMcpServerNames: [],
+      endpointMismatches: [],
+      warnings: [],
+    });
+    api.migrate.mockResolvedValue({});
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <TooltipProvider>
+          <Convergence issuerId="target-id" targetName="Named target" />
+        </TooltipProvider>
+      </QueryClientProvider>,
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Review" }));
+    expect(
+      await screen.findByRole("heading", {
+        name: "Consolidate https://source.example",
+      }),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(/Move clients from https:\/\/source.example/),
+    ).toBeTruthy();
+    await waitFor(() =>
+      expect(
+        (
+          screen.getByRole("button", {
+            name: "Consolidate",
+          }) as HTMLButtonElement
+        ).disabled,
+      ).toBe(false),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Consolidate" }));
+    await waitFor(() =>
+      expect(api.migrate).toHaveBeenCalledWith({
+        sourceId: "source-id",
+        targetId: "target-id",
+      }),
+    );
+  },
+);

--- a/client/admin/src/pages/remote-session-issuers/Convergence.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/Convergence.test.tsx
@@ -344,3 +344,28 @@ it("resets pagination and closes migration review when the target changes", asyn
   });
   expect(api.migrate).not.toHaveBeenCalled();
 });
+
+it("hides the cached empty state after a failed candidates refetch", async () => {
+  api.candidates.mockResolvedValue({ result: { items: [] } });
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <TooltipProvider>
+        <Convergence issuerId="target" />
+      </TooltipProvider>
+    </QueryClientProvider>,
+  );
+  expect(
+    await screen.findByText("No matching organization or project issuers."),
+  ).toBeTruthy();
+  api.candidates.mockRejectedValue(new Error("Candidates unavailable"));
+  await client.invalidateQueries({ queryKey: ["candidates"] });
+  expect((await screen.findByRole("alert")).textContent).toContain(
+    "Candidates unavailable",
+  );
+  expect(
+    screen.queryByText("No matching organization or project issuers."),
+  ).toBeNull();
+});

--- a/client/admin/src/pages/remote-session-issuers/Convergence.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/Convergence.test.tsx
@@ -21,7 +21,7 @@ vi.mock("@/lib/gramAdminClient", () => ({
   }),
   adminGetGlobalIssuerMigratePreflightQuery: (r: unknown) => ({
     queryKey: ["preflight", r],
-    queryFn: () => api.preflight(),
+    queryFn: () => api.preflight(r),
   }),
   adminMigrateToGlobalIssuer: api.migrate,
 }));
@@ -265,3 +265,82 @@ it.each([undefined, "", "   "])(
     );
   },
 );
+
+it("resets pagination and closes migration review when the target changes", async () => {
+  api.candidates.mockResolvedValue({
+    result: {
+      items: [
+        {
+          issuer: {
+            id: "source",
+            name: "Source provider",
+            issuer: "https://source.example",
+          },
+          organizationId: "owner",
+          clientCount: 1,
+          endpointMismatches: [],
+          warnings: [],
+        },
+      ],
+      nextCursor: "target-a-page-2",
+    },
+  });
+  api.preflight.mockResolvedValue({
+    canMigrate: true,
+    clientCount: 1,
+    targetTenantClientCount: 0,
+    mcpServerNames: [],
+    conflictingMcpServerNames: [],
+    endpointMismatches: [],
+    warnings: [],
+  });
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const view = (issuerId: string) => (
+    <QueryClientProvider client={client}>
+      <TooltipProvider>
+        <Convergence issuerId={issuerId} />
+      </TooltipProvider>
+    </QueryClientProvider>
+  );
+  const { rerender } = render(view("target-a"));
+  await screen.findByRole("button", { name: "Review" });
+  fireEvent.click(screen.getByRole("button", { name: "Next" }));
+  await waitFor(() =>
+    expect(api.candidates).toHaveBeenCalledWith({
+      targetId: "target-a",
+      cursor: "target-a-page-2",
+      limit: 50,
+    }),
+  );
+  fireEvent.click(await screen.findByRole("button", { name: "Review" }));
+  await waitFor(() =>
+    expect(
+      (screen.getByRole("button", { name: "Consolidate" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false),
+  );
+  rerender(view("target-b"));
+  expect(screen.queryByRole("dialog")).toBeNull();
+  await screen.findByRole("button", { name: "Review" });
+  expect(
+    (screen.getByRole("button", { name: "Previous" }) as HTMLButtonElement)
+      .disabled,
+  ).toBe(true);
+  expect(api.candidates).toHaveBeenLastCalledWith({
+    targetId: "target-b",
+    cursor: undefined,
+    limit: 50,
+  });
+  expect(api.candidates).not.toHaveBeenCalledWith({
+    targetId: "target-b",
+    cursor: "target-a-page-2",
+    limit: 50,
+  });
+  expect(api.preflight).not.toHaveBeenCalledWith({
+    sourceId: "source",
+    targetId: "target-b",
+  });
+  expect(api.migrate).not.toHaveBeenCalled();
+});

--- a/client/admin/src/pages/remote-session-issuers/Convergence.tsx
+++ b/client/admin/src/pages/remote-session-issuers/Convergence.tsx
@@ -1,0 +1,410 @@
+import { toast } from "sonner";
+import { invalidateIssuerQueries } from "./issuerQueries";
+import type { JSX } from "react";
+import { useRef, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createColumnHelper, useTable } from "@tanstack/react-table";
+import type { IssuerFieldMismatch } from "@gram/admin-client/models/components/issuerfieldmismatch";
+import type { IssuerConvergenceCandidate } from "@gram/admin-client/models/components/issuerconvergencecandidate";
+import { InfoIcon } from "lucide-react";
+import { dataTableFeatures, DataTable } from "@/components/data-table";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  adminGetGlobalIssuerMigratePreflightQuery,
+  adminListGlobalIssuerConvergenceCandidatesQuery,
+  adminMigrateToGlobalIssuer,
+} from "@/lib/gramAdminClient";
+export function ConvergenceHelp(): JSX.Element | null {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label="About convergence"
+        >
+          <InfoIcon className="size-4" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-sm">
+        Organization or project issuers that use the same upstream identity
+        provider as this platform issuer. They may be migrated to the shared
+        platform configuration after compatibility checks pass.
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+function fieldLabel(field: string): string {
+  const labels: Record<string, string> = {
+    authorization_endpoint: "Authorization endpoint",
+    token_endpoint: "Token endpoint",
+    registration_endpoint: "Registration endpoint",
+    jwks_uri: "JWKS URI",
+    scopes_supported: "Scopes",
+    grant_types_supported: "Grant types",
+    response_types_supported: "Response types",
+    token_endpoint_auth_methods_supported:
+      "Token endpoint authentication methods",
+    code_challenge_methods_supported: "PKCE code challenge methods",
+    client_id_metadata_document_supported: "Client ID Metadata Document",
+    revocation_endpoint: "Revocation endpoint",
+    scope_override: "Scope override",
+  };
+  return (
+    labels[field] ??
+    field.replaceAll("_", " ").replace(/^./, (c) => c.toUpperCase())
+  );
+}
+function Differences({ items }: { items: IssuerFieldMismatch[] }) {
+  return (
+    <dl className="grid gap-2 text-sm">
+      {items.map((m, i) => (
+        <div key={`${m.field}-${i}`}>
+          <dt className="font-medium">{fieldLabel(m.field)}</dt>
+          <dd className="break-all text-muted-foreground">
+            Source:{" "}
+            {m.sourceValues
+              ? m.sourceValues.join(", ") || "empty"
+              : m.sourceValue === ""
+                ? "empty"
+                : (m.sourceValue ?? "not set")}
+            <br />
+            Platform:{" "}
+            {m.targetValues
+              ? m.targetValues.join(", ") || "empty"
+              : m.targetValue === ""
+                ? "empty"
+                : (m.targetValue ?? "not set")}
+          </dd>
+          {(m.sourceValues || m.targetValues) && (
+            <>
+              <dd>
+                Added:{" "}
+                {(m.targetValues ?? [])
+                  .filter((value) => !m.sourceValues?.includes(value))
+                  .join(", ") || "None"}
+              </dd>
+              <dd>
+                Dropped:{" "}
+                {(m.sourceValues ?? [])
+                  .filter((value) => !m.targetValues?.includes(value))
+                  .join(", ") || "None"}
+              </dd>
+            </>
+          )}
+        </div>
+      ))}
+    </dl>
+  );
+}
+export function MigrationReview({
+  sourceId,
+  targetId,
+  sourceName,
+  sourceOwner,
+  targetName,
+  onClose,
+}: {
+  sourceId: string;
+  targetId: string;
+  sourceName?: string;
+  sourceOwner?: string;
+  targetName?: string;
+  onClose: () => void;
+}): JSX.Element | null {
+  const cache = useQueryClient();
+  const preflight = useQuery({
+    ...adminGetGlobalIssuerMigratePreflightQuery({ sourceId, targetId }),
+    staleTime: 0,
+  });
+  const [pending, setPending] = useState(false);
+  const busy = useRef(false);
+  const [error, setError] = useState("");
+  const data = preflight.data;
+  const migrate = async () => {
+    if (
+      busy.current ||
+      !data?.canMigrate ||
+      preflight.isFetching ||
+      preflight.error
+    )
+      return;
+    busy.current = true;
+    setPending(true);
+    setError("");
+    try {
+      await adminMigrateToGlobalIssuer({ sourceId, targetId });
+      await invalidateIssuerQueries(cache);
+      toast.success("Issuer consolidated");
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Migration failed");
+      await preflight.refetch();
+    } finally {
+      busy.current = false;
+      setPending(false);
+    }
+  };
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open && !pending) onClose();
+      }}
+    >
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Consolidate {sourceName || sourceId}</DialogTitle>
+          <DialogDescription>
+            Move clients from {sourceName || sourceId}
+            {` (owned by ${sourceOwner || "Unknown organization"})`} onto
+            platform issuer {targetName || targetId}, then remove the original.
+            Existing sessions keep working.
+          </DialogDescription>
+        </DialogHeader>
+        {preflight.isPending && <p role="status">Checking compatibility…</p>}
+        {preflight.error && (
+          <p role="alert">
+            {preflight.error.message}
+            <Button variant="ghost" onClick={() => void preflight.refetch()}>
+              Retry
+            </Button>
+          </p>
+        )}
+        {error && <p role="alert">{error}</p>}
+        {data && (
+          <div className="grid gap-4">
+            <p>
+              {data.clientCount} clients will move.{" "}
+              {data.targetTenantClientCount} tenant clients already use this
+              platform issuer.
+            </p>
+            {data.mcpServerNames.length > 0 && (
+              <div>
+                <h3 className="font-medium">Affected MCP servers</h3>
+                <ul>
+                  {data.mcpServerNames.map((n, i) => (
+                    <li key={i}>{n}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {data.endpointMismatches.length > 0 && (
+              <section>
+                <h3 className="font-medium">
+                  Different authorization server — migration blocked
+                </h3>
+                <Differences items={data.endpointMismatches} />
+              </section>
+            )}
+            {data.conflictingMcpServerNames.length > 0 && (
+              <section>
+                <h3 className="font-medium">
+                  Conflicting MCP server bindings — migration blocked
+                </h3>
+                <ul>
+                  {data.conflictingMcpServerNames.map((n, i) => (
+                    <li key={i}>{n}</li>
+                  ))}
+                </ul>
+              </section>
+            )}
+            {data.warnings.length > 0 && (
+              <section>
+                <h3 className="font-medium">
+                  Metadata differs; platform values become authoritative
+                </h3>
+                <Differences items={data.warnings} />
+              </section>
+            )}
+          </div>
+        )}
+        <DialogFooter>
+          <Button variant="ghost" disabled={pending} onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            disabled={
+              pending ||
+              preflight.isFetching ||
+              !!preflight.error ||
+              data?.canMigrate !== true
+            }
+            onClick={() => void migrate()}
+          >
+            {pending ? "Consolidating…" : "Consolidate"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+const column = createColumnHelper<
+  typeof dataTableFeatures,
+  IssuerConvergenceCandidate
+>();
+const empty: IssuerConvergenceCandidate[] = [];
+export function Convergence({
+  issuerId,
+  targetName,
+}: {
+  issuerId: string;
+  targetName?: string;
+}): JSX.Element | null {
+  const [cursors, setCursors] = useState<(string | undefined)[]>([undefined]);
+  const [sourceId, setSourceId] = useState<string>();
+  const query = useQuery(
+    adminListGlobalIssuerConvergenceCandidatesQuery({
+      targetId: issuerId,
+      cursor: cursors.at(-1),
+      limit: 50,
+    }),
+  );
+  const columns = column.columns([
+    column.display({
+      id: "issuer",
+      header: "Issuer",
+      cell: ({ row }) => (
+        <div>
+          {row.original.issuer.name || row.original.issuer.issuer}
+          <p className="text-muted-foreground text-xs">
+            {row.original.issuer.issuer}
+          </p>
+        </div>
+      ),
+    }),
+    column.display({
+      id: "scope",
+      header: "Scope",
+      cell: ({ row }) => (
+        <div>
+          {row.original.organizationName ||
+            row.original.organizationId ||
+            "Unknown organization"}
+          <p className="text-muted-foreground text-xs">
+            {row.original.issuer.projectId
+              ? `Project: ${row.original.issuer.projectId}`
+              : "Organization"}
+          </p>
+        </div>
+      ),
+    }),
+    column.accessor("clientCount", { header: "Clients" }),
+    column.display({
+      id: "status",
+      header: "Compatibility",
+      cell: ({ row }) =>
+        row.original.endpointMismatches.length
+          ? `Different authorization server (${row.original.endpointMismatches.map((m) => fieldLabel(m.field)).join(", ")} differ)`
+          : row.original.warnings.length
+            ? `${row.original.warnings.map((m) => fieldLabel(m.field)).join(", ")} differ; platform values become authoritative`
+            : "No blockers found",
+    }),
+    column.display({
+      id: "review",
+      header: "",
+      cell: ({ row }) => (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setSourceId(row.original.issuer.id)}
+        >
+          Review
+        </Button>
+      ),
+    }),
+  ]);
+  const table = useTable({
+    features: dataTableFeatures,
+    columns,
+    data: query.data?.result.items ?? empty,
+    getRowId: (r) => r.issuer.id,
+  });
+  return (
+    <div className="grid gap-4">
+      <div className="flex items-center gap-1">
+        <h2 className="text-lg font-semibold">Convergence</h2>
+        <ConvergenceHelp />
+      </div>
+      <p className="text-muted-foreground text-sm">
+        Candidate status is advisory. Review runs the authoritative
+        compatibility preflight.
+      </p>
+      {query.isPending && <p role="status">Loading candidates…</p>}
+      {query.error && (
+        <p role="alert">
+          {query.error.message}
+          <Button variant="ghost" onClick={() => void query.refetch()}>
+            Retry
+          </Button>
+        </p>
+      )}
+      <DataTable>
+        <DataTable.Header table={table} />
+        <DataTable.Body>
+          {table.getRowModel().rows.map((row) => (
+            <DataTable.Row key={row.id} row={row} />
+          ))}
+        </DataTable.Body>
+      </DataTable>
+      {query.data?.result.items.length === 0 && (
+        <p>No matching organization or project issuers.</p>
+      )}
+      <div className="flex justify-end gap-2">
+        <Button
+          variant="outline"
+          disabled={cursors.length === 1 || query.isFetching}
+          onClick={() => setCursors((c) => c.slice(0, -1))}
+        >
+          Previous
+        </Button>
+        <Button
+          variant="outline"
+          disabled={!query.data?.result.nextCursor || query.isFetching}
+          onClick={() =>
+            setCursors((c) => [...c, query.data?.result.nextCursor])
+          }
+        >
+          Next
+        </Button>
+      </div>
+      {sourceId && (
+        <MigrationReview
+          sourceId={sourceId}
+          targetId={issuerId}
+          targetName={targetName}
+          sourceName={
+            query.data?.result.items
+              .find((c) => c.issuer.id === sourceId)
+              ?.issuer.name?.trim() ||
+            query.data?.result.items
+              .find((c) => c.issuer.id === sourceId)
+              ?.issuer.issuer?.trim()
+          }
+          sourceOwner={
+            query.data?.result.items.find((c) => c.issuer.id === sourceId)
+              ?.organizationName ||
+            query.data?.result.items.find((c) => c.issuer.id === sourceId)
+              ?.organizationId ||
+            "Unknown organization"
+          }
+          onClose={() => setSourceId(undefined)}
+        />
+      )}
+    </div>
+  );
+}

--- a/client/admin/src/pages/remote-session-issuers/Convergence.tsx
+++ b/client/admin/src/pages/remote-session-issuers/Convergence.tsx
@@ -367,7 +367,7 @@ function TargetConvergence({
           ))}
         </DataTable.Body>
       </DataTable>
-      {query.data?.result.items.length === 0 && (
+      {!query.error && query.data?.result.items.length === 0 && (
         <p>No matching organization or project issuers.</p>
       )}
       <div className="flex justify-end gap-2">

--- a/client/admin/src/pages/remote-session-issuers/Convergence.tsx
+++ b/client/admin/src/pages/remote-session-issuers/Convergence.tsx
@@ -258,7 +258,13 @@ const column = createColumnHelper<
   IssuerConvergenceCandidate
 >();
 const empty: IssuerConvergenceCandidate[] = [];
-export function Convergence({
+export function Convergence(props: {
+  issuerId: string;
+  targetName?: string;
+}): JSX.Element | null {
+  return <TargetConvergence key={props.issuerId} {...props} />;
+}
+function TargetConvergence({
   issuerId,
   targetName,
 }: {


### PR DESCRIPTION
## Stack context

The standalone admin migration also needs to support consolidating tenant-owned issuer configurations into platform-managed issuers, not just creating and editing global records. This PR builds the convergence panel on the candidate, preflight, and migration operations exposed in [#6273](https://github.com/speakeasy-api/gram/pull/6273), using the shared data-access conventions from [#6276](https://github.com/speakeasy-api/gram/pull/6276).

The panel lets an operator inspect candidates and configuration mismatches before initiating a migration. Isolating this workflow keeps its decisions and feedback reviewable separately from routing and the main editor. The next PR, [#6280](https://github.com/speakeasy-api/gram/pull/6280), incorporates it into the reachable standalone admin experience.

## Summary

Add reusable convergence candidate, preflight, mismatch, and migration controls. This preparatory panel is not yet connected to a route.

## Motivation

Make issuer consolidation behavior independently reviewable before connecting it to standalone admin navigation.
