### PR TITLE
fix: repoint the workload key source at workload_issuers

### DIFF
--- a/.changeset/workload-issuer-admission.md
+++ b/.changeset/workload-issuer-admission.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Admission for the workload assertion grant: resolve an assertion's issuer to the row the rest of the grant is built on, share one issuer resolution between the management API and admission, bound admission lookups per endpoint, and remember recent rejections in the shared cache so a repeated unknown issuer costs no query on any replica

--- a/.changeset/workload-key-source-repoint.md
+++ b/.changeset/workload-key-source-repoint.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Verify workload assertions against the keys published by their `workload_issuers` record rather than a remote session issuer row. Not yet wired to any request path.

--- a/server/internal/mcp/authnchallenge_workloadallowlist.go
+++ b/server/internal/mcp/authnchallenge_workloadallowlist.go
@@ -1,0 +1,226 @@
+// Admission for the workload assertion grant: resolving an assertion's iss to
+// the issuer row the rest of the grant is built on. Sits in front of
+// workloadIssuerKeySource in authnchallenge_workloadauth.go, which reads that
+// row's stored jwks_uri.
+//
+// Resolving the issuer is not the same as admitting the workload, and this
+// stage only does the first. See errWorkloadIssuerUntrusted.
+
+package mcp
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"go.opentelemetry.io/otel/metric"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/speakeasy-api/gram/server/internal/ratelimit"
+	workloadidentity_repo "github.com/speakeasy-api/gram/server/internal/workloadidentity/repo"
+)
+
+const (
+	// workloadIssuerLookupTimeout bounds one admission lookup. The lookup runs
+	// detached from the caller's context, so nothing else bounds it.
+	workloadIssuerLookupTimeout = 5 * time.Second
+)
+
+// workloadIssuerLookupRate bounds how many lookups one endpoint drives into
+// the database, and is the only bound: singleflight collapses repeats of one
+// spelling, but a flood of distinct spellings shares no flight.
+//
+// Per endpoint rather than per replica, so one tenant cannot exhaust another's
+// budget. The bucket lives in Redis, so it is fleet-wide.
+var workloadIssuerLookupRate = ratelimit.PerMinute(120).WithBurst(30)
+
+// errWorkloadIssuerUntrusted reports an iss resolving to no workload issuer
+// row in the endpoint's tenancy — its own project, or the organization above.
+//
+// Weaker than "trusted for this workload": this stage establishes only that the
+// tenant registered the issuer. A CI provider signs every job on its platform,
+// so the subject admission that follows is the security boundary, not this.
+var errWorkloadIssuerUntrusted = errors.New("no workload issuer in this tenancy describes that issuer url")
+
+// errWorkloadIssuerLookupRateLimited reports a lookup refused for budget.
+// Nothing was decided about the issuer, so a caller mapping untrusted onto a
+// 401 must not answer one here.
+var errWorkloadIssuerLookupRateLimited = errors.New("workload issuer lookups are rate limited for this endpoint")
+
+// errWorkloadIssuerLimiterUnavailable reports that the limiter's store could
+// not answer. Fails closed, and stays distinct from a refusal so an outage is
+// not reported as a rate limit an operator can wait out.
+var errWorkloadIssuerLimiterUnavailable = errors.New("workload issuer lookup limiter unavailable")
+
+// errWorkloadIssuerURLInvalid marks a value that is not an issuer identifier
+// at all. Wrapped by a lookup before it consults anything, so admission can
+// tell "could never name a row" from "names no row we hold".
+var errWorkloadIssuerURLInvalid = errors.New("invalid issuer url")
+
+// newWorkloadIssuerLookupBudget builds the per-endpoint ceiling, or nil when
+// there is no store. Nil is not "unlimited" — an absent budget refuses, so a
+// deployment without the store does not get the grant.
+func newWorkloadIssuerLookupBudget(redisClient *redis.Client, meterProvider metric.MeterProvider) workloadIssuerBudget {
+	if redisClient == nil {
+		return nil
+	}
+
+	limiter := ratelimit.New(
+		ratelimit.NewRedisStore(redisClient),
+		"workload_issuer_lookup",
+		workloadIssuerLookupRate,
+		ratelimit.WithMetrics(meterProvider),
+	)
+
+	return limiter.Allow
+}
+
+// workloadIssuerBudget charges one lookup against a scope's ceiling. A
+// function rather than *ratelimit.Limiter so refusal and outage are testable
+// without the store; production passes (*ratelimit.Limiter).Allow.
+//
+// !Allowed is a decision the budget made; an error is it failing to make one.
+type workloadIssuerBudget func(ctx context.Context, scope string) (ratelimit.Result, error)
+
+// workloadIssuerLookup resolves an iss to the workload issuer row the
+// endpoint's tenant registered for it, false when none does. The endpoint is
+// the input because it names the tenancy the resolution runs against.
+//
+// The whole row rather than its id, because workloadIssuerKeySource reads
+// jwks_uri off it. A value that is not an issuer identifier is reported as an
+// error wrapping errWorkloadIssuerURLInvalid, before the store is consulted.
+type workloadIssuerLookup func(ctx context.Context, endpoint *ResolvedMcpEndpoint, issuerURL string) (workloadidentity_repo.WorkloadIssuer, bool, error)
+
+// workloadIssuerAdmission resolves an assertion's issuer to the row that
+// describes it.
+//
+// Safe for concurrent use; build one at wiring time.
+type workloadIssuerAdmission struct {
+	lookup workloadIssuerLookup
+
+	// inflight collapses concurrent resolutions of one key onto a single
+	// lookup. In-process is all it needs to be: it bounds a simultaneous
+	// burst, sustained load is the limiter's job.
+	inflight singleflight.Group
+
+	// charge bounds lookups reaching the database. Nil means no ceiling was
+	// wired, which admission treats as unprotected rather than unlimited.
+	charge workloadIssuerBudget
+}
+
+func newWorkloadIssuerAdmission(lookup workloadIssuerLookup, charge workloadIssuerBudget) *workloadIssuerAdmission {
+	return &workloadIssuerAdmission{
+		lookup:   lookup,
+		inflight: singleflight.Group{},
+		charge:   charge,
+	}
+}
+
+// workloadIssuerLookupScope names the budget an endpoint's lookups are charged
+// to: the authorization server's identifier, so no endpoint spends another's.
+//
+// A denial-of-service bound, deliberately not the tenancy the lookup resolves
+// against, so a flood at one of a tenant's servers cannot starve the rest.
+//
+// Never the issuer URL, which two organizations may share, and never anything
+// derived from the request, which would let a caller mint a fresh budget by
+// varying what it sends.
+func workloadIssuerLookupScope(endpoint *ResolvedMcpEndpoint) string {
+	return "workload-issuer-lookup:" + endpoint.UserSessionIssuerID.String()
+}
+
+// workloadIssuerResolution carries a lookup's result through singleflight, so
+// every sharer of a call sees the same row.
+type workloadIssuerResolution struct {
+	issuer workloadidentity_repo.WorkloadIssuer
+}
+
+// admit resolves issuerURL to the issuer row it names, or reports
+// errWorkloadIssuerUntrusted.
+//
+// Nothing here fetches, so an unrecognised iss cannot become an outbound
+// request. A rejection costs one indexed SELECT, bounded anyway because this
+// grant is reachable without credentials.
+func (a *workloadIssuerAdmission) admit(ctx context.Context, endpoint *ResolvedMcpEndpoint, issuerURL string) (workloadidentity_repo.WorkloadIssuer, error) {
+	ch := a.inflight.DoChan(workloadIssuerFlightKey(endpoint, issuerURL), func() (any, error) {
+		// Detached from the caller that opened the flight: values carry
+		// through, cancellation does not. Tying the flight's lifetime to that
+		// one caller would hand context.Canceled to everyone sharing the
+		// lookup the moment it went away. The caller keeps its own
+		// cancellation through the select below; what bounds the flight is
+		// this timeout.
+		lookupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), workloadIssuerLookupTimeout)
+		defer cancel()
+
+		// Charged before the query, so a refusal costs only the bucket read.
+		if a.charge == nil {
+			return nil, errWorkloadIssuerLimiterUnavailable
+		}
+		charged, chargeErr := a.charge(lookupCtx, workloadIssuerLookupScope(endpoint))
+		if chargeErr != nil {
+			return nil, fmt.Errorf("%w: %w", errWorkloadIssuerLimiterUnavailable, chargeErr)
+		}
+		if !charged.Allowed {
+			return nil, fmt.Errorf("%w: retry after %s", errWorkloadIssuerLookupRateLimited, charged.RetryAfter)
+		}
+
+		issuer, found, lookupErr := a.lookup(lookupCtx, endpoint, issuerURL)
+		switch {
+		case errors.Is(lookupErr, errWorkloadIssuerURLInvalid):
+			// No row could ever describe it. Reported as untrusted with the
+			// parse failure wrapped, so a caller can tell a malformed iss from
+			// an unknown one without the two answering differently on the wire.
+			return nil, fmt.Errorf("%w: %w", errWorkloadIssuerUntrusted, lookupErr)
+		case lookupErr != nil:
+			return nil, fmt.Errorf("resolve workload issuer: %w", lookupErr)
+		case !found:
+			return nil, errWorkloadIssuerUntrusted
+		}
+		return workloadIssuerResolution{issuer: issuer}, nil
+	})
+
+	select {
+	case <-ctx.Done():
+		// This caller gave up; the flight carries on for whoever else shares
+		// it. Deliberately not errWorkloadIssuerUntrusted — nothing was
+		// decided about this issuer.
+		return workloadidentity_repo.WorkloadIssuer{}, fmt.Errorf("await workload issuer admission: %w", ctx.Err())
+	case res := <-ch:
+		if res.Err != nil {
+			return workloadidentity_repo.WorkloadIssuer{}, res.Err
+		}
+		resolution, ok := res.Val.(workloadIssuerResolution)
+		if !ok {
+			return workloadidentity_repo.WorkloadIssuer{}, fmt.Errorf("resolve workload issuer: unexpected resolution %T", res.Val)
+		}
+		return resolution.issuer, nil
+	}
+}
+
+// workloadIssuerFlightKey identifies one in-flight lookup.
+//
+// Two callers share a key exactly when they would share a result, so the key is
+// what the lookup consumes: the tenancy it resolves under and the spelling it
+// resolves. Tenancy is the organization and project, not the user session
+// issuer — one issuer can back endpoints in different projects.
+//
+// Keyed on the supplied spelling rather than a canonical form: lookup matches a
+// closed set of spellings, so a row stored as https://IDP.example.com is not
+// found by a request spelling it in lowercase.
+//
+// Hashed and length-prefixed, as replay.Key is, because the spelling arrives
+// unauthenticated under no length bound.
+func workloadIssuerFlightKey(endpoint *ResolvedMcpEndpoint, issuerURL string) string {
+	sum := sha256.New()
+	for _, part := range []string{endpoint.OrganizationID, endpoint.ProjectID.String(), issuerURL} {
+		sum.Write([]byte(strconv.Itoa(len(part))))
+		sum.Write([]byte(":"))
+		sum.Write([]byte(part))
+	}
+	return base64.RawURLEncoding.EncodeToString(sum.Sum(nil))
+}

