### PR TITLE
feat: integrate admin issuer catalog and detail routes

### DIFF
--- a/.changeset/admin-issuer-route-integration.md
+++ b/.changeset/admin-issuer-route-integration.md
@@ -1,0 +1,5 @@
+---
+"admin": minor
+---
+
+Make the global issuer catalog, configuration editor, and convergence views available in standalone admin navigation.

--- a/client/admin/src/components/app-sidebar.test.tsx
+++ b/client/admin/src/components/app-sidebar.test.tsx
@@ -575,3 +575,11 @@ describe("AppSidebar", () => {
     );
   });
 });
+
+it("links the top-level remote session issuer catalog", async () => {
+  await renderRouteTree(routeTree, { initialPath: "/organizations" });
+  const link = await within(sidebar()).findByRole("link", {
+    name: "Remote session issuers",
+  });
+  expect(link.getAttribute("href")).toBe("/remote-session-issuers");
+});

--- a/client/admin/src/components/site-header.tsx
+++ b/client/admin/src/components/site-header.tsx
@@ -25,7 +25,11 @@ type CrumbRecord = { queryKey: QueryKey };
 // The cache hands back `unknown` for a key whose data tag the crumb type drops.
 function recordName(data: unknown): string | undefined {
   if (typeof data !== "object" || data === null) return undefined;
-  const { name } = data as { name?: unknown };
+  const record = data as {
+    name?: unknown;
+    issuer?: { name?: unknown; slug?: unknown };
+  };
+  const name = record.name ?? record.issuer?.name ?? record.issuer?.slug;
   return typeof name === "string" ? name : undefined;
 }
 

--- a/client/admin/src/lib/adminNav.ts
+++ b/client/admin/src/lib/adminNav.ts
@@ -1,5 +1,5 @@
 // The destinations the admin app offers from anywhere: the sidebar's global nav
-// and the command palette's "Go to" group are the same three views.
+// and the command palette's "Go to" group are the same views.
 //
 // It sits in `lib` beside `organizationFilters.ts`, and for the same reason:
 // two surfaces read it, and a list declared inside either one of them would
@@ -8,9 +8,20 @@
 // `as const` keeps each `to` a literal, which is what the router types check the
 // link and the navigation against.
 
-import { BuildingIcon, CalculatorIcon, FolderIcon } from "lucide-react";
+import {
+  BuildingIcon,
+  CalculatorIcon,
+  FolderIcon,
+  KeyRoundIcon,
+} from "lucide-react";
 
 export const ADMIN_NAV = [
+  {
+    to: "/remote-session-issuers",
+    label: "Remote session issuers",
+    keywords: "oauth identity providers issuers",
+    icon: KeyRoundIcon,
+  },
   {
     to: "/organizations",
     label: "Organizations",

--- a/client/admin/src/pages/remote-session-issuers/ConvergenceSummary.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/ConvergenceSummary.test.tsx
@@ -1,0 +1,28 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, expect, it, vi } from "vitest";
+import { ConvergenceSummary } from "./ConvergenceSummary";
+const result = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/gramAdminClient", () => ({
+  adminListGlobalIssuerConvergenceCandidatesQuery: () => ({
+    queryKey: ["summary"],
+    queryFn: result,
+  }),
+}));
+vi.mock("./Convergence", () => ({ ConvergenceHelp: () => null }));
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+}));
+afterEach(cleanup);
+it("reports a paginated lower bound rather than fabricated total or readiness", async () => {
+  result.mockResolvedValue({ result: { items: [{}, {}], nextCursor: "more" } });
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <ConvergenceSummary issuerId="target" />
+    </QueryClientProvider>,
+  );
+  expect(await screen.findByText(/At least 2 matching issuers/)).toBeTruthy();
+  expect(screen.getByText(/do not indicate migration readiness/)).toBeTruthy();
+});

--- a/client/admin/src/pages/remote-session-issuers/ConvergenceSummary.tsx
+++ b/client/admin/src/pages/remote-session-issuers/ConvergenceSummary.tsx
@@ -1,0 +1,47 @@
+import type { JSX } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { adminListGlobalIssuerConvergenceCandidatesQuery } from "@/lib/gramAdminClient";
+import { ConvergenceHelp } from "./Convergence";
+export function ConvergenceSummary({
+  issuerId,
+}: {
+  issuerId: string;
+}): JSX.Element {
+  const query = useQuery(
+    adminListGlobalIssuerConvergenceCandidatesQuery({
+      targetId: issuerId,
+      limit: 50,
+    }),
+  );
+  return (
+    <section className="grid gap-2">
+      <div className="flex items-center gap-1">
+        <h2 className="text-base font-semibold">Convergence</h2>
+        <ConvergenceHelp />
+      </div>
+      {query.isPending && <p role="status">Loading convergence summary…</p>}
+      {query.error && (
+        <p role="alert">
+          Convergence summary unavailable: {query.error.message}
+        </p>
+      )}
+      {query.data && (
+        <p className="text-muted-foreground text-sm">
+          {query.data.result.nextCursor
+            ? `At least ${query.data.result.items.length} matching issuers; more candidates are available on subsequent pages.`
+            : `${query.data.result.items.length} matching organization or project issuers.`}{" "}
+          Compatibility is checked individually during review; these counts do
+          not indicate migration readiness.
+        </p>
+      )}
+      <Link
+        to="/remote-session-issuers/$issuerId/convergence"
+        params={{ issuerId }}
+        className="text-sm underline underline-offset-4"
+      >
+        Review convergence candidates
+      </Link>
+    </section>
+  );
+}

--- a/client/admin/src/pages/remote-session-issuers/IssuerDetail.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerDetail.tsx
@@ -1,0 +1,144 @@
+import type { JSX } from "react";
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link, Outlet, useNavigate, useParams } from "@tanstack/react-router";
+import { Button } from "@/components/ui/button";
+import { adminGetGlobalIssuerQuery } from "@/lib/gramAdminClient";
+import { IssuerEditor } from "./IssuerEditor";
+import { IssuerLogo } from "./IssuerLogo";
+import { IssuerConfiguration } from "./IssuerConfiguration";
+import { IssuerActions } from "./IssuerActions";
+import { ConvergenceSummary } from "./ConvergenceSummary";
+import { Convergence } from "./Convergence";
+export function IssuerDetail(): JSX.Element | null {
+  const { issuerId } = useParams({ from: "/remote-session-issuers/$issuerId" });
+  const query = useQuery(adminGetGlobalIssuerQuery({ id: issuerId }));
+  return (
+    <div className="grid gap-6">
+      {query.isPending && <p role="status">Loading issuer…</p>}
+      {query.error && (
+        <p role="alert">
+          {query.error.message}
+          <Button variant="ghost" onClick={() => void query.refetch()}>
+            Retry
+          </Button>
+        </p>
+      )}
+      {query.data && (
+        <>
+          <header className="flex items-center gap-3">
+            {query.data.issuer.logoAssetId && (
+              <IssuerLogo id={query.data.issuer.logoAssetId} />
+            )}
+            <div>
+              <h1 className="text-xl font-semibold">
+                {query.data.issuer.name || query.data.issuer.issuer}
+              </h1>
+              <p className="text-muted-foreground text-sm break-all">
+                {query.data.issuer.issuer}
+              </p>
+            </div>
+          </header>
+          <nav aria-label="Issuer views" className="flex gap-2 border-b pb-3">
+            {(
+              [
+                { to: "/remote-session-issuers/$issuerId", label: "Overview" },
+                {
+                  to: "/remote-session-issuers/$issuerId/settings",
+                  label: "Settings",
+                },
+                {
+                  to: "/remote-session-issuers/$issuerId/convergence",
+                  label: "Convergence",
+                },
+              ] as const
+            ).map((tab) => (
+              <Button key={tab.label} variant="ghost" size="sm" asChild>
+                <Link
+                  to={tab.to}
+                  params={{ issuerId }}
+                  activeOptions={{ exact: true }}
+                  activeProps={{
+                    className: "bg-muted",
+                    "aria-current": "page",
+                  }}
+                >
+                  {tab.label}
+                </Link>
+              </Button>
+            ))}
+          </nav>
+          <Outlet />
+        </>
+      )}
+    </div>
+  );
+}
+export function IssuerOverview(): JSX.Element | null {
+  const { issuerId } = useParams({ from: "/remote-session-issuers/$issuerId" });
+  const { data } = useQuery(adminGetGlobalIssuerQuery({ id: issuerId }));
+  const navigate = useNavigate();
+  return data ? (
+    <div className="grid gap-6">
+      <dl className="grid gap-3 sm:grid-cols-2">
+        <div>
+          <dt className="text-muted-foreground text-sm">Scope</dt>
+          <dd>Platform</dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground text-sm">
+            Platform / tenant clients
+          </dt>
+          <dd>
+            {data.globalClientCount} / {data.tenantClientCount}
+          </dd>
+        </div>
+      </dl>
+      <IssuerConfiguration issuer={data.issuer} />
+      <ConvergenceSummary issuerId={issuerId} />
+      <IssuerActions
+        record={data}
+        onDeleted={async () => {
+          await navigate({ to: "/remote-session-issuers" });
+        }}
+      />
+    </div>
+  ) : null;
+}
+export function IssuerSettings(): JSX.Element | null {
+  const { issuerId } = useParams({ from: "/remote-session-issuers/$issuerId" });
+  const { data } = useQuery(adminGetGlobalIssuerQuery({ id: issuerId }));
+  const [revision, setRevision] = useState(0);
+  const [editorPending, setEditorPending] = useState(false);
+  const navigate = useNavigate();
+  return data ? (
+    <div className="grid max-w-2xl gap-6">
+      <IssuerEditor
+        key={`${issuerId}-${revision}`}
+        issuer={data.issuer}
+        tenantClientCount={data.tenantClientCount}
+        onPendingChange={setEditorPending}
+        onDone={() => setRevision((v) => v + 1)}
+      />
+      <IssuerActions
+        record={data}
+        showRefresh={false}
+        disabled={editorPending}
+        onDeleted={async () => {
+          await navigate({ to: "/remote-session-issuers" });
+        }}
+      />
+    </div>
+  ) : null;
+}
+export function IssuerConvergence(): JSX.Element | null {
+  const { issuerId } = useParams({ from: "/remote-session-issuers/$issuerId" });
+  const { data } = useQuery(adminGetGlobalIssuerQuery({ id: issuerId }));
+  return (
+    <Convergence
+      key={issuerId}
+      issuerId={issuerId}
+      targetName={data?.issuer.name || data?.issuer.issuer || issuerId}
+    />
+  );
+}

--- a/client/admin/src/pages/remote-session-issuers/IssuerEditor.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerEditor.test.tsx
@@ -412,36 +412,47 @@ it("keeps uncaptured saved capabilities omitted without fresh discovery", async 
   );
 });
 
-it("binds discovered metadata to the returned canonical issuer", async () => {
-  const canonical = "https://first.example";
-  api.discover.mockResolvedValue({
-    issuer: canonical,
-    authorizationEndpoint: `${canonical}/auth`,
-    tokenEndpoint: `${canonical}/token`,
-    scopesSupported: ["openid"],
-    discoveryWarnings: [],
-    clientIdMetadataDocumentSupported: true,
-  });
-  api.create.mockResolvedValue({});
-  mount();
-  fireEvent.change(screen.getByLabelText("Issuer URL"), {
-    target: { value: `${canonical}/tenant` },
-  });
-  fireEvent.click(screen.getByRole("button", { name: "Discover" }));
-  await waitFor(() =>
-    expect(
-      (screen.getByLabelText("Issuer URL") as HTMLInputElement).value,
-    ).toBe(canonical),
-  );
-  fireEvent.click(screen.getByRole("button", { name: "Create issuer" }));
-  await waitFor(() =>
-    expect(api.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        issuer: canonical,
-        tokenEndpoint: `${canonical}/token`,
-        scopesSupported: ["openid"],
-        clientIdMetadataDocumentSupported: true,
+it.each([false, true])(
+  "checks and saves the canonical issuer after discovery (editing: %s)",
+  async (editing) => {
+    const canonical = "https://first.example";
+    api.discover.mockResolvedValue({
+      issuer: canonical,
+      authorizationEndpoint: `${canonical}/auth`,
+      tokenEndpoint: `${canonical}/token`,
+      scopesSupported: ["openid"],
+      discoveryWarnings: [],
+      clientIdMetadataDocumentSupported: true,
+    });
+    api.create.mockResolvedValue({});
+    api.update.mockResolvedValue(savedIssuer);
+    mount(editing ? savedIssuer : undefined);
+    fireEvent.change(screen.getByLabelText("Issuer URL"), {
+      target: { value: `${canonical}/tenant` },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Discover" }));
+    await waitFor(() =>
+      expect(
+        (screen.getByLabelText("Issuer URL") as HTMLInputElement).value,
+      ).toBe(canonical),
+    );
+    await waitFor(() =>
+      expect(api.duplicates).toHaveBeenLastCalledWith({ issuer: canonical }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: editing ? "Save changes" : "Create issuer",
       }),
-    ),
-  );
-});
+    );
+    await waitFor(() =>
+      expect(editing ? api.update : api.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          issuer: canonical,
+          tokenEndpoint: `${canonical}/token`,
+          scopesSupported: ["openid"],
+          clientIdMetadataDocumentSupported: true,
+        }),
+      ),
+    );
+  },
+);

