### PR TITLE
chore: split the meta member upstream exchange

### DIFF
--- a/server/internal/background/openrouter_admin_mutation_generation_test.go
+++ b/server/internal/background/openrouter_admin_mutation_generation_test.go
@@ -31,29 +31,33 @@ func TestOpenRouterAdminAbortRetiresOnlyItsOperation(t *testing.T) {
 		reconciledCursor.Store(cursor.Load())
 		return cursor.Load(), nil
 	}, activity.RegisterOptions{Name: OpenRouterAdminReconcileActivityName})
-	updateBegin := func(id string, token *int64) {
+	var updateBegin func(string, *int64, func())
+	updateBegin = func(id string, token *int64, after func()) {
 		env.UpdateWorkflow(OpenRouterAdminBeginUpdate, id, &testsuite.TestUpdateCallback{
 			OnReject: func(err error) { require.NoError(t, err) },
 			OnAccept: func() {},
 			OnComplete: func(result any, err error) {
 				require.NoError(t, err)
-				if value, ok := result.(int64); ok {
-					*token = value
-				}
+				value, ok := result.(int64)
+				require.True(t, ok)
+				*token = value
+				after()
 			},
 		})
 	}
-	env.RegisterDelayedCallback(func() { updateBegin("a", &tokenA) }, time.Millisecond)
-	env.RegisterDelayedCallback(func() { updateBegin("b", &tokenB) }, 2*time.Millisecond)
-	env.RegisterDelayedCallback(func() { env.SignalWorkflow(OpenRouterAdminAbortSignal, tokenA) }, 3*time.Millisecond)
 	env.RegisterDelayedCallback(func() {
-		cursor.Store(1)
-		env.UpdateWorkflow(OpenRouterAdminCompleteUpdate, "complete-b", &testsuite.TestUpdateCallback{
-			OnReject:   func(err error) { require.NoError(t, err) },
-			OnAccept:   func() {},
-			OnComplete: func(_ any, err error) { require.NoError(t, err) },
-		}, tokenB)
-	}, 4*time.Millisecond)
+		updateBegin("a", &tokenA, func() {
+			updateBegin("b", &tokenB, func() {
+				env.SignalWorkflow(OpenRouterAdminAbortSignal, tokenA)
+				cursor.Store(1)
+				env.UpdateWorkflow(OpenRouterAdminCompleteUpdate, "complete-b", &testsuite.TestUpdateCallback{
+					OnReject:   func(err error) { require.NoError(t, err) },
+					OnAccept:   func() {},
+					OnComplete: func(_ any, err error) { require.NoError(t, err) },
+				}, tokenB)
+			})
+		})
+	}, time.Millisecond)
 
 	env.ExecuteWorkflow(testOpenRouterAdminWorkflow, openrouterkeys.AdminReconciliationScope{OrganizationID: "organization_placeholder", KeyType: "chat"})
 	require.NoError(t, env.GetWorkflowError())

--- a/server/internal/background/openrouter_admin_mutation_generation_test.go
+++ b/server/internal/background/openrouter_admin_mutation_generation_test.go
@@ -31,8 +31,7 @@ func TestOpenRouterAdminAbortRetiresOnlyItsOperation(t *testing.T) {
 		reconciledCursor.Store(cursor.Load())
 		return cursor.Load(), nil
 	}, activity.RegisterOptions{Name: OpenRouterAdminReconcileActivityName})
