### PR TITLE
feat: store-backed workload identity lookup

### DIFF
--- a/.changeset/workload-identity-admission-lookup.md
+++ b/.changeset/workload-identity-admission-lookup.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Read a workload identity's admission from the database, scoped to the caller's own project or the organization above it. Not yet wired to any request path.

--- a/server/internal/workloadidentity/admissionlookup.go
+++ b/server/internal/workloadidentity/admissionlookup.go
@@ -10,20 +10,16 @@ import (
 )
 
 // AdmissionParams addresses one admission check. Every field is part of the
-// key; none of them is optional in the sense that omitting it would widen the
-// search.
+// key; omitting one never widens the search.
 type AdmissionParams struct {
 	// OrganizationID scopes every row considered. Empty admits nothing.
 	OrganizationID string
 	// ProjectID selects the project tier when set. Unset is an
-	// organization-scoped caller, which sees only organization-tier
-	// admissions — a project's own decision never answers it. Same shape and
-	// meaning as ResolveIssuerParams.ProjectID.
+	// organization-scoped caller, which a project's own admission never
+	// answers. Same shape as ResolveIssuerParams.ProjectID.
 	ProjectID uuid.NullUUID
-	// WorkloadIssuerID is the workload_issuers row that vouches for the
-	// subject, never the issuer URL: re-registering an issuer is deliberately
-	// a new identity, and a discovery refresh must not silently repoint an
-	// existing admission.
+	// WorkloadIssuerID is the row that vouches for the subject, never the
+	// issuer URL: a discovery refresh must not repoint an existing admission.
 	WorkloadIssuerID uuid.UUID
 	// Subject is the sub claim the issuer asserted, exactly as it arrived.
 	Subject string
@@ -31,22 +27,16 @@ type AdmissionParams struct {
 
 // IsAdmitted reports whether a tenant recognises one workload as its own.
 //
-// This is the security boundary of the workload grant, and a different
-// question from the one the signature answered. A CI provider's issuer mints
-// genuine, correctly signed assertions for every job on its platform — every
-// one of that provider's other customers included — so a verified assertion
-// says only that the platform minted it. Presence here is what makes the
-// machine ours.
+// The security boundary of the grant. A CI provider signs genuine assertions
+// for every job on its platform, its other customers included, so a verified
+// assertion says only that the platform minted it. Presence here is what makes
+// the machine ours.
 //
-// False and an error are different answers, and a caller must never collapse
-// them. False is a decision. An error is the absence of one: a store outage
-// reported as non-admission would deny workloads that are in fact admitted,
-// and reported as admission would be far worse.
+// False and an error must never be collapsed: false is a decision, an error is
+// the absence of one.
 func IsAdmitted(ctx context.Context, db repo.DBTX, params AdmissionParams) (bool, error) {
-	// Checked before the store rather than left to the query, for the same
-	// reason ResolveIssuerByURL checks its organization: a tenancy or key hole
-	// should not depend on a data property a future seed or fixture could
-	// break. An empty subject must never match a row that happens to hold one.
+	// Checked before the store, like ResolveIssuerByURL's organization: a
+	// tenancy hole should not depend on a data property a seed could break.
 	switch {
 	case params.OrganizationID == "", params.WorkloadIssuerID == uuid.Nil, params.Subject == "":
 		return false, nil

--- a/server/internal/workloadidentity/admissionlookup.go
+++ b/server/internal/workloadidentity/admissionlookup.go
@@ -1,0 +1,66 @@
+package workloadidentity
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/internal/workloadidentity/repo"
+)
+
+// AdmissionParams addresses one admission check. Every field is part of the
+// key; none of them is optional in the sense that omitting it would widen the
+// search.
+type AdmissionParams struct {
+	// OrganizationID scopes every row considered. Empty admits nothing.
+	OrganizationID string
+	// ProjectID selects the project tier when set. Unset is an
+	// organization-scoped caller, which sees only organization-tier
+	// admissions — a project's own decision never answers it. Same shape and
+	// meaning as ResolveIssuerParams.ProjectID.
+	ProjectID uuid.NullUUID
+	// WorkloadIssuerID is the workload_issuers row that vouches for the
+	// subject, never the issuer URL: re-registering an issuer is deliberately
+	// a new identity, and a discovery refresh must not silently repoint an
+	// existing admission.
+	WorkloadIssuerID uuid.UUID
+	// Subject is the sub claim the issuer asserted, exactly as it arrived.
+	Subject string
+}
+
+// IsAdmitted reports whether a tenant recognises one workload as its own.
+//
+// This is the security boundary of the workload grant, and a different
+// question from the one the signature answered. A CI provider's issuer mints
+// genuine, correctly signed assertions for every job on its platform — every
+// one of that provider's other customers included — so a verified assertion
+// says only that the platform minted it. Presence here is what makes the
+// machine ours.
+//
+// False and an error are different answers, and a caller must never collapse
+// them. False is a decision. An error is the absence of one: a store outage
+// reported as non-admission would deny workloads that are in fact admitted,
+// and reported as admission would be far worse.
+func IsAdmitted(ctx context.Context, db repo.DBTX, params AdmissionParams) (bool, error) {
+	// Checked before the store rather than left to the query, for the same
+	// reason ResolveIssuerByURL checks its organization: a tenancy or key hole
+	// should not depend on a data property a future seed or fixture could
+	// break. An empty subject must never match a row that happens to hold one.
+	switch {
+	case params.OrganizationID == "", params.WorkloadIssuerID == uuid.Nil, params.Subject == "":
+		return false, nil
+	}
+
+	admitted, err := repo.New(db).WorkloadIdentityIsAdmitted(ctx, repo.WorkloadIdentityIsAdmittedParams{
+		OrganizationID:   params.OrganizationID,
+		ProjectID:        params.ProjectID,
+		WorkloadIssuerID: params.WorkloadIssuerID,
+		Subject:          params.Subject,
+	})
+	if err != nil {
+		return false, fmt.Errorf("check workload identity admission: %w", err)
+	}
+
+	return admitted, nil
+}

--- a/server/internal/workloadidentity/admissionlookup_test.go
+++ b/server/internal/workloadidentity/admissionlookup_test.go
@@ -12,11 +12,9 @@ import (
 
 const testSubject = "repo:acme/payments-api:ref:refs/heads/main"
 
-// seedAdmission writes one workload_identity_admissions row directly.
-//
-// Raw SQL for the same reason seedIssuer uses it: admitting and withdrawing
-// subjects is the management API's job and lands in a later milestone, while
-// this package is read-only by design.
+// seedAdmission writes one workload_identity_admissions row directly. Raw SQL
+// for the same reason seedIssuer uses it: writes are the management API's job,
+// and this package is read-only by design.
 func seedAdmission(t *testing.T, conn *pgxpool.Pool, organizationID string, projectID uuid.NullUUID, issuerID uuid.UUID, subject string) uuid.UUID {
 	t.Helper()
 
@@ -41,8 +39,7 @@ func withdraw(t *testing.T, conn *pgxpool.Pool, id uuid.UUID) {
 	require.NoError(t, err)
 }
 
-// admissionFixture is one tenant with one issuer, which is the smallest shape
-// an admission needs.
+// admissionFixture is one tenant with one issuer.
 type admissionFixture struct {
 	tenant   tenant
 	issuerID uuid.UUID
@@ -82,8 +79,7 @@ func TestIsAdmitted_AnAdmittedSubjectResolves(t *testing.T) {
 	require.True(t, admitted)
 }
 
-// The security boundary. A verified assertion proves the platform minted it,
-// not that the machine is ours.
+// A verified assertion proves the platform minted it, not that it is ours.
 func TestIsAdmitted_AnUnadmittedSubjectDoesNot(t *testing.T) {
 	t.Parallel()
 
@@ -99,8 +95,7 @@ func TestIsAdmitted_AnUnadmittedSubjectDoesNot(t *testing.T) {
 	require.False(t, admitted)
 }
 
-// Every component is load-bearing: changing any single one of them must not
-// resolve, which is what proves none is being ignored.
+// Changing any single component must not resolve.
 func TestIsAdmitted_EveryComponentOfTheKeyMustMatch(t *testing.T) {
 	t.Parallel()
 
@@ -149,8 +144,7 @@ func TestIsAdmitted_EveryComponentOfTheKeyMustMatch(t *testing.T) {
 	}
 }
 
-// The organization tier is visible to every project beneath it, which is what
-// makes an administrator's admission worth making once.
+// The organization tier is visible to every project beneath it.
 func TestIsAdmitted_TheOrganizationTierAnswersEveryProject(t *testing.T) {
 	t.Parallel()
 
@@ -168,8 +162,7 @@ func TestIsAdmitted_TheOrganizationTierAnswersEveryProject(t *testing.T) {
 	require.True(t, admitted)
 }
 
-// A project admits its own workload without an organization administrator
-// admitting it for them, which is the point of the tier.
+// A project admits its own workload without an organization administrator.
 func TestIsAdmitted_TheProjectTierAnswersItsOwnProject(t *testing.T) {
 	t.Parallel()
 
@@ -184,10 +177,8 @@ func TestIsAdmitted_TheProjectTierAnswersItsOwnProject(t *testing.T) {
 	require.True(t, admitted)
 }
 
-// TestIsAdmitted_ASiblingProjectsAdmissionDoesNot is the isolation the project
-// tier exists for, and the case a lookup keyed on the organization alone
-// silently loses: one team's decision must not admit a workload across the
-// whole organization.
+// The isolation the tier exists for, and the case a lookup keyed on the
+// organization alone silently loses.
 func TestIsAdmitted_ASiblingProjectsAdmissionDoesNot(t *testing.T) {
 	t.Parallel()
 
@@ -203,8 +194,7 @@ func TestIsAdmitted_ASiblingProjectsAdmissionDoesNot(t *testing.T) {
 	require.False(t, admitted)
 }
 
-// An organization-scoped caller names no project, and a project's private
-// admission must not answer it. The two nulls are not the same null.
+// A project's private admission must not answer a caller naming no project.
 func TestIsAdmitted_AnOrganizationScopedCallerSeesOnlyTheOrganizationTier(t *testing.T) {
 	t.Parallel()
 
@@ -229,9 +219,8 @@ func TestIsAdmitted_AnOrganizationScopedCallerSeesOnlyTheOrganizationTier(t *tes
 	require.True(t, admitted)
 }
 
-// A withdrawn admission stops answering. Soft delete is how withdrawal works,
-// so a lookup that ignored it would keep admitting a workload an administrator
-// believes they have removed.
+// Withdrawal is a soft delete; ignoring it would keep admitting a workload an
+// administrator believes they have removed.
 func TestIsAdmitted_AWithdrawnAdmissionDoesNotResolve(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/workloadidentity/admissionlookup_test.go
+++ b/server/internal/workloadidentity/admissionlookup_test.go
@@ -1,0 +1,249 @@
+package workloadidentity_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/workloadidentity"
+)
+
+const testSubject = "repo:acme/payments-api:ref:refs/heads/main"
+
+// seedAdmission writes one workload_identity_admissions row directly.
+//
+// Raw SQL for the same reason seedIssuer uses it: admitting and withdrawing
+// subjects is the management API's job and lands in a later milestone, while
+// this package is read-only by design.
+func seedAdmission(t *testing.T, conn *pgxpool.Pool, organizationID string, projectID uuid.NullUUID, issuerID uuid.UUID, subject string) uuid.UUID {
+	t.Helper()
+
+	var id uuid.UUID
+	err := conn.QueryRow( //nolint:glint // notestingrawsql: no create query exists yet; writes belong to the management API milestone
+		t.Context(), `
+		INSERT INTO workload_identity_admissions
+		  (organization_id, project_id, workload_issuer_id, subject)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id
+	`, organizationID, projectID, issuerID, subject).Scan(&id)
+	require.NoError(t, err)
+
+	return id
+}
+
+func withdraw(t *testing.T, conn *pgxpool.Pool, id uuid.UUID) {
+	t.Helper()
+
+	_, err := conn.Exec( //nolint:glint // notestingrawsql: see seedAdmission
+		t.Context(), `UPDATE workload_identity_admissions SET deleted_at = clock_timestamp() WHERE id = $1`, id)
+	require.NoError(t, err)
+}
+
+// admissionFixture is one tenant with one issuer, which is the smallest shape
+// an admission needs.
+type admissionFixture struct {
+	tenant   tenant
+	issuerID uuid.UUID
+}
+
+func newAdmissionFixture(t *testing.T, conn *pgxpool.Pool) admissionFixture {
+	t.Helper()
+
+	tenant := newTenant(t, conn)
+
+	return admissionFixture{
+		tenant:   tenant,
+		issuerID: seedIssuer(t, conn, tenant.organizationID, organizationTier(), "gh-actions", testIssuerURL, epoch),
+	}
+}
+
+func (f admissionFixture) params() workloadidentity.AdmissionParams {
+	return workloadidentity.AdmissionParams{
+		OrganizationID:   f.tenant.organizationID,
+		ProjectID:        projectTier(f.tenant.projectID),
+		WorkloadIssuerID: f.issuerID,
+		Subject:          testSubject,
+	}
+}
+
+func TestIsAdmitted_AnAdmittedSubjectResolves(t *testing.T) {
+	t.Parallel()
+
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+	fixture := newAdmissionFixture(t, conn)
+	seedAdmission(t, conn, fixture.tenant.organizationID, organizationTier(), fixture.issuerID, testSubject)
+
+	admitted, err := workloadidentity.IsAdmitted(t.Context(), conn, fixture.params())
+
+	require.NoError(t, err)
+	require.True(t, admitted)
+}
+
+// The security boundary. A verified assertion proves the platform minted it,
+// not that the machine is ours.
+func TestIsAdmitted_AnUnadmittedSubjectDoesNot(t *testing.T) {
+	t.Parallel()
+
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+	fixture := newAdmissionFixture(t, conn)
+	// Somebody else's job on the same trusted issuer.
+	seedAdmission(t, conn, fixture.tenant.organizationID, organizationTier(), fixture.issuerID, "repo:someone-else/their-api:ref:refs/heads/main")
+
+	admitted, err := workloadidentity.IsAdmitted(t.Context(), conn, fixture.params())
+
+	require.NoError(t, err)
+	require.False(t, admitted)
+}
+
+// Every component is load-bearing: changing any single one of them must not
+// resolve, which is what proves none is being ignored.
+func TestIsAdmitted_EveryComponentOfTheKeyMustMatch(t *testing.T) {
+	t.Parallel()
+
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+	fixture := newAdmissionFixture(t, conn)
+	seedAdmission(t, conn, fixture.tenant.organizationID, organizationTier(), fixture.issuerID, testSubject)
+
+	other := newTenant(t, conn)
+	otherIssuer := seedIssuer(t, conn, fixture.tenant.organizationID, organizationTier(), "staging", "https://staging.example.test", epoch)
+
+	for name, mutate := range map[string]func(workloadidentity.AdmissionParams) workloadidentity.AdmissionParams{
+		"another organization": func(p workloadidentity.AdmissionParams) workloadidentity.AdmissionParams {
+			p.OrganizationID = other.organizationID
+			return p
+		},
+		"another issuer": func(p workloadidentity.AdmissionParams) workloadidentity.AdmissionParams {
+			p.WorkloadIssuerID = otherIssuer
+			return p
+		},
+		"another subject": func(p workloadidentity.AdmissionParams) workloadidentity.AdmissionParams {
+			p.Subject = testSubject + ":other"
+			return p
+		},
+		"an empty organization": func(p workloadidentity.AdmissionParams) workloadidentity.AdmissionParams {
+			p.OrganizationID = ""
+			return p
+		},
+		"an empty subject": func(p workloadidentity.AdmissionParams) workloadidentity.AdmissionParams {
+			p.Subject = ""
+			return p
+		},
+		"no issuer": func(p workloadidentity.AdmissionParams) workloadidentity.AdmissionParams {
+			p.WorkloadIssuerID = uuid.Nil
+			return p
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			admitted, err := workloadidentity.IsAdmitted(t.Context(), conn, mutate(fixture.params()))
+
+			require.NoError(t, err)
+			require.False(t, admitted, "%s must not resolve against the admitted row", name)
+		})
+	}
+}
+
+// The organization tier is visible to every project beneath it, which is what
+// makes an administrator's admission worth making once.
+func TestIsAdmitted_TheOrganizationTierAnswersEveryProject(t *testing.T) {
+	t.Parallel()
+
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+	fixture := newAdmissionFixture(t, conn)
+	seedAdmission(t, conn, fixture.tenant.organizationID, organizationTier(), fixture.issuerID, testSubject)
+
+	elsewhere := fixture.params()
+	elsewhere.ProjectID = projectTier(newProject(t, conn, fixture.tenant.organizationID))
+
+	admitted, err := workloadidentity.IsAdmitted(t.Context(), conn, elsewhere)
+
+	require.NoError(t, err)
+	require.True(t, admitted)
+}
+
+// A project admits its own workload without an organization administrator
+// admitting it for them, which is the point of the tier.
+func TestIsAdmitted_TheProjectTierAnswersItsOwnProject(t *testing.T) {
+	t.Parallel()
+
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+	fixture := newAdmissionFixture(t, conn)
+	seedAdmission(t, conn, fixture.tenant.organizationID, projectTier(fixture.tenant.projectID), fixture.issuerID, testSubject)
+
+	admitted, err := workloadidentity.IsAdmitted(t.Context(), conn, fixture.params())
+
+	require.NoError(t, err)
+	require.True(t, admitted)
+}
+
+// TestIsAdmitted_ASiblingProjectsAdmissionDoesNot is the isolation the project
+// tier exists for, and the case a lookup keyed on the organization alone
+// silently loses: one team's decision must not admit a workload across the
+// whole organization.
+func TestIsAdmitted_ASiblingProjectsAdmissionDoesNot(t *testing.T) {
+	t.Parallel()
+
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+	fixture := newAdmissionFixture(t, conn)
+	sibling := newProject(t, conn, fixture.tenant.organizationID)
+	seedAdmission(t, conn, fixture.tenant.organizationID, projectTier(sibling), fixture.issuerID, testSubject)
+
+	admitted, err := workloadidentity.IsAdmitted(t.Context(), conn, fixture.params())
+
+	require.NoError(t, err)
+	require.False(t, admitted)
+}
+
+// An organization-scoped caller names no project, and a project's private
+// admission must not answer it. The two nulls are not the same null.
+func TestIsAdmitted_AnOrganizationScopedCallerSeesOnlyTheOrganizationTier(t *testing.T) {
+	t.Parallel()
+
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+	fixture := newAdmissionFixture(t, conn)
+	projectRow := seedAdmission(t, conn, fixture.tenant.organizationID, projectTier(fixture.tenant.projectID), fixture.issuerID, testSubject)
+
+	organizationScoped := fixture.params()
+	organizationScoped.ProjectID = organizationTier()
+
+	admitted, err := workloadidentity.IsAdmitted(t.Context(), conn, organizationScoped)
+	require.NoError(t, err)
+	require.False(t, admitted, "a project's admission must not answer a caller that named no project")
+
+	// The same caller, once the organization itself admits the subject.
+	withdraw(t, conn, projectRow)
+	seedAdmission(t, conn, fixture.tenant.organizationID, organizationTier(), fixture.issuerID, testSubject)
+
+	admitted, err = workloadidentity.IsAdmitted(t.Context(), conn, organizationScoped)
+	require.NoError(t, err)
+	require.True(t, admitted)
+}
+
+// A withdrawn admission stops answering. Soft delete is how withdrawal works,
+// so a lookup that ignored it would keep admitting a workload an administrator
+// believes they have removed.
+func TestIsAdmitted_AWithdrawnAdmissionDoesNotResolve(t *testing.T) {
+	t.Parallel()
+
+	conn, err := infra.CloneTestDatabase(t, "testdb")
+	require.NoError(t, err)
+	fixture := newAdmissionFixture(t, conn)
+	id := seedAdmission(t, conn, fixture.tenant.organizationID, organizationTier(), fixture.issuerID, testSubject)
+
+	withdraw(t, conn, id)
+
+	admitted, err := workloadidentity.IsAdmitted(t.Context(), conn, fixture.params())
+
+	require.NoError(t, err)
+	require.False(t, admitted)
+}

--- a/server/internal/workloadidentity/queries.sql
+++ b/server/internal/workloadidentity/queries.sql
@@ -31,3 +31,34 @@ WHERE issuer = ANY(@issuers::text[])
   AND (project_id = @project_id OR project_id IS NULL)
   AND deleted IS FALSE
 ORDER BY created_at ASC, id ASC;
+
+-- name: WorkloadIdentityIsAdmitted :one
+-- Whether this organization recognises one workload: a subject, vouched for by
+-- one workload issuer row, admitted in the caller's own project or at the
+-- organization tier above it.
+--
+-- EXISTS rather than the row, because the answer is the whole of what admission
+-- needs and returning a row would invite a caller to read something else off it
+-- and widen the security boundary by accident.
+--
+-- The tenancy predicate matches ListWorkloadIssuersByIssuerURL exactly, and for
+-- the same reason: organization_id is checked unconditionally so a project-tier
+-- row cannot answer outside its own organization, and the project arm reads the
+-- caller's project or the organization tier. When @project_id is NULL the
+-- project arm is not true, so an organization-scoped caller sees only
+-- organization-tier admissions — a project's private decision never answers a
+-- caller that named no project.
+--
+-- Exact equality on subject: it arrives from a verified assertion and is
+-- compared as the platform minted it. No pattern, prefix or case folding, and
+-- deliberately no expression around the column, which would make
+-- workload_identity_admissions_lookup_idx unusable.
+SELECT EXISTS (
+  SELECT 1
+  FROM workload_identity_admissions
+  WHERE organization_id = @organization_id
+    AND workload_issuer_id = @workload_issuer_id
+    AND subject = @subject
+    AND (project_id = @project_id OR project_id IS NULL)
+    AND deleted IS FALSE
+);

--- a/server/internal/workloadidentity/queries.sql
+++ b/server/internal/workloadidentity/queries.sql
@@ -33,26 +33,19 @@ WHERE issuer = ANY(@issuers::text[])
 ORDER BY created_at ASC, id ASC;
 
 -- name: WorkloadIdentityIsAdmitted :one
--- Whether this organization recognises one workload: a subject, vouched for by
--- one workload issuer row, admitted in the caller's own project or at the
--- organization tier above it.
+-- Whether this tenant recognises one workload: a subject vouched for by one
+-- issuer row, admitted in the caller's own project or the organization above.
 --
--- EXISTS rather than the row, because the answer is the whole of what admission
--- needs and returning a row would invite a caller to read something else off it
--- and widen the security boundary by accident.
+-- EXISTS rather than the row, so a caller cannot read anything else off it and
+-- widen the security boundary by accident.
 --
--- The tenancy predicate matches ListWorkloadIssuersByIssuerURL exactly, and for
--- the same reason: organization_id is checked unconditionally so a project-tier
--- row cannot answer outside its own organization, and the project arm reads the
--- caller's project or the organization tier. When @project_id is NULL the
--- project arm is not true, so an organization-scoped caller sees only
--- organization-tier admissions — a project's private decision never answers a
--- caller that named no project.
+-- Tenancy matches ListWorkloadIssuersByIssuerURL: organization_id
+-- unconditionally, so a project-tier row cannot answer outside its
+-- organization, and the project arm is not true for a NULL @project_id, so an
+-- organization-scoped caller sees only organization-tier rows.
 --
--- Exact equality on subject: it arrives from a verified assertion and is
--- compared as the platform minted it. No pattern, prefix or case folding, and
--- deliberately no expression around the column, which would make
--- workload_identity_admissions_lookup_idx unusable.
+-- Exact equality on subject, compared as the platform minted it. No expression
+-- around the column, which would make the lookup index unusable.
 SELECT EXISTS (
   SELECT 1
   FROM workload_identity_admissions

--- a/server/internal/workloadidentity/repo/queries.sql.go
+++ b/server/internal/workloadidentity/repo/queries.sql.go
@@ -84,3 +84,54 @@ func (q *Queries) ListWorkloadIssuersByIssuerURL(ctx context.Context, arg ListWo
 	}
 	return items, nil
 }
+
+const workloadIdentityIsAdmitted = `-- name: WorkloadIdentityIsAdmitted :one
+SELECT EXISTS (
+  SELECT 1
+  FROM workload_identity_admissions
+  WHERE organization_id = $1
+    AND workload_issuer_id = $2
+    AND subject = $3
+    AND (project_id = $4 OR project_id IS NULL)
+    AND deleted IS FALSE
+)
+`
+
+type WorkloadIdentityIsAdmittedParams struct {
+	OrganizationID   string
+	WorkloadIssuerID uuid.UUID
+	Subject          string
+	ProjectID        uuid.NullUUID
+}
+
+// Whether this organization recognises one workload: a subject, vouched for by
+// one workload issuer row, admitted in the caller's own project or at the
+// organization tier above it.
+//
+// EXISTS rather than the row, because the answer is the whole of what admission
+// needs and returning a row would invite a caller to read something else off it
+// and widen the security boundary by accident.
+//
+// The tenancy predicate matches ListWorkloadIssuersByIssuerURL exactly, and for
+// the same reason: organization_id is checked unconditionally so a project-tier
+// row cannot answer outside its own organization, and the project arm reads the
+// caller's project or the organization tier. When @project_id is NULL the
+// project arm is not true, so an organization-scoped caller sees only
+// organization-tier admissions — a project's private decision never answers a
+// caller that named no project.
+//
+// Exact equality on subject: it arrives from a verified assertion and is
+// compared as the platform minted it. No pattern, prefix or case folding, and
+// deliberately no expression around the column, which would make
+// workload_identity_admissions_lookup_idx unusable.
+func (q *Queries) WorkloadIdentityIsAdmitted(ctx context.Context, arg WorkloadIdentityIsAdmittedParams) (bool, error) {
+	row := q.db.QueryRow(ctx, workloadIdentityIsAdmitted,
+		arg.OrganizationID,
+		arg.WorkloadIssuerID,
+		arg.Subject,
+		arg.ProjectID,
+	)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}

--- a/server/internal/workloadidentity/repo/queries.sql.go
+++ b/server/internal/workloadidentity/repo/queries.sql.go
@@ -104,26 +104,19 @@ type WorkloadIdentityIsAdmittedParams struct {
 	ProjectID        uuid.NullUUID
 }
 
-// Whether this organization recognises one workload: a subject, vouched for by
-// one workload issuer row, admitted in the caller's own project or at the
-// organization tier above it.
+// Whether this tenant recognises one workload: a subject vouched for by one
+// issuer row, admitted in the caller's own project or the organization above.
 //
-// EXISTS rather than the row, because the answer is the whole of what admission
-// needs and returning a row would invite a caller to read something else off it
-// and widen the security boundary by accident.
+// EXISTS rather than the row, so a caller cannot read anything else off it and
+// widen the security boundary by accident.
 //
-// The tenancy predicate matches ListWorkloadIssuersByIssuerURL exactly, and for
-// the same reason: organization_id is checked unconditionally so a project-tier
-// row cannot answer outside its own organization, and the project arm reads the
-// caller's project or the organization tier. When @project_id is NULL the
-// project arm is not true, so an organization-scoped caller sees only
-// organization-tier admissions — a project's private decision never answers a
-// caller that named no project.
+// Tenancy matches ListWorkloadIssuersByIssuerURL: organization_id
+// unconditionally, so a project-tier row cannot answer outside its
+// organization, and the project arm is not true for a NULL @project_id, so an
+// organization-scoped caller sees only organization-tier rows.
 //
-// Exact equality on subject: it arrives from a verified assertion and is
-// compared as the platform minted it. No pattern, prefix or case folding, and
-// deliberately no expression around the column, which would make
-// workload_identity_admissions_lookup_idx unusable.
+// Exact equality on subject, compared as the platform minted it. No expression
+// around the column, which would make the lookup index unusable.
 func (q *Queries) WorkloadIdentityIsAdmitted(ctx context.Context, arg WorkloadIdentityIsAdmittedParams) (bool, error) {
 	row := q.db.QueryRow(ctx, workloadIdentityIsAdmitted,
 		arg.OrganizationID,


### PR DESCRIPTION
AIM-255

## Summary

The database side of the admission interface #5952 defines and wires empty. One query and the function over it, in `server/internal/workloadidentity` beside `ResolveIssuerByURL`, so both reads on the workload path share one `repo.DBTX`.

`WorkloadIdentityIsAdmitted` returns `EXISTS`, not the row — the boolean is the whole of what admission needs, and returning a row invites a caller to read something else off it.

The tenancy predicate is deliberately identical to the issuer resolver's: `organization_id` unconditionally, so a project-tier row can never answer outside its organization, and a project arm reading the caller's own project or the organization tier. The subject is matched by exact equality, with no expression around the column that would make the lookup index unusable.

## The two nulls

`project_id` is nullable on the table and on the query, and they mean different things — an **unset row** is the organization tier and answers every project, an **unset query** is an organization-scoped caller a project-tier row must not answer. SQL gives this for free: `project_id = @project_id` is not true when the parameter is NULL. Both directions are tested.

## Failing closed before the store

An empty organization, nil issuer or empty subject returns `(false, nil)` without querying, for the same reason `ResolveIssuerByURL` checks its organization: a tenancy hole should not depend on a data property a seed could break. A store error propagates as an error and never as non-admission.

## Motivation

#5952 ships the admission logic with no storage so the security logic stays independently testable. This supplies the store behind it. No production caller yet — AIM-259 is the grant that will call it.

## Stacking

Based on #5952, which defines the types. Deliberately not stacked behind #6282 or #5878: this is the last Urgent item in the verification milestone and only needs those types.