--- a/client/admin/src/pages/remote-session-issuers/IssuerEditor.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerEditor.test.tsx
@@ -7,7 +7,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { IssuerEditor } from "./IssuerEditor";
 const api = vi.hoisted(() => ({
   create: vi.fn(),
@@ -15,7 +15,7 @@ const api = vi.hoisted(() => ({
   update: vi.fn(),
   refresh: vi.fn(),
   upload: vi.fn(),
-  duplicates: vi.fn().mockResolvedValue({ matches: [] }),
+  duplicates: vi.fn(),
 }));
 vi.mock("@/lib/gramAdminClient", () => ({
   adminCreateGlobalIssuer: api.create,
@@ -48,7 +48,10 @@ vi.mock("./IssuerLogo", () => ({
 }));
 afterEach(() => {
   cleanup();
-  vi.clearAllMocks();
+});
+beforeEach(() => {
+  vi.resetAllMocks();
+  api.duplicates.mockResolvedValue({ matches: [] });
 });
 function mount(issuer?: RemoteSessionIssuer) {
   render(
@@ -526,4 +529,34 @@ it("allows manual endpoint edits without discovery when the saved identity is un
     ),
   );
   expect(api.discover).not.toHaveBeenCalled();
+});
+
+it("omits seeded discovery metadata when saving an unrelated edit", async () => {
+  mount({
+    ...savedIssuer,
+    scopesSupported: ["old-scope"],
+    claimsSupported: ["old-claim"],
+    serviceDocumentation: "https://saved.example/docs",
+    codeChallengeMethodsSupported: ["S256"],
+    clientIdMetadataDocumentSupported: true,
+  });
+  api.update.mockResolvedValue(savedIssuer);
+  fireEvent.change(screen.getByLabelText("Display name"), {
+    target: { value: "Renamed provider" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+  await waitFor(() => expect(api.update).toHaveBeenCalledOnce());
+  const payload = api.update.mock.calls[0]![0];
+  expect(payload.name).toBe("Renamed provider");
+  for (const key of [
+    "scopesSupported",
+    "claimsSupported",
+    "serviceDocumentation",
+    "codeChallengeMethodsSupported",
+    "clientIdMetadataDocumentSupported",
+  ]) {
+    expect(JSON.parse(JSON.stringify(payload))).not.toHaveProperty(key);
+  }
+  expect(api.discover).not.toHaveBeenCalled();
+  expect(api.refresh).not.toHaveBeenCalled();
 });

--- a/client/admin/src/pages/remote-session-issuers/IssuerEditor.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerEditor.test.tsx
@@ -357,3 +357,57 @@ it("restores all saved endpoints when returning to the saved URL", async () => {
     ),
   );
 });
+
+const nullableCapabilities = [
+  "codeChallengeMethodsSupported",
+  "introspectionEndpointAuthMethodsSupported",
+  "idTokenSigningAlgValuesSupported",
+  "claimsSupported",
+] as const;
+it.each([undefined, null])(
+  "clears saved capabilities omitted by fresh discovery (%s)",
+  async (absent) => {
+    mount({
+      ...savedIssuer,
+      ...Object.fromEntries(
+        nullableCapabilities.map((key) => [key, ["stale"]]),
+      ),
+    });
+    api.discover.mockResolvedValue({
+      issuer: "https://changed.example",
+      discoveryWarnings: [],
+      ...Object.fromEntries(nullableCapabilities.map((key) => [key, absent])),
+    });
+    api.update.mockResolvedValue(savedIssuer);
+    fireEvent.change(screen.getByLabelText("Issuer URL"), {
+      target: { value: "https://changed.example" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Discover" }));
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "Discover" })).toBeNull(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    await waitFor(() =>
+      expect(api.update).toHaveBeenCalledWith(
+        expect.objectContaining(
+          Object.fromEntries(nullableCapabilities.map((key) => [key, []])),
+        ),
+      ),
+    );
+  },
+);
+it("keeps uncaptured saved capabilities omitted without fresh discovery", async () => {
+  mount({
+    ...savedIssuer,
+    ...Object.fromEntries(nullableCapabilities.map((key) => [key, null])),
+  });
+  api.update.mockResolvedValue(savedIssuer);
+  fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+  await waitFor(() =>
+    expect(api.update).toHaveBeenCalledWith(
+      expect.objectContaining(
+        Object.fromEntries(nullableCapabilities.map((key) => [key, undefined])),
+      ),
+    ),
+  );
+});

--- a/client/admin/src/pages/remote-session-issuers/IssuerEditor.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerEditor.test.tsx
@@ -456,3 +456,74 @@ it.each([false, true])(
     );
   },
 );
+
+it("requires discovery before saving a changed existing identity and replaces old metadata", async () => {
+  const canonical = "https://new.example";
+  mount({
+    ...savedIssuer,
+    scopesSupported: ["old-scope"],
+    claimsSupported: ["old-claim"],
+    serviceDocumentation: "https://saved.example/docs",
+    opPolicyUri: "https://saved.example/policy",
+    clientIdMetadataDocumentSupported: true,
+  });
+  api.update.mockResolvedValue(savedIssuer);
+  api.discover.mockResolvedValue({
+    issuer: canonical,
+    tokenEndpoint: `${canonical}/token`,
+    scopesSupported: ["new-scope"],
+    claimsSupported: ["new-claim"],
+    serviceDocumentation: `${canonical}/docs`,
+    clientIdMetadataDocumentSupported: false,
+    discoveryWarnings: [],
+  });
+  fireEvent.change(screen.getByLabelText("Issuer URL"), {
+    target: { value: `${canonical}/tenant` },
+  });
+  const save = screen.getByRole("button", { name: "Save changes" });
+  expect((save as HTMLButtonElement).disabled).toBe(true);
+  fireEvent.click(save);
+  fireEvent.submit(save.closest("form")!);
+  expect(api.update).not.toHaveBeenCalled();
+  expect(
+    screen.getByText("Discover the new issuer URL before saving changes."),
+  ).toBeTruthy();
+  fireEvent.click(screen.getByRole("button", { name: "Discover" }));
+  await waitFor(() =>
+    expect(api.duplicates).toHaveBeenLastCalledWith({ issuer: canonical }),
+  );
+  await waitFor(() => expect((save as HTMLButtonElement).disabled).toBe(false));
+  fireEvent.click(save);
+  await waitFor(() =>
+    expect(api.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issuer: canonical,
+        tokenEndpoint: `${canonical}/token`,
+        scopesSupported: ["new-scope"],
+        claimsSupported: ["new-claim"],
+        serviceDocumentation: `${canonical}/docs`,
+        opPolicyUri: "",
+        clientIdMetadataDocumentSupported: false,
+      }),
+    ),
+  );
+});
+
+it("allows manual endpoint edits without discovery when the saved identity is unchanged", async () => {
+  mount(savedIssuer);
+  api.update.mockResolvedValue(savedIssuer);
+  fireEvent.change(screen.getByLabelText("Token endpoint"), {
+    target: { value: "https://saved.example/manual-token" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+  await waitFor(() =>
+    expect(api.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issuer: savedIssuer.issuer,
+        tokenEndpoint: "https://saved.example/manual-token",
+        codeChallengeMethodsSupported: undefined,
+      }),
+    ),
+  );
+  expect(api.discover).not.toHaveBeenCalled();
+});

--- a/client/admin/src/pages/remote-session-issuers/IssuerEditor.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerEditor.test.tsx
@@ -560,3 +560,50 @@ it("omits seeded discovery metadata when saving an unrelated edit", async () => 
   expect(api.discover).not.toHaveBeenCalled();
   expect(api.refresh).not.toHaveBeenCalled();
 });
+
+it.each([false, true])(
+  "uses discovery snapshot for endpoint warnings (advertised: %s)",
+  async (advertised) => {
+    api.discover.mockResolvedValue({
+      issuer: "https://first.example",
+      ...(advertised
+        ? {
+            authorizationEndpoint: "https://first.example/auth",
+            tokenEndpoint: "https://first.example/token",
+          }
+        : {}),
+      discoveryWarnings: [],
+      clientIdMetadataDocumentSupported: false,
+    });
+    mount();
+    fireEvent.change(screen.getByLabelText("Issuer URL"), {
+      target: { value: "https://first.example" },
+    });
+    for (const label of ["Authorization endpoint", "Token endpoint"]) {
+      fireEvent.change(screen.getByLabelText(label), {
+        target: { value: "https://manual.example/endpoint" },
+      });
+    }
+    fireEvent.click(screen.getByRole("button", { name: "Discover" }));
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "Discover" })).toBeNull(),
+    );
+    for (const label of ["Authorization endpoint", "Token endpoint"]) {
+      if (advertised) {
+        fireEvent.change(screen.getByLabelText(label), {
+          target: { value: "" },
+        });
+        expect(
+          screen.queryByText(`${label} not advertised by the issuer.`),
+        ).toBeNull();
+      } else {
+        expect((screen.getByLabelText(label) as HTMLInputElement).value).toBe(
+          "https://manual.example/endpoint",
+        );
+        expect(
+          screen.getByText(`${label} not advertised by the issuer.`),
+        ).toBeTruthy();
+      }
+    }
+  },
+);