-	var updateBegin func(string, *int64, func())
-	updateBegin = func(id string, token *int64, after func()) {
+	updateBegin := func(id string, token *int64, after func()) {
 		env.UpdateWorkflow(OpenRouterAdminBeginUpdate, id, &testsuite.TestUpdateCallback{
 			OnReject: func(err error) { require.NoError(t, err) },
 			OnAccept: func() {},

--- a/server/internal/mcp/serve_meta_handshake_test.go
+++ b/server/internal/mcp/serve_meta_handshake_test.go
@@ -1,0 +1,187 @@
+package mcp_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+)
+
+// handshakeUpstream is a scripted member that records the handshake dispatch runs against it.
+type handshakeUpstream struct {
+	url       string
+	sessionID string
+	// initializeError answers initialize with a JSON-RPC error envelope instead of a result.
+	initializeError bool
+	// truncatesInitialize mints a session on initialize, then drops the connection mid-body.
+	truncatesInitialize bool
+	mu                  sync.Mutex
+	requests            []handshakeRequest
+}
+
+type handshakeRequest struct {
+	method    string
+	rpcMethod string
+	session   string
+	version   string
+}
+
+func newHandshakeUpstream(t *testing.T, sessionID string, initializeError bool) *handshakeUpstream {
+	t.Helper()
+	u := &handshakeUpstream{url: "", sessionID: sessionID, initializeError: initializeError, truncatesInitialize: false, mu: sync.Mutex{}, requests: nil}
+	srv := httptest.NewServer(http.HandlerFunc(u.serve))
+	t.Cleanup(srv.Close)
+	u.url = srv.URL
+	return u
+}
+
+func (u *handshakeUpstream) serve(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	var rpc struct {
+		ID     json.RawMessage `json:"id"`
+		Method string          `json:"method"`
+	}
+	_ = json.Unmarshal(body, &rpc)
+	u.mu.Lock()
+	u.requests = append(u.requests, handshakeRequest{method: r.Method, rpcMethod: rpc.Method, session: r.Header.Get("Mcp-Session-Id"), version: r.Header.Get("MCP-Protocol-Version")})
+	u.mu.Unlock()
+
+	if r.Method == http.MethodDelete {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	reply := func(envelope map[string]any) {
+		envelope["jsonrpc"] = "2.0"
+		envelope["id"] = rpc.ID
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(envelope)
+	}
+	switch rpc.Method {
+	case "initialize":
+		if u.sessionID != "" {
+			w.Header().Set("Mcp-Session-Id", u.sessionID)
+		}
+		if u.truncatesInitialize {
+			// The session is allocated before the body fails.
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":`))
+			if err := http.NewResponseController(w).Flush(); err != nil {
+				return
+			}
+			if conn, _, err := http.NewResponseController(w).Hijack(); err == nil {
+				_ = conn.Close()
+			}
+			return
+		}
+		if u.initializeError {
+			// A live member that answers initialize with a JSON-RPC error yet mints a session and serves calls on it.
+			reply(map[string]any{"error": map[string]any{"code": -32602, "message": "unsupported client capabilities"}})
+			return
+		}
+		reply(map[string]any{"result": map[string]any{"protocolVersion": "2025-06-18", "capabilities": map[string]any{"tools": map[string]any{}}, "serverInfo": map[string]any{"name": "scripted", "version": "1"}}})
+	case "notifications/initialized":
+		w.WriteHeader(http.StatusAccepted)
+	case "tools/list":
+		reply(map[string]any{"result": map[string]any{"tools": []map[string]any{{"name": "ping", "description": "pong", "inputSchema": map[string]any{"type": "object"}}}}})
+	case "tools/call":
+		reply(map[string]any{"result": map[string]any{"content": []map[string]any{{"type": "text", "text": "pong"}}}})
+	default:
+		w.WriteHeader(http.StatusNotFound)
+	}
+}
+
+func (u *handshakeUpstream) drain() []handshakeRequest {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	got := u.requests
+	u.requests = nil
+	return got
+}
+
+func acks(requests []handshakeRequest) []handshakeRequest {
+	var out []handshakeRequest
+	for _, r := range requests {
+		if r.rpcMethod == "notifications/initialized" {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func driveMemberTool(t *testing.T, upstream *handshakeUpstream, memberSuffix string) []handshakeRequest {
+	t.Helper()
+	text, isError, requests := driveMemberToolResult(t, upstream, memberSuffix)
+	require.False(t, isError, "execute_tool result: %s", text)
+	require.Contains(t, text, "pong")
+	return requests
+}
+
+func driveMemberToolResult(t *testing.T, upstream *handshakeUpstream, memberSuffix string) (string, bool, []handshakeRequest) {
+	t.Helper()
+	ctx, ti := newTestMCPService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+
+	slug := "meta-handshake-" + uuid.NewString()[:8]
+	meta := createMetaMcpEndpoint(t, ctx, ti.conn, *authCtx.ProjectID, authCtx.ActiveOrganizationID, slug, uuid.Nil)
+	memberSlug := "member-" + memberSuffix + "-" + uuid.NewString()[:8]
+	seedMetaMemberWithUpstream(t, ctx, ti.conn, *authCtx.ProjectID, meta.ID, "scripted member", memberSlug, 1, upstream.url)
+
+	envelope := callMetaTool(t, ctx, ti, slug, "execute_tool", map[string]any{"name": memberSlug + "--ping", "arguments": map[string]any{}})
+	text, isError := metaToolResultText(t, envelope)
+	return text, isError, upstream.drain()
+}
+
+// Dispatch acknowledges every session the member minted, even when initialize answered with a JSON-RPC error; only the consent probe judges the body.
+func TestServePublic_MetaEndpoint_DispatchAcknowledgesMintedSessionAfterInitializeError(t *testing.T) {
+	t.Parallel()
+
+	upstream := newHandshakeUpstream(t, "sess-"+uuid.NewString()[:8], true)
+	requests := driveMemberTool(t, upstream, "initerror")
+
+	acked := acks(requests)
+	require.Len(t, acked, 1, "requests: %+v", requests)
+	require.Equal(t, upstream.sessionID, acked[0].session, "the acknowledgment rides the minted session")
+}
+
+// Dispatch sends no acknowledgment to a stateless member: with no session there is nothing to initialize.
+func TestServePublic_MetaEndpoint_DispatchSkipsAcknowledgmentForStatelessMember(t *testing.T) {
+	t.Parallel()
+
+	upstream := newHandshakeUpstream(t, "", false)
+	requests := driveMemberTool(t, upstream, "stateless")
+
+	require.Empty(t, acks(requests), "requests: %+v", requests)
+	for _, r := range requests {
+		require.NotEqual(t, http.MethodDelete, r.method, "a stateless member has no session to close")
+	}
+}
+
+// A session minted on an initialize whose body then fails is captured from the
+// upstream response, so dispatch still closes it instead of stranding it.
+func TestServePublic_MetaEndpoint_DispatchClosesSessionMintedBeforeBodyFailure(t *testing.T) {
+	t.Parallel()
+
+	upstream := newHandshakeUpstream(t, "sess-"+uuid.NewString()[:8], false)
+	upstream.truncatesInitialize = true
+	text, isError, requests := driveMemberToolResult(t, upstream, "truncated")
+	require.True(t, isError, "a member that drops mid-initialize is a member error: %s", text)
+
+	deletes := 0
+	for _, r := range requests {
+		if r.method == http.MethodDelete {
+			deletes++
+			require.Equal(t, upstream.sessionID, r.session, "the DELETE names the session the failed initialize minted")
+		}
+	}
+	require.Equal(t, 1, deletes, "requests: %+v", requests)
+}

--- a/server/internal/mcp/serve_meta_proxy.go
+++ b/server/internal/mcp/serve_meta_proxy.go
@@ -90,9 +90,12 @@ func routeMetaMemberToken(tokens map[uuid.UUID]remotesessions.UpstreamToken, mem
 	default:
 		// Several credentials claim the same upstream, so forwarding any one
 		// would be a guess. Name the duplication rather than the symptom.
-		return "", &metaMemberError{message: fmt.Sprintf("server %q has %d upstream credentials recorded for the same upstream, so none can be chosen; disconnect the duplicates from this gateway's sign-in and reconnect once", member.slug, found)}
+		return "", fmt.Errorf("%w: %w", errAmbiguousMemberCredential, &metaMemberError{message: fmt.Sprintf("server %q has %d upstream credentials recorded for the same upstream, so none can be chosen; disconnect the duplicates from this gateway's sign-in and reconnect once", member.slug, found)})
 	}
 }
+
+// errAmbiguousMemberCredential marks several stored credentials claiming one member's upstream.
+var errAmbiguousMemberCredential = errors.New("ambiguous member credential")
 
 // memberProxyBuilder yields a fresh proxy per upstream exchange, since a
 // Proxy is a one-request value. It takes the exchange's own context so a
@@ -114,12 +117,7 @@ func memberAuthFailure(member metaMember, anonymous bool) error {
 	return &metaMemberError{message: fmt.Sprintf("server %q rejected the stored credential; reconnect it from this gateway's sign-in page", member.slug)}
 }
 
-// dialMetaMember loads the member's backend rows, routes its credential
-// strictly, and returns the per-exchange proxy builder with the routing
-// outcome. The snapshot already
-// enforced mcp:connect for private members with the same key
-// authorizeProxyBackendAccess uses; per-tool RBAC for private members
-// attaches inside the proxy build.
+// dialMetaMember routes a member for dispatch and counts the routing outcome.
 func (s *Service) dialMetaMember(
 	ctx context.Context,
 	logger *slog.Logger,
@@ -127,12 +125,35 @@ func (s *Service) dialMetaMember(
 	member metaMember,
 	callerIdentity string,
 ) (memberDial, error) {
+	dial, backend, err := s.routeMetaMember(ctx, logger, gate, member, callerIdentity)
+	switch {
+	case errors.Is(err, errAmbiguousMemberCredential):
+		s.metrics.RecordMetaMemberDispatch(ctx, backend, mcpmetrics.MetaDispatchAmbiguous)
+	case err == nil:
+		s.metrics.RecordMetaMemberDispatch(ctx, backend, dispatchOutcome(dial.anonymous))
+	}
+	return dial, err
+}
+
+// routeMetaMember loads the member's backend rows, routes its credential
+// strictly, and returns the per-exchange proxy builder with the routing
+// outcome and the backend kind. The snapshot already
+// enforced mcp:connect for private members with the same key
+// authorizeProxyBackendAccess uses; per-tool RBAC for private members
+// attaches inside the proxy build. Uncounted, so probes can use it.
+func (s *Service) routeMetaMember(
+	ctx context.Context,
+	logger *slog.Logger,
+	gate metaGateContext,
+	member metaMember,
+	callerIdentity string,
+) (memberDial, string, error) {
 	serverRow, err := mcpservers_repo.New(s.db).GetMCPServerByIDAndProjectID(ctx, mcpservers_repo.GetMCPServerByIDAndProjectIDParams{
 		ID:        member.serverID,
 		ProjectID: gate.projectID,
 	})
 	if err != nil {
-		return memberDial{}, fmt.Errorf("load meta MCP member server: %w", err)
+		return memberDial{}, "", fmt.Errorf("load meta MCP member server: %w", err)
 	}
 
 	// gate.toolSelection is provably nil today: meta endpoints mint no tool
@@ -148,21 +169,19 @@ func (s *Service) dialMetaMember(
 			// The snapshot query does not join the backend source tables, so a
 			// soft-deleted upstream still yields a member. Isolate it rather
 			// than failing every member of the gateway.
-			return memberDial{}, &metaMemberError{message: fmt.Sprintf("server %q is not currently servable", member.slug)}
+			return memberDial{}, "remote", &metaMemberError{message: fmt.Sprintf("server %q is not currently servable", member.slug)}
 		}
 		if rerr != nil {
-			return memberDial{}, fmt.Errorf("load meta MCP member upstream: %w", rerr)
+			return memberDial{}, "remote", fmt.Errorf("load meta MCP member upstream: %w", rerr)
 		}
 		headers, herr := remotemcp.NewHeaders(s.logger, s.db, s.enc).ListHeaders(ctx, remoteServer.ID, false)
 		if herr != nil {
-			return memberDial{}, fmt.Errorf("load meta MCP member upstream headers: %w", herr)
+			return memberDial{}, "remote", fmt.Errorf("load meta MCP member upstream headers: %w", herr)
 		}
 		upstreamToken, terr := routeMetaMemberToken(gate.tokens, member, strings.TrimRight(remoteServer.Url, "/"))
 		if terr != nil {
-			s.metrics.RecordMetaMemberDispatch(ctx, "remote", mcpmetrics.MetaDispatchAmbiguous)
-			return memberDial{}, terr
+			return memberDial{}, "remote", terr
 		}
-		s.metrics.RecordMetaMemberDispatch(ctx, "remote", dispatchOutcome(upstreamToken))
 		return memberDial{anonymous: upstreamToken == "", build: func(context.Context) (*proxy.Proxy, error) {
 			// No WWW-Authenticate relay: a member's auth challenge must not
 			// invite the client to re-authenticate against the meta MCP.
@@ -170,15 +189,13 @@ func (s *Service) dialMetaMember(
 			// Meta-MCP-synthesized initializes are not client sessions.
 			p.InitializeRequestInterceptors = nil
 			return p, nil
-		}}, nil
+		}}, "remote", nil
 
 	case member.tunneledServerID.Valid:
 		upstreamToken, terr := routeMetaMemberToken(gate.tokens, member, strings.TrimRight(member.tunneledResourceIdentifier, "/"))
 		if terr != nil {
-			s.metrics.RecordMetaMemberDispatch(ctx, "tunneled", mcpmetrics.MetaDispatchAmbiguous)
-			return memberDial{}, terr
+			return memberDial{}, "tunneled", terr
 		}
-		s.metrics.RecordMetaMemberDispatch(ctx, "tunneled", dispatchOutcome(upstreamToken))
 		// Per-member namespace so one caller's handshake, calls, and DELETE
 		// land on one tunnel gateway.
 		affinity := tunnelrouting.HashedClientAffinityKey("meta:"+member.serverID.String(), callerIdentity)
@@ -189,15 +206,15 @@ func (s *Service) dialMetaMember(
 			}
 			p.InitializeRequestInterceptors = nil
 			return p, nil
-		}}, nil
+		}}, "tunneled", nil
 
 	default:
-		return memberDial{}, &metaMemberError{message: fmt.Sprintf("server %q is not currently servable", member.slug)}
+		return memberDial{}, "", &metaMemberError{message: fmt.Sprintf("server %q is not currently servable", member.slug)}
 	}
 }
 
-func dispatchOutcome(token string) mcpmetrics.MetaDispatchOutcome {
-	if token == "" {
+func dispatchOutcome(anonymous bool) mcpmetrics.MetaDispatchOutcome {
+	if anonymous {
 		return mcpmetrics.MetaDispatchAnonymous
 	}
 	return mcpmetrics.MetaDispatchCredentialed
@@ -288,44 +305,65 @@ type memberSession struct {
 	sessionID string
 }
 
-// openMemberSession runs the initialize handshake. On any failure after a
-// session was minted, the session is closed before returning.
-func (s *Service) openMemberSession(ctx context.Context, logger *slog.Logger, dial memberDial, member metaMember) (*memberSession, error) {
-	initBody, err := marshalUpstreamRequest(mcpjsonrpc.StringID("gram-gateway-init"), "initialize", map[string]any{
+// upstreamHandshake is the last handshake status and the session the upstream minted, if any.
+type upstreamHandshake struct {
+	status    int
+	sessionID string
+}
+
+// handshakeUpstream runs initialize, then notifications/initialized on any minted session; the caller closes any sessionID it reports.
+func (s *Service) handshakeUpstream(ctx context.Context, build memberProxyBuilder, name string) (upstreamHandshake, error) {
+	var none upstreamHandshake
+	initID := mcpjsonrpc.StringID("gram-gateway-init")
+	initBody, err := marshalUpstreamRequest(initID, "initialize", map[string]any{
 		"protocolVersion": metaMemberUpstreamProtocolVersion,
 		"capabilities":    map[string]any{},
 		"clientInfo":      map[string]string{"name": "gram-gateway", "version": "1"},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("marshal upstream initialize: %w", err)
+		return none, fmt.Errorf("marshal upstream initialize: %w", err)
 	}
-	initRec, err := s.memberExchange(ctx, dial.build, member, initBody, "")
+	initRec, err := s.upstreamExchange(ctx, build, name, initBody, "")
+	if initRec == nil {
+		return none, err
+	}
+	hs := upstreamHandshake{status: initRec.status, sessionID: initRec.header.Get(proxy.McpSessionIDHeader)}
 	if err != nil {
-		return nil, err
+		return hs, err
 	}
-	if initRec.status == http.StatusUnauthorized || initRec.status == http.StatusForbidden {
-		return nil, memberAuthFailure(member, dial.anonymous)
-	}
-	if initRec.status < http.StatusOK || initRec.status >= http.StatusMultipleChoices {
-		return nil, memberUpstreamFailure(member, initRec.status)
+	if !upstreamStatusOK(hs.status) || hs.sessionID == "" {
+		return hs, nil
 	}
 
-	sess := &memberSession{svc: s, logger: logger, dial: dial, member: member, sessionID: initRec.header.Get(proxy.McpSessionIDHeader)}
-	if sess.sessionID != "" {
-		ackBody := []byte(`{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}`)
-		ackRec, aerr := s.memberExchange(ctx, dial.build, member, ackBody, sess.sessionID)
-		if aerr != nil || ackRec.status < http.StatusOK || ackRec.status >= http.StatusMultipleChoices {
-			sess.close(ctx)
-			if aerr != nil {
-				return nil, aerr
-			}
-			if ackRec.status == http.StatusUnauthorized || ackRec.status == http.StatusForbidden {
-				return nil, memberAuthFailure(member, dial.anonymous)
-			}
-			return nil, memberUpstreamFailure(member, ackRec.status)
-		}
+	ackBody := []byte(`{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}`)
+	ackRec, aerr := s.upstreamExchange(ctx, build, name, ackBody, hs.sessionID)
+	if aerr != nil {
+		return hs, aerr
 	}
-	return sess, nil
+	hs.status = ackRec.status
+	return hs, nil
+}
+
+func upstreamStatusOK(status int) bool {
+	return status >= http.StatusOK && status < http.StatusMultipleChoices
+}
+
+// openMemberSession runs the handshake; any session minted by a failed one is closed before returning.
+func (s *Service) openMemberSession(ctx context.Context, logger *slog.Logger, dial memberDial, member metaMember) (*memberSession, error) {
+	hs, err := s.handshakeUpstream(ctx, dial.build, member.slug)
+	if err != nil {
+		closeUpstreamSession(ctx, logger, dial.build, hs.sessionID, memberSessionCloseTimeout, attr.SlogMcpServerID(member.serverID.String()))
+		return nil, err
+	}
+	if hs.status == http.StatusUnauthorized || hs.status == http.StatusForbidden {
+		closeUpstreamSession(ctx, logger, dial.build, hs.sessionID, memberSessionCloseTimeout, attr.SlogMcpServerID(member.serverID.String()))
+		return nil, memberAuthFailure(member, dial.anonymous)
+	}
+	if !upstreamStatusOK(hs.status) {
+		closeUpstreamSession(ctx, logger, dial.build, hs.sessionID, memberSessionCloseTimeout, attr.SlogMcpServerID(member.serverID.String()))
+		return nil, memberUpstreamFailure(member, hs.status)
+	}
+	return &memberSession{svc: s, logger: logger, dial: dial, member: member, sessionID: hs.sessionID}, nil
 }
 
 // call performs one JSON-RPC request in this session and returns the
@@ -336,7 +374,7 @@ func (sess *memberSession) call(ctx context.Context, method string, params any) 
 	if err != nil {
 		return nil, nil, fmt.Errorf("marshal upstream %s request: %w", method, err)
 	}
-	rec, err := sess.svc.memberExchange(ctx, sess.dial.build, sess.member, body, sess.sessionID)
+	rec, err := sess.svc.upstreamExchange(ctx, sess.dial.build, sess.member.slug, body, sess.sessionID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -357,15 +395,21 @@ func (sess *memberSession) call(ctx context.Context, method string, params any) 
 	return envelope.Result, envelope.Error, nil
 }
 
-// close best-effort terminates the upstream session, on a detached context so
-// an expired member-call deadline cannot strand it.
+// close best-effort terminates the upstream session.
 func (sess *memberSession) close(ctx context.Context) {
-	if sess.sessionID == "" {
+	closeUpstreamSession(ctx, sess.logger, sess.dial.build, sess.sessionID, memberSessionCloseTimeout, attr.SlogMcpServerID(sess.member.serverID.String()))
+}
+
+// closeUpstreamSession best-effort terminates a session on a detached context
+// bounded by budget alone, so a session minted just as the exchange's own
+// deadline expired is still closed.
+func closeUpstreamSession(ctx context.Context, logger *slog.Logger, build memberProxyBuilder, sessionID string, budget time.Duration, attrs ...slog.Attr) {
+	if sessionID == "" {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), memberSessionCloseTimeout)
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), budget)
 	defer cancel()
-	p, err := sess.dial.build(ctx)
+	p, err := build(ctx)
 	if err != nil {
 		return
 	}
@@ -373,9 +417,9 @@ func (sess *memberSession) close(ctx context.Context) {
 	if err != nil {
 		return
 	}
-	req.Header.Set(proxy.McpSessionIDHeader, sess.sessionID)
+	req.Header.Set(proxy.McpSessionIDHeader, sessionID)
 	if err := serveProxyBackend(httptest.NewRecorder(), req, p); err != nil {
-		sess.logger.DebugContext(ctx, "close meta MCP member session", attr.SlogError(err), attr.SlogMcpServerID(sess.member.serverID.String()))
+		logger.LogAttrs(ctx, slog.LevelDebug, "close upstream mcp session", append(attrs, attr.SlogError(err))...)
 	}
 }
 
@@ -401,12 +445,12 @@ func (s *Service) callProxiedMember(
 	return sess.call(ctx, method, params)
 }
 
-// memberExchange drives one HTTP exchange through a fresh member proxy.
-func (s *Service) memberExchange(ctx context.Context, build memberProxyBuilder, member metaMember, body []byte, sessionID string) (*memberResponseRecorder, error) {
+// upstreamExchange drives one HTTP exchange through a fresh proxy from build; name labels member-scoped errors.
+func (s *Service) upstreamExchange(ctx context.Context, build memberProxyBuilder, name string, body []byte, sessionID string) (*memberResponseRecorder, error) {
 	p, err := build(ctx)
 	if err != nil {
 		// A tunnel with no live route is a member outage, not a meta MCP bug.
-		return nil, &metaMemberError{message: fmt.Sprintf("server %q is not reachable right now", member.slug)}
+		return nil, &metaMemberError{message: fmt.Sprintf("server %q is not reachable right now", name)}
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "/", bytes.NewReader(body))
@@ -421,10 +465,25 @@ func (s *Service) memberExchange(ctx context.Context, build memberProxyBuilder, 
 	}
 
 	rec := newMemberResponseRecorder()
-	if err := serveProxyBackend(rec, req, p); err != nil {
+	upstreamSessionID := ""
+	interceptResponse := p.UpstreamResponseInterceptor
+	p.UpstreamResponseInterceptor = func(ctx context.Context, resp *http.Response) error {
+		// Capture the session before buffering JSON or relaying SSE: either body
+		// can fail after the upstream has already allocated the session.
+		upstreamSessionID = resp.Header.Get(proxy.McpSessionIDHeader)
+		if interceptResponse != nil {
+			return interceptResponse(ctx, resp)
+		}
+		return nil
+	}
+	err = serveProxyBackend(rec, req, p)
+	if upstreamSessionID != "" {
+		rec.header.Set(proxy.McpSessionIDHeader, upstreamSessionID)
+	}
+	if err != nil {
 		// Timeouts, unreachable upstreams, and relayed protocol rejections
-		// are the member's outage, not the meta MCP's.
-		return nil, &metaMemberError{message: fmt.Sprintf("server %q did not answer: upstream unreachable or timed out", member.slug)}
+		// are the member's outage, not the meta MCP's. Preserve cleanup metadata.
+		return rec, &metaMemberError{message: fmt.Sprintf("server %q did not answer: upstream unreachable or timed out", name)}
 	}
 	return rec, nil
 }

--- a/server/internal/mcp/serve_meta_proxy.go
+++ b/server/internal/mcp/serve_meta_proxy.go
@@ -268,7 +268,7 @@ type memberResponseRecorder struct {
 func newMemberResponseRecorder() *memberResponseRecorder {
 	return &memberResponseRecorder{
 		header:    make(http.Header),
-		status:    http.StatusOK,
+		status:    0, // Remains unset until the upstream answers.
 		body:      bytes.Buffer{},
 		truncated: false,
 	}
@@ -312,7 +312,7 @@ type upstreamHandshake struct {
 }
 
 // handshakeUpstream runs initialize, then notifications/initialized on any minted session; the caller closes any sessionID it reports.
-func (s *Service) handshakeUpstream(ctx context.Context, build memberProxyBuilder, name string) (upstreamHandshake, error) {
+func (s *Service) handshakeUpstream(ctx context.Context, build memberProxyBuilder, member metaMember) (upstreamHandshake, error) {
 	var none upstreamHandshake
 	initID := mcpjsonrpc.StringID("gram-gateway-init")
 	initBody, err := marshalUpstreamRequest(initID, "initialize", map[string]any{
@@ -323,7 +323,7 @@ func (s *Service) handshakeUpstream(ctx context.Context, build memberProxyBuilde
 	if err != nil {
 		return none, fmt.Errorf("marshal upstream initialize: %w", err)
 	}
-	initRec, err := s.upstreamExchange(ctx, build, name, initBody, "")
+	initRec, err := s.upstreamExchange(ctx, build, member.slug, initBody, "")
 	if initRec == nil {
 		return none, err
 	}
@@ -336,7 +336,7 @@ func (s *Service) handshakeUpstream(ctx context.Context, build memberProxyBuilde
 	}
 
 	ackBody := []byte(`{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}`)
-	ackRec, aerr := s.upstreamExchange(ctx, build, name, ackBody, hs.sessionID)
+	ackRec, aerr := s.upstreamExchange(ctx, build, member.slug, ackBody, hs.sessionID)
 	if aerr != nil {
 		return hs, aerr
 	}
@@ -350,7 +350,7 @@ func upstreamStatusOK(status int) bool {
 
 // openMemberSession runs the handshake; any session minted by a failed one is closed before returning.
 func (s *Service) openMemberSession(ctx context.Context, logger *slog.Logger, dial memberDial, member metaMember) (*memberSession, error) {
-	hs, err := s.handshakeUpstream(ctx, dial.build, member.slug)
+	hs, err := s.handshakeUpstream(ctx, dial.build, member)
 	if err != nil {
 		closeUpstreamSession(ctx, logger, dial.build, hs.sessionID, memberSessionCloseTimeout, attr.SlogMcpServerID(member.serverID.String()))
 		return nil, err

--- a/server/internal/mcp/serve_meta_proxy_internal_test.go
+++ b/server/internal/mcp/serve_meta_proxy_internal_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/google/uuid"
@@ -11,6 +12,16 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 )
+
+func TestMemberResponseRecorderStatusStartsUnset(t *testing.T) {
+	t.Parallel()
+
+	rec := newMemberResponseRecorder()
+	require.Zero(t, rec.status)
+
+	rec.WriteHeader(http.StatusNoContent)
+	require.Equal(t, http.StatusNoContent, rec.status)
+}
 
 // The strict meta MCP router: exact resource match only, no lone-token
 // fallback for remote members; tunneled members route by their own derived

--- a/server/internal/mcp/serve_meta_proxy_internal_test.go
+++ b/server/internal/mcp/serve_meta_proxy_internal_test.go
@@ -163,6 +163,7 @@ func TestRouteMetaMemberToken(t *testing.T) {
 		_, err := routeMetaMemberToken(m, remoteMember, "https://a.example.com/mcp")
 		var memberErr *metaMemberError
 		require.ErrorAs(t, err, &memberErr)
+		require.ErrorIs(t, err, errAmbiguousMemberCredential, "callers can tell a configuration state from a probe or dispatch failure")
 	})
 }
 

--- a/server/internal/mcp/serveendpoint.go
+++ b/server/internal/mcp/serveendpoint.go
@@ -683,29 +683,53 @@ func (s *Service) serveRemoteBackend(
 		return err
 	}
 
+	build, err := s.remoteBackendProxyBuilder(ctx, logger, endpoint.ProjectID, organizationID, mcpServer, upstreamAuth, wwwAuthenticate, selection)
+	if err != nil {
+		return err
+	}
+	p, err := build(ctx)
+	if err != nil {
+		return err
+	}
+
+	return serveProxyBackend(w, r.WithContext(ctx), p)
+}
+
+// remoteBackendProxyBuilder loads a remote-backed server once and yields fresh one-request proxies for it.
+func (s *Service) remoteBackendProxyBuilder(
+	ctx context.Context,
+	logger *slog.Logger,
+	projectID uuid.UUID,
+	organizationID string,
+	mcpServer *mcpserversrepo.McpServer,
+	upstreamAuth string,
+	wwwAuthenticate string,
+	selection *toolfilter.SessionSelection,
+	options ...remotemcp.BuildOption,
+) (memberProxyBuilder, error) {
 	server, err := remotemcprepo.New(s.db).GetServerByID(ctx, remotemcprepo.GetServerByIDParams{
 		ID:        mcpServer.RemoteMcpServerID.UUID,
-		ProjectID: endpoint.ProjectID,
+		ProjectID: projectID,
 	})
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
-		return oops.E(oops.CodeNotFound, err, "remote mcp server not found").LogWarn(ctx, logger)
+		return nil, oops.E(oops.CodeNotFound, err, "remote mcp server not found").LogWarn(ctx, logger)
 	case err != nil:
-		return oops.E(oops.CodeUnexpected, err, "load remote mcp server").LogError(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "load remote mcp server").LogError(ctx, logger)
 	}
 
 	headers, err := remotemcp.NewHeaders(s.logger, s.db, s.enc).ListHeaders(ctx, server.ID, false)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "load remote mcp server headers").LogError(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, err, "load remote mcp server headers").LogError(ctx, logger)
 	}
 
 	if s.remoteProxyManager == nil {
-		return oops.E(oops.CodeUnexpected, nil, "remote MCP proxy manager is unavailable").LogError(ctx, logger)
+		return nil, oops.E(oops.CodeUnexpected, nil, "remote MCP proxy manager is unavailable").LogError(ctx, logger)
 	}
 
-	p := s.remoteProxyManager.Build(logger, &server, mcpServer.ID.String(), headers, mcpServer.Visibility, organizationID, endpoint.ProjectID.String(), upstreamAuth, wwwAuthenticate, selection)
-
-	return serveProxyBackend(w, r.WithContext(ctx), p)
+	return func(context.Context) (*proxy.Proxy, error) {
+		return s.remoteProxyManager.Build(logger, &server, mcpServer.ID.String(), headers, mcpServer.Visibility, organizationID, projectID.String(), upstreamAuth, wwwAuthenticate, selection, options...), nil
+	}, nil
 }
 
 func serveProxyBackend(w http.ResponseWriter, r *http.Request, p *proxy.Proxy) error {


### PR DESCRIPTION
AIM-204, part 2 of 5, stacked on #6291.

- `openMemberSession`/`memberExchange` become `handshakeUpstream`/`upstreamExchange`/`closeUpstreamSession`, keyed by a proxy builder and a name so the consent probe (part 4) can drive the same exchange.
- `dialMetaMember` becomes a counting wrapper over the new `routeMetaMember`, which routes without recording a dispatch metric.
- The upstream session id is captured via `UpstreamResponseInterceptor`, so a session minted before the body fails is still closed (regression: `DispatchClosesSessionMintedBeforeBodyFailure`).
- `errAmbiguousMemberCredential` sentinel wraps the duplicate-credential member error.
- Detached session closes keep their own `memberSessionCloseTimeout` even when the exchange context has expired (cubic).
- Dispatch support for 2026-07-28-only members (stateless ping fallback) is out of AIM-204 scope and dropped from this stack; separate ticket.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the meta member upstream exchange into reusable pieces so the AIM-204 consent probe can drive the same session dispatch without counting as traffic.

- `openMemberSession`/`memberExchange` become `handshakeUpstream`/`upstreamExchange`/`closeUpstreamSession`, keyed by a proxy builder and a name.
- `dialMetaMember` is now a counting wrapper over the uncounted `routeMetaMember`.
- The session ID is captured via `UpstreamResponseInterceptor`, so a session minted before a failed body is still closed.
- The response recorder's status now starts unset instead of `200`, so a failed upstream body stays distinguishable from a successful one.
- Duplicate-credential member errors are wrapped in the `errAmbiguousMemberCredential` sentinel.
- Detached session closes keep their own `memberSessionCloseTimeout` even when the exchange context has expired.
- The OpenRouter admin mutation test now chains update callbacks through a helper so ordering is deterministic instead of timing-based.

<sup>Written for commit 265ca52ab42614175c045c0e8458a6e833863a05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

