### PR TITLE
fix: improve project guide onboarding

### DIFF
--- a/client/dashboard/src/components/project-guide/ProjectGuide.test.tsx
+++ b/client/dashboard/src/components/project-guide/ProjectGuide.test.tsx
@@ -17,6 +17,7 @@ import {
 } from "./journeys";
 import {
   LISTEN_TIMEOUT_SECONDS,
+  MCP_SETUP_CONFIRMATION_DELAY_MS,
   PROJECT_GUIDE_MICRO_STEP_DELAY_MS,
 } from "./projectGuideMachine";
 import type {
@@ -230,10 +231,10 @@ describe("ProjectGuide", () => {
     const { rerender } = render(<ProjectGuide />);
 
     fireEvent.click(
-      screen.getByRole("button", { name: /Govern a third-party MCP/ }),
+      screen.getByRole("button", { name: /Deploy an MCP gateway/ }),
     );
     expect(
-      screen.getByRole("heading", { name: "Govern a third-party MCP" }),
+      screen.getByRole("heading", { name: "Deploy an MCP gateway" }),
     ).toBeTruthy();
 
     slugs.current = { orgSlug: "org", projectSlug: "another-project" };
@@ -245,7 +246,7 @@ describe("ProjectGuide", () => {
       }),
     ).toBeTruthy();
     expect(
-      screen.queryByRole("heading", { name: "Govern a third-party MCP" }),
+      screen.queryByRole("heading", { name: "Deploy an MCP gateway" }),
     ).toBeNull();
   });
 
@@ -266,7 +267,9 @@ describe("ProjectGuide", () => {
       }),
     ).toBeTruthy();
     expect(
-      screen.getByRole("button", { name: /Govern a third-party MCP/ }),
+      screen.getByRole("button", {
+        name: "Govern AI data access: Deploy an MCP gateway",
+      }),
     ).toBeTruthy();
     expect(
       screen.getByTestId("project-guide-secret-block-card").textContent,
@@ -288,14 +291,14 @@ describe("ProjectGuide", () => {
     }
   });
 