--- a/client/admin/src/pages/remote-session-issuers/IssuerEditor.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerEditor.test.tsx
@@ -1,0 +1,321 @@
+import type { RemoteSessionIssuer } from "@gram/admin-client/models/components/remotesessionissuer";
+import {
+  cleanup,
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, expect, it, vi } from "vitest";
+import { IssuerEditor } from "./IssuerEditor";
+const api = vi.hoisted(() => ({
+  create: vi.fn(),
+  discover: vi.fn(),
+  update: vi.fn(),
+  refresh: vi.fn(),
+  upload: vi.fn(),
+  duplicates: vi.fn().mockResolvedValue({ matches: [] }),
+}));
+vi.mock("@/lib/gramAdminClient", () => ({
+  adminCreateGlobalIssuer: api.create,
+  adminUpdateGlobalIssuer: api.update,
+  adminRefreshGlobalIssuerMetadata: api.refresh,
+  adminUploadPlatformImage: api.upload,
+  adminFetchGlobalIssuerMetadata: api.discover,
+  adminGetGlobalIssuerDuplicatePreflightQuery: (request: unknown) => ({
+    queryKey: ["duplicates", request],
+    queryFn: () => api.duplicates(request),
+  }),
+}));
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    params,
+    children,
+    onClick,
+  }: {
+    params: { issuerId: string };
+    children: React.ReactNode;
+    onClick: () => void;
+  }) => (
+    <a href={`/remote-session-issuers/${params.issuerId}`} onClick={onClick}>
+      {children}
+    </a>
+  ),
+}));
+vi.mock("./IssuerLogo", () => ({
+  IssuerLogo: ({ id }: { id: string }) => <span>Logo {id}</span>,
+}));
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+function mount(issuer?: RemoteSessionIssuer) {
+  render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <IssuerEditor issuer={issuer} onDone={vi.fn<() => void>()} />
+    </QueryClientProvider>,
+  );
+}
+it("derives name and slug independently without overwriting edits", () => {
+  mount();
+  fireEvent.change(screen.getByLabelText("Issuer URL"), {
+    target: { value: "https://first.example" },
+  });
+  expect(
+    (screen.getByLabelText("Display name") as HTMLInputElement).value,
+  ).toBe("first.example");
+  fireEvent.change(screen.getByLabelText("Display name"), {
+    target: { value: "Custom" },
+  });
+  fireEvent.change(screen.getByLabelText("Issuer URL"), {
+    target: { value: "https://second.example" },
+  });
+  expect(
+    (screen.getByLabelText("Display name") as HTMLInputElement).value,
+  ).toBe("Custom");
+  expect((screen.getByLabelText("Slug") as HTMLInputElement).value).toBe(
+    "second-example",
+  );
+});
+it("retains a failed create draft and reports the failure", async () => {
+  api.create.mockRejectedValue(new Error("Save refused"));
+  mount();
+  fireEvent.change(screen.getByLabelText("Issuer URL"), {
+    target: { value: "https://first.example" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Create issuer" }));
+  await waitFor(() => expect(api.create).toHaveBeenCalled());
+  expect((await screen.findByRole("alert")).textContent).toContain(
+    "Save refused",
+  );
+  expect((screen.getByLabelText("Issuer URL") as HTMLInputElement).value).toBe(
+    "https://first.example",
+  );
+});
+it("resets only nonempty discovered endpoints and clears all four on URL change", async () => {
+  api.discover.mockResolvedValue({
+    issuer: "https://first.example",
+    authorizationEndpoint: "https://first.example/auth",
+    tokenEndpoint: "https://first.example/token",
+    discoveryWarnings: [],
+    clientIdMetadataDocumentSupported: false,
+  });
+  mount();
+  fireEvent.change(screen.getByLabelText("Issuer URL"), {
+    target: { value: "https://first.example" },
+  });
+  fireEvent.change(screen.getByLabelText("Registration endpoint"), {
+    target: { value: "https://manual.example/register" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Discover" }));
+  await waitFor(() =>
+    expect(
+      (screen.getByLabelText("Authorization endpoint") as HTMLInputElement)
+        .value,
+    ).toBe("https://first.example/auth"),
+  );
+  expect(screen.queryByRole("button", { name: "Reset endpoints" })).toBeNull();
+  fireEvent.change(screen.getByLabelText("Authorization endpoint"), {
+    target: { value: "https://manual.example/auth" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Reset endpoints" }));
+  expect(
+    (screen.getByLabelText("Authorization endpoint") as HTMLInputElement).value,
+  ).toBe("https://first.example/auth");
+  expect(
+    (screen.getByLabelText("Registration endpoint") as HTMLInputElement).value,
+  ).toBe("https://manual.example/register");
+  fireEvent.change(screen.getByLabelText("Issuer URL"), {
+    target: { value: "https://second.example" },
+  });
+  for (const label of [
+    "Authorization endpoint",
+    "Token endpoint",
+    "Registration endpoint",
+    "JWKS URI",
+  ])
+    expect((screen.getByLabelText(label) as HTMLInputElement).value).toBe("");
+  expect(screen.getByRole("button", { name: "Discover" })).toBeTruthy();
+});
+it("preserves manually entered create endpoints before any discovery snapshot", () => {
+  mount();
+  fireEvent.change(screen.getByLabelText("Authorization endpoint"), {
+    target: { value: "https://manual.example/auth" },
+  });
+  fireEvent.change(screen.getByLabelText("Issuer URL"), {
+    target: { value: "https://second.example" },
+  });
+  expect(
+    (screen.getByLabelText("Authorization endpoint") as HTMLInputElement).value,
+  ).toBe("https://manual.example/auth");
+});
+
+const savedIssuer = {
+  id: "saved",
+  issuer: "https://saved.example",
+  name: "Saved provider",
+  slug: "saved",
+  logoAssetId: "old-logo",
+  authorizationEndpoint: "https://saved.example/auth",
+  tokenEndpoint: "https://saved.example/token",
+  clientIdMetadataDocumentSupported: false,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  oidc: false,
+  passthrough: false,
+  organizationId: "",
+  projectId: "",
+} satisfies RemoteSessionIssuer;
+it("clears saved endpoints on URL edits before discovery", () => {
+  mount(savedIssuer);
+  fireEvent.change(screen.getByLabelText("Issuer URL"), {
+    target: { value: "https://changed.example" },
+  });
+  expect(
+    (screen.getByLabelText("Authorization endpoint") as HTMLInputElement).value,
+  ).toBe("");
+  expect(
+    screen.queryByRole("button", { name: "Refresh saved metadata" }),
+  ).toBeNull();
+});
+it("refresh persists metadata while retaining unrelated unsaved names", async () => {
+  api.refresh.mockResolvedValue({
+    issuer: {
+      ...savedIssuer,
+      authorizationEndpoint: "https://saved.example/new-auth",
+    },
+    discoveryWarnings: ["Discovery warning"],
+  });
+  mount(savedIssuer);
+  fireEvent.change(screen.getByLabelText("Display name"), {
+    target: { value: "Unsaved name" },
+  });
+  fireEvent.click(
+    screen.getByRole("button", { name: "Refresh saved metadata" }),
+  );
+  expect(await screen.findByText("Discovery warning")).toBeTruthy();
+  expect(api.refresh).toHaveBeenCalledWith({ id: "saved" });
+  expect(
+    (screen.getByLabelText("Display name") as HTMLInputElement).value,
+  ).toBe("Unsaved name");
+  expect(
+    (screen.getByLabelText("Authorization endpoint") as HTMLInputElement).value,
+  ).toBe("https://saved.example/new-auth");
+});
+it("holds saves during logo upload and sends explicit logo removal", async () => {
+  let finish: (value: { asset: { id: string } }) => void = () => {};
+  api.upload.mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        finish = resolve;
+      }),
+  );
+  api.update.mockResolvedValue(savedIssuer);
+  mount(savedIssuer);
+  fireEvent.change(screen.getByLabelText("Logo"), {
+    target: { files: [new File(["image"], "logo.png", { type: "image/png" })] },
+  });
+  fireEvent.submit(screen.getByLabelText("Issuer URL").closest("form")!);
+  expect(api.update).not.toHaveBeenCalled();
+  finish({ asset: { id: "new-logo" } });
+  expect(await screen.findByText("Logo new-logo")).toBeTruthy();
+  fireEvent.click(screen.getByRole("button", { name: "Remove logo" }));
+  fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+  await waitFor(() =>
+    expect(api.update).toHaveBeenCalledWith(
+      expect.objectContaining({ logoAssetId: "" }),
+    ),
+  );
+});
+it("rejects logos over the baseline four MiB limit without uploading", async () => {
+  mount(savedIssuer);
+  fireEvent.change(screen.getByLabelText("Logo"), {
+    target: {
+      files: [
+        new File([new Uint8Array(4 * 1024 * 1024 + 1)], "large.png", {
+          type: "image/png",
+        }),
+      ],
+    },
+  });
+  expect((await screen.findByRole("alert")).textContent).toContain("4 MiB");
+  expect(api.upload).not.toHaveBeenCalled();
+});
+
+it("selectively resets saved endpoints without losing the unsaved name or doing discovery", () => {
+  mount(savedIssuer);
+  expect(screen.queryByRole("button", { name: "Discover" })).toBeNull();
+  fireEvent.change(screen.getByLabelText("Display name"), {
+    target: { value: "Unsaved label" },
+  });
+  fireEvent.change(screen.getByLabelText("Authorization endpoint"), {
+    target: { value: "https://manual.example/auth" },
+  });
+  fireEvent.change(screen.getByLabelText("Registration endpoint"), {
+    target: { value: "https://manual.example/register" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Reset endpoints" }));
+  expect(
+    (screen.getByLabelText("Authorization endpoint") as HTMLInputElement).value,
+  ).toBe(savedIssuer.authorizationEndpoint);
+  expect(
+    (screen.getByLabelText("Registration endpoint") as HTMLInputElement).value,
+  ).toBe("https://manual.example/register");
+  expect(
+    (screen.getByLabelText("Display name") as HTMLInputElement).value,
+  ).toBe("Unsaved label");
+  expect(api.discover).not.toHaveBeenCalled();
+  expect(api.refresh).not.toHaveBeenCalled();
+});
+it("checks valid URLs on blur and links matching IDs while excluding itself", async () => {
+  api.duplicates.mockResolvedValue({
+    matches: [
+      {
+        id: "saved",
+        tier: "global",
+        name: "Self",
+        issuer: "https://saved.example",
+        slug: "saved",
+        projectName: "",
+      },
+      {
+        id: "existing",
+        tier: "global",
+        name: "Other provider",
+        issuer: "https://other.example",
+        slug: "other",
+        projectName: "",
+      },
+    ],
+  });
+  mount(savedIssuer);
+  expect(
+    await screen.findByRole("link", { name: "View existing provider" }),
+  ).toBeTruthy();
+  expect(
+    screen
+      .getByRole("link", { name: "View existing provider" })
+      .getAttribute("href"),
+  ).toBe("/remote-session-issuers/existing");
+  api.duplicates.mockClear();
+  fireEvent.change(screen.getByLabelText("Issuer URL"), {
+    target: { value: "not-a-url" },
+  });
+  fireEvent.blur(screen.getByLabelText("Issuer URL"));
+  expect(api.duplicates).not.toHaveBeenCalled();
+  fireEvent.change(screen.getByLabelText("Issuer URL"), {
+    target: { value: "https://settled.example" },
+  });
+  expect(api.duplicates).not.toHaveBeenCalled();
+  fireEvent.blur(screen.getByLabelText("Issuer URL"));
+  await waitFor(() =>
+    expect(api.duplicates).toHaveBeenCalledWith({
+      issuer: "https://settled.example",
+    }),
+  );
+});

--- a/client/admin/src/pages/remote-session-issuers/IssuerEditor.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerEditor.test.tsx
@@ -319,3 +319,41 @@ it("checks valid URLs on blur and links matching IDs while excluding itself", as
     }),
   );
 });
+
+it("restores all saved endpoints when returning to the saved URL", async () => {
+  const issuer = {
+    ...savedIssuer,
+    registrationEndpoint: "https://saved.example/register",
+    jwksUri: "https://saved.example/jwks",
+  };
+  api.update.mockResolvedValue({ issuer });
+  mount(issuer);
+  fireEvent.change(screen.getByLabelText("Issuer URL"), {
+    target: { value: "https://changed.example" },
+  });
+  fireEvent.change(screen.getByLabelText("Issuer URL"), {
+    target: { value: issuer.issuer },
+  });
+  for (const [label, value] of [
+    ["Authorization endpoint", issuer.authorizationEndpoint],
+    ["Token endpoint", issuer.tokenEndpoint],
+    ["Registration endpoint", issuer.registrationEndpoint],
+    ["JWKS URI", issuer.jwksUri],
+  ] as const) {
+    expect((screen.getByLabelText(label) as HTMLInputElement).value).toBe(
+      value,
+    );
+  }
+  fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+  await waitFor(() =>
+    expect(api.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: issuer.id,
+        authorizationEndpoint: issuer.authorizationEndpoint,
+        tokenEndpoint: issuer.tokenEndpoint,
+        registrationEndpoint: issuer.registrationEndpoint,
+        jwksUri: issuer.jwksUri,
+      }),
+    ),
+  );
+});

--- a/client/admin/src/pages/remote-session-issuers/IssuerEditor.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerEditor.test.tsx
@@ -411,3 +411,37 @@ it("keeps uncaptured saved capabilities omitted without fresh discovery", async 
     ),
   );
 });
+
+it("binds discovered metadata to the returned canonical issuer", async () => {
+  const canonical = "https://first.example";
+  api.discover.mockResolvedValue({
+    issuer: canonical,
+    authorizationEndpoint: `${canonical}/auth`,
+    tokenEndpoint: `${canonical}/token`,
+    scopesSupported: ["openid"],
+    discoveryWarnings: [],
+    clientIdMetadataDocumentSupported: true,
+  });
+  api.create.mockResolvedValue({});
+  mount();
+  fireEvent.change(screen.getByLabelText("Issuer URL"), {
+    target: { value: `${canonical}/tenant` },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Discover" }));
+  await waitFor(() =>
+    expect(
+      (screen.getByLabelText("Issuer URL") as HTMLInputElement).value,
+    ).toBe(canonical),
+  );
+  fireEvent.click(screen.getByRole("button", { name: "Create issuer" }));
+  await waitFor(() =>
+    expect(api.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issuer: canonical,
+        tokenEndpoint: `${canonical}/token`,
+        scopesSupported: ["openid"],
+        clientIdMetadataDocumentSupported: true,
+      }),
+    ),
+  );
+});

