### PR TITLE
feat: publish remote session client JWKS

### DIFF
--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -573,6 +573,10 @@ func Attach(mux goahttp.Muxer, service *Service, metadataService *mcpmetadata.Se
 	// Public, unauthenticated outbound-CIMD document endpoint. Deployment-global
 	// (not slug-scoped): clients are addressed by their globally unique id.
 	o11y.AttachHandler(mux, "GET", "/.well-known/oauth-client/{id}", oops.ErrHandle(service.logger, service.HandleClientMetadataDocument).ServeHTTP)
+	// Public keys for outbound clients. This remains available independently of
+	// management entitlements so registered counterparties can keep verifying
+	// client assertions.
+	o11y.AttachHandler(mux, "GET", "/.well-known/oauth-client/{id}/jwks.json", oops.ErrHandle(service.logger, service.HandleClientJSONWebKeySet).ServeHTTP)
 	o11y.AttachHandler(mux, "GET", "/.well-known/openai-apps-challenge", oops.ErrHandle(service.logger, service.HandleOpenAIAppsChallenge).ServeHTTP)
 	o11y.AttachHandler(mux, "POST", PublicServerRoute, oops.MCPErrHandle(service.logger, service.ServePublic).ServeHTTP)
 	o11y.AttachHandler(mux, "GET", PublicServerRoute, oops.MCPErrHandle(service.logger, func(w http.ResponseWriter, r *http.Request) error {
@@ -626,6 +630,13 @@ func (s *Service) HandleLegacyProxyCallback(w http.ResponseWriter, r *http.Reque
 // remote-session handlers without reaching into the unexported manager field.
 func (s *Service) HandleClientMetadataDocument(w http.ResponseWriter, r *http.Request) error {
 	return s.remoteChallengeMgr.HandleClientMetadataDocument(w, r) //nolint:wrapcheck // thin passthrough; the inner handler already writes the HTTP response.
+}
+
+// HandleClientJSONWebKeySet is the public outbound-client key set endpoint at
+// `GET /.well-known/oauth-client/{id}/jwks.json`. Thin passthrough to the
+// remote-session manager that owns client key publication.
+func (s *Service) HandleClientJSONWebKeySet(w http.ResponseWriter, r *http.Request) error {
+	return s.remoteChallengeMgr.HandleClientJSONWebKeySet(w, r) //nolint:wrapcheck // thin passthrough; the inner handler already writes the HTTP response.
 }
 
 // HandleOpenAIAppsChallenge serves the domain-verification token configured

--- a/server/internal/remotesessions/cimd.go
+++ b/server/internal/remotesessions/cimd.go
@@ -27,11 +27,20 @@ import (
 	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 )
 
-// clientMetadataDocumentMaxAgeSeconds is the Cache-Control max-age for served
-// CIMD documents. Longer than the well-known metadata TTL: a document is keyed
-// by an immutable client_id and changes only if the client's scope or callback
-// does, so upstream Authorization Servers can safely cache it for an hour.
-const clientMetadataDocumentMaxAgeSeconds = 3600
+const (
+	// clientMetadataDocumentMaxAgeSeconds is the Cache-Control max-age for
+	// served CIMD documents. Longer than the well-known metadata TTL: a
+	// document is keyed by an immutable client_id and changes only if the
+	// client's registration does, so upstream Authorization Servers can safely
+	// cache it for an hour.
+	clientMetadataDocumentMaxAgeSeconds = 3600
+
+	// clientJSONWebKeySetMaxAgeSeconds lets verifiers cache client public keys
+	// for an hour. Key rotation publishes pending keys before activating them
+	// and retains retired keys, so both sides of the rotation overlap this
+	// freshness window.
+	clientJSONWebKeySetMaxAgeSeconds = 3600
+)
 
 // cimdClientName is the client_name Gram publishes in every CIMD document. It
 // is what the end user sees on the upstream's consent screen, so it carries the
@@ -56,6 +65,14 @@ func ClientMetadataDocumentURL(serverURL *url.URL, clientID uuid.UUID) string {
 	return strings.TrimRight(serverURL.String(), "/") + clientMetadataDocumentPath + clientID.String()
 }
 
+// ClientJSONWebKeySetURL builds the platform-canonical public key set URL for
+// a remote-session client. The path uses the client's globally unique primary
+// key rather than its upstream client_id, which can be URL-shaped or reused by
+// different issuers.
+func ClientJSONWebKeySetURL(serverURL *url.URL, clientID uuid.UUID) string {
+	return ClientMetadataDocumentURL(serverURL, clientID) + "/jwks.json"
+}
+
 // clientMetadataDocument is the JSON body served at the CIMD endpoint. Fields
 // follow RFC 7591 client metadata as referenced by the CIMD draft. scope is a
 // space-delimited string per RFC 7591 §2 (not an array).
@@ -65,6 +82,7 @@ type clientMetadataDocument struct {
 	RedirectURIs            []string `json:"redirect_uris"`
 	GrantTypes              []string `json:"grant_types"`
 	ResponseTypes           []string `json:"response_types"`
+	JWKSURI                 string   `json:"jwks_uri,omitempty"`
 	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
 	Scope                   string   `json:"scope,omitempty"`
 }
@@ -72,15 +90,18 @@ type clientMetadataDocument struct {
 // BuildClientMetadataDocument renders the CIMD document for a client. clientID
 // MUST equal the URL the document is served at (the CIMD invariant the upstream
 // AS validates); redirectURI is Gram's outbound callback for this deployment;
-// scope is the client's explicit upstream scopes, omitted when empty.
-func BuildClientMetadataDocument(clientID, redirectURI string, scope []string) clientMetadataDocument {
+// tokenEndpointAuthMethod is the method the client actually uses; jwksURI is
+// present only while a key set is attached; scope is the client's explicit
+// upstream scopes, omitted when empty.
+func BuildClientMetadataDocument(clientID, redirectURI string, tokenEndpointAuthMethod TokenEndpointAuthMethod, jwksURI string, scope []string) clientMetadataDocument {
 	return clientMetadataDocument{
 		ClientID:                clientID,
 		ClientName:              cimdClientName,
 		RedirectURIs:            []string{redirectURI},
 		GrantTypes:              []string{"authorization_code", "refresh_token"},
 		ResponseTypes:           []string{"code"},
-		TokenEndpointAuthMethod: string(TokenEndpointAuthMethodNone),
+		JWKSURI:                 jwksURI,
+		TokenEndpointAuthMethod: string(tokenEndpointAuthMethod),
 		Scope:                   strings.Join(scope, " "),
 	}
 }
@@ -133,8 +154,20 @@ func (m *ChallengeManager) HandleClientMetadataDocument(w http.ResponseWriter, r
 	}
 
 	// client_id is the stored canonical URL (== the value sent upstream), not a
-	// host-derived one, so it always matches what the AS dereferenced.
-	doc := BuildClientMetadataDocument(row.ClientIDMetadataUri.String, m.callbackURL(canonicalCallbackRouteBase), row.Scope)
+	// host-derived one, so it always matches what the AS dereferenced. The JWKS
+	// URL is likewise built from the configured platform origin rather than the
+	// request host.
+	jwksURI := ""
+	if row.HasJsonWebKeySet {
+		jwksURI = ClientJSONWebKeySetURL(m.serverURL, row.ID)
+	}
+	doc := BuildClientMetadataDocument(
+		row.ClientIDMetadataUri.String,
+		m.callbackURL(canonicalCallbackRouteBase),
+		TokenEndpointAuthMethod(row.TokenEndpointAuthMethod),
+		jwksURI,
+		row.Scope,
+	)
 
 	body, err := json.Marshal(doc)
 	if err != nil {
@@ -142,4 +175,33 @@ func (m *ChallengeManager) HandleClientMetadataDocument(w http.ResponseWriter, r
 	}
 
 	return httpcache.WriteCacheableJSON(ctx, w, r, m.logger, "application/json; charset=utf-8", clientMetadataDocumentMaxAgeSeconds, body)
+}
+
+// HandleClientJSONWebKeySet serves the public keys for a remote-session client
+// at GET /.well-known/oauth-client/{id}/jwks.json. Any live client with a live
+// attached set is addressable, including non-CIMD clients whose administrator
+// registered this URL manually. A client without an attached set 404s.
+func (m *ChallengeManager) HandleClientJSONWebKeySet(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+
+	// The registered URL always names the platform origin. Serving a
+	// custom-domain variant would expose a location no counterparty was given.
+	if customdomains.FromContext(ctx) != nil {
+		return oops.E(oops.CodeNotFound, nil, "client JSON Web Key Set not found")
+	}
+
+	clientID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		return oops.E(oops.CodeNotFound, err, "client JSON Web Key Set not found")
+	}
+
+	body, err := remotesessions_repo.New(m.db).GetRemoteSessionClientJsonWebKeySetDocument(ctx, clientID)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return oops.E(oops.CodeNotFound, nil, "client JSON Web Key Set not found")
+	case err != nil:
+		return oops.E(oops.CodeUnexpected, err, "load client JSON Web Key Set").LogError(ctx, m.logger)
+	}
+
+	return httpcache.WriteCacheableJSON(ctx, w, r, m.logger, "application/jwk-set+json", clientJSONWebKeySetMaxAgeSeconds, body)
 }

--- a/server/internal/remotesessions/cimd_test.go
+++ b/server/internal/remotesessions/cimd_test.go
@@ -144,7 +144,8 @@ func TestBuildClientMetadataDocument(t *testing.T) {
 	const clientID = "https://app.getgram.ai/.well-known/oauth-client/abc"
 	const redirectURI = "https://app.getgram.ai/mcp/remote_login_callback"
 
-	doc := remotesessions.BuildClientMetadataDocument(clientID, redirectURI, []string{"read", "write"})
+	const jwksURI = "https://app.getgram.ai/.well-known/oauth-client/abc/jwks.json"
+	doc := remotesessions.BuildClientMetadataDocument(clientID, redirectURI, remotesessions.TokenEndpointAuthMethodPrivateKeyJWT, jwksURI, []string{"read", "write"})
 
 	body, err := json.Marshal(doc)
 	require.NoError(t, err)
@@ -157,14 +158,21 @@ func TestBuildClientMetadataDocument(t *testing.T) {
 	require.Equal(t, []any{redirectURI}, got["redirect_uris"])
 	require.Equal(t, []any{"authorization_code", "refresh_token"}, got["grant_types"])
 	require.Equal(t, []any{"code"}, got["response_types"])
-	require.Equal(t, "none", got["token_endpoint_auth_method"], "CIMD is public-mode only")
+	require.Equal(t, jwksURI, got["jwks_uri"])
+	require.Equal(t, "private_key_jwt", got["token_endpoint_auth_method"])
 	require.Equal(t, "read write", got["scope"], "scope is space-delimited per RFC 7591")
 }
 
 func TestBuildClientMetadataDocument_OmitsEmptyScope(t *testing.T) {
 	t.Parallel()
 
-	doc := remotesessions.BuildClientMetadataDocument("https://app.getgram.ai/.well-known/oauth-client/abc", "https://app.getgram.ai/mcp/remote_login_callback", nil)
+	doc := remotesessions.BuildClientMetadataDocument(
+		"https://app.getgram.ai/.well-known/oauth-client/abc",
+		"https://app.getgram.ai/mcp/remote_login_callback",
+		remotesessions.TokenEndpointAuthMethodNone,
+		"",
+		nil,
+	)
 
 	body, err := json.Marshal(doc)
 	require.NoError(t, err)
@@ -173,6 +181,8 @@ func TestBuildClientMetadataDocument_OmitsEmptyScope(t *testing.T) {
 	require.NoError(t, json.Unmarshal(body, &got))
 	_, present := got["scope"]
 	require.False(t, present, "scope must be omitted when the client has no explicit scopes")
+	_, present = got["jwks_uri"]
+	require.False(t, present, "jwks_uri must be omitted when the client has no attached key set")
 }
 
 func TestClientMetadataDocumentURL(t *testing.T) {
@@ -213,6 +223,35 @@ func TestHandleClientMetadataDocument_ServesDocument(t *testing.T) {
 	require.Equal(t, []any{cimdServerURL + "/mcp/remote_login_callback"}, redirectURIs)
 	require.Equal(t, "none", got["token_endpoint_auth_method"])
 	require.Equal(t, "read:tools", got["scope"])
+	_, present := got["jwks_uri"]
+	require.False(t, present)
+}
+
+func TestHandleClientMetadataDocument_PublishesAttachedKeySetAndStoredAuthMethod(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	ti.enableCustomerManagedKeys(t, ctx, authCtx.ActiveOrganizationID)
+
+	issuerID := createCIMDIssuer(t, ctx, ti, "cimd-jwks", "https://idp.example.com/authorize", "https://idp.example.com/token")
+	userIssuer := createUserSessionIssuer(t, ctx, ti.conn, "cimd-jwks-usi")
+	created := createCimdClient(t, ctx, ti, issuerID.String(), userIssuer.String(), nil)
+	clientID := uuid.MustParse(created.ID)
+	setID := createJsonWebKeySet(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "cimd-jwks-set")
+	attachJsonWebKeySet(t, ctx, ti, created.ID, setID)
+	forceTokenEndpointAuthMethod(t, ctx, ti.conn, clientID, *authCtx.ProjectID, string(remotesessions.TokenEndpointAuthMethodPrivateKeyJWT))
+
+	mgr := newCIMDChallengeManager(t, ti, cimdServerURL)
+	rec := httptest.NewRecorder()
+	require.NoError(t, mgr.HandleClientMetadataDocument(rec, cimdDocumentRequest(t, created.ID, false)))
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, "private_key_jwt", got["token_endpoint_auth_method"])
+	require.Equal(t, remotesessions.ClientJSONWebKeySetURL(mustURL(t, cimdServerURL), clientID), got["jwks_uri"])
 }
 
 func TestHandleClientMetadataDocument_NotFoundUnknownID(t *testing.T) {

--- a/server/internal/remotesessions/clientjwksdocument_test.go
+++ b/server/internal/remotesessions/clientjwksdocument_test.go
@@ -1,0 +1,183 @@
+package remotesessions_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	orgclientsgen "github.com/speakeasy-api/gram/server/gen/organization_remote_session_clients"
+	"github.com/speakeasy-api/gram/server/internal/customdomains"
+	"github.com/speakeasy-api/gram/server/internal/oops"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+)
+
+func clientJSONWebKeySetRequest(t *testing.T, id string, customDomain bool) *http.Request {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-client/"+id+"/jwks.json", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", id)
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	if customDomain {
+		ctx = customdomains.WithContext(ctx, &customdomains.Context{
+			OrganizationID: "org-jwks",
+			Domain:         "mcp.customer.example.com",
+			DomainID:       uuid.New(),
+		})
+	}
+
+	return req.WithContext(ctx)
+}
+
+func attachJsonWebKeySet(t *testing.T, ctx context.Context, ti *testInstance, clientID string, setID uuid.UUID) {
+	t.Helper()
+
+	_, err := ti.service.AttachClientKeySet(ctx, &orgclientsgen.AttachClientKeySetPayload{
+		ID:              clientID,
+		JSONWebKeySetID: setID.String(),
+	})
+	require.NoError(t, err)
+}
+
+func TestClientJSONWebKeySetURL(t *testing.T) {
+	t.Parallel()
+
+	id := uuid.MustParse("00000000-0000-0000-0000-0000000000aa")
+	want := "https://app.getgram.ai/.well-known/oauth-client/" + id.String() + "/jwks.json"
+	require.Equal(t, want, remotesessions.ClientJSONWebKeySetURL(mustURL(t, "https://app.getgram.ai"), id))
+	require.Equal(t, want, remotesessions.ClientJSONWebKeySetURL(mustURL(t, "https://app.getgram.ai/"), id))
+}
+
+func TestHandleClientJSONWebKeySet_ServesLiveKeysForManualClient(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	organizationID := activeOrganizationID(t, ctx)
+	ti.enableCustomerManagedKeys(t, ctx, organizationID)
+
+	issuerID := createRemoteIssuer(t, ctx, ti, "jwks-document-issuer", "")
+	userIssuerID := createUserSessionIssuer(t, ctx, ti.conn, "jwks-document-usi")
+	clientID := createRemoteClient(t, ctx, ti, issuerID, userIssuerID.String(), "manual-client-id")
+	setID := createJsonWebKeySet(t, ctx, ti.conn, organizationID, "jwks-document-set")
+
+	createJsonWebKey(t, ctx, ti.conn, organizationID, setID, "pending", "pending-key")
+	createJsonWebKey(t, ctx, ti.conn, organizationID, setID, "active", "active-key")
+	createJsonWebKey(t, ctx, ti.conn, organizationID, setID, "retired", "retired-key")
+	revokedID := createJsonWebKey(t, ctx, ti.conn, organizationID, setID, "pending", "revoked-key")
+	revokeJsonWebKey(t, ctx, ti.conn, organizationID, revokedID)
+	attachJsonWebKeySet(t, ctx, ti, clientID, setID)
+
+	mgr := newCIMDChallengeManager(t, ti, cimdServerURL)
+	rec := httptest.NewRecorder()
+	require.NoError(t, mgr.HandleClientJSONWebKeySet(rec, clientJSONWebKeySetRequest(t, clientID, false)))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "application/jwk-set+json", rec.Header().Get("Content-Type"))
+	require.Equal(t, "public, max-age=3600", rec.Header().Get("Cache-Control"))
+	etag := rec.Header().Get("ETag")
+	require.NotEmpty(t, etag)
+
+	var document struct {
+		Keys []map[string]any `json:"keys"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &document))
+	kids := make([]string, 0, len(document.Keys))
+	for _, key := range document.Keys {
+		kid, ok := key["kid"].(string)
+		require.True(t, ok)
+		kids = append(kids, kid)
+
+		modulus, ok := key["n"].(string)
+		require.True(t, ok)
+		decodedModulus, err := base64.RawURLEncoding.DecodeString(modulus)
+		require.NoError(t, err)
+		require.Len(t, decodedModulus, 256, "fixture keys must carry a 2048-bit RSA modulus")
+		require.Equal(t, "AQAB", key["e"])
+	}
+	require.ElementsMatch(t, []string{"pending-key", "active-key", "retired-key"}, kids)
+	require.NotContains(t, kids, "revoked-key")
+
+	conditionalReq := clientJSONWebKeySetRequest(t, clientID, false)
+	conditionalReq.Header.Set("If-None-Match", etag)
+	conditionalRec := httptest.NewRecorder()
+	require.NoError(t, mgr.HandleClientJSONWebKeySet(conditionalRec, conditionalReq))
+	require.Equal(t, http.StatusNotModified, conditionalRec.Code)
+	require.Empty(t, conditionalRec.Body.String())
+}
+
+func TestHandleClientJSONWebKeySet_ServesEmptyAttachedSet(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	organizationID := activeOrganizationID(t, ctx)
+	ti.enableCustomerManagedKeys(t, ctx, organizationID)
+
+	issuerID := createRemoteIssuer(t, ctx, ti, "jwks-empty-issuer", "")
+	userIssuerID := createUserSessionIssuer(t, ctx, ti.conn, "jwks-empty-usi")
+	clientID := createRemoteClient(t, ctx, ti, issuerID, userIssuerID.String(), "empty-set-client")
+	setID := createJsonWebKeySet(t, ctx, ti.conn, organizationID, "jwks-empty-set")
+	attachJsonWebKeySet(t, ctx, ti, clientID, setID)
+
+	mgr := newCIMDChallengeManager(t, ti, cimdServerURL)
+	rec := httptest.NewRecorder()
+	require.NoError(t, mgr.HandleClientJSONWebKeySet(rec, clientJSONWebKeySetRequest(t, clientID, false)))
+	require.JSONEq(t, `{"keys":[]}`, rec.Body.String())
+}
+
+func TestHandleClientJSONWebKeySet_NotFoundWithoutAttachedSet(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	issuerID := createRemoteIssuer(t, ctx, ti, "jwks-no-set-issuer", "")
+	userIssuerID := createUserSessionIssuer(t, ctx, ti.conn, "jwks-no-set-usi")
+	clientID := createRemoteClient(t, ctx, ti, issuerID, userIssuerID.String(), "no-set-client")
+
+	mgr := newCIMDChallengeManager(t, ti, cimdServerURL)
+	err := mgr.HandleClientJSONWebKeySet(httptest.NewRecorder(), clientJSONWebKeySetRequest(t, clientID, false))
+	requireOopsCode(t, err, oops.CodeNotFound)
+}
+
+func TestHandleClientJSONWebKeySet_NotFoundUnknownID(t *testing.T) {
+	t.Parallel()
+
+	_, ti := newTestService(t)
+	mgr := newCIMDChallengeManager(t, ti, cimdServerURL)
+
+	err := mgr.HandleClientJSONWebKeySet(httptest.NewRecorder(), clientJSONWebKeySetRequest(t, uuid.NewString(), false))
+	requireOopsCode(t, err, oops.CodeNotFound)
+}
+
+func TestHandleClientJSONWebKeySet_NotFoundInvalidID(t *testing.T) {
+	t.Parallel()
+
+	_, ti := newTestService(t)
+	mgr := newCIMDChallengeManager(t, ti, cimdServerURL)
+
+	err := mgr.HandleClientJSONWebKeySet(httptest.NewRecorder(), clientJSONWebKeySetRequest(t, "not-a-uuid", false))
+	requireOopsCode(t, err, oops.CodeNotFound)
+}
+
+func TestHandleClientJSONWebKeySet_NotFoundOnCustomDomain(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestService(t)
+	organizationID := activeOrganizationID(t, ctx)
+	ti.enableCustomerManagedKeys(t, ctx, organizationID)
+
+	issuerID := createRemoteIssuer(t, ctx, ti, "jwks-domain-issuer", "")
+	userIssuerID := createUserSessionIssuer(t, ctx, ti.conn, "jwks-domain-usi")
+	clientID := createRemoteClient(t, ctx, ti, issuerID, userIssuerID.String(), "domain-client")
+	setID := createJsonWebKeySet(t, ctx, ti.conn, organizationID, "jwks-domain-set")
+	attachJsonWebKeySet(t, ctx, ti, clientID, setID)
+
+	mgr := newCIMDChallengeManager(t, ti, cimdServerURL)
+	err := mgr.HandleClientJSONWebKeySet(httptest.NewRecorder(), clientJSONWebKeySetRequest(t, clientID, true))
+	requireOopsCode(t, err, oops.CodeNotFound)
+}

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -709,11 +709,54 @@ WHERE link.remote_session_client_id = c.id
 -- already sends the upstream AS as client_id (CIMD rows never carry a secret).
 -- Mirrors GetRemoteSessionClientWithIssuerByID's id-only justification. A NULL
 -- client_id_metadata_uri (non-CIMD client) yields no row, so the handler 404s.
-SELECT client_id_metadata_uri, scope
-FROM remote_session_clients
-WHERE id = @id
-  AND client_id_metadata_uri IS NOT NULL
-  AND deleted IS FALSE;
+SELECT
+    c.id,
+    c.client_id_metadata_uri,
+    COALESCE(c.token_endpoint_auth_method, 'none')::text AS token_endpoint_auth_method,
+    CASE WHEN s.id IS NULL THEN false ELSE true END AS has_json_web_key_set,
+    c.scope
+FROM remote_session_clients AS c
+LEFT JOIN json_web_key_sets AS s
+  ON s.organization_id = c.organization_id
+ AND s.id = c.json_web_key_set_id
+ AND s.deleted IS FALSE
+WHERE c.id = @id
+  AND c.client_id_metadata_uri IS NOT NULL
+  AND c.deleted IS FALSE;
+
+-- name: GetRemoteSessionClientJsonWebKeySetDocument :one
+-- Public client JWKS endpoint lookup. Intentionally NOT project-scoped or
+-- entitlement-gated: a counterparty may depend on this unauthenticated URL to
+-- verify client assertions after the organization that configured it loses
+-- management access. The globally unique client primary key is the public
+-- address. A missing/deleted client or missing/deleted attached set yields no
+-- row, while an attached set with no keys yields {"keys":[]}.
+--
+-- Every live key is publishable. Pending keys must be visible before they
+-- become active, active keys verify new assertions, and retired keys remain
+-- visible for assertions minted before rotation. Revoked keys are always
+-- soft-deleted and therefore excluded. Ordering by immutable key id keeps the
+-- serialized document and its HTTP ETag stable between lifecycle changes.
+SELECT jsonb_build_object(
+    'keys',
+    COALESCE(
+        jsonb_agg(k.public_jwk ORDER BY k.id) FILTER (WHERE k.id IS NOT NULL),
+        '[]'::jsonb
+    )
+) AS document
+FROM remote_session_clients AS c
+JOIN json_web_key_sets AS s
+  ON s.organization_id = c.organization_id
+ AND s.id = c.json_web_key_set_id
+ AND s.deleted IS FALSE
+LEFT JOIN json_web_keys AS k
+  ON k.organization_id = s.organization_id
+ AND k.json_web_key_set_id = s.id
+ AND k.state IN ('pending', 'active', 'retired')
+ AND k.deleted IS FALSE
+WHERE c.id = @id
+  AND c.deleted IS FALSE
+GROUP BY c.id;
 
 -- name: GetLocalFixtureOrganizationRemoteSessionClient :one
 -- The local Platform MCP fixture owns at most one organization-scoped public

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -2295,16 +2295,28 @@ func (q *Queries) GetRemoteSessionClientByID(ctx context.Context, arg GetRemoteS
 }
 
 const getRemoteSessionClientForClientMetadataDocument = `-- name: GetRemoteSessionClientForClientMetadataDocument :one
-SELECT client_id_metadata_uri, scope
-FROM remote_session_clients
-WHERE id = $1
-  AND client_id_metadata_uri IS NOT NULL
-  AND deleted IS FALSE
+SELECT
+    c.id,
+    c.client_id_metadata_uri,
+    COALESCE(c.token_endpoint_auth_method, 'none')::text AS token_endpoint_auth_method,
+    CASE WHEN s.id IS NULL THEN false ELSE true END AS has_json_web_key_set,
+    c.scope
+FROM remote_session_clients AS c
+LEFT JOIN json_web_key_sets AS s
+  ON s.organization_id = c.organization_id
+ AND s.id = c.json_web_key_set_id
+ AND s.deleted IS FALSE
+WHERE c.id = $1
+  AND c.client_id_metadata_uri IS NOT NULL
+  AND c.deleted IS FALSE
 `
 
 type GetRemoteSessionClientForClientMetadataDocumentRow struct {
-	ClientIDMetadataUri pgtype.Text
-	Scope               []string
+	ID                      uuid.UUID
+	ClientIDMetadataUri     pgtype.Text
+	TokenEndpointAuthMethod string
+	HasJsonWebKeySet        bool
+	Scope                   []string
 }
 
 // Public CIMD document endpoint lookup. Intentionally NOT project-scoped: the
@@ -2316,8 +2328,56 @@ type GetRemoteSessionClientForClientMetadataDocumentRow struct {
 func (q *Queries) GetRemoteSessionClientForClientMetadataDocument(ctx context.Context, id uuid.UUID) (GetRemoteSessionClientForClientMetadataDocumentRow, error) {
 	row := q.db.QueryRow(ctx, getRemoteSessionClientForClientMetadataDocument, id)
 	var i GetRemoteSessionClientForClientMetadataDocumentRow
-	err := row.Scan(&i.ClientIDMetadataUri, &i.Scope)
+	err := row.Scan(
+		&i.ID,
+		&i.ClientIDMetadataUri,
+		&i.TokenEndpointAuthMethod,
+		&i.HasJsonWebKeySet,
+		&i.Scope,
+	)
 	return i, err
+}
+
+const getRemoteSessionClientJsonWebKeySetDocument = `-- name: GetRemoteSessionClientJsonWebKeySetDocument :one
+SELECT jsonb_build_object(
+    'keys',
+    COALESCE(
+        jsonb_agg(k.public_jwk ORDER BY k.id) FILTER (WHERE k.id IS NOT NULL),
+        '[]'::jsonb
+    )
+) AS document
+FROM remote_session_clients AS c
+JOIN json_web_key_sets AS s
+  ON s.organization_id = c.organization_id
+ AND s.id = c.json_web_key_set_id
+ AND s.deleted IS FALSE
+LEFT JOIN json_web_keys AS k
+  ON k.organization_id = s.organization_id
+ AND k.json_web_key_set_id = s.id
+ AND k.state IN ('pending', 'active', 'retired')
+ AND k.deleted IS FALSE
+WHERE c.id = $1
+  AND c.deleted IS FALSE
+GROUP BY c.id
+`
+
+// Public client JWKS endpoint lookup. Intentionally NOT project-scoped or
+// entitlement-gated: a counterparty may depend on this unauthenticated URL to
+// verify client assertions after the organization that configured it loses
+// management access. The globally unique client primary key is the public
+// address. A missing/deleted client or missing/deleted attached set yields no
+// row, while an attached set with no keys yields {"keys":[]}.
+//
+// Every live key is publishable. Pending keys must be visible before they
+// become active, active keys verify new assertions, and retired keys remain
+// visible for assertions minted before rotation. Revoked keys are always
+// soft-deleted and therefore excluded. Ordering by immutable key id keeps the
+// serialized document and its HTTP ETag stable between lifecycle changes.
+func (q *Queries) GetRemoteSessionClientJsonWebKeySetDocument(ctx context.Context, id uuid.UUID) ([]byte, error) {
+	row := q.db.QueryRow(ctx, getRemoteSessionClientJsonWebKeySetDocument, id)
+	var document []byte
+	err := row.Scan(&document)
+	return document, err
 }
 
 const getRemoteSessionClientRevocationTargetByID = `-- name: GetRemoteSessionClientRevocationTargetByID :one

--- a/server/internal/remotesessions/setup_test.go
+++ b/server/internal/remotesessions/setup_test.go
@@ -2,8 +2,12 @@ package remotesessions_test
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"log"
 	"net/url"
 	"os"
@@ -30,6 +34,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/environments"
 	"github.com/speakeasy-api/gram/server/internal/guardian"
+	jsonwebkeysetsrepo "github.com/speakeasy-api/gram/server/internal/jsonwebkeysets/repo"
 	mcpmetadatarepo "github.com/speakeasy-api/gram/server/internal/mcpmetadata/repo"
 	mcpserversrepo "github.com/speakeasy-api/gram/server/internal/mcpservers/repo"
 	"github.com/speakeasy-api/gram/server/internal/oops"
@@ -685,6 +690,54 @@ func createJsonWebKeySet(t *testing.T, ctx context.Context, conn *pgxpool.Pool, 
 	require.NoError(t, err)
 
 	return setID
+}
+
+// createJsonWebKey plants a valid public key in a fixture set without involving
+// the external KMS signer. Its private half exists only long enough to derive
+// the public modulus and is never persisted.
+func createJsonWebKey(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID string, setID uuid.UUID, state, kid string) uuid.UUID {
+	t.Helper()
+
+	set, err := jsonwebkeysetsrepo.New(conn).GetJsonWebKeySet(ctx, jsonwebkeysetsrepo.GetJsonWebKeySetParams{
+		ID:             setID,
+		OrganizationID: organizationID,
+	})
+	require.NoError(t, err)
+
+	keyMaterial, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	publicJWK, err := json.Marshal(map[string]string{
+		"alg": "RS256",
+		"e":   "AQAB",
+		"kid": kid,
+		"kty": "RSA",
+		"n":   base64.RawURLEncoding.EncodeToString(keyMaterial.N.Bytes()),
+		"use": "sig",
+	})
+	require.NoError(t, err)
+
+	key, err := jsonwebkeysetsrepo.New(conn).CreateJsonWebKey(ctx, jsonwebkeysetsrepo.CreateJsonWebKeyParams{
+		OrganizationID:  organizationID,
+		JsonWebKeySetID: setID,
+		ExternalKeyID:   set.ExternalKeyID,
+		State:           state,
+		Kid:             kid,
+		PublicJwk:       publicJWK,
+	})
+	require.NoError(t, err)
+
+	return key.ID
+}
+
+func revokeJsonWebKey(t *testing.T, ctx context.Context, conn *pgxpool.Pool, organizationID string, keyID uuid.UUID) {
+	t.Helper()
+
+	_, err := jsonwebkeysetsrepo.New(conn).RevokeJsonWebKey(ctx, jsonwebkeysetsrepo.RevokeJsonWebKeyParams{
+		ID:             keyID,
+		OrganizationID: organizationID,
+	})
+	require.NoError(t, err)
 }
 
 // forceTokenEndpointAuthMethod writes a token_endpoint_auth_method the Goa enum


### PR DESCRIPTION
AIM-157

## Summary

- Publish attached remote-session client public keys at `/.well-known/oauth-client/{id}/jwks.json` for CIMD and manually registered clients.
- Advertise `jwks_uri` and the stored token endpoint authentication method from CIMD metadata when a live key set is attached.
- Build deterministic JWK Set documents from pending, active, and retired keys in one database snapshot, with one-hour HTTP caching and not-found behavior for unavailable sets or non-platform hosts.
- Cover key lifecycle filtering, empty and missing sets, conditional requests, CIMD discovery, and host pinning.

## Motivation

Remote OAuth clients using asymmetric authentication need a stable public URL where counterparties can retrieve verification keys. Keeping publication independent of management entitlements preserves that contract, while atomic SQL aggregation avoids inconsistent documents during concurrent key rotation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes remote-session client public keys at a stable JWKS URL and advertises it in CIMD metadata.

**Behavior**
- New endpoint `/.well-known/oauth-client/{id}/jwks.json` serves pending, active, and retired public keys from an attached JWK set, excluding revoked keys, and returns a 404 when no live set is attached.
- The endpoint is pinned to the platform host and remains available even if management entitlements lapse, so counterparties can keep verifying assertions.
- CIMD documents now include `jwks_uri` when a key set is attached and reflect the client's stored `token_endpoint_auth_method` instead of hardcoded `"none"`.
- Both endpoints use one-hour HTTP caching and support conditional requests.

<sup>Written for commit eca147950e212167604c386a44f42db832b06ac9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