--- a/server/internal/mcp/authnchallenge_workloadallowlist_internal_test.go
+++ b/server/internal/mcp/authnchallenge_workloadallowlist_internal_test.go
@@ -1,0 +1,396 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/ratelimit"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	workloadidentity_repo "github.com/speakeasy-api/gram/server/internal/workloadidentity/repo"
+)
+
+// workloadTenantEndpoint names the tenancy an admission resolves under, which
+// is what the flight key is built from.
+func workloadTenantEndpoint(organizationID string, projectID, issuerID uuid.UUID) *ResolvedMcpEndpoint {
+	return &ResolvedMcpEndpoint{
+		OrganizationID:      organizationID,
+		ProjectID:           projectID,
+		UserSessionIssuerID: issuerID,
+	}
+}
+
+// workloadTestTenant is a fresh, fully distinct tenancy.
+func workloadTestTenant() *ResolvedMcpEndpoint {
+	return workloadTenantEndpoint(uuid.NewString(), uuid.New(), uuid.New())
+}
+
+// newWorkloadTestAdmission builds admission with no store behind it. There is
+// nothing to isolate between parallel tests: the only shared state is the
+// in-process flight map, and each test builds its own.
+func newWorkloadTestAdmission(t *testing.T, lookup workloadIssuerLookup, charge workloadIssuerBudget) *workloadIssuerAdmission {
+	t.Helper()
+
+	return newWorkloadIssuerAdmission(lookup, charge)
+}
+
+// countingLookup records every call so a test can assert what the miss path
+// did and did not consult. The counter is atomic because the concurrency test
+// calls it from many goroutines at once.
+type countingLookup struct {
+	calls atomic.Int64
+	// running and peak track how many lookups are inside the function at once,
+	// so a test can assert the slot bound rather than infer it from timing.
+	running atomic.Int64
+	peak    atomic.Int64
+	// release, when non-nil, holds the lookup open until the test closes it,
+	// so a test can guarantee callers pile up behind one in-flight call.
+	release chan struct{}
+	issuer  workloadidentity_repo.WorkloadIssuer
+	found   bool
+	err     error
+}
+
+func (l *countingLookup) fn() workloadIssuerLookup {
+	return func(_ context.Context, _ *ResolvedMcpEndpoint, _ string) (workloadidentity_repo.WorkloadIssuer, bool, error) {
+		l.calls.Add(1)
+		l.enter()
+		defer l.running.Add(-1)
+
+		if l.release != nil {
+			<-l.release
+		}
+		return l.issuer, l.found, l.err
+	}
+}
+
+// enter records one more concurrent lookup, raising the high-water mark.
+func (l *countingLookup) enter() {
+	running := l.running.Add(1)
+	for {
+		peak := l.peak.Load()
+		if running <= peak || l.peak.CompareAndSwap(peak, running) {
+			return
+		}
+	}
+}
+
+func TestWorkloadIssuerAdmission_TrustedIssuerResolves(t *testing.T) {
+	t.Parallel()
+
+	want := workloadidentity_repo.WorkloadIssuer{ID: uuid.New(), Name: "gh-actions", JwksUri: "https://token.actions.example.test/jwks"}
+	lookup := &countingLookup{issuer: want, found: true}
+	admission := newWorkloadTestAdmission(t, lookup.fn(), allowAllWorkloadLookups)
+
+	got, err := admission.admit(t.Context(), workloadTestTenant(), "https://token.actions.example.test")
+
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+// The core property of this ticket: an issuer nobody trusts is rejected
+// without a key source ever being built, so nothing downstream can turn a
+// request-supplied URL into an outbound fetch.
+func TestWorkloadIssuerAdmission_UntrustedIssuerRejectedWithoutEgress(t *testing.T) {
+	t.Parallel()
+
+	lookup := &countingLookup{found: false}
+	admission := newWorkloadTestAdmission(t, lookup.fn(), allowAllWorkloadLookups)
+
+	row, err := admission.admit(t.Context(), workloadTestTenant(), "https://attacker.example.test")
+
+	require.ErrorIs(t, err, errWorkloadIssuerUntrusted)
+	require.Equal(t, workloadidentity_repo.WorkloadIssuer{}, row, "a rejected issuer must yield no row, so no key source can be built from it")
+}
+
+// Without coordination, callers arriving together each cost a query. The
+// limiter bounds sustained load; this is what bounds a simultaneous burst.
+func TestWorkloadIssuerAdmission_ConcurrentMissesCollapseToOneLookup(t *testing.T) {
+	t.Parallel()
+
+	const callers = 32
+
+	lookup := &countingLookup{found: false, release: make(chan struct{})}
+	admission := newWorkloadTestAdmission(t, lookup.fn(), allowAllWorkloadLookups)
+	endpoint := workloadTestTenant()
+
+	// Held inside admit: one caller occupies the lookup, the rest join it.
+	var waiting atomic.Int64
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Go(func() {
+			waiting.Add(1)
+			defer waiting.Add(-1)
+			_, err := admission.admit(t.Context(), endpoint, "https://attacker.example.test")
+			require.ErrorIs(t, err, errWorkloadIssuerUntrusted)
+		})
+	}
+
+	// Every caller is inside admit before any of them is allowed to finish,
+	// so the burst is genuinely simultaneous rather than accidentally serial.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.EqualValues(c, callers, waiting.Load())
+	}, 5*time.Second, time.Millisecond)
+
+	close(lookup.release)
+	wg.Wait()
+
+	require.EqualValues(t, 1, lookup.calls.Load(), "concurrent rejections of one issuer must share a single lookup")
+}
+
+// Detaching the flight must not cost the caller its own cancellation. A client
+// that disconnects has to stop waiting immediately, while the flight it opened
+// carries on for anyone sharing it and still records what it found.
+func TestWorkloadIssuerAdmission_AbandonedCallerStopsWaitingButFlightFinishes(t *testing.T) {
+	t.Parallel()
+
+	const issuerURL = "https://attacker.example.test"
+
+	lookup := &countingLookup{found: false, release: make(chan struct{})}
+	admission := newWorkloadTestAdmission(t, lookup.fn(), allowAllWorkloadLookups)
+	endpoint := workloadTestTenant()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	var abandoned error
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, abandoned = admission.admit(ctx, endpoint, issuerURL)
+	}()
+
+	// The flight is inside the held-open lookup before the caller gives up, so
+	// this abandons work that is genuinely still running.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.EqualValues(c, 1, lookup.running.Load())
+	}, 5*time.Second, time.Millisecond)
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("a caller that gave up was left waiting on the flight it opened")
+	}
+
+	require.ErrorIs(t, abandoned, context.Canceled)
+	require.NotErrorIs(t, abandoned, errWorkloadIssuerUntrusted, "giving up decides nothing about the issuer, and must not be reported as a rejection")
+
+	// The flight runs to completion on its own timeout rather than being
+	// torn down with the caller that opened it. Releasing the lookup lets it
+	// finish; nothing restarts it.
+	close(lookup.release)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.EqualValues(c, 0, lookup.running.Load(), "the abandoned flight must finish rather than hang")
+	}, 5*time.Second, time.Millisecond)
+
+	require.EqualValues(t, 1, lookup.calls.Load(), "a caller giving up must not cause the lookup to run again")
+}
+
+// Two endpoints in different tenancies resolve independently, so one
+// rejection must never answer for the other.
+func TestWorkloadIssuerAdmission_FlightIsNotSharedAcrossTenancies(t *testing.T) {
+	t.Parallel()
+
+	lookup := &countingLookup{found: false}
+	admission := newWorkloadTestAdmission(t, lookup.fn(), allowAllWorkloadLookups)
+
+	const issuerURL = "https://idp.example.test"
+	_, err := admission.admit(t.Context(), workloadTestTenant(), issuerURL)
+	require.ErrorIs(t, err, errWorkloadIssuerUntrusted)
+	_, err = admission.admit(t.Context(), workloadTestTenant(), issuerURL)
+	require.ErrorIs(t, err, errWorkloadIssuerUntrusted)
+
+	require.EqualValues(t, 2, lookup.calls.Load(), "a second tenancy must be resolved on its own, not from the first's miss")
+}
+
+// One user session issuer can back endpoints in different projects: the
+// mcp_servers foreign key to it carries no project pinning, unlike
+// meta_mcp_servers' composite one. Since the lookup resolves under the
+// project, a miss recorded for one must not deny a project-tier trusted
+// issuer in the other.
+func TestWorkloadIssuerAdmission_FlightIsNotSharedAcrossProjectsOnOneIssuer(t *testing.T) {
+	t.Parallel()
+
+	lookup := &countingLookup{found: false}
+	admission := newWorkloadTestAdmission(t, lookup.fn(), allowAllWorkloadLookups)
+
+	organizationID := uuid.NewString()
+	sharedIssuer := uuid.New()
+	const issuerURL = "https://idp.example.test"
+
+	_, err := admission.admit(t.Context(), workloadTenantEndpoint(organizationID, uuid.New(), sharedIssuer), issuerURL)
+	require.ErrorIs(t, err, errWorkloadIssuerUntrusted)
+	_, err = admission.admit(t.Context(), workloadTenantEndpoint(organizationID, uuid.New(), sharedIssuer), issuerURL)
+	require.ErrorIs(t, err, errWorkloadIssuerUntrusted)
+
+	require.EqualValues(t, 2, lookup.calls.Load(), "two projects sharing one issuer must not share a flight")
+}
+
+// A malformed iss is reported as untrusted with the parse failure wrapped, so
+// a caller can tell "could never name a row" from "names no row we hold"
+// without the two answering differently on the wire.
+func TestWorkloadIssuerAdmission_MalformedIssuerKeepsItsReason(t *testing.T) {
+	t.Parallel()
+
+	lookup := &countingLookup{err: fmt.Errorf("%w: no host", errWorkloadIssuerURLInvalid)}
+	admission := newWorkloadTestAdmission(t, lookup.fn(), allowAllWorkloadLookups)
+
+	_, err := admission.admit(t.Context(), workloadTestTenant(), "not-a-url")
+	require.ErrorIs(t, err, errWorkloadIssuerUntrusted)
+	require.ErrorIs(t, err, errWorkloadIssuerURLInvalid)
+}
+
+// The non-obvious half of the key, asserted where it matters rather than only
+// at the key function. Lookup matches a closed candidate set that includes the
+// caller's own spelling, so two inputs sharing a canonical form do not
+// necessarily share a result: collapsing them would let the rejection of one
+// answer for the spelling that would have matched.
+func TestWorkloadIssuerAdmission_SpellingsSharingACanonicalFormResolveSeparately(t *testing.T) {
+	t.Parallel()
+
+	lookup := &countingLookup{found: false}
+	admission := newWorkloadTestAdmission(t, lookup.fn(), allowAllWorkloadLookups)
+	endpoint := workloadTestTenant()
+
+	_, err := admission.admit(t.Context(), endpoint, "https://idp.example.test")
+	require.ErrorIs(t, err, errWorkloadIssuerUntrusted)
+	_, err = admission.admit(t.Context(), endpoint, "https://IDP.example.test")
+	require.ErrorIs(t, err, errWorkloadIssuerUntrusted)
+
+	require.EqualValues(t, 2, lookup.calls.Load(), "a spelling the lookup may resolve differently must be resolved on its own")
+}
+
+// The key must distinguish exactly what the lookup distinguishes: same
+// tenancy and same spelling share an answer, and any difference in either
+// does not.
+func TestWorkloadIssuerFlightKey_SeparatesTenancyAndSpelling(t *testing.T) {
+	t.Parallel()
+
+	organizationID := uuid.NewString()
+	projectID, issuerID := uuid.New(), uuid.New()
+	endpoint := workloadTenantEndpoint(organizationID, projectID, issuerID)
+	const issuerURL = "https://idp.example.test"
+
+	base := workloadIssuerFlightKey(endpoint, issuerURL)
+
+	require.Equal(t, base, workloadIssuerFlightKey(workloadTenantEndpoint(organizationID, projectID, issuerID), issuerURL),
+		"one tenancy and one spelling must produce one key")
+	require.NotEqual(t, base, workloadIssuerFlightKey(workloadTenantEndpoint(organizationID, uuid.New(), issuerID), issuerURL),
+		"a different project resolves differently and must not share a key")
+	require.NotEqual(t, base, workloadIssuerFlightKey(workloadTenantEndpoint(uuid.NewString(), projectID, issuerID), issuerURL),
+		"a different organization resolves differently and must not share a key")
+	require.NotEqual(t, base, workloadIssuerFlightKey(endpoint, "https://IDP.example.test"),
+		"a spelling the lookup may resolve differently must not share a key")
+}
+
+// The issuer spelling arrives unauthenticated under no length bound, so an
+// entry must not grow with it: otherwise the entry cap would bound a count of
+// unbounded strings rather than memory.
+func TestWorkloadIssuerFlightKey_IsFixedSize(t *testing.T) {
+	t.Parallel()
+
+	endpoint := workloadTestTenant()
+
+	short := workloadIssuerFlightKey(endpoint, "https://a.test")
+	long := workloadIssuerFlightKey(endpoint, "https://a.test/"+strings.Repeat("x", 1<<20))
+
+	require.Len(t, long, len(short), "a megabyte of issuer must occupy no more key than a short one")
+}
+
+// allowAllWorkloadLookups is the budget for tests about something other than
+// the budget: every charge succeeds, so admission behaves as it does for an
+// endpoint well inside its ceiling.
+func allowAllWorkloadLookups(context.Context, string) (ratelimit.Result, error) {
+	return ratelimit.Result{Allowed: true, Remaining: 1, RetryAfter: 0}, nil
+}
+
+// The ceiling is the bound this path relies on, so a refusal must be its own
+// answer. Reported as errWorkloadIssuerUntrusted it would tell a caller the
+// issuer was rejected, which is a 401 and a lie; reported as nothing in
+// particular it would surface as a 5xx.
+func TestWorkloadIssuerAdmission_SpentBudgetIsNotATrustDecision(t *testing.T) {
+	t.Parallel()
+
+	lookup := &countingLookup{issuer: workloadidentity_repo.WorkloadIssuer{ID: uuid.New()}, found: true}
+	spent := func(context.Context, string) (ratelimit.Result, error) {
+		return ratelimit.Result{Allowed: false, Remaining: 0, RetryAfter: 3 * time.Second}, nil
+	}
+	admission := newWorkloadTestAdmission(t, lookup.fn(), spent)
+
+	_, err := admission.admit(t.Context(), workloadTestTenant(), "https://idp.example.test")
+
+	require.ErrorIs(t, err, errWorkloadIssuerLookupRateLimited)
+	require.NotErrorIs(t, err, errWorkloadIssuerUntrusted, "a spent budget decides nothing about the issuer")
+	require.EqualValues(t, 0, lookup.calls.Load(), "a refused charge must cost no query")
+}
+
+// An unreachable bucket is not a throttle. Running the lookup anyway would
+// spend exactly the budget the ceiling exists to protect, so it fails closed —
+// and stays distinguishable from a refusal an operator could wait out.
+func TestWorkloadIssuerAdmission_LimiterOutageFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	lookup := &countingLookup{issuer: workloadidentity_repo.WorkloadIssuer{ID: uuid.New()}, found: true}
+	outage := errors.New("redis unreachable")
+	admission := newWorkloadTestAdmission(t, lookup.fn(), func(context.Context, string) (ratelimit.Result, error) {
+		return ratelimit.Result{Allowed: false, Remaining: 0, RetryAfter: 0}, outage
+	})
+
+	_, err := admission.admit(t.Context(), workloadTestTenant(), "https://idp.example.test")
+
+	require.ErrorIs(t, err, errWorkloadIssuerLimiterUnavailable)
+	require.ErrorIs(t, err, outage)
+	require.NotErrorIs(t, err, errWorkloadIssuerLookupRateLimited, "an outage must not read as a rate limit")
+	require.EqualValues(t, 0, lookup.calls.Load(), "an unbounded lookup is exactly what the ceiling prevents")
+}
+
+// A ceiling that was never wired leaves this path with no bound at all. On a
+// grant reachable without credentials that is the condition the bound exists
+// for, so it refuses rather than running unprotected.
+func TestWorkloadIssuerAdmission_AbsentBudgetRefuses(t *testing.T) {
+	t.Parallel()
+
+	lookup := &countingLookup{issuer: workloadidentity_repo.WorkloadIssuer{ID: uuid.New()}, found: true}
+	admission := newWorkloadTestAdmission(t, lookup.fn(), nil)
+
+	_, err := admission.admit(t.Context(), workloadTestTenant(), "https://idp.example.test")
+
+	require.ErrorIs(t, err, errWorkloadIssuerLimiterUnavailable)
+	require.EqualValues(t, 0, lookup.calls.Load())
+}
+
+// The budget is per endpoint, which is the property that keeps a mitigation
+// from becoming a cross-tenant denial surface: one endpoint's spend must never
+// be charged against another's.
+func TestWorkloadIssuerLookupScope_SeparatesEndpoints(t *testing.T) {
+	t.Parallel()
+
+	issuerID := uuid.New()
+	shared := workloadTenantEndpoint(uuid.NewString(), uuid.New(), issuerID)
+
+	require.Equal(t, workloadIssuerLookupScope(shared),
+		workloadIssuerLookupScope(workloadTenantEndpoint(uuid.NewString(), uuid.New(), issuerID)),
+		"one authorization server is one budget, whatever project addresses it")
+	require.NotEqual(t, workloadIssuerLookupScope(shared), workloadIssuerLookupScope(workloadTestTenant()),
+		"a different endpoint must not spend this one's budget")
+	require.NotEqual(t, workloadIssuerLookupScope(shared), workloadFetchScope(shared),
+		"key fetches and admission lookups bound different resources and must not share a bucket")
+}
+
+// Without a store there are no buckets, and admission must not read that as
+// permission to run unbounded.
+func TestNewWorkloadIssuerLookupBudget_NilWithoutAStore(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, newWorkloadIssuerLookupBudget(nil, testenv.NewMeterProvider(t)),
+		"no store means no ceiling, which admission refuses rather than ignores")
+}