--- a/client/admin/src/pages/remote-session-issuers/IssuerEditor.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerEditor.tsx
@@ -140,9 +140,6 @@ export function IssuerEditor({
           !issuer && !dirty.slug
             ? (deriveSlugFromUrl(value) ?? f.slug)
             : f.slug,
-        ...(saved.current && value.trim() === saved.current.issuer
-          ? { discoveredSnapshot: snapshot(saved.current) }
-          : {}),
         ...(clear
           ? {
               authorizationEndpoint: "",
@@ -150,6 +147,14 @@ export function IssuerEditor({
               registrationEndpoint: "",
               jwksUri: "",
               discoveredSnapshot: null,
+            }
+          : {}),
+        ...(saved.current && value.trim() === saved.current.issuer
+          ? {
+              ...Object.fromEntries(
+                endpoints.map((key) => [key, saved.current?.[key] ?? ""]),
+              ),
+              discoveredSnapshot: snapshot(saved.current),
             }
           : {}),
       };

--- a/client/admin/src/pages/remote-session-issuers/IssuerEditor.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerEditor.tsx
@@ -179,7 +179,8 @@ export function IssuerEditor({
       });
       setForm((f) => ({
         ...f,
-        discoveredSnapshot: { ...discovered, url: f.issuerUrl.trim() },
+        issuerUrl: draft.issuer,
+        discoveredSnapshot: discovered,
         ...Object.fromEntries(
           endpoints.filter((k) => discovered[k]).map((k) => [k, discovered[k]]),
         ),

--- a/client/admin/src/pages/remote-session-issuers/IssuerEditor.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerEditor.tsx
@@ -206,6 +206,11 @@ export function IssuerEditor({
       await invalidateIssuerQueries(cache);
       toast.success("Issuer metadata refreshed");
     });
+  // Omitted discovery metadata is preserved by the update API, not cleared.
+  const discoveryRequired =
+    !!issuer &&
+    form.issuerUrl.trim() !== saved.current?.issuer &&
+    form.discoveredSnapshot?.url !== form.issuerUrl.trim();
   const resetAvailable =
     form.discoveredSnapshot &&
     endpoints.some(
@@ -226,6 +231,7 @@ export function IssuerEditor({
       className="flex flex-col gap-4"
       onSubmit={(e) => {
         e.preventDefault();
+        if (discoveryRequired) return;
         void run(async () => {
           const savedRecord = issuer
             ? await adminUpdateGlobalIssuer(buildUpdateIssuerForm(form))
@@ -237,6 +243,11 @@ export function IssuerEditor({
         });
       }}
     >
+      {discoveryRequired && (
+        <p role="alert" className="text-muted-foreground text-sm">
+          Discover the new issuer URL before saving changes.
+        </p>
+      )}
       {error && (
         <p role="alert" className="text-destructive text-sm">
           {error}
@@ -434,7 +445,7 @@ export function IssuerEditor({
             {" "}
             {issuer ? "Discard changes" : "Cancel"}
           </Button>
-          <Button type="submit">
+          <Button type="submit" disabled={discoveryRequired}>
             {pending ? "Working…" : issuer ? "Save changes" : "Create issuer"}
           </Button>
         </div>

--- a/client/admin/src/pages/remote-session-issuers/IssuerEditor.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerEditor.tsx
@@ -185,6 +185,7 @@ export function IssuerEditor({
           endpoints.filter((k) => discovered[k]).map((k) => [k, discovered[k]]),
         ),
       }));
+      setDuplicateUrl(draft.issuer);
       setWarnings(draft.discoveryWarnings);
       setDiscoverRan(true);
     });

--- a/client/admin/src/pages/remote-session-issuers/IssuerEditor.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerEditor.tsx
@@ -262,16 +262,18 @@ export function IssuerEditor({
       )}
       {discoverRan &&
         form.discoveredSnapshot &&
-        !form.authorizationEndpoint.trim() && (
+        !form.discoveredSnapshot.authorizationEndpoint.trim() && (
           <p className="text-muted-foreground text-sm">
             Authorization endpoint not advertised by the issuer.
           </p>
         )}
-      {discoverRan && form.discoveredSnapshot && !form.tokenEndpoint.trim() && (
-        <p className="text-muted-foreground text-sm">
-          Token endpoint not advertised by the issuer.
-        </p>
-      )}
+      {discoverRan &&
+        form.discoveredSnapshot &&
+        !form.discoveredSnapshot.tokenEndpoint.trim() && (
+          <p className="text-muted-foreground text-sm">
+            Token endpoint not advertised by the issuer.
+          </p>
+        )}
       {warnings.length > 0 && (
         <ul className="text-muted-foreground text-sm">
           {warnings.map((warning, i) => (

--- a/client/admin/src/pages/remote-session-issuers/IssuerEditor.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerEditor.tsx
@@ -1,0 +1,427 @@
+import { Link } from "@tanstack/react-router";
+import { invalidateIssuerQueries } from "./issuerQueries";
+import { toast } from "sonner";
+import type { JSX } from "react";
+import { useState, useRef } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import type { RemoteSessionIssuer } from "@gram/admin-client/models/components/remotesessionissuer";
+import type { RemoteSessionIssuerDraft } from "@gram/admin-client/models/components/remotesessionissuerdraft";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  adminCreateGlobalIssuer,
+  adminUpdateGlobalIssuer,
+  adminFetchGlobalIssuerMetadata,
+  adminRefreshGlobalIssuerMetadata,
+  adminUploadPlatformImage,
+  adminGetGlobalIssuerDuplicatePreflightQuery,
+} from "@/lib/gramAdminClient";
+import {
+  buildCreateIssuerForm,
+  buildUpdateIssuerForm,
+  deriveNameFromUrl,
+  deriveSlugFromUrl,
+  type DiscoveredEndpoints,
+  type IssuerSettingsFormState,
+} from "./issuerForm";
+import { IssuerLogo } from "./IssuerLogo";
+const endpoints = [
+  "authorizationEndpoint",
+  "tokenEndpoint",
+  "registrationEndpoint",
+  "jwksUri",
+] as const;
+function snapshot(
+  record: RemoteSessionIssuer | RemoteSessionIssuerDraft,
+): DiscoveredEndpoints {
+  return {
+    url: record.issuer,
+    authorizationEndpoint: record.authorizationEndpoint ?? "",
+    tokenEndpoint: record.tokenEndpoint ?? "",
+    registrationEndpoint: record.registrationEndpoint ?? "",
+    jwksUri: record.jwksUri ?? "",
+    scopesSupported: record.scopesSupported ?? [],
+    grantTypesSupported: record.grantTypesSupported ?? [],
+    responseTypesSupported: record.responseTypesSupported ?? [],
+    tokenEndpointAuthMethodsSupported:
+      record.tokenEndpointAuthMethodsSupported ?? [],
+    codeChallengeMethodsSupported: record.codeChallengeMethodsSupported ?? null,
+    clientIdMetadataDocumentSupported: record.clientIdMetadataDocumentSupported,
+    revocationEndpoint: record.revocationEndpoint ?? "",
+    serviceDocumentation: record.serviceDocumentation ?? "",
+    opPolicyUri: record.opPolicyUri ?? "",
+    opTosUri: record.opTosUri ?? "",
+    userinfoEndpoint: record.userinfoEndpoint ?? "",
+    introspectionEndpoint: record.introspectionEndpoint ?? "",
+    introspectionEndpointAuthMethodsSupported:
+      record.introspectionEndpointAuthMethodsSupported ?? null,
+    idTokenSigningAlgValuesSupported:
+      record.idTokenSigningAlgValuesSupported ?? null,
+    claimsSupported: record.claimsSupported ?? null,
+    backchannelLogoutSupported: record.backchannelLogoutSupported ?? null,
+    authorizationResponseIssParameterSupported:
+      record.authorizationResponseIssParameterSupported ?? null,
+  };
+}
+function initial(record?: RemoteSessionIssuer): IssuerSettingsFormState {
+  return {
+    id: record?.id ?? "",
+    name: record?.name ?? "",
+    slug: record?.slug ?? "",
+    logoAssetId: record?.logoAssetId ?? "",
+    clientSetupDocumentationUrl: record?.clientSetupDocumentationUrl ?? "",
+    issuerUrl: record?.issuer ?? "",
+    authorizationEndpoint: record?.authorizationEndpoint ?? "",
+    tokenEndpoint: record?.tokenEndpoint ?? "",
+    registrationEndpoint: record?.registrationEndpoint ?? "",
+    jwksUri: record?.jwksUri ?? "",
+    discoveredSnapshot: record ? snapshot(record) : null,
+  };
+}
+export function IssuerEditor({
+  issuer,
+  tenantClientCount = 0,
+  onDone,
+  onPendingChange,
+  onCreated,
+}: {
+  issuer?: RemoteSessionIssuer;
+  tenantClientCount?: number;
+  onDone: () => void;
+  onPendingChange?: (pending: boolean) => void;
+  onCreated?: (id: string) => Promise<void>;
+}): JSX.Element | null {
+  const cache = useQueryClient();
+  const [form, setForm] = useState(() => initial(issuer));
+  const saved = useRef(issuer);
+  const [dirty, setDirty] = useState({ name: false, slug: false });
+  const [pending, setPending] = useState(false);
+  const busy = useRef(false);
+  const [error, setError] = useState("");
+  const [warnings, setWarnings] = useState<string[]>([]);
+  const [discoverRan, setDiscoverRan] = useState(false);
+  const [duplicateUrl, setDuplicateUrl] = useState(issuer?.issuer ?? "");
+  const duplicates = useQuery({
+    ...adminGetGlobalIssuerDuplicatePreflightQuery({
+      issuer: duplicateUrl,
+    }),
+    enabled: !!duplicateUrl,
+  });
+  const run = async (action: () => Promise<void>) => {
+    if (busy.current) return;
+    busy.current = true;
+    setPending(true);
+    onPendingChange?.(true);
+    setError("");
+    try {
+      await action();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Request failed");
+    } finally {
+      busy.current = false;
+      setPending(false);
+      onPendingChange?.(false);
+    }
+  };
+  const changeUrl = (value: string) => {
+    setDuplicateUrl("");
+    setDiscoverRan(false);
+    setForm((f) => {
+      const reference = f.discoveredSnapshot?.url ?? saved.current?.issuer;
+      const clear = reference !== undefined && value.trim() !== reference;
+      return {
+        ...f,
+        issuerUrl: value,
+        name:
+          !issuer && !dirty.name
+            ? (deriveNameFromUrl(value) ?? f.name)
+            : f.name,
+        slug:
+          !issuer && !dirty.slug
+            ? (deriveSlugFromUrl(value) ?? f.slug)
+            : f.slug,
+        ...(saved.current && value.trim() === saved.current.issuer
+          ? { discoveredSnapshot: snapshot(saved.current) }
+          : {}),
+        ...(clear
+          ? {
+              authorizationEndpoint: "",
+              tokenEndpoint: "",
+              registrationEndpoint: "",
+              jwksUri: "",
+              discoveredSnapshot: null,
+            }
+          : {}),
+      };
+    });
+    setWarnings([]);
+  };
+  const discover = () =>
+    run(async () => {
+      const draft = await adminFetchGlobalIssuerMetadata({
+        issuer: form.issuerUrl.trim(),
+      });
+      const discovered = snapshot(draft);
+      setForm((f) => ({
+        ...f,
+        discoveredSnapshot: { ...discovered, url: f.issuerUrl.trim() },
+        ...Object.fromEntries(
+          endpoints.filter((k) => discovered[k]).map((k) => [k, discovered[k]]),
+        ),
+      }));
+      setWarnings(draft.discoveryWarnings);
+      setDiscoverRan(true);
+    });
+  const refresh = () =>
+    run(async () => {
+      if (!issuer) return;
+      const result = await adminRefreshGlobalIssuerMetadata({ id: issuer.id });
+      saved.current = result.issuer;
+      const discovered = snapshot(result.issuer);
+      setForm((f) => ({
+        ...f,
+        issuerUrl: result.issuer.issuer,
+        discoveredSnapshot: discovered,
+        ...Object.fromEntries(endpoints.map((k) => [k, discovered[k]])),
+      }));
+      setWarnings(result.discoveryWarnings);
+      setDiscoverRan(true);
+      await invalidateIssuerQueries(cache);
+      toast.success("Issuer metadata refreshed");
+    });
+  const resetAvailable =
+    form.discoveredSnapshot &&
+    endpoints.some(
+      (k) =>
+        form.discoveredSnapshot?.[k] && form[k] !== form.discoveredSnapshot[k],
+    );
+  const fields = [
+    ["name", "Display name"],
+    ["slug", "Slug"],
+    ["clientSetupDocumentationUrl", "Client setup documentation URL"],
+    ["authorizationEndpoint", "Authorization endpoint"],
+    ["tokenEndpoint", "Token endpoint"],
+    ["registrationEndpoint", "Registration endpoint"],
+    ["jwksUri", "JWKS URI"],
+  ] as const;
+  return (
+    <form
+      className="flex flex-col gap-4"
+      onSubmit={(e) => {
+        e.preventDefault();
+        void run(async () => {
+          const savedRecord = issuer
+            ? await adminUpdateGlobalIssuer(buildUpdateIssuerForm(form))
+            : await adminCreateGlobalIssuer(buildCreateIssuerForm(form));
+          await invalidateIssuerQueries(cache);
+          toast.success(issuer ? "Issuer saved" : "Issuer created");
+          onDone();
+          if (!issuer) await onCreated?.(savedRecord.id);
+        });
+      }}
+    >
+      {error && (
+        <p role="alert" className="text-destructive text-sm">
+          {error}
+        </p>
+      )}
+      {discoverRan &&
+        form.discoveredSnapshot &&
+        !form.authorizationEndpoint.trim() && (
+          <p className="text-muted-foreground text-sm">
+            Authorization endpoint not advertised by the issuer.
+          </p>
+        )}
+      {discoverRan && form.discoveredSnapshot && !form.tokenEndpoint.trim() && (
+        <p className="text-muted-foreground text-sm">
+          Token endpoint not advertised by the issuer.
+        </p>
+      )}
+      {warnings.length > 0 && (
+        <ul className="text-muted-foreground text-sm">
+          {warnings.map((warning, i) => (
+            <li key={i}>{warning}</li>
+          ))}
+        </ul>
+      )}
+      {tenantClientCount > 0 && (
+        <p className="text-muted-foreground text-sm">
+          Tenant clients use this issuer. Changing endpoints may disrupt
+          existing integrations.
+        </p>
+      )}
+      <fieldset disabled={pending} className="flex flex-col gap-4">
+        <div className="grid gap-2">
+          <label className="text-sm font-medium" htmlFor="issuer-url">
+            Issuer URL
+          </label>
+          <Input
+            id="issuer-url"
+            type="url"
+            required
+            value={form.issuerUrl}
+            onChange={(e) => changeUrl(e.target.value)}
+            onBlur={() => {
+              const url = form.issuerUrl.trim();
+              try {
+                if (["http:", "https:"].includes(new URL(url).protocol))
+                  setDuplicateUrl(url);
+              } catch {
+                setDuplicateUrl("");
+              }
+            }}
+          />
+        </div>
+        {duplicateUrl && duplicates.error && (
+          <p role="alert">
+            Duplicate check unavailable: {duplicates.error.message}
+          </p>
+        )}
+        {duplicateUrl &&
+          duplicates.data?.matches
+            .filter((m) => m.id !== issuer?.id)
+            .map((m) => (
+              <p key={m.id} className="text-muted-foreground text-sm">
+                Existing {m.tier} issuer: {m.name || m.slug} ({m.issuer})
+                {m.projectName && ` — ${m.projectName}`}{" "}
+                <Link
+                  to="/remote-session-issuers/$issuerId"
+                  params={{ issuerId: m.id }}
+                  className="underline underline-offset-4"
+                  aria-disabled={pending}
+                  onClick={(e) => {
+                    if (pending) e.preventDefault();
+                    else if (!issuer) onDone();
+                  }}
+                >
+                  View existing provider
+                </Link>
+              </p>
+            ))}
+        <div className="flex flex-wrap gap-2">
+          {!form.discoveredSnapshot &&
+            (!issuer || form.issuerUrl.trim() !== saved.current?.issuer) && (
+              <Button
+                type="button"
+                variant="outline"
+                disabled={!form.issuerUrl.trim()}
+                onClick={() => void discover()}
+              >
+                Discover
+              </Button>
+            )}
+          {resetAvailable && (
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() =>
+                setForm((f) => ({
+                  ...f,
+                  ...Object.fromEntries(
+                    endpoints
+                      .filter((k) => f.discoveredSnapshot?.[k])
+                      .map((k) => [k, f.discoveredSnapshot?.[k]]),
+                  ),
+                }))
+              }
+            >
+              Reset endpoints
+            </Button>
+          )}
+          {issuer && form.issuerUrl.trim() === saved.current?.issuer && (
+            <Button
+              type="button"
+              variant="outline"
+              disabled={form.issuerUrl.trim() !== saved.current?.issuer}
+              onClick={() => void refresh()}
+            >
+              Refresh saved metadata
+            </Button>
+          )}
+        </div>
+        {issuer && form.issuerUrl.trim() === saved.current?.issuer && (
+          <p className="text-muted-foreground text-sm">
+            Refresh saves discovered metadata immediately. Other edits are not
+            saved until you choose Save changes.
+          </p>
+        )}
+        {fields.map(([key, label]) => (
+          <div key={key} className="grid gap-2">
+            <label className="text-sm font-medium" htmlFor={`issuer-${key}`}>
+              {label}
+            </label>
+            <Input
+              id={`issuer-${key}`}
+              type={
+                key.endsWith("Endpoint") ||
+                key === "jwksUri" ||
+                key === "clientSetupDocumentationUrl"
+                  ? "url"
+                  : "text"
+              }
+              required={key === "slug"}
+              pattern={key === "slug" ? "[a-z0-9]+(?:-[a-z0-9]+)*" : undefined}
+              value={form[key]}
+              onChange={(e) => {
+                setForm((f) => ({ ...f, [key]: e.target.value }));
+                if (key === "name" || key === "slug")
+                  setDirty((d) => ({ ...d, [key]: true }));
+              }}
+            />
+          </div>
+        ))}
+        <div className="grid gap-2">
+          <label className="text-sm font-medium" htmlFor="issuer-logo">
+            Logo
+          </label>
+          {form.logoAssetId && <IssuerLogo id={form.logoAssetId} />}
+          <Input
+            id="issuer-logo"
+            type="file"
+            accept="image/png,image/jpeg,image/gif,image/webp"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file)
+                void run(async () => {
+                  if (file.size > 4 * 1024 * 1024)
+                    throw new Error("Image must be 4 MiB or smaller");
+                  const result = await adminUploadPlatformImage(file);
+                  setForm((f) => ({ ...f, logoAssetId: result.asset.id }));
+                });
+              e.target.value = "";
+            }}
+          />
+          {form.logoAssetId && (
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setForm((f) => ({ ...f, logoAssetId: "" }))}
+            >
+              Remove logo
+            </Button>
+          )}
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => {
+              setForm(initial(saved.current));
+              setDiscoverRan(false);
+              setDuplicateUrl(saved.current?.issuer ?? "");
+              setWarnings([]);
+              setError("");
+              if (!issuer) onDone();
+            }}
+          >
+            {" "}
+            {issuer ? "Discard changes" : "Cancel"}
+          </Button>
+          <Button type="submit">
+            {pending ? "Working…" : issuer ? "Save changes" : "Create issuer"}
+          </Button>
+        </div>
+      </fieldset>
+    </form>
+  );
+}

--- a/client/admin/src/pages/remote-session-issuers/IssuerEditor.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerEditor.tsx
@@ -234,7 +234,14 @@ export function IssuerEditor({
         if (discoveryRequired) return;
         void run(async () => {
           const savedRecord = issuer
-            ? await adminUpdateGlobalIssuer(buildUpdateIssuerForm(form))
+            ? await adminUpdateGlobalIssuer(
+                buildUpdateIssuerForm({
+                  ...form,
+                  discoveredSnapshot: discoverRan
+                    ? form.discoveredSnapshot
+                    : null,
+                }),
+              )
             : await adminCreateGlobalIssuer(buildCreateIssuerForm(form));
           await invalidateIssuerQueries(cache);
           toast.success(issuer ? "Issuer saved" : "Issuer created");

--- a/client/admin/src/pages/remote-session-issuers/IssuerEditor.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerEditor.tsx
@@ -166,7 +166,17 @@ export function IssuerEditor({
       const draft = await adminFetchGlobalIssuerMetadata({
         issuer: form.issuerUrl.trim(),
       });
-      const discovered = snapshot(draft);
+      // Fresh discovery captured omission; saved-record null still means uncaptured.
+      const discovered = snapshot({
+        ...draft,
+        codeChallengeMethodsSupported:
+          draft.codeChallengeMethodsSupported ?? [],
+        introspectionEndpointAuthMethodsSupported:
+          draft.introspectionEndpointAuthMethodsSupported ?? [],
+        idTokenSigningAlgValuesSupported:
+          draft.idTokenSigningAlgValuesSupported ?? [],
+        claimsSupported: draft.claimsSupported ?? [],
+      });
       setForm((f) => ({
         ...f,
         discoveredSnapshot: { ...discovered, url: f.issuerUrl.trim() },

--- a/client/admin/src/pages/remote-session-issuers/IssuerList.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerList.test.tsx
@@ -20,10 +20,19 @@ vi.mock("@tanstack/react-router", () => ({
   Link: ({
     params,
     children,
+    "aria-label": ariaLabel,
   }: {
     params: { issuerId: string };
     children: React.ReactNode;
-  }) => <a href={`/remote-session-issuers/${params.issuerId}`}>{children}</a>,
+    "aria-label"?: string;
+  }) => (
+    <a
+      href={`/remote-session-issuers/${params.issuerId}`}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </a>
+  ),
 }));
 vi.mock("./IssuerEditor", () => ({
   IssuerEditor: () => <div>Create form</div>,
@@ -65,7 +74,7 @@ it("renders each issuer's own View link and paginates the catalog", async () => 
                   {
                     issuer: {
                       id: "two",
-                      name: "Second",
+                      name: "",
                       issuer: "https://second.example",
                       slug: "second",
                     },
@@ -87,7 +96,9 @@ it("renders each issuer's own View link and paginates the catalog", async () => 
     </QueryClientProvider>,
   );
   expect(
-    (await screen.findByRole("link", { name: "View" })).getAttribute("href"),
+    (await screen.findByRole("link", { name: "View First" })).getAttribute(
+      "href",
+    ),
   ).toBe("/remote-session-issuers/one");
   fireEvent.click(screen.getByRole("button", { name: "Next" }));
   await waitFor(() =>
@@ -103,10 +114,14 @@ it("renders each issuer's own View link and paginates the catalog", async () => 
       .disabled,
   ).toBe(true);
   finishPage();
-  expect(await screen.findByText("Second")).toBeTruthy();
-  expect(screen.getByRole("link", { name: "View" }).getAttribute("href")).toBe(
-    "/remote-session-issuers/two",
-  );
+  expect(
+    await screen.findByRole("link", { name: "View https://second.example" }),
+  ).toBeTruthy();
+  expect(
+    screen
+      .getByRole("link", { name: "View https://second.example" })
+      .getAttribute("href"),
+  ).toBe("/remote-session-issuers/two");
 });
 it("shows query errors without claiming the catalog is empty", async () => {
   list.mockRejectedValue(new Error("Catalog unavailable"));

--- a/client/admin/src/pages/remote-session-issuers/IssuerList.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerList.test.tsx
@@ -1,0 +1,106 @@
+import {
+  cleanup,
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, expect, it, vi } from "vitest";
+import { IssuerList } from "./IssuerList";
+const list = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/gramAdminClient", () => ({
+  adminListGlobalIssuersQuery: (request: unknown) => ({
+    queryKey: ["issuers", request],
+    queryFn: () => list(request),
+  }),
+}));
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => vi.fn(),
+  Link: ({
+    params,
+    children,
+  }: {
+    params: { issuerId: string };
+    children: React.ReactNode;
+  }) => <a href={`/remote-session-issuers/${params.issuerId}`}>{children}</a>,
+}));
+vi.mock("./IssuerEditor", () => ({
+  IssuerEditor: () => <div>Create form</div>,
+}));
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+it("renders each issuer's own View link and paginates the catalog", async () => {
+  list
+    .mockResolvedValueOnce({
+      result: {
+        items: [
+          {
+            issuer: {
+              id: "one",
+              name: "First",
+              issuer: "https://first.example",
+              slug: "first",
+            },
+            globalClientCount: 2,
+            tenantClientCount: 3,
+          },
+        ],
+        nextCursor: "page2",
+      },
+    })
+    .mockResolvedValueOnce({
+      result: {
+        items: [
+          {
+            issuer: {
+              id: "two",
+              name: "Second",
+              issuer: "https://second.example",
+              slug: "second",
+            },
+            globalClientCount: 0,
+            tenantClientCount: 1,
+          },
+        ],
+      },
+    });
+  render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <IssuerList />
+    </QueryClientProvider>,
+  );
+  expect(
+    (await screen.findByRole("link", { name: "View" })).getAttribute("href"),
+  ).toBe("/remote-session-issuers/one");
+  fireEvent.click(screen.getByRole("button", { name: "Next" }));
+  await waitFor(() =>
+    expect(list).toHaveBeenLastCalledWith({ cursor: "page2", limit: 50 }),
+  );
+  expect(await screen.findByText("Second")).toBeTruthy();
+  expect(screen.getByRole("link", { name: "View" }).getAttribute("href")).toBe(
+    "/remote-session-issuers/two",
+  );
+});
+it("shows query errors without claiming the catalog is empty", async () => {
+  list.mockRejectedValue(new Error("Catalog unavailable"));
+  render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <IssuerList />
+    </QueryClientProvider>,
+  );
+  expect((await screen.findByRole("alert")).textContent).toContain(
+    "Catalog unavailable",
+  );
+  expect(screen.queryByText("No issuers found")).toBeNull();
+});

--- a/client/admin/src/pages/remote-session-issuers/IssuerList.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerList.test.tsx
@@ -122,6 +122,14 @@ it("renders each issuer's own View link and paginates the catalog", async () => 
       .getByRole("link", { name: "View https://second.example" })
       .getAttribute("href"),
   ).toBe("/remote-session-issuers/two");
+  expect(
+    (screen.getByRole("button", { name: "Next" }) as HTMLButtonElement)
+      .disabled,
+  ).toBe(true);
+  expect(
+    (screen.getByRole("button", { name: "Previous" }) as HTMLButtonElement)
+      .disabled,
+  ).toBe(false);
 });
 it("shows query errors without claiming the catalog is empty", async () => {
   list.mockRejectedValue(new Error("Catalog unavailable"));

--- a/client/admin/src/pages/remote-session-issuers/IssuerList.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerList.test.tsx
@@ -6,7 +6,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { IssuerList } from "./IssuerList";
 const list = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/gramAdminClient", () => ({
@@ -28,11 +28,15 @@ vi.mock("@tanstack/react-router", () => ({
 vi.mock("./IssuerEditor", () => ({
   IssuerEditor: () => <div>Create form</div>,
 }));
+beforeEach(() => {
+  list.mockReset().mockResolvedValue({ result: { items: [] } });
+});
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
 });
 it("renders each issuer's own View link and paginates the catalog", async () => {
+  let finishPage = () => {};
   list
     .mockResolvedValueOnce({
       result: {
@@ -51,22 +55,28 @@ it("renders each issuer's own View link and paginates the catalog", async () => 
         nextCursor: "page2",
       },
     })
-    .mockResolvedValueOnce({
-      result: {
-        items: [
-          {
-            issuer: {
-              id: "two",
-              name: "Second",
-              issuer: "https://second.example",
-              slug: "second",
-            },
-            globalClientCount: 0,
-            tenantClientCount: 1,
-          },
-        ],
-      },
-    });
+    .mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishPage = () =>
+            resolve({
+              result: {
+                items: [
+                  {
+                    issuer: {
+                      id: "two",
+                      name: "Second",
+                      issuer: "https://second.example",
+                      slug: "second",
+                    },
+                    globalClientCount: 0,
+                    tenantClientCount: 1,
+                  },
+                ],
+              },
+            });
+        }),
+    );
   render(
     <QueryClientProvider
       client={
@@ -83,6 +93,18 @@ it("renders each issuer's own View link and paginates the catalog", async () => 
   await waitFor(() =>
     expect(list).toHaveBeenLastCalledWith({ cursor: "page2", limit: 50 }),
   );
+  expect(screen.getByText("First")).toBeTruthy();
+  expect(
+    (screen.getByRole("button", { name: "Next" }) as HTMLButtonElement)
+      .disabled,
+  ).toBe(true);
+  expect(
+    (screen.getByRole("button", { name: "Previous" }) as HTMLButtonElement)
+      .disabled,
+  ).toBe(true);
+  fireEvent.click(screen.getByRole("button", { name: "Next" }));
+  expect(list).toHaveBeenCalledTimes(2);
+  finishPage();
   expect(await screen.findByText("Second")).toBeTruthy();
   expect(screen.getByRole("link", { name: "View" }).getAttribute("href")).toBe(
     "/remote-session-issuers/two",

--- a/client/admin/src/pages/remote-session-issuers/IssuerList.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerList.test.tsx
@@ -102,8 +102,6 @@ it("renders each issuer's own View link and paginates the catalog", async () => 
     (screen.getByRole("button", { name: "Previous" }) as HTMLButtonElement)
       .disabled,
   ).toBe(true);
-  fireEvent.click(screen.getByRole("button", { name: "Next" }));
-  expect(list).toHaveBeenCalledTimes(2);
   finishPage();
   expect(await screen.findByText("Second")).toBeTruthy();
   expect(screen.getByRole("link", { name: "View" }).getAttribute("href")).toBe(

--- a/client/admin/src/pages/remote-session-issuers/IssuerList.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerList.test.tsx
@@ -104,3 +104,20 @@ it("shows query errors without claiming the catalog is empty", async () => {
   );
   expect(screen.queryByText("No issuers found")).toBeNull();
 });
+
+it("shows a refetch error instead of the stale empty state", async () => {
+  list.mockResolvedValueOnce({ result: { items: [] } });
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <IssuerList />
+    </QueryClientProvider>,
+  );
+  expect(await screen.findByText("No issuers found")).toBeTruthy();
+  list.mockRejectedValue(new Error("Refetch refused"));
+  await client.invalidateQueries();
+  expect(await screen.findByText("Refetch refused")).toBeTruthy();
+  expect(screen.queryByText("No issuers found")).toBeNull();
+});

--- a/client/admin/src/pages/remote-session-issuers/IssuerList.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerList.tsx
@@ -55,6 +55,7 @@ const columns = column.columns([
         <Link
           to="/remote-session-issuers/$issuerId"
           params={{ issuerId: row.original.issuer.id }}
+          aria-label={`View ${row.original.issuer.name || row.original.issuer.issuer}`}
         >
           View
         </Link>

--- a/client/admin/src/pages/remote-session-issuers/IssuerList.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerList.tsx
@@ -1,0 +1,159 @@
+import type { JSX } from "react";
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link, useNavigate } from "@tanstack/react-router";
+import { createColumnHelper, useTable } from "@tanstack/react-table";
+import type { GlobalRemoteSessionIssuer } from "@gram/admin-client/models/components/globalremotesessionissuer";
+import { dataTableFeatures, DataTable } from "@/components/data-table";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { adminListGlobalIssuersQuery } from "@/lib/gramAdminClient";
+import { IssuerLogo } from "./IssuerLogo";
+import { IssuerActions } from "./IssuerActions";
+import { IssuerEditor } from "./IssuerEditor";
+const column = createColumnHelper<
+  typeof dataTableFeatures,
+  GlobalRemoteSessionIssuer
+>();
+const columns = column.columns([
+  column.display({
+    id: "provider",
+    header: "Provider",
+    cell: ({ row }) => (
+      <div>
+        {row.original.issuer.logoAssetId && (
+          <IssuerLogo id={row.original.issuer.logoAssetId} />
+        )}
+        <div className="font-medium">
+          {row.original.issuer.name || row.original.issuer.issuer}
+        </div>
+        <div className="text-muted-foreground text-xs">
+          {row.original.issuer.issuer}
+        </div>
+      </div>
+    ),
+  }),
+  column.accessor((r) => r.issuer.slug, { id: "slug", header: "Slug" }),
+  column.accessor("globalClientCount", { header: "Platform clients" }),
+  column.accessor("tenantClientCount", { header: "Tenant clients" }),
+  column.display({
+    id: "management",
+    header: "Actions",
+    cell: ({ row }) => <IssuerActions record={row.original} />,
+  }),
+  column.display({
+    id: "actions",
+    header: "",
+    cell: ({ row }) => (
+      <Button asChild variant="outline" size="sm">
+        <Link
+          to="/remote-session-issuers/$issuerId"
+          params={{ issuerId: row.original.issuer.id }}
+        >
+          View
+        </Link>
+      </Button>
+    ),
+  }),
+]);
+const empty: GlobalRemoteSessionIssuer[] = [];
+export function IssuerList(): JSX.Element | null {
+  const navigate = useNavigate();
+  const [cursors, setCursors] = useState<(string | undefined)[]>([undefined]);
+  const [creating, setCreating] = useState(false);
+  const [pending, setPending] = useState(false);
+  const query = useQuery(
+    adminListGlobalIssuersQuery({ cursor: cursors.at(-1), limit: 50 }),
+  );
+  const table = useTable({
+    features: dataTableFeatures,
+    getRowId: (row) => row.issuer.id,
+    data: query.data?.result.items ?? empty,
+    columns,
+  });
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-semibold">Remote session issuers</h1>
+          <p className="text-muted-foreground text-sm">
+            Shared platform identity provider configuration.
+          </p>
+        </div>
+        <Button onClick={() => setCreating(true)}>Create issuer</Button>
+      </div>
+      {query.isPending && <p role="status">Loading issuers…</p>}
+      {query.error && (
+        <div role="alert">
+          {query.error.message}
+          <Button variant="ghost" onClick={() => void query.refetch()}>
+            Retry
+          </Button>
+        </div>
+      )}
+      <DataTable>
+        <DataTable.Header table={table} />
+        <DataTable.Body>
+          {table.getRowModel().rows.map((row) => (
+            <DataTable.Row key={row.id} row={row} />
+          ))}
+        </DataTable.Body>
+      </DataTable>
+      {query.data?.result.items.length === 0 && <p>No issuers found</p>}
+      <div className="flex justify-end gap-2">
+        <Button
+          variant="outline"
+          disabled={cursors.length === 1 || query.isFetching}
+          onClick={() => setCursors((c) => c.slice(0, -1))}
+        >
+          Previous
+        </Button>
+        <Button
+          variant="outline"
+          disabled={!query.data?.result.nextCursor || query.isFetching}
+          onClick={() =>
+            setCursors((c) => [...c, query.data?.result.nextCursor])
+          }
+        >
+          Next
+        </Button>
+      </div>
+      <Dialog
+        open={creating}
+        onOpenChange={(open) => {
+          if (!pending) setCreating(open);
+        }}
+      >
+        <DialogContent
+          className="max-h-[90vh] overflow-y-auto sm:max-w-2xl"
+          onInteractOutside={(e) => e.preventDefault()}
+        >
+          <DialogHeader>
+            <DialogTitle>Create issuer</DialogTitle>
+            <DialogDescription>
+              Add a shared platform identity provider.
+            </DialogDescription>
+          </DialogHeader>
+          {creating && (
+            <IssuerEditor
+              onCreated={async (id) => {
+                await navigate({
+                  to: "/remote-session-issuers/$issuerId",
+                  params: { issuerId: id },
+                });
+              }}
+              onPendingChange={setPending}
+              onDone={() => setCreating(false)}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/client/admin/src/pages/remote-session-issuers/IssuerList.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerList.tsx
@@ -105,7 +105,9 @@ export function IssuerList(): JSX.Element | null {
           ))}
         </DataTable.Body>
       </DataTable>
-      {query.data?.result.items.length === 0 && <p>No issuers found</p>}
+      {!query.error && query.data?.result.items.length === 0 && (
+        <p>No issuers found</p>
+      )}
       <div className="flex justify-end gap-2">
         <Button
           variant="outline"

--- a/client/admin/src/pages/remote-session-issuers/IssuerList.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerList.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from "react";
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { createColumnHelper, useTable } from "@tanstack/react-table";
 import type { GlobalRemoteSessionIssuer } from "@gram/admin-client/models/components/globalremotesessionissuer";
@@ -68,9 +68,10 @@ export function IssuerList(): JSX.Element | null {
   const [cursors, setCursors] = useState<(string | undefined)[]>([undefined]);
   const [creating, setCreating] = useState(false);
   const [pending, setPending] = useState(false);
-  const query = useQuery(
-    adminListGlobalIssuersQuery({ cursor: cursors.at(-1), limit: 50 }),
-  );
+  const query = useQuery({
+    ...adminListGlobalIssuersQuery({ cursor: cursors.at(-1), limit: 50 }),
+    placeholderData: keepPreviousData,
+  });
   const table = useTable({
     features: dataTableFeatures,
     getRowId: (row) => row.issuer.id,

--- a/client/admin/src/pages/remote-session-issuers/IssuerList.tsx
+++ b/client/admin/src/pages/remote-session-issuers/IssuerList.tsx
@@ -98,14 +98,16 @@ export function IssuerList(): JSX.Element | null {
           </Button>
         </div>
       )}
-      <DataTable>
-        <DataTable.Header table={table} />
-        <DataTable.Body>
-          {table.getRowModel().rows.map((row) => (
-            <DataTable.Row key={row.id} row={row} />
-          ))}
-        </DataTable.Body>
-      </DataTable>
+      <div className="overflow-auto">
+        <DataTable>
+          <DataTable.Header table={table} />
+          <DataTable.Body>
+            {table.getRowModel().rows.map((row) => (
+              <DataTable.Row key={row.id} row={row} />
+            ))}
+          </DataTable.Body>
+        </DataTable>
+      </div>
       {!query.error && query.data?.result.items.length === 0 && (
         <p>No issuers found</p>
       )}

--- a/client/admin/src/pages/remote-session-issuers/createRoute.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/createRoute.test.tsx
@@ -1,0 +1,55 @@
+import { cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient } from "@tanstack/react-query";
+import { Outlet } from "@tanstack/react-router";
+import { afterEach, expect, it, vi } from "vitest";
+import { routeTree } from "@/routeTree.gen";
+import { renderRouteTree } from "@/test/harness";
+const create = vi.hoisted(() => vi.fn());
+vi.mock("@/layouts/AdminLayout", () => ({ AdminLayout: () => <Outlet /> }));
+vi.mock("./IssuerDetail", () => ({
+  IssuerDetail: () => <Outlet />,
+  IssuerOverview: () => <h1>Created overview</h1>,
+  IssuerSettings: () => null,
+  IssuerConvergence: () => null,
+}));
+vi.mock("@/lib/gramAdminClient", () => ({
+  adminListGlobalIssuersQuery: () => ({
+    queryKey: ["@gram/admin-client", "admin", "listGlobalIssuers"],
+    queryFn: async () => ({ result: { items: [] } }),
+  }),
+  adminGetGlobalIssuerDuplicatePreflightQuery: () => ({
+    queryKey: ["duplicates"],
+    queryFn: async () => ({ matches: [] }),
+  }),
+  adminCreateGlobalIssuer: create,
+}));
+afterEach(cleanup);
+it("navigates to the returned issuer ID only after invalidation completes", async () => {
+  const cache = new QueryClient();
+  let finish: () => void = () => {};
+  const invalidation = vi.spyOn(cache, "invalidateQueries").mockImplementation(
+    () =>
+      new Promise<void>((resolve) => {
+        finish = resolve;
+      }),
+  );
+  create.mockResolvedValue({ id: "returned-id" });
+  const { router } = await renderRouteTree(routeTree, {
+    initialPath: "/remote-session-issuers",
+    queryClient: cache,
+  });
+  fireEvent.click(await screen.findByRole("button", { name: "Create issuer" }));
+  fireEvent.change(screen.getByLabelText("Issuer URL"), {
+    target: { value: "https://new.example" },
+  });
+  fireEvent.submit(screen.getByLabelText("Issuer URL").closest("form")!);
+  await waitFor(() => expect(invalidation).toHaveBeenCalled());
+  expect(router.state.location.pathname).toBe("/remote-session-issuers");
+  finish();
+  expect(
+    await screen.findByRole("heading", { name: "Created overview" }),
+  ).toBeTruthy();
+  expect(router.state.location.pathname).toBe(
+    "/remote-session-issuers/returned-id",
+  );
+});

--- a/client/admin/src/pages/remote-session-issuers/routes.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/routes.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { Outlet } from "@tanstack/react-router";
 import { renderRouteTree } from "@/test/harness";
 import { routeTree } from "@/routeTree.gen";
@@ -29,6 +29,9 @@ vi.mock("@/lib/gramAdminClient", () => ({
     }),
   }),
 }));
+beforeEach(() => {
+  remove.mockReset();
+});
 afterEach(cleanup);
 it("supports direct settings entry and native overview/convergence navigation", async () => {
   const { router } = await renderRouteTree(routeTree, {

--- a/client/admin/src/pages/remote-session-issuers/routes.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/routes.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { Outlet } from "@tanstack/react-router";
 import { renderRouteTree } from "@/test/harness";
@@ -13,8 +19,10 @@ vi.mock("@/pages/remote-session-issuers/Convergence", () => ({
   ConvergenceHelp: () => null,
 }));
 const remove = vi.hoisted(() => vi.fn());
+const refresh = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/gramAdminClient", () => ({
   adminDeleteGlobalIssuer: remove,
+  adminRefreshGlobalIssuerMetadata: refresh,
   adminGetGlobalIssuerQuery: ({ id }: { id: string }) => ({
     queryKey: ["issuer", id],
     queryFn: async () => ({
@@ -31,6 +39,7 @@ vi.mock("@/lib/gramAdminClient", () => ({
 }));
 beforeEach(() => {
   remove.mockReset();
+  refresh.mockReset().mockResolvedValue({ discoveryWarnings: [] });
 });
 afterEach(cleanup);
 it("supports direct settings entry and native overview/convergence navigation", async () => {
@@ -78,8 +87,10 @@ it("keeps server dependency-race errors visible after delete confirmation", asyn
   });
   fireEvent.click(await screen.findByRole("button", { name: "Delete issuer" }));
   expect(await screen.findByText(/Counts are advisory/)).toBeTruthy();
-  const buttons = screen.getAllByRole("button", { name: "Delete issuer" });
-  fireEvent.click(buttons[buttons.length - 1]!);
+  const dialog = await screen.findByRole("dialog");
+  fireEvent.click(
+    within(dialog).getByRole("button", { name: "Delete issuer" }),
+  );
   expect((await screen.findByRole("alert")).textContent).toContain(
     "Tenant dependencies changed",
   );
@@ -87,4 +98,20 @@ it("keeps server dependency-race errors visible after delete confirmation", asyn
   expect(router.state.location.pathname).toBe(
     "/remote-session-issuers/example",
   );
+});
+
+it("refreshes issuer metadata and displays discovery warnings", async () => {
+  refresh.mockResolvedValue({
+    discoveryWarnings: ["Discovery endpoint unavailable"],
+  });
+  await renderRouteTree(routeTree, {
+    initialPath: "/remote-session-issuers/example",
+  });
+  fireEvent.click(
+    await screen.findByRole("button", { name: "Refresh metadata" }),
+  );
+  expect(
+    await screen.findByText("Discovery endpoint unavailable"),
+  ).toBeTruthy();
+  expect(refresh).toHaveBeenCalledExactlyOnceWith({ id: "example" });
 });

--- a/client/admin/src/pages/remote-session-issuers/routes.test.tsx
+++ b/client/admin/src/pages/remote-session-issuers/routes.test.tsx
@@ -1,0 +1,87 @@
+import { cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { Outlet } from "@tanstack/react-router";
+import { renderRouteTree } from "@/test/harness";
+import { routeTree } from "@/routeTree.gen";
+vi.mock("./ConvergenceSummary", () => ({ ConvergenceSummary: () => null }));
+vi.mock("@/layouts/AdminLayout", () => ({ AdminLayout: () => <Outlet /> }));
+vi.mock("@/pages/remote-session-issuers/IssuerEditor", () => ({
+  IssuerEditor: () => <h2>Settings form</h2>,
+}));
+vi.mock("@/pages/remote-session-issuers/Convergence", () => ({
+  Convergence: () => <h2>Candidate review</h2>,
+  ConvergenceHelp: () => null,
+}));
+const remove = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/gramAdminClient", () => ({
+  adminDeleteGlobalIssuer: remove,
+  adminGetGlobalIssuerQuery: ({ id }: { id: string }) => ({
+    queryKey: ["issuer", id],
+    queryFn: async () => ({
+      issuer: {
+        id,
+        name: "Example provider",
+        slug: "example",
+        issuer: "https://issuer.example",
+      },
+      globalClientCount: 2,
+      tenantClientCount: 3,
+    }),
+  }),
+}));
+afterEach(cleanup);
+it("supports direct settings entry and native overview/convergence navigation", async () => {
+  const { router } = await renderRouteTree(routeTree, {
+    initialPath: "/remote-session-issuers/example/settings",
+  });
+  expect(
+    await screen.findByRole("heading", { name: "Settings form" }),
+  ).toBeTruthy();
+  expect(
+    screen.getByRole("link", { name: "Settings" }).getAttribute("href"),
+  ).toBe("/remote-session-issuers/example/settings");
+  fireEvent.click(screen.getByRole("link", { name: "Overview" }));
+  await waitFor(() =>
+    expect(router.state.location.pathname).toBe(
+      "/remote-session-issuers/example",
+    ),
+  );
+  expect(await screen.findByText("Platform / tenant clients")).toBeTruthy();
+  fireEvent.click(screen.getByRole("link", { name: "Convergence" }));
+  expect(
+    await screen.findByRole("heading", { name: "Candidate review" }),
+  ).toBeTruthy();
+  expect(router.state.location.pathname).toBe(
+    "/remote-session-issuers/example/convergence",
+  );
+  router.history.back();
+  await waitFor(() =>
+    expect(router.state.location.pathname).toBe(
+      "/remote-session-issuers/example",
+    ),
+  );
+  router.history.forward();
+  await waitFor(() =>
+    expect(router.state.location.pathname).toBe(
+      "/remote-session-issuers/example/convergence",
+    ),
+  );
+});
+
+it("keeps server dependency-race errors visible after delete confirmation", async () => {
+  remove.mockRejectedValue(new Error("Tenant dependencies changed"));
+  const { router } = await renderRouteTree(routeTree, {
+    initialPath: "/remote-session-issuers/example",
+  });
+  fireEvent.click(await screen.findByRole("button", { name: "Delete issuer" }));
+  expect(await screen.findByText(/Counts are advisory/)).toBeTruthy();
+  const buttons = screen.getAllByRole("button", { name: "Delete issuer" });
+  fireEvent.click(buttons[buttons.length - 1]!);
+  expect((await screen.findByRole("alert")).textContent).toContain(
+    "Tenant dependencies changed",
+  );
+  expect(remove).toHaveBeenCalledWith({ id: "example" });
+  expect(router.state.location.pathname).toBe(
+    "/remote-session-issuers/example",
+  );
+});

--- a/client/admin/src/routeTree.gen.ts
+++ b/client/admin/src/routeTree.gen.ts
@@ -12,16 +12,22 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as OrganizationsRouteImport } from './routes/organizations'
 import { Route as ProjectsRouteImport } from './routes/projects'
+import { Route as RemoteSessionIssuersRouteImport } from './routes/remote-session-issuers'
 import { Route as StokenCalculatorRouteImport } from './routes/stoken-calculator'
 import { Route as OrganizationsIndexRouteImport } from './routes/organizations.index'
 import { Route as OrganizationsIdOrSlugRouteImport } from './routes/organizations.$idOrSlug'
 import { Route as ProjectsIndexRouteImport } from './routes/projects.index'
 import { Route as ProjectsIdOrSlugRouteImport } from './routes/projects.$idOrSlug'
+import { Route as RemoteSessionIssuersIndexRouteImport } from './routes/remote-session-issuers.index'
+import { Route as RemoteSessionIssuersIssuerIdRouteImport } from './routes/remote-session-issuers.$issuerId'
 import { Route as OrganizationsIdOrSlugIndexRouteImport } from './routes/organizations.$idOrSlug.index'
 import { Route as OrganizationsIdOrSlugActivityRouteImport } from './routes/organizations.$idOrSlug.activity'
 import { Route as OrganizationsIdOrSlugBillingRouteImport } from './routes/organizations.$idOrSlug.billing'
 import { Route as OrganizationsIdOrSlugFeaturesRouteImport } from './routes/organizations.$idOrSlug.features'
 import { Route as OrganizationsIdOrSlugMembersRouteImport } from './routes/organizations.$idOrSlug.members'
+import { Route as RemoteSessionIssuersIssuerIdIndexRouteImport } from './routes/remote-session-issuers.$issuerId.index'
+import { Route as RemoteSessionIssuersIssuerIdConvergenceRouteImport } from './routes/remote-session-issuers.$issuerId.convergence'
+import { Route as RemoteSessionIssuersIssuerIdSettingsRouteImport } from './routes/remote-session-issuers.$issuerId.settings'
 import { Route as OrganizationsIdOrSlugProjectsIndexRouteImport } from './routes/organizations.$idOrSlug.projects.index'
 import { Route as OrganizationsIdOrSlugProjectsProjectIdOrSlugRouteImport } from './routes/organizations.$idOrSlug.projects.$projectIdOrSlug'
 
@@ -38,6 +44,11 @@ const OrganizationsRoute = OrganizationsRouteImport.update({
 const ProjectsRoute = ProjectsRouteImport.update({
   id: '/projects',
   path: '/projects',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const RemoteSessionIssuersRoute = RemoteSessionIssuersRouteImport.update({
+  id: '/remote-session-issuers',
+  path: '/remote-session-issuers',
   getParentRoute: () => rootRouteImport,
 } as any)
 const StokenCalculatorRoute = StokenCalculatorRouteImport.update({
@@ -65,6 +76,18 @@ const ProjectsIdOrSlugRoute = ProjectsIdOrSlugRouteImport.update({
   path: '/$idOrSlug',
   getParentRoute: () => ProjectsRoute,
 } as any)
+const RemoteSessionIssuersIndexRoute =
+  RemoteSessionIssuersIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => RemoteSessionIssuersRoute,
+  } as any)
+const RemoteSessionIssuersIssuerIdRoute =
+  RemoteSessionIssuersIssuerIdRouteImport.update({
+    id: '/$issuerId',
+    path: '/$issuerId',
+    getParentRoute: () => RemoteSessionIssuersRoute,
+  } as any)
 const OrganizationsIdOrSlugIndexRoute =
   OrganizationsIdOrSlugIndexRouteImport.update({
     id: '/',
@@ -95,6 +118,24 @@ const OrganizationsIdOrSlugMembersRoute =
     path: '/members',
     getParentRoute: () => OrganizationsIdOrSlugRoute,
   } as any)
+const RemoteSessionIssuersIssuerIdIndexRoute =
+  RemoteSessionIssuersIssuerIdIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => RemoteSessionIssuersIssuerIdRoute,
+  } as any)
+const RemoteSessionIssuersIssuerIdConvergenceRoute =
+  RemoteSessionIssuersIssuerIdConvergenceRouteImport.update({
+    id: '/convergence',
+    path: '/convergence',
+    getParentRoute: () => RemoteSessionIssuersIssuerIdRoute,
+  } as any)
+const RemoteSessionIssuersIssuerIdSettingsRoute =
+  RemoteSessionIssuersIssuerIdSettingsRouteImport.update({
+    id: '/settings',
+    path: '/settings',
+    getParentRoute: () => RemoteSessionIssuersIssuerIdRoute,
+  } as any)
 const OrganizationsIdOrSlugProjectsIndexRoute =
   OrganizationsIdOrSlugProjectsIndexRouteImport.update({
     id: '/projects/',
@@ -112,16 +153,22 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/organizations': typeof OrganizationsRouteWithChildren
   '/projects': typeof ProjectsRouteWithChildren
+  '/remote-session-issuers': typeof RemoteSessionIssuersRouteWithChildren
   '/stoken-calculator': typeof StokenCalculatorRoute
   '/organizations/$idOrSlug': typeof OrganizationsIdOrSlugRouteWithChildren
   '/projects/$idOrSlug': typeof ProjectsIdOrSlugRoute
+  '/remote-session-issuers/$issuerId': typeof RemoteSessionIssuersIssuerIdRouteWithChildren
   '/organizations/': typeof OrganizationsIndexRoute
   '/projects/': typeof ProjectsIndexRoute
+  '/remote-session-issuers/': typeof RemoteSessionIssuersIndexRoute
   '/organizations/$idOrSlug/activity': typeof OrganizationsIdOrSlugActivityRoute
   '/organizations/$idOrSlug/billing': typeof OrganizationsIdOrSlugBillingRoute
   '/organizations/$idOrSlug/features': typeof OrganizationsIdOrSlugFeaturesRoute
   '/organizations/$idOrSlug/members': typeof OrganizationsIdOrSlugMembersRoute
+  '/remote-session-issuers/$issuerId/convergence': typeof RemoteSessionIssuersIssuerIdConvergenceRoute
+  '/remote-session-issuers/$issuerId/settings': typeof RemoteSessionIssuersIssuerIdSettingsRoute
   '/organizations/$idOrSlug/': typeof OrganizationsIdOrSlugIndexRoute
+  '/remote-session-issuers/$issuerId/': typeof RemoteSessionIssuersIssuerIdIndexRoute
   '/organizations/$idOrSlug/projects/$projectIdOrSlug': typeof OrganizationsIdOrSlugProjectsProjectIdOrSlugRoute
   '/organizations/$idOrSlug/projects/': typeof OrganizationsIdOrSlugProjectsIndexRoute
 }
@@ -131,11 +178,15 @@ export interface FileRoutesByTo {
   '/projects/$idOrSlug': typeof ProjectsIdOrSlugRoute
   '/organizations': typeof OrganizationsIndexRoute
   '/projects': typeof ProjectsIndexRoute
+  '/remote-session-issuers': typeof RemoteSessionIssuersIndexRoute
   '/organizations/$idOrSlug/activity': typeof OrganizationsIdOrSlugActivityRoute
   '/organizations/$idOrSlug/billing': typeof OrganizationsIdOrSlugBillingRoute
   '/organizations/$idOrSlug/features': typeof OrganizationsIdOrSlugFeaturesRoute
   '/organizations/$idOrSlug/members': typeof OrganizationsIdOrSlugMembersRoute
+  '/remote-session-issuers/$issuerId/convergence': typeof RemoteSessionIssuersIssuerIdConvergenceRoute
+  '/remote-session-issuers/$issuerId/settings': typeof RemoteSessionIssuersIssuerIdSettingsRoute
   '/organizations/$idOrSlug': typeof OrganizationsIdOrSlugIndexRoute
+  '/remote-session-issuers/$issuerId': typeof RemoteSessionIssuersIssuerIdIndexRoute
   '/organizations/$idOrSlug/projects/$projectIdOrSlug': typeof OrganizationsIdOrSlugProjectsProjectIdOrSlugRoute
   '/organizations/$idOrSlug/projects': typeof OrganizationsIdOrSlugProjectsIndexRoute
 }
@@ -144,16 +195,22 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/organizations': typeof OrganizationsRouteWithChildren
   '/projects': typeof ProjectsRouteWithChildren
+  '/remote-session-issuers': typeof RemoteSessionIssuersRouteWithChildren
   '/stoken-calculator': typeof StokenCalculatorRoute
   '/organizations/$idOrSlug': typeof OrganizationsIdOrSlugRouteWithChildren
   '/projects/$idOrSlug': typeof ProjectsIdOrSlugRoute
+  '/remote-session-issuers/$issuerId': typeof RemoteSessionIssuersIssuerIdRouteWithChildren
   '/organizations/': typeof OrganizationsIndexRoute
   '/projects/': typeof ProjectsIndexRoute
+  '/remote-session-issuers/': typeof RemoteSessionIssuersIndexRoute
   '/organizations/$idOrSlug/activity': typeof OrganizationsIdOrSlugActivityRoute
   '/organizations/$idOrSlug/billing': typeof OrganizationsIdOrSlugBillingRoute
   '/organizations/$idOrSlug/features': typeof OrganizationsIdOrSlugFeaturesRoute
   '/organizations/$idOrSlug/members': typeof OrganizationsIdOrSlugMembersRoute
+  '/remote-session-issuers/$issuerId/convergence': typeof RemoteSessionIssuersIssuerIdConvergenceRoute
+  '/remote-session-issuers/$issuerId/settings': typeof RemoteSessionIssuersIssuerIdSettingsRoute
   '/organizations/$idOrSlug/': typeof OrganizationsIdOrSlugIndexRoute
+  '/remote-session-issuers/$issuerId/': typeof RemoteSessionIssuersIssuerIdIndexRoute
   '/organizations/$idOrSlug/projects/$projectIdOrSlug': typeof OrganizationsIdOrSlugProjectsProjectIdOrSlugRoute
   '/organizations/$idOrSlug/projects/': typeof OrganizationsIdOrSlugProjectsIndexRoute
 }
@@ -163,16 +220,22 @@ export interface FileRouteTypes {
     | '/'
     | '/organizations'
     | '/projects'
+    | '/remote-session-issuers'
     | '/stoken-calculator'
     | '/organizations/$idOrSlug'
     | '/projects/$idOrSlug'
+    | '/remote-session-issuers/$issuerId'
     | '/organizations/'
     | '/projects/'
+    | '/remote-session-issuers/'
     | '/organizations/$idOrSlug/activity'
     | '/organizations/$idOrSlug/billing'
     | '/organizations/$idOrSlug/features'
     | '/organizations/$idOrSlug/members'
+    | '/remote-session-issuers/$issuerId/convergence'
+    | '/remote-session-issuers/$issuerId/settings'
     | '/organizations/$idOrSlug/'
+    | '/remote-session-issuers/$issuerId/'
     | '/organizations/$idOrSlug/projects/$projectIdOrSlug'
     | '/organizations/$idOrSlug/projects/'
   fileRoutesByTo: FileRoutesByTo
@@ -182,11 +245,15 @@ export interface FileRouteTypes {
     | '/projects/$idOrSlug'
     | '/organizations'
     | '/projects'
+    | '/remote-session-issuers'
     | '/organizations/$idOrSlug/activity'
     | '/organizations/$idOrSlug/billing'
     | '/organizations/$idOrSlug/features'
     | '/organizations/$idOrSlug/members'
+    | '/remote-session-issuers/$issuerId/convergence'
+    | '/remote-session-issuers/$issuerId/settings'
     | '/organizations/$idOrSlug'
+    | '/remote-session-issuers/$issuerId'
     | '/organizations/$idOrSlug/projects/$projectIdOrSlug'
     | '/organizations/$idOrSlug/projects'
   id:
@@ -194,16 +261,22 @@ export interface FileRouteTypes {
     | '/'
     | '/organizations'
     | '/projects'
+    | '/remote-session-issuers'
     | '/stoken-calculator'
     | '/organizations/$idOrSlug'
     | '/projects/$idOrSlug'
+    | '/remote-session-issuers/$issuerId'
     | '/organizations/'
     | '/projects/'
+    | '/remote-session-issuers/'
     | '/organizations/$idOrSlug/activity'
     | '/organizations/$idOrSlug/billing'
     | '/organizations/$idOrSlug/features'
     | '/organizations/$idOrSlug/members'
+    | '/remote-session-issuers/$issuerId/convergence'
+    | '/remote-session-issuers/$issuerId/settings'
     | '/organizations/$idOrSlug/'
+    | '/remote-session-issuers/$issuerId/'
     | '/organizations/$idOrSlug/projects/$projectIdOrSlug'
     | '/organizations/$idOrSlug/projects/'
   fileRoutesById: FileRoutesById
@@ -212,6 +285,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   OrganizationsRoute: typeof OrganizationsRouteWithChildren
   ProjectsRoute: typeof ProjectsRouteWithChildren
+  RemoteSessionIssuersRoute: typeof RemoteSessionIssuersRouteWithChildren
   StokenCalculatorRoute: typeof StokenCalculatorRoute
 }
 
@@ -236,6 +310,13 @@ declare module '@tanstack/react-router' {
       path: '/projects'
       fullPath: '/projects'
       preLoaderRoute: typeof ProjectsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/remote-session-issuers': {
+      id: '/remote-session-issuers'
+      path: '/remote-session-issuers'
+      fullPath: '/remote-session-issuers'
+      preLoaderRoute: typeof RemoteSessionIssuersRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/stoken-calculator': {
@@ -273,6 +354,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProjectsIdOrSlugRouteImport
       parentRoute: typeof ProjectsRoute
     }
+    '/remote-session-issuers/': {
+      id: '/remote-session-issuers/'
+      path: '/'
+      fullPath: '/remote-session-issuers/'
+      preLoaderRoute: typeof RemoteSessionIssuersIndexRouteImport
+      parentRoute: typeof RemoteSessionIssuersRoute
+    }
+    '/remote-session-issuers/$issuerId': {
+      id: '/remote-session-issuers/$issuerId'
+      path: '/$issuerId'
+      fullPath: '/remote-session-issuers/$issuerId'
+      preLoaderRoute: typeof RemoteSessionIssuersIssuerIdRouteImport
+      parentRoute: typeof RemoteSessionIssuersRoute
+    }
     '/organizations/$idOrSlug/': {
       id: '/organizations/$idOrSlug/'
       path: '/'
@@ -307,6 +402,27 @@ declare module '@tanstack/react-router' {
       fullPath: '/organizations/$idOrSlug/members'
       preLoaderRoute: typeof OrganizationsIdOrSlugMembersRouteImport
       parentRoute: typeof OrganizationsIdOrSlugRoute
+    }
+    '/remote-session-issuers/$issuerId/': {
+      id: '/remote-session-issuers/$issuerId/'
+      path: '/'
+      fullPath: '/remote-session-issuers/$issuerId/'
+      preLoaderRoute: typeof RemoteSessionIssuersIssuerIdIndexRouteImport
+      parentRoute: typeof RemoteSessionIssuersIssuerIdRoute
+    }
+    '/remote-session-issuers/$issuerId/convergence': {
+      id: '/remote-session-issuers/$issuerId/convergence'
+      path: '/convergence'
+      fullPath: '/remote-session-issuers/$issuerId/convergence'
+      preLoaderRoute: typeof RemoteSessionIssuersIssuerIdConvergenceRouteImport
+      parentRoute: typeof RemoteSessionIssuersIssuerIdRoute
+    }
+    '/remote-session-issuers/$issuerId/settings': {
+      id: '/remote-session-issuers/$issuerId/settings'
+      path: '/settings'
+      fullPath: '/remote-session-issuers/$issuerId/settings'
+      preLoaderRoute: typeof RemoteSessionIssuersIssuerIdSettingsRouteImport
+      parentRoute: typeof RemoteSessionIssuersIssuerIdRoute
     }
     '/organizations/$idOrSlug/projects/': {
       id: '/organizations/$idOrSlug/projects/'
@@ -380,10 +496,46 @@ const ProjectsRouteWithChildren = ProjectsRoute._addFileChildren(
   ProjectsRouteChildren,
 )
 
+interface RemoteSessionIssuersIssuerIdRouteChildren {
+  RemoteSessionIssuersIssuerIdConvergenceRoute: typeof RemoteSessionIssuersIssuerIdConvergenceRoute
+  RemoteSessionIssuersIssuerIdSettingsRoute: typeof RemoteSessionIssuersIssuerIdSettingsRoute
+  RemoteSessionIssuersIssuerIdIndexRoute: typeof RemoteSessionIssuersIssuerIdIndexRoute
+}
+
+const RemoteSessionIssuersIssuerIdRouteChildren: RemoteSessionIssuersIssuerIdRouteChildren =
+  {
+    RemoteSessionIssuersIssuerIdConvergenceRoute:
+      RemoteSessionIssuersIssuerIdConvergenceRoute,
+    RemoteSessionIssuersIssuerIdSettingsRoute:
+      RemoteSessionIssuersIssuerIdSettingsRoute,
+    RemoteSessionIssuersIssuerIdIndexRoute:
+      RemoteSessionIssuersIssuerIdIndexRoute,
+  }
+
+const RemoteSessionIssuersIssuerIdRouteWithChildren =
+  RemoteSessionIssuersIssuerIdRoute._addFileChildren(
+    RemoteSessionIssuersIssuerIdRouteChildren,
+  )
+
+interface RemoteSessionIssuersRouteChildren {
+  RemoteSessionIssuersIssuerIdRoute: typeof RemoteSessionIssuersIssuerIdRouteWithChildren
+  RemoteSessionIssuersIndexRoute: typeof RemoteSessionIssuersIndexRoute
+}
+
+const RemoteSessionIssuersRouteChildren: RemoteSessionIssuersRouteChildren = {
+  RemoteSessionIssuersIssuerIdRoute:
+    RemoteSessionIssuersIssuerIdRouteWithChildren,
+  RemoteSessionIssuersIndexRoute: RemoteSessionIssuersIndexRoute,
+}
+
+const RemoteSessionIssuersRouteWithChildren =
+  RemoteSessionIssuersRoute._addFileChildren(RemoteSessionIssuersRouteChildren)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   OrganizationsRoute: OrganizationsRouteWithChildren,
   ProjectsRoute: ProjectsRouteWithChildren,
+  RemoteSessionIssuersRoute: RemoteSessionIssuersRouteWithChildren,
   StokenCalculatorRoute: StokenCalculatorRoute,
 }
 export const routeTree = rootRouteImport

--- a/client/admin/src/routes/remote-session-issuers.$issuerId.convergence.tsx
+++ b/client/admin/src/routes/remote-session-issuers.$issuerId.convergence.tsx
@@ -1,0 +1,5 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { IssuerConvergence } from "@/pages/remote-session-issuers/IssuerDetail";
+export const Route = createFileRoute(
+  "/remote-session-issuers/$issuerId/convergence",
+)({ component: IssuerConvergence, staticData: { crumb: "Convergence" } });

--- a/client/admin/src/routes/remote-session-issuers.$issuerId.index.tsx
+++ b/client/admin/src/routes/remote-session-issuers.$issuerId.index.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { IssuerOverview } from "@/pages/remote-session-issuers/IssuerDetail";
+export const Route = createFileRoute("/remote-session-issuers/$issuerId/")({
+  component: IssuerOverview,
+  staticData: { crumb: "Overview" },
+});

--- a/client/admin/src/routes/remote-session-issuers.$issuerId.settings.tsx
+++ b/client/admin/src/routes/remote-session-issuers.$issuerId.settings.tsx
@@ -1,0 +1,5 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { IssuerSettings } from "@/pages/remote-session-issuers/IssuerDetail";
+export const Route = createFileRoute(
+  "/remote-session-issuers/$issuerId/settings",
+)({ component: IssuerSettings, staticData: { crumb: "Settings" } });

--- a/client/admin/src/routes/remote-session-issuers.$issuerId.tsx
+++ b/client/admin/src/routes/remote-session-issuers.$issuerId.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { IssuerDetail } from "@/pages/remote-session-issuers/IssuerDetail";
+import { adminGetGlobalIssuerQuery } from "@/lib/gramAdminClient";
+export const Route = createFileRoute("/remote-session-issuers/$issuerId")({
+  component: IssuerDetail,
+  staticData: {
+    crumb: (params) =>
+      params.issuerId
+        ? {
+            queryKey: adminGetGlobalIssuerQuery({ id: params.issuerId })
+              .queryKey,
+          }
+        : undefined,
+  },
+});

--- a/client/admin/src/routes/remote-session-issuers.index.tsx
+++ b/client/admin/src/routes/remote-session-issuers.index.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { IssuerList } from "@/pages/remote-session-issuers/IssuerList";
+export const Route = createFileRoute("/remote-session-issuers/")({
+  component: IssuerList,
+  staticData: { crumb: "" },
+});

--- a/client/admin/src/routes/remote-session-issuers.tsx
+++ b/client/admin/src/routes/remote-session-issuers.tsx
@@ -1,0 +1,4 @@
+import { createFileRoute } from "@tanstack/react-router";
+export const Route = createFileRoute("/remote-session-issuers")({
+  staticData: { crumb: "Remote session issuers" },
+});


### PR DESCRIPTION
## Stack context

This is the integration point for the stack: the backend and reusable frontend layers become a reachable platform issuer-management experience in standalone admin. It connects the issuer and image APIs, form payload semantics from [#6275](https://github.com/speakeasy-api/gram/pull/6275), queries and logos from [#6276](https://github.com/speakeasy-api/gram/pull/6276), configuration display from [#6277](https://github.com/speakeasy-api/gram/pull/6277), actions from [#6278](https://github.com/speakeasy-api/gram/pull/6278), and convergence controls from [#6279](https://github.com/speakeasy-api/gram/pull/6279).

The new routes and navigation bring together the issuer catalog, detail view, create/edit flow, metadata discovery, logo management, and convergence workflow. The dashboard management surface remains intact in this PR so the standalone replacement can be accepted before removal. [#6281](https://github.com/speakeasy-api/gram/pull/6281) is the separate final removal step.

## Summary

Connect the issuer catalog, detail, configuration editor, and convergence views to standalone admin routes and navigation. Regenerate the route tree and keep the existing dashboard surface intact.

## Motivation

Make global issuer management reachable in the standalone admin application while preserving the legacy dashboard until parity acceptance.
