### PR TITLE
fix: stop policing the shape of an AI scan config dir

### DIFF
--- a/.changeset/ai-scan-config-dir-trailing-slash.md
+++ b/.changeset/ai-scan-config-dir-trailing-slash.md
@@ -1,0 +1,6 @@
+---
+"server": patch
+"dashboard": patch
+---
+
+Accept an AI scan target config dir written with a trailing slash, such as `~/Library/Application Support/com.openai.chat/`, instead of rejecting it for an empty path segment.

--- a/.changeset/ai-scan-config-dir-trailing-slash.md
+++ b/.changeset/ai-scan-config-dir-trailing-slash.md
@@ -3,4 +3,4 @@
 "dashboard": patch
 ---
 
-Accept an AI scan target config dir written with a trailing slash, such as `~/Library/Application Support/com.openai.chat/`, instead of rejecting it for an empty path segment.
+Stop policing the shape of an AI scan target config dir. Any path the device agent can resolve is accepted, including one written with a trailing slash such as `~/Library/Application Support/com.openai.chat/`.

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -68066,9 +68066,7 @@ components:
           type: array
           items:
             type: string
-            pattern: ^~?/[^\\]+$
-            maxLength: 256
-          description: Home-relative (~/...) or absolute (/...) directories whose existence marks the tool as installed.
+          description: Directories whose existence marks the tool as installed, taken as home-relative unless they start with /.
           maxItems: 16
         process_names:
           type: array