--- a/server/internal/mcp/authnchallenge_workloadauth.go
+++ b/server/internal/mcp/authnchallenge_workloadauth.go
@@ -19,9 +19,10 @@ import (
 // keys and never registers them with us. jwks_uri is stored on the row at
 // discovery time, so nothing is fetched or probed here.
 //
-// jwks_uri is NOT NULL on workload_issuers, so the empty check guards a row
-// that should not exist rather than an operator error. Errors name the issuer
-// by name; a workload issuer has no slug, its URL being its canonical name.
+// jwks_uri is NOT NULL on workload_issuers but carries no non-empty CHECK, so
+// the empty check guards invalid persisted data rather than an unstorable row.
+// Errors name the issuer by name; a workload issuer has no slug, its URL being
+// its canonical name.
 func workloadIssuerKeySource(endpoint *ResolvedMcpEndpoint, issuer *workloadidentity_repo.WorkloadIssuer) (jwks.Source, error) {
 	if issuer.JwksUri == "" {
 		return jwks.Source{}, fmt.Errorf("workload issuer %q records no jwks_uri", issuer.Name)

--- a/server/internal/mcp/authnchallenge_workloadauth.go
+++ b/server/internal/mcp/authnchallenge_workloadauth.go
@@ -12,22 +12,16 @@ import (
 	workloadidentity_repo "github.com/speakeasy-api/gram/server/internal/workloadidentity/repo"
 )
 
-// workloadIssuerKeySource builds the key source a trusted workload issuer's
-// assertions verify against.
+// workloadIssuerKeySource builds the key source a workload issuer's assertions
+// verify against.
 //
-// Only one shape exists here, unlike clientKeySource's two: a workload
-// issuer publishes its keys and never registers them with us, so there is no
-// inline key set to consider. The jwks_uri arrives on the row from the RFC
-// 8414 / OIDC discovery the management API runs when an issuer is created or
-// refreshed, which is why nothing is fetched or probed on this path.
+// One shape only, unlike clientKeySource's two: a workload issuer publishes its
+// keys and never registers them with us. jwks_uri is stored on the row at
+// discovery time, so nothing is fetched or probed here.
 //
-// The row comes from workloadidentity.ResolveIssuerByURL, where jwks_uri is
-// NOT NULL by construction: a workload issuer that can verify nothing must
-// not be storable. The empty check below is therefore a guard against a row
-// that should not exist rather than an operator error to explain, and names
-// the issuer by name because that is the identifier an operator works with.
-// A workload issuer has no slug: its issuer URL is already its canonical
-// machine-readable name.
+// jwks_uri is NOT NULL on workload_issuers, so the empty check guards a row
+// that should not exist rather than an operator error. Errors name the issuer
+// by name; a workload issuer has no slug, its URL being its canonical name.
 func workloadIssuerKeySource(endpoint *ResolvedMcpEndpoint, issuer *workloadidentity_repo.WorkloadIssuer) (jwks.Source, error) {
 	if issuer.JwksUri == "" {
 		return jwks.Source{}, fmt.Errorf("workload issuer %q records no jwks_uri", issuer.Name)

--- a/server/internal/mcp/authnchallenge_workloadauth.go
+++ b/server/internal/mcp/authnchallenge_workloadauth.go
@@ -8,8 +8,8 @@ package mcp
 import (
 	"fmt"
 
-	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 	"github.com/speakeasy-api/gram/server/internal/usersessions/jwks"
+	workloadidentity_repo "github.com/speakeasy-api/gram/server/internal/workloadidentity/repo"
 )
 
 // workloadIssuerKeySource builds the key source a trusted workload issuer's
@@ -21,19 +21,21 @@ import (
 // 8414 / OIDC discovery the management API runs when an issuer is created or
 // refreshed, which is why nothing is fetched or probed on this path.
 //
-// An issuer row with no jwks_uri is a setup error, not a bad assertion, and
-// says so: discovery either never ran or the issuer's document omitted the
-// field. Answering it like a rejected workload would send an operator
-// hunting through their platform's configuration for a problem that is on
-// ours.
-func workloadIssuerKeySource(endpoint *ResolvedMcpEndpoint, issuer *remotesessions_repo.RemoteSessionIssuer) (jwks.Source, error) {
-	if !issuer.JwksUri.Valid || issuer.JwksUri.String == "" {
-		return jwks.Source{}, fmt.Errorf("trusted issuer %q records no jwks_uri: re-run discovery for it", issuer.Slug)
+// The row comes from workloadidentity.ResolveIssuerByURL, where jwks_uri is
+// NOT NULL by construction: a workload issuer that can verify nothing must
+// not be storable. The empty check below is therefore a guard against a row
+// that should not exist rather than an operator error to explain, and names
+// the issuer by name because that is the identifier an operator works with.
+// A workload issuer has no slug: its issuer URL is already its canonical
+// machine-readable name.
+func workloadIssuerKeySource(endpoint *ResolvedMcpEndpoint, issuer *workloadidentity_repo.WorkloadIssuer) (jwks.Source, error) {
+	if issuer.JwksUri == "" {
+		return jwks.Source{}, fmt.Errorf("workload issuer %q records no jwks_uri", issuer.Name)
 	}
 
-	source, err := jwks.NewRemoteSource(issuer.JwksUri.String)
+	source, err := jwks.NewRemoteSource(issuer.JwksUri)
 	if err != nil {
-		return jwks.Source{}, fmt.Errorf("trusted issuer %q jwks_uri: %w", issuer.Slug, err)
+		return jwks.Source{}, fmt.Errorf("workload issuer %q jwks_uri: %w", issuer.Name, err)
 	}
 
 	return source.WithFetchScope(workloadFetchScope(endpoint)), nil

--- a/server/internal/mcp/authnchallenge_workloadauth_internal_test.go
+++ b/server/internal/mcp/authnchallenge_workloadauth_internal_test.go
@@ -30,11 +30,8 @@ func TestWorkloadIssuerKeySource_BuildsRemoteSource(t *testing.T) {
 	require.Equal(t, "https://example.test/keys", source.CacheKey(), "the cache key is the jwks_uri, shared across every scope naming it")
 }
 
-// TestWorkloadIssuerKeySource_EmptyJwksURIIsRefused pins the guard rather than
-// an operator-facing path: jwks_uri is NOT NULL on workload_issuers, so a row
-// reaching here without one did not come from the table. The check earns its
-// place by refusing to build a source that could verify nothing, and it names
-// the issuer so an impossible row is still identifiable.
+// Pins the guard, not an operator-facing path: jwks_uri is NOT NULL, so a row
+// reaching here without one did not come from the table.
 func TestWorkloadIssuerKeySource_EmptyJwksURIIsRefused(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/mcp/authnchallenge_workloadauth_internal_test.go
+++ b/server/internal/mcp/authnchallenge_workloadauth_internal_test.go
@@ -4,18 +4,17 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
-	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	workloadidentity_repo "github.com/speakeasy-api/gram/server/internal/workloadidentity/repo"
 )
 
 func workloadTestEndpoint(issuerID uuid.UUID) *ResolvedMcpEndpoint {
 	return &ResolvedMcpEndpoint{UserSessionIssuerID: issuerID}
 }
 
-func workloadTestIssuer(slug string, jwksURI pgtype.Text) *remotesessions_repo.RemoteSessionIssuer {
-	return &remotesessions_repo.RemoteSessionIssuer{Slug: slug, JwksUri: jwksURI}
+func workloadTestIssuer(name string, jwksURI string) *workloadidentity_repo.WorkloadIssuer {
+	return &workloadidentity_repo.WorkloadIssuer{Name: name, JwksUri: jwksURI}
 }
 
 func TestWorkloadIssuerKeySource_BuildsRemoteSource(t *testing.T) {
@@ -24,38 +23,28 @@ func TestWorkloadIssuerKeySource_BuildsRemoteSource(t *testing.T) {
 	issuerID := uuid.New()
 	source, err := workloadIssuerKeySource(
 		workloadTestEndpoint(issuerID),
-		workloadTestIssuer("gh-actions", pgtype.Text{String: "https://example.test/keys", Valid: true}),
+		workloadTestIssuer("gh-actions", "https://example.test/keys"),
 	)
 
 	require.NoError(t, err)
 	require.Equal(t, "https://example.test/keys", source.CacheKey(), "the cache key is the jwks_uri, shared across every scope naming it")
 }
 
-func TestWorkloadIssuerKeySource_MissingJwksURIIsASetupError(t *testing.T) {
+// TestWorkloadIssuerKeySource_EmptyJwksURIIsRefused pins the guard rather than
+// an operator-facing path: jwks_uri is NOT NULL on workload_issuers, so a row
+// reaching here without one did not come from the table. The check earns its
+// place by refusing to build a source that could verify nothing, and it names
+// the issuer so an impossible row is still identifiable.
+func TestWorkloadIssuerKeySource_EmptyJwksURIIsRefused(t *testing.T) {
 	t.Parallel()
 
-	for _, tt := range []struct {
-		name    string
-		jwksURI pgtype.Text
-	}{
-		{name: "null", jwksURI: pgtype.Text{String: "", Valid: false}},
-		{name: "empty", jwksURI: pgtype.Text{String: "", Valid: true}},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+	_, err := workloadIssuerKeySource(
+		workloadTestEndpoint(uuid.New()),
+		workloadTestIssuer("gh-actions", ""),
+	)
 
-			_, err := workloadIssuerKeySource(
-				workloadTestEndpoint(uuid.New()),
-				workloadTestIssuer("gh-actions", tt.jwksURI),
-			)
-
-			require.Error(t, err)
-			// The message has to name the issuer and point at discovery: this
-			// is our configuration gap, not the caller's assertion.
-			require.ErrorContains(t, err, "gh-actions")
-			require.ErrorContains(t, err, "re-run discovery")
-		})
-	}
+	require.Error(t, err)
+	require.ErrorContains(t, err, "gh-actions")
 }
 
 func TestWorkloadIssuerKeySource_RejectsUnusableJwksURI(t *testing.T) {
@@ -63,7 +52,7 @@ func TestWorkloadIssuerKeySource_RejectsUnusableJwksURI(t *testing.T) {
 
 	_, err := workloadIssuerKeySource(
 		workloadTestEndpoint(uuid.New()),
-		workloadTestIssuer("gh-actions", pgtype.Text{String: "http://example.test/keys", Valid: true}),
+		workloadTestIssuer("gh-actions", "http://example.test/keys"),
 	)
 
 	require.Error(t, err, "plain http must not become a key source")

--- a/server/internal/mcp/authnchallenge_workloadauth_internal_test.go
+++ b/server/internal/mcp/authnchallenge_workloadauth_internal_test.go
@@ -30,8 +30,8 @@ func TestWorkloadIssuerKeySource_BuildsRemoteSource(t *testing.T) {
 	require.Equal(t, "https://example.test/keys", source.CacheKey(), "the cache key is the jwks_uri, shared across every scope naming it")
 }
 
-// Pins the guard, not an operator-facing path: jwks_uri is NOT NULL, so a row
-// reaching here without one did not come from the table.
+// Pins the guard: jwks_uri is NOT NULL but carries no non-empty CHECK, so an
+// empty one is storable and has to be refused here.
 func TestWorkloadIssuerKeySource_EmptyJwksURIIsRefused(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
AIM-265

## Summary

`workloadIssuerKeySource` now takes the `workload_issuers` row that `workloadidentity.ResolveIssuerByURL` returns, instead of a `remote_session_issuers` row. No reference to `remote_session_issuers` remains on the workload verification path.

Two changes follow from the new table rather than being decisions made here:

- **The missing-`jwks_uri` branch stops being an operator error.** `jwks_uri` is stored at discovery time and is `NOT NULL`, so there is no discovery gap for the old "re-run discovery" advice to describe. The check stays as a guard over invalid persisted data — `NOT NULL` does not exclude `""`, and unlike `name` the column carries no non-empty `CHECK`.
- **Errors name the issuer by `name`.** A workload issuer has no slug: its issuer URL is already its canonical machine-readable identity.

Fetch scoping and the per-authorization-server budget are untouched.

## Motivation

This shipped in #5840 before the schema reversal and was the last thing on the verification path still bound to the table the project moved off. The key source decides which keys an assertion is verified against, so leaving it pointed at the abandoned table is what stopped the verification milestone closing honestly.

No production caller yet — AIM-259 is the grant that will call it — so this repoints the seam before anything depends on the wrong shape of it.