-  it("animates only journeys that have not started", () => {
+  it("keeps both chooser visuals static regardless of journey progress", () => {
     const { rerender } = render(<ProjectGuide />);
 
     expect(
       screen
         .getByTestId("project-guide-graphic-third-party-mcp")
         .getAttribute("data-animated"),
-    ).toBe("true");
+    ).toBe("false");
 
     statusByJourney.current = {
       "third-party-mcp": "in-progress",
@@ -312,14 +315,14 @@ describe("ProjectGuide", () => {
       screen
         .getByTestId("project-guide-graphic-secret-block")
         .getAttribute("data-animated"),
-    ).toBe("true");
+    ).toBe("false");
   });
 
   it("keeps the other journey switchable when a selected path opens", () => {
     render(<ProjectGuide />);
 
     const openingControl = screen.getByRole("button", {
-      name: /Govern a third-party MCP/,
+      name: /Deploy an MCP gateway/,
     });
     const controlledRegionId = openingControl.getAttribute("aria-controls");
     expect(openingControl.getAttribute("aria-expanded")).toBe("false");
@@ -327,7 +330,7 @@ describe("ProjectGuide", () => {
     fireEvent.click(openingControl);
 
     const activeRegion = screen.getByRole("region", {
-      name: "Govern a third-party MCP",
+      name: "Deploy an MCP gateway",
     });
     expect(activeRegion.id).toBe(controlledRegionId);
     expect(
@@ -354,7 +357,7 @@ describe("ProjectGuide", () => {
     );
 
     expect(
-      screen.getByRole("heading", { name: "Govern a third-party MCP" }),
+      screen.getByRole("heading", { name: "Deploy an MCP gateway" }),
     ).toBeTruthy();
     expect(
       screen.getByRole("button", {
@@ -366,8 +369,9 @@ describe("ProjectGuide", () => {
         "The catalog lists servers from the official MCP Registry. Installing one creates a governed endpoint in front of the vendor's server — the vendor's URL is already known, and nothing upstream changes.",
       ),
     ).toBeTruthy();
-    expect(screen.getByText("Read the server's tool list")).toBeTruthy();
-    expect(screen.getByText("Install it into this project")).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { name: "Pick and set up a server" }),
+    ).toBeTruthy();
     expect(
       screen.getByRole("log", { name: "Journey A activity" }).textContent,
     ).toContain("Ready to start");
@@ -396,7 +400,7 @@ describe("ProjectGuide", () => {
     render(<ProjectGuide />);
 
     fireEvent.click(
-      screen.getByRole("button", { name: /Govern a third-party MCP/ }),
+      screen.getByRole("button", { name: /Deploy an MCP gateway/ }),
     );
     fireEvent.click(screen.getByRole("button", { name: "Start the journey" }));
 
@@ -452,7 +456,7 @@ describe("ProjectGuide", () => {
     render(<ProjectGuide />);
 
     fireEvent.click(
-      screen.getByRole("button", { name: /Govern a third-party MCP/ }),
+      screen.getByRole("button", { name: /Deploy an MCP gateway/ }),
     );
     fireEvent.click(screen.getByRole("button", { name: "Start the journey" }));
 
@@ -484,6 +488,18 @@ describe("ProjectGuide", () => {
       "running",
     );
     await act(() => vi.advanceTimersByTime(PROJECT_GUIDE_MICRO_STEP_DELAY_MS));
+    expect(screen.getByTestId("project-guide-run").dataset.displayState).toBe(
+      "confirming",
+    );
+    expect(activity.textContent).toContain("Linear mcp server is now setup");
+
+    await act(() =>
+      vi.advanceTimersByTime(MCP_SETUP_CONFIRMATION_DELAY_MS - 1),
+    );
+    expect(screen.getByTestId("project-guide-run").dataset.displayState).toBe(
+      "confirming",
+    );
+    await act(() => vi.advanceTimersByTime(1));
     expect(screen.getByTestId("project-guide-run").dataset.displayState).toBe(
       "checkpoint",
     );
@@ -528,7 +544,7 @@ describe("ProjectGuide", () => {
     const view = render(<ProjectGuide />);
 
     fireEvent.click(
-      screen.getByRole("button", { name: /Govern a third-party MCP/ }),
+      screen.getByRole("button", { name: /Deploy an MCP gateway/ }),
     );
     fireEvent.click(screen.getByRole("button", { name: "Start the journey" }));
     await advanceGuideDelay();
@@ -633,7 +649,7 @@ describe("ProjectGuide", () => {
 
     render(<ProjectGuide />);
     fireEvent.click(
-      screen.getByRole("button", { name: /Govern a third-party MCP/ }),
+      screen.getByRole("button", { name: /Deploy an MCP gateway/ }),
     );
     fireEvent.click(screen.getByRole("button", { name: "Start the journey" }));
     await advanceGuideDelay();
@@ -659,13 +675,12 @@ describe("ProjectGuide", () => {
       screen.getByRole("log", { name: "Journey A activity" }).textContent,
     ).toContain("Linear mcp server is now setup");
 
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "Server is installed",
-      }),
+    expect(screen.getByTestId("project-guide-run").dataset.displayState).toBe(
+      "confirming",
     );
+    await act(() => vi.advanceTimersByTime(MCP_SETUP_CONFIRMATION_DELAY_MS));
     expect(
-      screen.getByRole("heading", { name: "Ask the agent to list the tools" }),
+      screen.getByRole("heading", { name: "Connect your client" }),
     ).toBeTruthy();
     expect(
       mcpOperations.current.prepareActivityBaseline,
@@ -678,7 +693,7 @@ describe("ProjectGuide", () => {
     render(<ProjectGuide />);
 
     fireEvent.click(
-      screen.getByRole("button", { name: /Govern a third-party MCP/ }),
+      screen.getByRole("button", { name: /Deploy an MCP gateway/ }),
     );
     fireEvent.click(
       screen.getByRole("button", {
@@ -788,7 +803,7 @@ describe("ProjectGuide", () => {
 
     const view = render(<ProjectGuide />);
     fireEvent.click(
-      screen.getByRole("button", { name: /Govern a third-party MCP/ }),
+      screen.getByRole("button", { name: /Deploy an MCP gateway/ }),
     );
     fireEvent.click(screen.getByRole("button", { name: "Start the journey" }));
     await advanceGuideDelay();
@@ -852,7 +867,7 @@ describe("ProjectGuide", () => {
 
     const view = render(<ProjectGuide />);
     fireEvent.click(
-      screen.getByRole("button", { name: /Govern a third-party MCP/ }),
+      screen.getByRole("button", { name: /Deploy an MCP gateway/ }),
     );
     fireEvent.click(screen.getByRole("button", { name: "Start the journey" }));
     await advanceGuideDelay();
@@ -950,7 +965,7 @@ describe("ProjectGuide", () => {
     );
     expect(
       screen.getByText(
-        "Run the command below to install the observability plugin, then restart your agent so its activity can stream into this project.",
+        "Run the command below to install the observability plugin, then restart your agent so prompts can be inspected by this project's policies.",
       ),
     ).toBeTruthy();
     expect(screen.queryByText(/Your turn · Add it to your agent/)).toBeNull();
@@ -982,7 +997,7 @@ describe("ProjectGuide", () => {
     render(<ProjectGuide />);
 
     fireEvent.click(
-      screen.getByRole("button", { name: /Govern a third-party MCP/ }),
+      screen.getByRole("button", { name: /Deploy an MCP gateway/ }),
     );
     fireEvent.click(screen.getByRole("button", { name: "Start the journey" }));
     await advanceGuideDelay();
@@ -1028,7 +1043,7 @@ describe("ProjectGuide", () => {
     expect(screen.getByText("Coordinator output line")).toBeTruthy();
     expect(screen.getByText("Coordinator event card")).toBeTruthy();
     expect(
-      screen.getByRole("region", { name: "Govern a third-party MCP" }).id,
+      screen.getByRole("region", { name: "Deploy an MCP gateway" }).id,
     ).toBe("fixture-run");
 
     fireEvent.click(screen.getByRole("button", { name: "Continue run" }));
@@ -1080,7 +1095,7 @@ describe("ProjectGuide", () => {
   it.each([
     {
       journey: PROJECT_GUIDE_JOURNEYS[1]!,
-      title: "Govern a third-party MCP",
+      title: "Deploy an MCP gateway",
     },
     {
       journey: PROJECT_GUIDE_JOURNEYS[0]!,
@@ -1092,7 +1107,9 @@ describe("ProjectGuide", () => {
       statusByJourney.current[journey.id] = "in-progress";
       render(<ProjectGuide />);
 
-      fireEvent.click(screen.getByRole("button", { name: title }));
+      fireEvent.click(
+        screen.getByRole("button", { name: `${journey.headline}: ${title}` }),
+      );
       fireEvent.click(
         screen.getByRole("button", {
           name: `Rewind to ${journey.steps[0]}`,
@@ -1184,7 +1201,7 @@ describe("ProjectGuide", () => {
     render(<ProjectGuide />);
 
     fireEvent.click(
-      screen.getByRole("button", { name: /Govern a third-party MCP/ }),
+      screen.getByRole("button", { name: /Deploy an MCP gateway/ }),
     );
 
     expect(
@@ -1248,7 +1265,7 @@ describe("ProjectGuide", () => {
     render(<ProjectGuide />);
 
     fireEvent.click(
-      screen.getByRole("button", { name: /Govern a third-party MCP/ }),
+      screen.getByRole("button", { name: /Deploy an MCP gateway/ }),
     );
 
     expect(
@@ -1267,7 +1284,7 @@ describe("ProjectGuide", () => {
     mcpOperations.current.projectStatePending = true;
     const view = render(<ProjectGuide />);
     fireEvent.click(
-      screen.getByRole("button", { name: /Govern a third-party MCP/ }),
+      screen.getByRole("button", { name: /Deploy an MCP gateway/ }),
     );
 
     expect(
@@ -1449,7 +1466,7 @@ describe("ProjectGuide", () => {
 
     const view = render(<ProjectGuide />);
     fireEvent.click(
-      screen.getByRole("button", { name: /Govern a third-party MCP/ }),
+      screen.getByRole("button", { name: /Deploy an MCP gateway/ }),
     );
 
     fireEvent.click(screen.getByRole("button", { name: /Linear.*2 tools/ }));
@@ -1616,7 +1633,7 @@ describe("ProjectGuide", () => {
     );
     expect(
       screen.getByText(
-        "Run the command below to install the observability plugin, then restart your agent so its activity can stream into this project.",
+        "Run the command below to install the observability plugin, then restart your agent so prompts can be inspected by this project's policies.",
       ),
     ).toBeTruthy();
     expect(
@@ -1923,7 +1940,7 @@ describe("ProjectGuide", () => {
 
     const view = render(<ProjectGuide />);
     fireEvent.click(
-      screen.getByRole("button", { name: /Govern a third-party MCP/ }),
+      screen.getByRole("button", { name: /Deploy an MCP gateway/ }),
     );
     fireEvent.click(screen.getByRole("button", { name: "Start the journey" }));
     await advanceGuideDelay();

--- a/client/dashboard/src/components/project-guide/ProjectGuide.test.tsx
+++ b/client/dashboard/src/components/project-guide/ProjectGuide.test.tsx
@@ -291,14 +291,31 @@ describe("ProjectGuide", () => {
     }
   });
 
-  it("keeps both chooser visuals static regardless of journey progress", () => {
+  it("preserves the original eyebrow typography on every graphic node", () => {
+    render(<ProjectGuide />);
+
+    for (const label of [
+      "Your agent",
+      "Your client",
+      "Secrets policy",
+      "Your endpoint",
+      "Model provider",
+      "Upstream",
+    ]) {
+      const eyebrow = screen.getByText(label);
+      expect(eyebrow.classList.contains("text-eyebrow")).toBe(true);
+      expect(eyebrow.classList.contains("text-muted-foreground")).toBe(true);
+    }
+  });
+
+  it("animates both chooser visuals regardless of journey progress", () => {
     const { rerender } = render(<ProjectGuide />);
 
     expect(
       screen
         .getByTestId("project-guide-graphic-third-party-mcp")
         .getAttribute("data-animated"),
-    ).toBe("false");
+    ).toBe("true");
 
     statusByJourney.current = {
       "third-party-mcp": "in-progress",
@@ -310,12 +327,12 @@ describe("ProjectGuide", () => {
       screen
         .getByTestId("project-guide-graphic-third-party-mcp")
         .getAttribute("data-animated"),
-    ).toBe("false");
+    ).toBe("true");
     expect(
       screen
         .getByTestId("project-guide-graphic-secret-block")
         .getAttribute("data-animated"),
-    ).toBe("false");
+    ).toBe("true");
   });
 
   it("keeps the other journey switchable when a selected path opens", () => {

--- a/client/dashboard/src/components/project-guide/ProjectGuide.tsx
+++ b/client/dashboard/src/components/project-guide/ProjectGuide.tsx
@@ -58,7 +58,19 @@ import { useMachine } from "@xstate/react";
 import { motion, useReducedMotion } from "motion/react";
 import { useCallback, useEffect, useRef } from "react";
 import { Link, useNavigate } from "react-router";
-import { ChevronLeft, Home } from "lucide-react";
+import {
+  BrainCircuit,
+  ChevronLeft,
+  Home,
+  Network,
+  Server,
+  ShieldCheck,
+} from "lucide-react";
+import {
+  ClaudeCodeIcon,
+  CodexIcon,
+  CursorIcon,
+} from "@/components/agent-providers/AgentProviderIcon";
 
 type McpGuideOperations = ReturnType<typeof useMcpGuideOperations>;
 type SecretGuideOperations = ReturnType<typeof useSecretGuideOperations>;
@@ -449,6 +461,8 @@ function primaryActionFor(
       };
     case "preparing":
       return { label: "Preparing the next step…", disabled: true };
+    case "confirming":
+      return { label: "Server setup complete", disabled: true };
     case "checkpoint":
       if (journey.id === "third-party-mcp" && currentStep === 1) {
         return {
@@ -609,11 +623,6 @@ function ProjectGuideStepContent({
   );
 }
 
-const MCP_CATALOG_PHASES = [
-  "Read the server's tool list",
-  "Install it into this project",
-] as const;
-
 const SECRET_POLICY_PHASES = [
   "Enable the Secrets category",
   "Scope user prompts",
@@ -681,29 +690,6 @@ function SecretPolicyPhases({
     <ProjectGuidePhaseChecklist
       labels={SECRET_POLICY_PHASES}
       statuses={statuses}
-    />
-  );
-}
-
-function McpCatalogPhases({
-  displayState,
-  operationProgress,
-  hasError,
-}: {
-  displayState: ProjectGuideDisplayState;
-  operationProgress: number | null;
-  hasError: boolean;
-}): JSX.Element {
-  return (
-    <ProjectGuidePhaseChecklist
-      labels={MCP_CATALOG_PHASES}
-      statuses={phaseStatuses(
-        MCP_CATALOG_PHASES,
-        displayState,
-        operationProgress,
-        hasError,
-        [0, 0.5],
-      )}
     />
   );
 }
@@ -984,8 +970,6 @@ function McpStepBody({
 
 function McpCatalogSelection({
   displayState,
-  operationProgress,
-  error,
   operations,
   onMcpServerSelected,
 }: {
@@ -1044,11 +1028,6 @@ function McpCatalogSelection({
           );
         })}
       </div>
-      <McpCatalogPhases
-        displayState={displayState}
-        operationProgress={operationProgress}
-        hasError={Boolean(error) || operations.catalogError}
-      />
     </div>
   );
 }
@@ -1359,13 +1338,12 @@ function JourneyChoice({
     <button
       type="button"
       onClick={onSelect}
-      aria-label={journey.title}
+      aria-label={`${journey.headline}: ${journey.title}`}
       aria-controls={controlsId}
       aria-expanded="false"
       className="flex h-full w-full flex-col text-left"
     >
-      <JourneyGraphic journey={journey} status={status} />
-      <span className="border-border bg-background flex flex-col gap-2 border-t px-10 py-8 transition-all hover:bg-card hover:shadow-inner">
+      <span className="border-border bg-background flex flex-col gap-2 border-b px-10 py-8">
         <span className="flex items-center gap-2.5">
           {journey.steps.map((step, index) => (
             <span
@@ -1385,31 +1363,37 @@ function JourneyChoice({
           ))}
           <span className="text-eyebrow text-disabled">{progressLabel}</span>
         </span>
-        <span className="text-xl leading-tight">{journey.title}</span>
-        <span className="text-muted-foreground text-sm leading-relaxed max-w-lg">
+        <span className="text-display-xs leading-tight">
+          {journey.headline}
+        </span>
+        <span className="font-mono text-sm" style={{ color: fixture.accent }}>
+          {journey.title}
+        </span>
+        <span className="text-muted-foreground max-w-lg text-sm leading-relaxed">
           {journey.win}
         </span>
-        <span className="flex items-center gap-3 pt-1">
-          <span className="font-mono text-sm">
-            {isComplete
-              ? "Review"
-              : isInProgress
-                ? "Resume the run"
-                : "Open the journey"}
-          </span>
-          <span
-            className="h-px flex-1"
-            style={{ backgroundColor: fixture.accent }}
-          />
-          <span className="text-disabled font-mono text-xs">
-            {journey.steps.length} steps · ~4 min
-          </span>
-          <span className="font-mono text-sm" style={{ color: fixture.accent }}>
-            →
-          </span>
-        </span>
-        <span className="sr-only">{statusLabel}</span>
       </span>
+      <JourneyGraphic journey={journey} status={status} />
+      <span className="border-border bg-background flex items-center gap-3 border-t px-10 py-6 transition-colors hover:bg-card">
+        <span className="font-mono text-sm">
+          {isComplete
+            ? "Review"
+            : isInProgress
+              ? "Resume the run"
+              : "Open the journey"}
+        </span>
+        <span
+          className="h-px flex-1"
+          style={{ backgroundColor: fixture.accent }}
+        />
+        <span className="text-disabled font-mono text-xs">
+          {journey.steps.length} steps · ~4 min
+        </span>
+        <span className="font-mono text-sm" style={{ color: fixture.accent }}>
+          →
+        </span>
+      </span>
+      <span className="sr-only">{statusLabel}</span>
     </button>
   );
 }
@@ -1422,15 +1406,15 @@ function JourneyGraphic({
   status: JourneyStatus;
 }): JSX.Element {
   const fixture = PROJECT_GUIDE_FIXTURES[journey.id];
-  const reducedMotion = useReducedMotion();
   const isMcp = journey.id === "third-party-mcp";
-  const plates = isMcp
+  const plates: JourneyGraphicPlateData[] = isMcp
     ? [
         {
           zone: "Your client",
           name: "claude code · cursor · codex",
           on: "connected",
           off: "not connected",
+          icon: "agents",
         },
         {
           zone: "Your endpoint",
@@ -1438,12 +1422,14 @@ function JourneyGraphic({
           nameOff: "no endpoint yet",
           on: "verified",
           off: "not installed",
+          icon: "gateway",
         },
         {
           zone: "Upstream",
           name: "linear · vendor server",
           on: "27 tools",
           off: "not picked",
+          icon: "server",
         },
       ]
     : [
@@ -1453,6 +1439,7 @@ function JourneyGraphic({
           nameOff: "claude code · cursor",
           on: "streaming",
           off: "no plugin",
+          icon: "agents",
         },
         {
           zone: "Secrets policy",
@@ -1460,16 +1447,18 @@ function JourneyGraphic({
           nameOff: "no policy yet",
           on: "enforcing",
           off: "off",
+          icon: "policy",
         },
         {
           zone: "Model provider",
           name: "anthropic · openai",
           on: "unsafe prompt not received",
           off: "unproven",
+          icon: "provider",
         },
       ];
   const active = status !== "not-started" && status !== "unreadable";
-  const animated = !reducedMotion && status === "not-started";
+  const animated = false;
 
   return (
     <span
@@ -1518,6 +1507,7 @@ type JourneyGraphicPlateData = {
   nameOff?: string;
   on: string;
   off: string;
+  icon: "agents" | "gateway" | "policy" | "provider" | "server";
 };
 
 const graphicLiveOpacity = [0, 0, 0, 0, 1, 1, 0, 0, 0];
@@ -1525,9 +1515,55 @@ const graphicOffOpacity = [1, 1, 0, 0, 0, 0, 0, 0, 1];
 const graphicLoopTimes = [0, 0.46, 0.52, 0.94, 0.99];
 const graphicTextLoopTimes = [0, 0.4, 0.46, 0.52, 0.58, 0.9, 0.94, 0.96, 1];
 const graphicStateTransition = {
-  duration: 0.16,
+  duration: 0,
   ease: [0.2, 0.7, 0.3, 1] as const,
 };
+
+function JourneyGraphicIcon({
+  icon,
+}: {
+  icon: JourneyGraphicPlateData["icon"];
+}): JSX.Element {
+  if (icon === "agents") {
+    return (
+      <span
+        aria-hidden="true"
+        className="flex shrink-0 items-center -space-x-1.5"
+      >
+        {[
+          { name: "Claude Code", Icon: ClaudeCodeIcon },
+          { name: "Cursor", Icon: CursorIcon },
+          { name: "Codex", Icon: CodexIcon },
+        ].map(({ name, Icon: AgentIcon }) => (
+          <span
+            key={name}
+            className="border-border bg-background flex size-8 items-center justify-center rounded-full border"
+          >
+            <AgentIcon className="size-4" />
+          </span>
+        ))}
+      </span>
+    );
+  }
+
+  const GraphicIcon =
+    icon === "gateway"
+      ? Network
+      : icon === "policy"
+        ? ShieldCheck
+        : icon === "provider"
+          ? BrainCircuit
+          : Server;
+
+  return (
+    <span
+      aria-hidden="true"
+      className="border-border bg-background flex size-9 shrink-0 items-center justify-center border"
+    >
+      <GraphicIcon className="text-muted-foreground size-4" strokeWidth={1.5} />
+    </span>
+  );
+}
 
 function JourneyGraphicPlate({
   accent,
@@ -1612,6 +1648,7 @@ function JourneyGraphicPlate({
         />
       )}
       <span className="flex items-center gap-3">
+        <JourneyGraphicIcon icon={plate.icon} />
         <span className="flex min-w-0 flex-1 flex-col gap-1">
           <span className="text-eyebrow text-muted-foreground">
             {plate.zone}

--- a/client/dashboard/src/components/project-guide/ProjectGuide.tsx
+++ b/client/dashboard/src/components/project-guide/ProjectGuide.tsx
@@ -59,12 +59,14 @@ import { motion, useReducedMotion } from "motion/react";
 import { useCallback, useEffect, useRef } from "react";
 import { Link, useNavigate } from "react-router";
 import {
-  BrainCircuit,
+  Sparkles,
   ChevronLeft,
   Home,
-  Network,
-  Server,
+  Eye,
+  EyeOff,
+  Globe,
   ShieldCheck,
+  ShieldX,
 } from "lucide-react";
 import {
   ClaudeCodeIcon,
@@ -1458,7 +1460,8 @@ function JourneyGraphic({
         },
       ];
   const active = status !== "not-started" && status !== "unreadable";
-  const animated = false;
+  const reducedMotion = useReducedMotion();
+  const animated = !reducedMotion;
 
   return (
     <span
@@ -1521,8 +1524,10 @@ const graphicStateTransition = {
 
 function JourneyGraphicIcon({
   icon,
+  active = false,
 }: {
   icon: JourneyGraphicPlateData["icon"];
+  active?: boolean;
 }): JSX.Element {
   if (icon === "agents") {
     return (
@@ -1548,17 +1553,21 @@ function JourneyGraphicIcon({
 
   const GraphicIcon =
     icon === "gateway"
-      ? Network
-      : icon === "policy"
+      ? active
         ? ShieldCheck
+        : ShieldX
+      : icon === "policy"
+        ? active
+          ? Eye
+          : EyeOff
         : icon === "provider"
-          ? BrainCircuit
-          : Server;
+          ? Sparkles
+          : Globe;
 
   return (
     <span
       aria-hidden="true"
-      className="border-border bg-background flex size-9 shrink-0 items-center justify-center border"
+      className="flex size-5 shrink-0 items-center justify-center"
     >
       <GraphicIcon className="text-muted-foreground size-4" strokeWidth={1.5} />
     </span>
@@ -1647,15 +1656,58 @@ function JourneyGraphicPlate({
           }}
         />
       )}
-      <span className="flex items-center gap-3">
-        <JourneyGraphicIcon icon={plate.icon} />
-        <span className="flex min-w-0 flex-1 flex-col gap-1">
-          <span className="text-eyebrow text-muted-foreground">
+      <span
+        className={cn(
+          plate.icon === "agents"
+            ? "flex items-center gap-3"
+            : "grid grid-cols-[auto_minmax(0,1fr)] items-center gap-x-2 gap-y-1",
+        )}
+      >
+        <span
+          className={cn(
+            plate.icon !== "agents" && "col-start-1 row-start-2",
+            "shrink-0",
+          )}
+        >
+          {plate.icon === "policy" || plate.icon === "gateway" ? (
+            <span aria-hidden="true" className="grid shrink-0">
+              <motion.span
+                initial={false}
+                animate={offOpacity}
+                transition={offTransition}
+                className="col-start-1 row-start-1"
+              >
+                <JourneyGraphicIcon icon={plate.icon} active={false} />
+              </motion.span>
+              <motion.span
+                initial={false}
+                animate={liveOpacity}
+                transition={liveTransition}
+                className="col-start-1 row-start-1"
+              >
+                <JourneyGraphicIcon icon={plate.icon} active />
+              </motion.span>
+            </span>
+          ) : (
+            <JourneyGraphicIcon icon={plate.icon} />
+          )}
+        </span>
+        <span
+          className={
+            plate.icon === "agents"
+              ? "flex min-w-0 flex-1 flex-col gap-1"
+              : "contents"
+          }
+        >
+          <span
+            className={`text-eyebrow text-muted-foreground ${plate.icon !== "agents" ? "col-span-2 col-start-1 row-start-1" : ""}`}
+          >
             {plate.zone}
           </span>
           <span
             className={cn(
               "relative grid min-w-0 text-sm",
+              plate.icon !== "agents" && "col-start-2 row-start-2",
               isCenter && "text-xl",
             )}
           >
@@ -1677,7 +1729,9 @@ function JourneyGraphicPlate({
             </motion.span>
           </span>
         </span>
-        <span className="text-eyebrow relative mt-0 mb-auto grid min-w-0 flex-[0_1_35%] text-right">
+        <span
+          className={`text-eyebrow relative mt-0 mb-auto grid min-w-0 text-right ${plate.icon === "agents" ? "flex-[0_1_35%]" : "col-span-2 col-start-1 row-start-3 mt-1"}`}
+        >
           <motion.span
             initial={false}
             animate={offOpacity}

--- a/client/dashboard/src/components/project-guide/ProjectGuideRun.tsx
+++ b/client/dashboard/src/components/project-guide/ProjectGuideRun.tsx
@@ -41,6 +41,8 @@ function stepStateLabel(displayState: ProjectGuideDisplayState): string {
       return "running";
     case "preparing":
       return "preparing";
+    case "confirming":
+      return "complete";
     case "waiting":
       return "listening";
     case "paused":

--- a/client/dashboard/src/components/project-guide/journeys.ts
+++ b/client/dashboard/src/components/project-guide/journeys.ts
@@ -29,6 +29,7 @@ export const JOURNEY_STATUS_LABELS: Record<JourneyStatus, string> = {
 
 export type JourneyMeta = {
   id: JourneyId;
+  headline: string;
   title: string;
   /** The observable win, stated as the user would describe it afterwards. */
   win: string;
@@ -74,8 +75,9 @@ export const PROJECT_GUIDE_COMPLETE = {
 export const PROJECT_GUIDE_JOURNEYS: JourneyMeta[] = [
   {
     id: "secret-block",
+    headline: "Secure AI usage",
     title: "Block a leaked credential mid-prompt",
-    win: "A secrets policy denies any prompt carrying a credential. The attempt lands in Risk Events with the rule that caught it, the matched span, and who sent it.",
+    win: "Create a deny policy for secrets, then watch it stop a synthetic credential before it reaches the model.",
     completion: {
       heading: "The prompt was denied.",
       body: "The prompt matched the secrets policy and was rejected before the model answered. The finding sits in Risk Events with the rule that fired, the matched span, the severity, and who sent it.",
@@ -83,17 +85,18 @@ export const PROJECT_GUIDE_JOURNEYS: JourneyMeta[] = [
     },
     steps: SECRET_BLOCK_STEPS,
     stepBlurbs: [
-      "A policy goes live that looks for secrets — API keys, tokens, private keys — in the prompts people send. It denies anything that matches, for everyone in the org.",
-      "Speakeasy builds the observability plugin for this project and signs it. You get a package to download — the next step installs it in your client.",
-      "Run the command below to install the observability plugin, then restart your agent so its activity can stream into this project.",
+      "Create a secrets policy that denies prompts containing API keys, tokens, or private keys for everyone in the organization.",
+      "The observability plugin sends agent activity to this project so policies can inspect prompts before they reach the model. Download it here, then install it in your client.",
+      "Run the command below to install the observability plugin, then restart your agent so prompts can be inspected by this project's policies.",
       "This key is synthetic and inert. It exists so the rule has something real-shaped to catch. The call should not survive the machine.",
       "The policy denies the request and a finding lands in Risk Events. It carries the rule that fired, the matched span, the severity, and who sent it.",
     ],
   },
   {
     id: "third-party-mcp",
-    title: "Govern a third-party MCP",
-    win: "Install a vendor's MCP server, connect your agent to it, and watch the first call arrive with the actor, the tools, and the result attached.",
+    headline: "Govern AI data access",
+    title: "Deploy an MCP gateway",
+    win: "Put a governed endpoint in front of a third-party MCP server, then watch the first authorized tool call arrive in your logs.",
     completion: {
       heading: "The path is governed.",
       body: "Your client now reaches the selected server through an endpoint you own. Tool lists are filtered to what each caller may use, every call lands in tool logs, and the vendor's server never changed. Remove the server and the path closes.",

--- a/client/dashboard/src/components/project-guide/projectGuideMachine.test.ts
+++ b/client/dashboard/src/components/project-guide/projectGuideMachine.test.ts
@@ -2,6 +2,7 @@ import { createActor } from "xstate";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   LISTEN_TIMEOUT_SECONDS,
+  MCP_SETUP_CONFIRMATION_DELAY_MS,
   PROJECT_GUIDE_OUTPUT_LIMIT,
   getProjectGuideCurrentStep,
   projectGuideMachine,
@@ -54,6 +55,7 @@ function reachCheckpoint(
   service: ReturnType<typeof coordinator>["service"],
   signals: ProjectGuideOperationSignal[],
 ): void {
+  vi.useFakeTimers();
   openMcp(service);
   service.send({ type: "START" });
   report(service, {
@@ -67,6 +69,7 @@ function reachCheckpoint(
       scope: latestScope(signals),
       result: "MCP ready",
     });
+    vi.advanceTimersByTime(MCP_SETUP_CONFIRMATION_DELAY_MS);
   }
   service.send({
     type: "USER_CHECKPOINT_COMPLETE",
@@ -142,16 +145,21 @@ describe("project guide coordinator contract", () => {
     openMcp(service);
 
     service.send({ type: "SELECT_MCP_SERVER", name: "Linear" });
-    expect(service.getSnapshot().context.output.at(-1)).toMatchObject({
-      kind: "note",
-      message: "Linear selected. Ready to start the journey",
-    });
+    service.send({ type: "SELECT_MCP_SERVER", name: "Notion" });
+    expect(
+      service
+        .getSnapshot()
+        .context.output.filter((entry) =>
+          entry.message.endsWith(" selected. Ready to start the journey"),
+        )
+        .map((entry) => entry.message),
+    ).toEqual(["Notion selected. Ready to start the journey"]);
 
     service.send({ type: "START" });
-    service.send({ type: "SELECT_MCP_SERVER", name: "Notion" });
+    service.send({ type: "SELECT_MCP_SERVER", name: "Linear" });
 
     expect(service.getSnapshot().context.output.at(-1)?.message).not.toBe(
-      "Notion selected. Ready to start the journey",
+      "Linear selected. Ready to start the journey",
     );
     expect(signals).toHaveLength(1);
   });
@@ -237,7 +245,8 @@ describe("project guide coordinator contract", () => {
     });
   });
 
-  it("waits for MCP baseline preparation before advancing", () => {
+  it("shows MCP setup success immediately, then advances after the confirmation dwell", () => {
+    vi.useFakeTimers();
     const { service, signals } = coordinator();
     openMcp(service);
     service.send({ type: "START" });
@@ -262,11 +271,72 @@ describe("project guide coordinator contract", () => {
       result: "Linear mcp server is now setup",
     });
 
+    expect(service.getSnapshot().value).toBe("confirming");
+    expect(service.getSnapshot().context.output.at(-1)).toMatchObject({
+      kind: "result",
+      message: "Linear mcp server is now setup",
+    });
+    expect(getProjectGuideCurrentStep(service.getSnapshot().context)).toBe(0);
+
+    service.send({ type: "USER_CHECKPOINT_COMPLETE", result: "ignored" });
+    vi.advanceTimersByTime(MCP_SETUP_CONFIRMATION_DELAY_MS - 1);
+    expect(service.getSnapshot().value).toBe("confirming");
+    expect(getProjectGuideCurrentStep(service.getSnapshot().context)).toBe(0);
+
+    vi.advanceTimersByTime(1);
     expect(service.getSnapshot().value).toBe("checkpoint");
     expect(getProjectGuideCurrentStep(service.getSnapshot().context)).toBe(1);
     expect(
       service.getSnapshot().context.completedByPath["third-party-mcp"],
     ).toEqual([0]);
+  });
+
+  it("cancels the MCP confirmation dwell on BACK or SWITCH", () => {
+    vi.useFakeTimers();
+
+    const back = coordinator();
+    openMcp(back.service);
+    back.service.send({ type: "START" });
+    report(back.service, {
+      type: "success",
+      scope: latestScope(back.signals),
+      result: "Server installed",
+    });
+    report(back.service, {
+      type: "success",
+      scope: latestScope(back.signals),
+      result: "MCP ready",
+    });
+    expect(back.service.getSnapshot().value).toBe("confirming");
+    back.service.send({ type: "BACK" });
+    vi.advanceTimersByTime(MCP_SETUP_CONFIRMATION_DELAY_MS);
+    expect(back.service.getSnapshot().value).toBe("opening");
+    expect(back.service.getSnapshot().context.activePath).toBeNull();
+
+    const switched = coordinator();
+    openMcp(switched.service);
+    switched.service.send({ type: "START" });
+    report(switched.service, {
+      type: "success",
+      scope: latestScope(switched.signals),
+      result: "Server installed",
+    });
+    report(switched.service, {
+      type: "success",
+      scope: latestScope(switched.signals),
+      result: "MCP ready",
+    });
+    expect(switched.service.getSnapshot().value).toBe("confirming");
+    switched.service.send({
+      type: "SWITCH",
+      path: "secret-block",
+      resumeStep: 0,
+    });
+    vi.advanceTimersByTime(MCP_SETUP_CONFIRMATION_DELAY_MS);
+    expect(switched.service.getSnapshot().value).toBe("ready");
+    expect(switched.service.getSnapshot().context.activePath).toBe(
+      "secret-block",
+    );
   });
 
   it("starts Secret Step 2 immediately after an agent is selected", () => {
@@ -445,6 +515,7 @@ describe("project guide coordinator contract", () => {
   });
 
   it("rejects a duplicate success from the attempt before retry", () => {
+    vi.useFakeTimers();
     const { service, signals } = coordinator();
     openMcp(service);
     service.send({ type: "START" });
@@ -493,6 +564,8 @@ describe("project guide coordinator contract", () => {
         result: "MCP ready",
       },
     });
+    expect(service.getSnapshot().value).toBe("confirming");
+    vi.advanceTimersByTime(MCP_SETUP_CONFIRMATION_DELAY_MS);
     expect(getProjectGuideCurrentStep(service.getSnapshot().context)).toBe(1);
   });
 });

--- a/client/dashboard/src/components/project-guide/projectGuideMachine.ts
+++ b/client/dashboard/src/components/project-guide/projectGuideMachine.ts
@@ -15,12 +15,14 @@ export type ProjectGuideEventCard = {
 export const PROJECT_GUIDE_OUTPUT_LIMIT = 18;
 export const LISTEN_TIMEOUT_SECONDS = 90;
 export const PROJECT_GUIDE_MICRO_STEP_DELAY_MS = 3000;
+export const MCP_SETUP_CONFIRMATION_DELAY_MS = 2000;
 
 export type ProjectGuideDisplayState =
   | "opening"
   | "ready"
   | "running"
   | "preparing"
+  | "confirming"
   | "checkpoint"
   | "waiting"
   | "paused"
@@ -454,12 +456,21 @@ export const projectGuideMachine = setup({
     ),
     recordMcpServerSelected: assign(({ context, event }) => {
       if (event.type !== "SELECT_MCP_SERVER") return {};
-      return appendOutput(context, [
+      return appendOutput(
         {
-          kind: "note",
-          message: `${event.name} selected. Ready to start the journey`,
+          ...context,
+          output: context.output.filter(
+            (entry) =>
+              !entry.message.endsWith(" selected. Ready to start the journey"),
+          ),
         },
-      ]);
+        [
+          {
+            kind: "note",
+            message: `${event.name} selected. Ready to start the journey`,
+          },
+        ],
+      );
     }),
     recordStart: assign(({ context }) => {
       const mode = stepMode(context);
@@ -491,6 +502,29 @@ export const projectGuideMachine = setup({
             : Math.min(1, Math.max(0, progress)),
       };
     }),
+    recordMcpSetupConfirmation: assign(({ context, event }) => {
+      if (event.type !== "ADAPTER_REPORT" || event.report.type !== "success")
+        return {};
+      return {
+        ...appendOutput(context, [
+          { kind: "result", message: event.report.result },
+        ]),
+        operationProgress: 1,
+      };
+    }),
+    advanceMcpSetup: assign(({ context }) => ({
+      completedByPath: { ...context.completedByPath, "third-party-mcp": [0] },
+      ...appendOutput(context, [
+        {
+          kind: "next",
+          message: `Next · ${narrativeStepLabel("third-party-mcp", 1)}`,
+        },
+      ]),
+      elapsedListeningSeconds: 0,
+      operationProgress: null,
+      error: null,
+      attempt: 0,
+    })),
     recordSuccessAndAdvance: assign(({ context, event }) => {
       let result: string;
       if (event.type === "ADAPTER_REPORT" && event.report.type === "success") {
@@ -790,8 +824,8 @@ export const projectGuideMachine = setup({
         ADAPTER_REPORT: [
           {
             guard: "currentSuccessReport",
-            target: "checkpoint",
-            actions: "recordSuccessAndAdvance",
+            target: "confirming",
+            actions: "recordMcpSetupConfirmation",
           },
           {
             guard: "currentErrorReport",
@@ -799,6 +833,14 @@ export const projectGuideMachine = setup({
             actions: ["rememberPreparingError", "recordError"],
           },
         ],
+      },
+    },
+    confirming: {
+      after: {
+        [MCP_SETUP_CONFIRMATION_DELAY_MS]: {
+          target: "checkpoint",
+          actions: "advanceMcpSetup",
+        },
       },
     },
     checkpoint: {


### PR DESCRIPTION
## Summary
- Put business-value headlines, tactical subtitles, and descriptions above the guide chooser visuals.
- Restore consistent animation, add state-specific icons, and simplify icon layout while preserving typography.
- Show MCP setup confirmation for two seconds before automatically advancing; replace previous server-selection messages and remove duplicate phase boxes.
- Clarify plugin and secrets-policy copy, with regression coverage for transitions, selection, and typography.

## Motivation
Make onboarding easier to understand and follow, especially the transition from server setup to client connection. This is a draft while visual polish continues.

## Remaining work
- Address cramped Agent / Client logo clusters on narrow screens.
- Live activity logs and the final onboarding payoff are deferred to separate work.
- Leaked-credentials completion debugging is outside this change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves project guide onboarding by reworking the journey chooser and the MCP setup transition. The MCP journey is renamed from "Govern a third-party MCP" to "Deploy an MCP gateway", and each chooser card now leads with a business-value headline, tactical subtitle, and description above the graphic.

- Both chooser visuals animate regardless of journey progress, with state-specific icons for connected, verified, enforcing, and unproven states.
- Removes the duplicate MCP catalog phase checklist.
- MCP setup success now shows a two-second "Server setup complete" confirmation before auto-advancing; the manual "Server is installed" button and server-selection messages are gone, and BACK or SWITCH cancels the timer.
- Clarifies plugin install and secrets-policy copy.
- Adds regression coverage for transitions, server selection, and graphic typography.

**Remaining work**
- Cramped agent/client logo clusters on narrow screens.
- Live activity logs and the final onboarding payoff are deferred to separate work.
- Leaked-credentials completion debugging is out of scope.

<sup>Written for commit 111c3978e745dd6b3ee008f28e44a9b0b6402868. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