--- a/client/dashboard/src/pages/device-agent/ai-scan-target-draft.test.ts
+++ b/client/dashboard/src/pages/device-agent/ai-scan-target-draft.test.ts
@@ -38,30 +38,16 @@ describe("slugFromName", () => {
 });
 
 describe("normalizeConfigDir", () => {
-  it("anchors bare names in the home folder and keeps anchored paths", () => {
-    expect(normalizeConfigDir(".claude")).toBe("~/.claude");
-    expect(normalizeConfigDir(" Library/Application Support/Cursor ")).toBe(
-      "~/Library/Application Support/Cursor",
-    );
+  it("only trims what was typed", () => {
+    expect(normalizeConfigDir(" .claude ")).toBe(".claude");
     expect(normalizeConfigDir("~/.codex")).toBe("~/.codex");
+    expect(
+      normalizeConfigDir("~/Library/Application Support/com.openai.chat/"),
+    ).toBe("~/Library/Application Support/com.openai.chat/");
     expect(normalizeConfigDir("/opt/homebrew/etc/claude")).toBe(
       "/opt/homebrew/etc/claude",
     );
-    expect(normalizeConfigDir("~")).toBe("~/");
     expect(normalizeConfigDir("  ")).toBe("");
-  });
-
-  it("drops a trailing slash without unanchoring the path", () => {
-    expect(
-      normalizeConfigDir("~/Library/Application Support/com.openai.chat/"),
-    ).toBe("~/Library/Application Support/com.openai.chat");
-    expect(normalizeConfigDir(".claude/")).toBe("~/.claude");
-    expect(normalizeConfigDir("/opt/homebrew/etc/claude//")).toBe(
-      "/opt/homebrew/etc/claude",
-    );
-    // The whole home or root folder stays as written so it is still refused.
-    expect(normalizeConfigDir("~/")).toBe("~/");
-    expect(normalizeConfigDir("/")).toBe("/");
   });
 });
 
@@ -80,30 +66,18 @@ describe("validateDraft", () => {
     expect(
       validateDraft({ ...base, binaries: ["../../etc/passwd"] }).binaries,
     ).toContain("bare command name");
-    expect(
-      validateDraft({ ...base, configDirs: ["~/"] }).configDirs,
-    ).toBeDefined();
-    expect(
-      validateDraft({ ...base, configDirs: ["~/../.ssh"] }).configDirs,
-    ).toBeDefined();
-    expect(
-      validateDraft({ ...base, configDirs: [".claude"] }).configDirs,
-    ).toBeDefined();
-    expect(
-      validateDraft({ ...base, configDirs: ["/opt/../etc"] }).configDirs,
-    ).toBeDefined();
-    expect(
-      validateDraft({ ...base, configDirs: ["/opt/homebrew/etc/claude"] })
-        .configDirs,
-    ).toBeUndefined();
-    expect(
-      validateDraft({
-        ...base,
-        configDirs: [
-          normalizeConfigDir("~/Library/Application Support/com.openai.chat/"),
-        ],
-      }).configDirs,
-    ).toBeUndefined();
+    // A config dir is any path the agent can resolve, so nothing about its
+    // shape is rejected here.
+    for (const dir of [
+      ".claude",
+      "~/.claude/",
+      "/opt/../etc",
+      "~/Library/Application Support/com.openai.chat/",
+    ]) {
+      expect(
+        validateDraft({ ...base, configDirs: [dir] }).configDirs,
+      ).toBeUndefined();
+    }
     expect(
       validateDraft({ ...base, processNames: [".*"] }).processNames,
     ).toBeDefined();

--- a/client/dashboard/src/pages/device-agent/ai-scan-target-draft.test.ts
+++ b/client/dashboard/src/pages/device-agent/ai-scan-target-draft.test.ts
@@ -50,6 +50,19 @@ describe("normalizeConfigDir", () => {
     expect(normalizeConfigDir("~")).toBe("~/");
     expect(normalizeConfigDir("  ")).toBe("");
   });
+
+  it("drops a trailing slash without unanchoring the path", () => {
+    expect(
+      normalizeConfigDir("~/Library/Application Support/com.openai.chat/"),
+    ).toBe("~/Library/Application Support/com.openai.chat");
+    expect(normalizeConfigDir(".claude/")).toBe("~/.claude");
+    expect(normalizeConfigDir("/opt/homebrew/etc/claude//")).toBe(
+      "/opt/homebrew/etc/claude",
+    );
+    // The whole home or root folder stays as written so it is still refused.
+    expect(normalizeConfigDir("~/")).toBe("~/");
+    expect(normalizeConfigDir("/")).toBe("/");
+  });
 });
 
 describe("validateDraft", () => {
@@ -82,6 +95,14 @@ describe("validateDraft", () => {
     expect(
       validateDraft({ ...base, configDirs: ["/opt/homebrew/etc/claude"] })
         .configDirs,
+    ).toBeUndefined();
+    expect(
+      validateDraft({
+        ...base,
+        configDirs: [
+          normalizeConfigDir("~/Library/Application Support/com.openai.chat/"),
+        ],
+      }).configDirs,
     ).toBeUndefined();
     expect(
       validateDraft({ ...base, processNames: [".*"] }).processNames,

--- a/client/dashboard/src/pages/device-agent/ai-scan-target-draft.ts
+++ b/client/dashboard/src/pages/device-agent/ai-scan-target-draft.ts
@@ -98,44 +98,10 @@ function codePoints(value: string): number {
   return Array.from(value).length;
 }
 
-// normalizeConfigDir anchors what was typed the way the agent resolves it: a
-// path starting with ~/ or / is kept, anything else is taken to be inside
-// the home folder. A trailing slash names the same directory, so it is
-// dropped rather than read as an empty last segment. A bare "~/" or "/"
-// stays as typed, so the validator still refuses the whole home or root
-// folder.
+// normalizeConfigDir just trims what was typed. The path is taken as
+// home-relative unless it starts with /, and the device agent resolves it.
 export function normalizeConfigDir(dir: string): string {
-  const trimmed = dir.trim();
-  if (trimmed === "") return "";
-  if (trimmed === "~") return "~/";
-  const anchored =
-    trimmed.startsWith("~/") || trimmed.startsWith("/")
-      ? trimmed
-      : `~/${trimmed}`;
-  const withoutTrailingSlash = anchored.replace(/\/+$/, "");
-  return withoutTrailingSlash === "" || withoutTrailingSlash === "~"
-    ? anchored
-    : withoutTrailingSlash;
-}
-
-function configDirProblem(dir: string): string | undefined {
-  if (codePoints(dir) > 256) return `"${dir}" is longer than 256 characters`;
-  let rest: string;
-  if (dir.startsWith("~/")) {
-    rest = dir.slice(2);
-  } else if (dir.startsWith("/")) {
-    rest = dir.slice(1);
-  } else {
-    return `"${dir}" must start with ~/ or /`;
-  }
-  if (/[\\\0]/.test(dir)) return `"${dir}" must not contain backslashes`;
-  if (rest === "") return `"${dir}" always exists; name a directory inside it`;
-  for (const segment of rest.split("/")) {
-    if (segment === "" || segment === "." || segment === "..") {
-      return `"${dir}" must not contain empty, "." or ".." segments`;
-    }
-  }
-  return undefined;
+  return dir.trim();
 }
 
 function listProblem(
@@ -179,7 +145,7 @@ export function validateDraft(draft: Draft): DraftErrors {
       ? undefined
       : `"${bin}" must be a bare command name, not a path`,
   );
-  errors.configDirs = listProblem(configDirs, "config dirs", configDirProblem);
+  errors.configDirs = listProblem(configDirs, "config dirs", () => undefined);
   errors.processNames = listProblem(processNames, "process names", (proc) =>
     PROCESS_NAME_PATTERN.test(proc)
       ? undefined

--- a/client/dashboard/src/pages/device-agent/ai-scan-target-draft.ts
+++ b/client/dashboard/src/pages/device-agent/ai-scan-target-draft.ts
@@ -100,13 +100,22 @@ function codePoints(value: string): number {
 
 // normalizeConfigDir anchors what was typed the way the agent resolves it: a
 // path starting with ~/ or / is kept, anything else is taken to be inside
-// the home folder.
+// the home folder. A trailing slash names the same directory, so it is
+// dropped rather than read as an empty last segment. A bare "~/" or "/"
+// stays as typed, so the validator still refuses the whole home or root
+// folder.
 export function normalizeConfigDir(dir: string): string {
   const trimmed = dir.trim();
   if (trimmed === "") return "";
   if (trimmed === "~") return "~/";
-  if (trimmed.startsWith("~/") || trimmed.startsWith("/")) return trimmed;
-  return `~/${trimmed}`;
+  const anchored =
+    trimmed.startsWith("~/") || trimmed.startsWith("/")
+      ? trimmed
+      : `~/${trimmed}`;
+  const withoutTrailingSlash = anchored.replace(/\/+$/, "");
+  return withoutTrailingSlash === "" || withoutTrailingSlash === "~"
+    ? anchored
+    : withoutTrailingSlash;
 }
 
 function configDirProblem(dir: string): string | undefined {
@@ -120,6 +129,7 @@ function configDirProblem(dir: string): string | undefined {
     return `"${dir}" must start with ~/ or /`;
   }
   if (/[\\\0]/.test(dir)) return `"${dir}" must not contain backslashes`;
+  if (rest === "") return `"${dir}" always exists; name a directory inside it`;
   for (const segment of rest.split("/")) {
     if (segment === "" || segment === "." || segment === "..") {
       return `"${dir}" must not contain empty, "." or ".." segments`;

--- a/client/dashboard/src/pages/device-agent/ai-scan-target-editor-sheet.tsx
+++ b/client/dashboard/src/pages/device-agent/ai-scan-target-editor-sheet.tsx
@@ -241,7 +241,9 @@ function EditorForm({
             onChange={(value) =>
               update(
                 "configDirs",
-                Array.from(new Set(value.map(normalizeConfigDir))),
+                Array.from(
+                  new Set(value.map(normalizeConfigDir).filter(Boolean)),
+                ),
               )
             }
           />

--- a/client/dashboard/src/sdk/src/models/components/aiscantargetsignatures.ts
+++ b/client/dashboard/src/sdk/src/models/components/aiscantargetsignatures.ts
@@ -21,7 +21,7 @@ export type AiScanTargetSignatures = {
    */
   bundleIds: Array<string>;
   /**
-   * Home-relative (~/...) or absolute (/...) directories whose existence marks the tool as installed.
+   * Directories whose existence marks the tool as installed, taken as home-relative unless they start with /.
    */
   configDirs: Array<string>;
   /**

--- a/server/design/agent/design.go
+++ b/server/design/agent/design.go
@@ -530,7 +530,6 @@ const (
 	aiScanBinaryPattern       = `^[A-Za-z0-9._-]{1,64}$`
 	aiScanProcessNamePattern  = `^[A-Za-z0-9 ._-]{1,64}$`
 	aiScanPlistKeyPattern     = `^[A-Za-z0-9]{1,64}$`
-	aiScanConfigDirPattern    = `^~?/[^\\]+$`
 )
 
 var AiScanTargetSignaturesModel = Type("AiScanTargetSignatures", func() {
@@ -541,10 +540,7 @@ var AiScanTargetSignaturesModel = Type("AiScanTargetSignatures", func() {
 	Attribute("binaries", ArrayOf(String, func() { Pattern(aiScanBinaryPattern) }), "Bare command names resolved on the device PATH; never a path.", func() {
 		MaxLength(aiScanMaxSignatureEntries)
 	})
-	Attribute("config_dirs", ArrayOf(String, func() {
-		Pattern(aiScanConfigDirPattern)
-		MaxLength(256)
-	}), "Home-relative (~/...) or absolute (/...) directories whose existence marks the tool as installed.", func() {
+	Attribute("config_dirs", ArrayOf(String), "Directories whose existence marks the tool as installed, taken as home-relative unless they start with /.", func() {
 		MaxLength(aiScanMaxSignatureEntries)
 	})
 	Attribute("process_names", ArrayOf(String, func() { Pattern(aiScanProcessNamePattern) }), "Exact process names checked for the running signal.", func() {

--- a/server/gen/agent/service.go
+++ b/server/gen/agent/service.go
@@ -208,8 +208,8 @@ type AiScanTargetSignatures struct {
 	BundleIds []string
 	// Bare command names resolved on the device PATH; never a path.
 	Binaries []string
-	// Home-relative (~/...) or absolute (/...) directories whose existence marks
-	// the tool as installed.
+	// Directories whose existence marks the tool as installed, taken as
+	// home-relative unless they start with /.
 	ConfigDirs []string
 	// Exact process names checked for the running signal.
 	ProcessNames []string

--- a/server/gen/http/agent/client/cli.go
+++ b/server/gen/http/agent/client/cli.go
@@ -156,7 +156,7 @@ func BuildUpsertAiScanTargetPayload(agentUpsertAiScanTargetBody string, agentUps
 	{
 		err = json.Unmarshal([]byte(agentUpsertAiScanTargetBody), &body)
 		if err != nil {
-			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"category\": \"local_model\",\n      \"display_name\": \"aa\",\n      \"enabled\": false,\n      \"id\": \"1\",\n      \"signatures\": {\n         \"binaries\": [\n            \".\",\n            \".\",\n            \".\"\n         ],\n         \"bundle_ids\": [\n            \".\",\n            \".\",\n            \".\"\n         ],\n         \"config_dirs\": [\n            \"aaa\",\n            \"aaa\",\n            \"aaa\"\n         ],\n         \"process_names\": [\n            \"-\",\n            \"-\",\n            \"-\"\n         ]\n      },\n      \"version_plist_key\": \"1\"\n   }'")
+			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"category\": \"local_model\",\n      \"display_name\": \"aa\",\n      \"enabled\": false,\n      \"id\": \"1\",\n      \"signatures\": {\n         \"binaries\": [\n            \".\",\n            \".\",\n            \".\"\n         ],\n         \"bundle_ids\": [\n            \".\",\n            \".\",\n            \".\"\n         ],\n         \"config_dirs\": [\n            \"abc123\",\n            \"abc123\",\n            \"abc123\"\n         ],\n         \"process_names\": [\n            \"-\",\n            \"-\",\n            \"-\"\n         ]\n      },\n      \"version_plist_key\": \"1\"\n   }'")
 		}
 		if body.Signatures == nil {
 			err = goa.MergeErrors(err, goa.MissingFieldError("signatures", "body"))

--- a/server/gen/http/agent/client/types.go
+++ b/server/gen/http/agent/client/types.go
@@ -2316,8 +2316,8 @@ type AiScanTargetSignaturesResponseBody struct {
 	BundleIds []string `form:"bundle_ids,omitempty" json:"bundle_ids,omitempty" xml:"bundle_ids,omitempty"`
 	// Bare command names resolved on the device PATH; never a path.
 	Binaries []string `form:"binaries,omitempty" json:"binaries,omitempty" xml:"binaries,omitempty"`
-	// Home-relative (~/...) or absolute (/...) directories whose existence marks
-	// the tool as installed.
+	// Directories whose existence marks the tool as installed, taken as
+	// home-relative unless they start with /.
 	ConfigDirs []string `form:"config_dirs,omitempty" json:"config_dirs,omitempty" xml:"config_dirs,omitempty"`
 	// Exact process names checked for the running signal.
 	ProcessNames []string `form:"process_names,omitempty" json:"process_names,omitempty" xml:"process_names,omitempty"`
@@ -2331,8 +2331,8 @@ type AiScanTargetSignaturesRequestBody struct {
 	BundleIds []string `form:"bundle_ids" json:"bundle_ids" xml:"bundle_ids"`
 	// Bare command names resolved on the device PATH; never a path.
 	Binaries []string `form:"binaries" json:"binaries" xml:"binaries"`
-	// Home-relative (~/...) or absolute (/...) directories whose existence marks
-	// the tool as installed.
+	// Directories whose existence marks the tool as installed, taken as
+	// home-relative unless they start with /.
 	ConfigDirs []string `form:"config_dirs" json:"config_dirs" xml:"config_dirs"`
 	// Exact process names checked for the running signal.
 	ProcessNames []string `form:"process_names" json:"process_names" xml:"process_names"`
@@ -7244,12 +7244,6 @@ func ValidateAiScanTargetSignaturesResponseBody(body *AiScanTargetSignaturesResp
 	if len(body.ConfigDirs) > 16 {
 		err = goa.MergeErrors(err, goa.InvalidLengthError("body.config_dirs", body.ConfigDirs, len(body.ConfigDirs), 16, false))
 	}
-	for _, e := range body.ConfigDirs {
-		err = goa.MergeErrors(err, goa.ValidatePattern("body.config_dirs[*]", e, "^~?/[^\\\\]+$"))
-		if utf8.RuneCountInString(e) > 256 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.config_dirs[*]", e, utf8.RuneCountInString(e), 256, false))
-		}
-	}
 	if len(body.ProcessNames) > 16 {
 		err = goa.MergeErrors(err, goa.InvalidLengthError("body.process_names", body.ProcessNames, len(body.ProcessNames), 16, false))
 	}
@@ -7288,12 +7282,6 @@ func ValidateAiScanTargetSignaturesRequestBody(body *AiScanTargetSignaturesReque
 	}
 	if len(body.ConfigDirs) > 16 {
 		err = goa.MergeErrors(err, goa.InvalidLengthError("body.config_dirs", body.ConfigDirs, len(body.ConfigDirs), 16, false))
-	}
-	for _, e := range body.ConfigDirs {
-		err = goa.MergeErrors(err, goa.ValidatePattern("body.config_dirs[*]", e, "^~?/[^\\\\]+$"))
-		if utf8.RuneCountInString(e) > 256 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.config_dirs[*]", e, utf8.RuneCountInString(e), 256, false))
-		}
 	}
 	if len(body.ProcessNames) > 16 {
 		err = goa.MergeErrors(err, goa.InvalidLengthError("body.process_names", body.ProcessNames, len(body.ProcessNames), 16, false))

--- a/server/gen/http/agent/server/types.go
+++ b/server/gen/http/agent/server/types.go
@@ -2316,8 +2316,8 @@ type AiScanTargetSignaturesResponseBody struct {
 	BundleIds []string `form:"bundle_ids" json:"bundle_ids" xml:"bundle_ids"`
 	// Bare command names resolved on the device PATH; never a path.
 	Binaries []string `form:"binaries" json:"binaries" xml:"binaries"`
-	// Home-relative (~/...) or absolute (/...) directories whose existence marks
-	// the tool as installed.
+	// Directories whose existence marks the tool as installed, taken as
+	// home-relative unless they start with /.
 	ConfigDirs []string `form:"config_dirs" json:"config_dirs" xml:"config_dirs"`
 	// Exact process names checked for the running signal.
 	ProcessNames []string `form:"process_names" json:"process_names" xml:"process_names"`
@@ -2345,8 +2345,8 @@ type AiScanTargetSignaturesRequestBody struct {
 	BundleIds []string `form:"bundle_ids,omitempty" json:"bundle_ids,omitempty" xml:"bundle_ids,omitempty"`
 	// Bare command names resolved on the device PATH; never a path.
 	Binaries []string `form:"binaries,omitempty" json:"binaries,omitempty" xml:"binaries,omitempty"`
-	// Home-relative (~/...) or absolute (/...) directories whose existence marks
-	// the tool as installed.
+	// Directories whose existence marks the tool as installed, taken as
+	// home-relative unless they start with /.
 	ConfigDirs []string `form:"config_dirs,omitempty" json:"config_dirs,omitempty" xml:"config_dirs,omitempty"`
 	// Exact process names checked for the running signal.
 	ProcessNames []string `form:"process_names,omitempty" json:"process_names,omitempty" xml:"process_names,omitempty"`
@@ -4449,12 +4449,6 @@ func ValidateAiScanTargetSignaturesRequestBody(body *AiScanTargetSignaturesReque
 	}
 	if len(body.ConfigDirs) > 16 {
 		err = goa.MergeErrors(err, goa.InvalidLengthError("body.config_dirs", body.ConfigDirs, len(body.ConfigDirs), 16, false))
-	}
-	for _, e := range body.ConfigDirs {
-		err = goa.MergeErrors(err, goa.ValidatePattern("body.config_dirs[*]", e, "^~?/[^\\\\]+$"))
-		if utf8.RuneCountInString(e) > 256 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("body.config_dirs[*]", e, utf8.RuneCountInString(e), 256, false))
-		}
 	}
 	if len(body.ProcessNames) > 16 {
 		err = goa.MergeErrors(err, goa.InvalidLengthError("body.process_names", body.ProcessNames, len(body.ProcessNames), 16, false))

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -11106,7 +11106,7 @@ func agentUpsertAiScanTargetUsage() {
 
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "agent upsert-ai-scan-target --body '{\n      \"category\": \"local_model\",\n      \"display_name\": \"aa\",\n      \"enabled\": false,\n      \"id\": \"1\",\n      \"signatures\": {\n         \"binaries\": [\n            \".\",\n            \".\",\n            \".\"\n         ],\n         \"bundle_ids\": [\n            \".\",\n            \".\",\n            \".\"\n         ],\n         \"config_dirs\": [\n            \"aaa\",\n            \"aaa\",\n            \"aaa\"\n         ],\n         \"process_names\": [\n            \"-\",\n            \"-\",\n            \"-\"\n         ]\n      },\n      \"version_plist_key\": \"1\"\n   }' --session-token \"abc123\"")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "agent upsert-ai-scan-target --body '{\n      \"category\": \"local_model\",\n      \"display_name\": \"aa\",\n      \"enabled\": false,\n      \"id\": \"1\",\n      \"signatures\": {\n         \"binaries\": [\n            \".\",\n            \".\",\n            \".\"\n         ],\n         \"bundle_ids\": [\n            \".\",\n            \".\",\n            \".\"\n         ],\n         \"config_dirs\": [\n            \"abc123\",\n            \"abc123\",\n            \"abc123\"\n         ],\n         \"process_names\": [\n            \"-\",\n            \"-\",\n            \"-\"\n         ]\n      },\n      \"version_plist_key\": \"1\"\n   }' --session-token \"abc123\"")
 }
 
 func agentDeleteAiScanTargetUsage() {

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -70738,9 +70738,7 @@ components:
                     type: array
                     items:
                         type: string
-                        pattern: ^~?/[^\\]+$
-                        maxLength: 256
-                    description: Home-relative (~/...) or absolute (/...) directories whose existence marks the tool as installed.
+                    description: Directories whose existence marks the tool as installed, taken as home-relative unless they start with /.
                     maxItems: 16
                 process_names:
                     type: array

--- a/server/internal/agent/aiscan_targets_test.go
+++ b/server/internal/agent/aiscan_targets_test.go
@@ -216,6 +216,29 @@ func TestDeleteAiScanTargetRefusesIdsTheOrganizationDoesNotOwn(t *testing.T) {
 	requireAiScanErrorCode(t, err, oops.CodeNotFound)
 }
 
+func TestUpsertAiScanTargetStoresAConfigDirWithoutItsTrailingSlash(t *testing.T) {
+	t.Parallel()
+	ctx, ti := newTestAgentService(t)
+	ctx = authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, ti.orgID))
+
+	payload := chatgptDesktopPayload()
+	payload.Signatures.ConfigDirs = []string{"~/Library/Application Support/com.openai.chat/"}
+	result, err := ti.service.UpsertAiScanTarget(ctx, payload)
+	require.NoError(t, err)
+	require.Equal(t,
+		[]string{"~/Library/Application Support/com.openai.chat"},
+		result.Target.Signatures.ConfigDirs,
+		"a directory written with a trailing slash is the same directory",
+	)
+
+	// A bare home or root folder is still refused rather than silently made
+	// into something the agent would probe.
+	payload = chatgptDesktopPayload()
+	payload.Signatures.ConfigDirs = []string{"~/"}
+	_, err = ti.service.UpsertAiScanTarget(ctx, payload)
+	requireAiScanErrorCode(t, err, oops.CodeBadRequest)
+}
+
 func TestUpsertAiScanTargetRejectsWhatAgentsWouldRefuse(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestAgentService(t)

--- a/server/internal/agent/aiscan_targets_test.go
+++ b/server/internal/agent/aiscan_targets_test.go
@@ -216,27 +216,19 @@ func TestDeleteAiScanTargetRefusesIdsTheOrganizationDoesNotOwn(t *testing.T) {
 	requireAiScanErrorCode(t, err, oops.CodeNotFound)
 }
 
-func TestUpsertAiScanTargetStoresAConfigDirWithoutItsTrailingSlash(t *testing.T) {
+func TestUpsertAiScanTargetKeepsAConfigDirAsItWasWritten(t *testing.T) {
 	t.Parallel()
 	ctx, ti := newTestAgentService(t)
 	ctx = authztest.WithExactGrants(t, ctx, authz.NewGrant(authz.ScopeOrgAdmin, ti.orgID))
 
 	payload := chatgptDesktopPayload()
-	payload.Signatures.ConfigDirs = []string{"~/Library/Application Support/com.openai.chat/"}
+	payload.Signatures.ConfigDirs = []string{"~/Library/Application Support/com.openai.chat/", ".claude"}
 	result, err := ti.service.UpsertAiScanTarget(ctx, payload)
 	require.NoError(t, err)
 	require.Equal(t,
-		[]string{"~/Library/Application Support/com.openai.chat"},
+		[]string{"~/Library/Application Support/com.openai.chat/", ".claude"},
 		result.Target.Signatures.ConfigDirs,
-		"a directory written with a trailing slash is the same directory",
 	)
-
-	// A bare home or root folder is still refused rather than silently made
-	// into something the agent would probe.
-	payload = chatgptDesktopPayload()
-	payload.Signatures.ConfigDirs = []string{"~/"}
-	_, err = ti.service.UpsertAiScanTarget(ctx, payload)
-	requireAiScanErrorCode(t, err, oops.CodeBadRequest)
 }
 
 func TestUpsertAiScanTargetRejectsWhatAgentsWouldRefuse(t *testing.T) {

--- a/server/internal/agent/aiscantargets.go
+++ b/server/internal/agent/aiscantargets.go
@@ -235,26 +235,9 @@ func signaturesFromPayload(signatures *gen.AiScanTargetSignatures) aitargets.Sig
 	return aitargets.Signatures{
 		BundleIDs:    trimAll(signatures.BundleIds),
 		Binaries:     trimAll(signatures.Binaries),
-		ConfigDirs:   normalizeConfigDirs(trimAll(signatures.ConfigDirs)),
+		ConfigDirs:   trimAll(signatures.ConfigDirs),
 		ProcessNames: trimAll(signatures.ProcessNames),
 	}
-}
-
-// normalizeConfigDirs drops the trailing slash a directory path is often
-// written with, so "~/.claude/" is stored and served as "~/.claude" rather
-// than rejected for an empty last segment. A bare "~/" or "/" is left as it
-// was written: those name the whole home or root folder, which the validator
-// still refuses.
-func normalizeConfigDirs(dirs []string) []string {
-	out := make([]string, 0, len(dirs))
-	for _, dir := range dirs {
-		if trimmed := strings.TrimRight(dir, "/"); trimmed != "" && trimmed != "~" {
-			out = append(out, trimmed)
-		} else {
-			out = append(out, dir)
-		}
-	}
-	return out
 }
 
 // trimAll trims entries and drops blank ones.

--- a/server/internal/agent/aiscantargets.go
+++ b/server/internal/agent/aiscantargets.go
@@ -235,9 +235,26 @@ func signaturesFromPayload(signatures *gen.AiScanTargetSignatures) aitargets.Sig
 	return aitargets.Signatures{
 		BundleIDs:    trimAll(signatures.BundleIds),
 		Binaries:     trimAll(signatures.Binaries),
-		ConfigDirs:   trimAll(signatures.ConfigDirs),
+		ConfigDirs:   normalizeConfigDirs(trimAll(signatures.ConfigDirs)),
 		ProcessNames: trimAll(signatures.ProcessNames),
 	}
+}
+
+// normalizeConfigDirs drops the trailing slash a directory path is often
+// written with, so "~/.claude/" is stored and served as "~/.claude" rather
+// than rejected for an empty last segment. A bare "~/" or "/" is left as it
+// was written: those name the whole home or root folder, which the validator
+// still refuses.
+func normalizeConfigDirs(dirs []string) []string {
+	out := make([]string, 0, len(dirs))
+	for _, dir := range dirs {
+		if trimmed := strings.TrimRight(dir, "/"); trimmed != "" && trimmed != "~" {
+			out = append(out, trimmed)
+		} else {
+			out = append(out, dir)
+		}
+	}
+	return out
 }
 
 // trimAll trims entries and drops blank ones.

--- a/server/internal/agent/aitargets/aitargets.go
+++ b/server/internal/agent/aitargets/aitargets.go
@@ -41,8 +41,9 @@ type Signatures struct {
 	// Binaries are bare command names resolved on the device PATH.
 	Binaries []string `json:"binaries"`
 
-	// ConfigDirs are home-relative directories whose existence marks the
-	// tool as installed.
+	// ConfigDirs are directories whose existence marks the tool as
+	// installed, resolved by the agent relative to the home folder unless
+	// they start with "/".
 	ConfigDirs []string `json:"config_dirs"`
 
 	// ProcessNames are exact process names checked for the running signal.

--- a/server/internal/agent/aitargets/validate.go
+++ b/server/internal/agent/aitargets/validate.go
@@ -20,9 +20,6 @@ const (
 	// MaxSignatureEntries caps each signature list on a target.
 	MaxSignatureEntries = 16
 
-	// MaxConfigDirLength caps a config-dir signature.
-	MaxConfigDirLength = 256
-
 	// MaxDisplayNameLength caps the display name.
 	MaxDisplayNameLength = 128
 
@@ -112,11 +109,6 @@ func ValidateTarget(target Target) error {
 			return fail("binary %q must be a bare command name matching %s", bin, binaryPattern)
 		}
 	}
-	for _, dir := range sig.ConfigDirs {
-		if err := validateConfigDir(dir); err != nil {
-			return fail("config dir %q: %v", dir, err)
-		}
-	}
 	for _, proc := range sig.ProcessNames {
 		if !processNamePattern.MatchString(proc) {
 			return fail("process name %q must match %s", proc, processNamePattern)
@@ -127,38 +119,6 @@ func ValidateTarget(target Target) error {
 	}
 	if len(sig.BundleIDs)+len(sig.Binaries)+len(sig.ConfigDirs) == 0 {
 		return fail("at least one install signature (bundle id, binary, or config dir) is required")
-	}
-	return nil
-}
-
-// validateConfigDir admits home-relative (~/...) and absolute (/...)
-// directories with at least one real segment: "~/" and "/" alone always
-// exist, "." or ".." could walk the probe somewhere else, and a bare relative
-// path has no anchor on the device.
-func validateConfigDir(dir string) error {
-	if utf8.RuneCountInString(dir) > MaxConfigDirLength {
-		return fmt.Errorf("exceeds %d characters", MaxConfigDirLength)
-	}
-	var rest string
-	switch {
-	case strings.HasPrefix(dir, "~/"):
-		rest = dir[2:]
-	case strings.HasPrefix(dir, "/"):
-		rest = dir[1:]
-	default:
-		return errors.New("must start with ~/ or /")
-	}
-	if strings.ContainsAny(dir, "\\\x00") {
-		return errors.New("must not contain backslashes or NUL")
-	}
-	if rest == "" {
-		return errors.New("always exists; name a directory inside it")
-	}
-	for segment := range strings.SplitSeq(rest, "/") {
-		switch segment {
-		case "", ".", "..":
-			return errors.New("must not contain empty, \".\", or \"..\" segments")
-		}
 	}
 	return nil
 }

--- a/server/internal/agent/aitargets/validate.go
+++ b/server/internal/agent/aitargets/validate.go
@@ -151,6 +151,9 @@ func validateConfigDir(dir string) error {
 	if strings.ContainsAny(dir, "\\\x00") {
 		return errors.New("must not contain backslashes or NUL")
 	}
+	if rest == "" {
+		return errors.New("always exists; name a directory inside it")
+	}
 	for segment := range strings.SplitSeq(rest, "/") {
 		switch segment {
 		case "", ".", "..":

--- a/server/internal/agent/aitargets/validate_test.go
+++ b/server/internal/agent/aitargets/validate_test.go
@@ -101,6 +101,26 @@ func TestValidateTargetRejectsEachRule(t *testing.T) {
 	}
 }
 
+// The whole home or root folder is refused for its own reason, not for an
+// empty path segment: the dashboard editor says the same thing, so an admin
+// reaching this rule through the CLI or SDK is told what to do about it.
+func TestValidateTargetExplainsWhyABareHomeOrRootConfigDirIsRefused(t *testing.T) {
+	t.Parallel()
+
+	for _, dir := range []string{"~/", "/"} {
+		target := validTarget()
+		target.Signatures.ConfigDirs = []string{dir}
+		err := aitargets.ValidateTarget(target)
+		require.ErrorIs(t, err, aitargets.ErrInvalidTarget)
+		require.ErrorContains(t, err, "always exists; name a directory inside it", "config dir %q", dir)
+	}
+
+	// A real path with an interior empty segment still reports that.
+	target := validTarget()
+	target.Signatures.ConfigDirs = []string{"~/.claude//x"}
+	require.ErrorContains(t, aitargets.ValidateTarget(target), `must not contain empty, ".", or ".." segments`)
+}
+
 func TestValidateRejectsDuplicateIDsAndOversizedLists(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/agent/aitargets/validate_test.go
+++ b/server/internal/agent/aitargets/validate_test.go
@@ -73,17 +73,6 @@ func TestValidateTargetRejectsEachRule(t *testing.T) {
 		"binary absolute path":       func(x *aitargets.Target) { x.Signatures.Binaries = []string{"/usr/bin/claude"} },
 		"binary dot":                 func(x *aitargets.Target) { x.Signatures.Binaries = []string{"."} },
 		"binary dot dot":             func(x *aitargets.Target) { x.Signatures.Binaries = []string{".."} },
-		"config dir bare relative":   func(x *aitargets.Target) { x.Signatures.ConfigDirs = []string{".claude"} },
-		"config dir root only":       func(x *aitargets.Target) { x.Signatures.ConfigDirs = []string{"/"} },
-		"config dir absolute walk":   func(x *aitargets.Target) { x.Signatures.ConfigDirs = []string{"/opt/../etc"} },
-		"config dir home only":       func(x *aitargets.Target) { x.Signatures.ConfigDirs = []string{"~/"} },
-		"config dir bare tilde":      func(x *aitargets.Target) { x.Signatures.ConfigDirs = []string{"~"} },
-		"config dir parent walk":     func(x *aitargets.Target) { x.Signatures.ConfigDirs = []string{"~/../.ssh"} },
-		"config dir dot segment":     func(x *aitargets.Target) { x.Signatures.ConfigDirs = []string{"~/./.ssh"} },
-		"config dir empty segment":   func(x *aitargets.Target) { x.Signatures.ConfigDirs = []string{"~/.claude//x"} },
-		"config dir trailing slash":  func(x *aitargets.Target) { x.Signatures.ConfigDirs = []string{"~/.claude/"} },
-		"config dir backslash":       func(x *aitargets.Target) { x.Signatures.ConfigDirs = []string{`~/.claude\x`} },
-		"config dir too long":        func(x *aitargets.Target) { x.Signatures.ConfigDirs = []string{"~/" + strings.Repeat("a", 256)} },
 		"process name regex meta":    func(x *aitargets.Target) { x.Signatures.ProcessNames = []string{".*"} },
 		"process name with slash":    func(x *aitargets.Target) { x.Signatures.ProcessNames = []string{"bin/claude"} },
 		"plist key with dot":         func(x *aitargets.Target) { x.VersionHint = &aitargets.VersionHint{PlistKey: "CF.Bundle"} },
@@ -101,24 +90,24 @@ func TestValidateTargetRejectsEachRule(t *testing.T) {
 	}
 }
 
-// The whole home or root folder is refused for its own reason, not for an
-// empty path segment: the dashboard editor says the same thing, so an admin
-// reaching this rule through the CLI or SDK is told what to do about it.
-func TestValidateTargetExplainsWhyABareHomeOrRootConfigDirIsRefused(t *testing.T) {
+// A config dir is whatever the device agent can resolve: a home-relative
+// prefix or an absolute path, however it was written. The agent only checks
+// whether the directory exists, so the shape is not worth policing here.
+func TestValidateTargetAcceptsAnyConfigDirShape(t *testing.T) {
 	t.Parallel()
 
-	for _, dir := range []string{"~/", "/"} {
+	for _, dir := range []string{
+		".claude",
+		"~/.claude",
+		"~/.claude/",
+		"/opt/homebrew/etc/claude",
+		"~/Library/Application Support/com.openai.chat/",
+		"Library/Application Support/Cursor",
+	} {
 		target := validTarget()
 		target.Signatures.ConfigDirs = []string{dir}
-		err := aitargets.ValidateTarget(target)
-		require.ErrorIs(t, err, aitargets.ErrInvalidTarget)
-		require.ErrorContains(t, err, "always exists; name a directory inside it", "config dir %q", dir)
+		require.NoError(t, aitargets.ValidateTarget(target), "config dir %q", dir)
 	}
-
-	// A real path with an interior empty segment still reports that.
-	target := validTarget()
-	target.Signatures.ConfigDirs = []string{"~/.claude//x"}
-	require.ErrorContains(t, aitargets.ValidateTarget(target), `must not contain empty, ".", or ".." segments`)
 }
 
 func TestValidateRejectsDuplicateIDsAndOversizedLists(t *testing.T) {


### PR DESCRIPTION
## Summary

A config dir signature typed with a trailing slash — `~/Library/Application Support/com.openai.chat/` — was rejected with `must not contain empty, "." or ".." segments`. Rather than teach the rule about one more spelling, this drops the rule. A config dir is now any path the device agent can resolve: a home-relative prefix or an absolute path, however it was written.

Removed across all three layers that were enforcing the shape:

- **Goa design** — the `^~?/[^\\]+$` pattern and the 256-character cap on each entry. Regenerated artifacts ride along.
- **`aitargets.validateConfigDir`** — deleted, along with `MaxConfigDirLength`. `ValidateTarget` no longer inspects config dirs.
- **Dashboard** — `configDirProblem` deleted; `normalizeConfigDir` now only trims, instead of rewriting the entry to force a `~/` anchor.

The `trimAll` pass on write (drop surrounding whitespace and blank entries) and the 16-entries-per-list cap are what remain. Total served size is still bounded by `MaxEnvelopeBytes`, so removing the per-entry length cap does not uncap the payload.

Tests were inverted to match: the cases that pinned each rejected shape are replaced by one on each side asserting these paths are accepted.

## Motivation

The agent only checks whether a directory exists, and the list is edited by org admins, so the shape of the path was never load-bearing. The rules cost an admin a rejected form for a trailing slash — a conventional way to write a directory — and bought nothing the agent needed. Three separate implementations of the same rule also meant three places to keep in step, which is how the message for a bare `~/` came to differ between the dashboard and the API.

Note for the device agent: its decode-time validator mirrors these rules, so it may still refuse shapes the API now accepts (a bare `.claude` prefix, or a `..` segment). Nothing in the compiled-in defaults changes, so existing catalogs are unaffected, but that validator should be loosened to match before admins are pointed at the wider range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
