### PR TITLE
feat: store remote session validation verdicts

### DIFF
--- a/server/internal/attr/conventions.go
+++ b/server/internal/attr/conventions.go
@@ -504,6 +504,7 @@ const (
 	UserSessionClientMigratedCountKey = attribute.Key("gram.user_session_client.migrated_count")
 
 	RemoteSessionIssuerIDKey            = attribute.Key("gram.remote_session_issuer.id")
+	RemoteSessionIDKey                  = attribute.Key("gram.remote_session.id")
 	RemoteSessionClientMigratedCountKey = attribute.Key("gram.remote_session_client.migrated_count")
 	RemoteSessionRevokeDroppedCountKey  = attribute.Key("gram.remote_session.revoke_dropped_count")
 	// RemoteSessionAccessExpiresAtKey is the upstream-reported deadline of a
@@ -2072,6 +2073,11 @@ func SlogUserSessionClientID(v string) slog.Attr {
 func RemoteSessionIssuerID(v string) attribute.KeyValue { return RemoteSessionIssuerIDKey.String(v) }
 func SlogRemoteSessionIssuerID(v string) slog.Attr {
 	return slog.String(string(RemoteSessionIssuerIDKey), v)
+}
+
+func RemoteSessionID(v string) attribute.KeyValue { return RemoteSessionIDKey.String(v) }
+func SlogRemoteSessionID(v string) slog.Attr {
+	return slog.String(string(RemoteSessionIDKey), v)
 }
 
 func RemoteSessionClientMigratedCount(v int64) attribute.KeyValue {

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -443,6 +443,16 @@ type RemoteSessionState struct {
 	ConnectedAs string
 	// IdentitySource names the interface ConnectedAs came from.
 	IdentitySource string
+	// ID is the remote_sessions row a verdict is written against.
+	ID uuid.UUID
+	// UpdatedAt is the row's CAS token; a verdict only lands while it still holds.
+	UpdatedAt time.Time
+	// LastValidatedAt is when a probe last presented the credential; nil when never.
+	LastValidatedAt *time.Time
+	// ValidationStatus is that probe's verdict, empty when never validated.
+	ValidationStatus ValidationOutcome
+	// ValidationReason is the Gram-authored explanation of a non-valid verdict.
+	ValidationReason string
 }
 
 // RemoteSessionStatuses returns, per remote_session_client_id, the state of
@@ -489,6 +499,11 @@ func (m *ChallengeManager) RemoteSessionStatuses(
 			expires := row.AuthorizationExpiresAt.Time
 			authorizationExpiresAt = &expires
 		}
+		var lastValidatedAt *time.Time
+		if row.LastValidatedAt.Valid {
+			validated := row.LastValidatedAt.Time
+			lastValidatedAt = &validated
+		}
 		statuses[row.RemoteSessionClientID] = RemoteSessionState{
 			Status:                 RemoteSessionStatus(row.Status),
 			AutoRefresh:            row.AutoRefresh,
@@ -500,6 +515,11 @@ func (m *ChallengeManager) RemoteSessionStatuses(
 			Scopes:                 row.Scopes,
 			ConnectedAs:            conv.Default(row.UpstreamEmail.String, row.UpstreamDisplayName.String),
 			IdentitySource:         row.IdentitySource.String,
+			ID:                     row.ID,
+			UpdatedAt:              row.UpdatedAt.Time,
+			LastValidatedAt:        lastValidatedAt,
+			ValidationStatus:       ValidationOutcome(row.ValidationStatus.String),
+			ValidationReason:       row.ValidationReason.String,
 		}
 	}
 	return statuses, nil

--- a/server/internal/remotesessions/migrateissuer_test.go
+++ b/server/internal/remotesessions/migrateissuer_test.go
@@ -138,7 +138,7 @@ func TestMigrateIssuer_PreservesRemoteSessionWithoutReauth(t *testing.T) {
 	// Before: the token resolves under the source issuer's id.
 	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject)
 	require.NoError(t, err)
-	require.Equal(t, map[uuid.UUID]remotesessions.UpstreamToken{sourceUUID: {Token: "upstream-access-token", Resource: "", RemoteSessionClientID: clientUUID}}, tokens)
+	require.Equal(t, map[uuid.UUID]remotesessions.UpstreamToken{sourceUUID: {Token: "upstream-access-token", Resource: "", RemoteSessionClientID: clientUUID}}, tokenCredentials(tokens))
 
 	auditBefore, err := audittest.AuditLogCountByAction(ctx, ti.conn, audit.ActionRemoteSessionIssuerMigrate)
 	require.NoError(t, err)
@@ -153,7 +153,7 @@ func TestMigrateIssuer_PreservesRemoteSessionWithoutReauth(t *testing.T) {
 	// Nothing re-authenticated; only the client's foreign key moved.
 	tokens, err = mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject)
 	require.NoError(t, err)
-	require.Equal(t, map[uuid.UUID]remotesessions.UpstreamToken{targetID: {Token: "upstream-access-token", Resource: "", RemoteSessionClientID: clientUUID}}, tokens)
+	require.Equal(t, map[uuid.UUID]remotesessions.UpstreamToken{targetID: {Token: "upstream-access-token", Resource: "", RemoteSessionClientID: clientUUID}}, tokenCredentials(tokens))
 
 	// The session row itself was neither deleted nor rewritten.
 	q := repo.New(ti.conn)

--- a/server/internal/remotesessions/platformmigrateissuer_test.go
+++ b/server/internal/remotesessions/platformmigrateissuer_test.go
@@ -133,7 +133,7 @@ func TestMigrateToGlobalIssuer_PreservesRemoteSessionWithoutReauth(t *testing.T)
 
 	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject)
 	require.NoError(t, err)
-	require.Equal(t, map[uuid.UUID]remotesessions.UpstreamToken{sourceUUID: {Token: "upstream-access-token", Resource: "", RemoteSessionClientID: clientUUID}}, tokens)
+	require.Equal(t, map[uuid.UUID]remotesessions.UpstreamToken{sourceUUID: {Token: "upstream-access-token", Resource: "", RemoteSessionClientID: clientUUID}}, tokenCredentials(tokens))
 
 	result, err := ti.service.MigrateToGlobalIssuer(withAdmin(t, ctx), platformMigratePayload(sourceID, targetID.String()))
 	require.NoError(t, err)
@@ -145,7 +145,7 @@ func TestMigrateToGlobalIssuer_PreservesRemoteSessionWithoutReauth(t *testing.T)
 	// client's foreign key moved.
 	tokens, err = mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject)
 	require.NoError(t, err)
-	require.Equal(t, map[uuid.UUID]remotesessions.UpstreamToken{targetID: {Token: "upstream-access-token", Resource: "", RemoteSessionClientID: clientUUID}}, tokens)
+	require.Equal(t, map[uuid.UUID]remotesessions.UpstreamToken{targetID: {Token: "upstream-access-token", Resource: "", RemoteSessionClientID: clientUUID}}, tokenCredentials(tokens))
 
 	q := repo.New(ti.conn)
 	activeSessions, err := q.CountActiveRemoteSessionsByClientID(ctx, clientUUID)

--- a/server/internal/remotesessions/queries.sql
+++ b/server/internal/remotesessions/queries.sql
@@ -992,7 +992,11 @@ SET deleted_at = clock_timestamp(),
     upstream_email = NULL,
     upstream_display_name = NULL,
     identity_source = NULL,
-    enrichment = NULL
+    enrichment = NULL,
+    -- The credential is gone, so nothing it was observed doing survives it.
+    last_validated_at = NULL,
+    validation_status = NULL,
+    validation_reason = NULL
 WHERE remote_session_client_id = @remote_session_client_id AND deleted IS FALSE
 RETURNING remote_session_client_id, access_token_encrypted, refresh_token_encrypted;
 
@@ -1007,7 +1011,11 @@ SET deleted_at = clock_timestamp(),
     upstream_email = NULL,
     upstream_display_name = NULL,
     identity_source = NULL,
-    enrichment = NULL
+    enrichment = NULL,
+    -- The credential is gone, so nothing it was observed doing survives it.
+    last_validated_at = NULL,
+    validation_status = NULL,
+    validation_reason = NULL
 WHERE remote_session_client_id = ANY(@remote_session_client_ids::uuid[]) AND deleted IS FALSE
 RETURNING remote_session_client_id, access_token_encrypted, refresh_token_encrypted;
 
@@ -1097,6 +1105,10 @@ SET
     refresh_expires_at = @refresh_expires_at,
     scopes = @scopes,
     resource = COALESCE(resource, NULLIF(sqlc.narg('backfill_resource')::text, '')),
+    -- A refreshed token has not been presented anywhere yet.
+    last_validated_at = NULL,
+    validation_status = NULL,
+    validation_reason = NULL,
     updated_at = clock_timestamp()
 WHERE subject_urn = @subject_urn
   AND remote_session_client_id = @remote_session_client_id
@@ -1175,6 +1187,29 @@ WHERE id = @id
   AND updated_at = @expected_updated_at
 RETURNING *;
 
+-- name: SetRemoteSessionValidation :execrows
+-- Records the last probe verdict for the grant the probe presented; updated_at is the CAS token and is left alone.
+-- Bound to the challenge's tenant through the client row. Older observations never overwrite newer ones,
+-- and an unknown never overwrites a stored valid.
+UPDATE remote_sessions AS s
+SET
+    last_validated_at = @last_validated_at,
+    validation_status = @validation_status::text,
+    validation_reason = sqlc.narg('validation_reason')::text
+WHERE s.id = @id
+  AND s.subject_urn = @subject_urn
+  AND s.remote_session_client_id = @remote_session_client_id
+  AND s.deleted IS FALSE
+  AND s.updated_at = @expected_updated_at
+  AND (s.last_validated_at IS NULL OR s.last_validated_at <= @last_validated_at)
+  AND (@validation_status::text <> 'unknown' OR s.validation_status IS DISTINCT FROM 'valid')
+  AND EXISTS (
+    SELECT 1 FROM remote_session_clients AS c
+    WHERE c.id = s.remote_session_client_id
+      AND c.deleted IS FALSE
+      AND (c.project_id = @project_id::uuid OR (c.project_id IS NULL AND (c.organization_id IS NULL OR c.organization_id = @organization_id::text)))
+  );
+
 -- name: ListRemoteSessionStatusesForSubject :many
 -- Bulk lookup for the consent renderer: returns each non-deleted
 -- remote_session the subject holds on a client bound to the requesting
@@ -1220,6 +1255,11 @@ SELECT
   s.upstream_email,
   s.upstream_display_name,
   s.identity_source,
+  s.id,
+  s.updated_at,
+  s.last_validated_at,
+  s.validation_status,
+  s.validation_reason,
   (s.refresh_token_encrypted IS NOT NULL
     AND (s.authorization_expires_at IS NULL OR s.authorization_expires_at > now())
     AND (s.refresh_expires_at IS NULL OR s.refresh_expires_at > now()))::boolean AS can_refresh,
@@ -1422,7 +1462,11 @@ SET deleted_at = clock_timestamp(),
     upstream_email = NULL,
     upstream_display_name = NULL,
     identity_source = NULL,
-    enrichment = NULL
+    enrichment = NULL,
+    -- The credential is gone, so nothing it was observed doing survives it.
+    last_validated_at = NULL,
+    validation_status = NULL,
+    validation_reason = NULL
 FROM remote_session_clients AS c, user_session_issuers AS usi
 WHERE s.id = @id
   AND s.remote_session_client_id = c.id
@@ -1488,7 +1532,11 @@ SET deleted_at = COALESCE(s.deleted_at, sqlc.narg('revoked_at')::timestamptz, cl
     upstream_email = NULL,
     upstream_display_name = NULL,
     identity_source = NULL,
-    enrichment = NULL
+    enrichment = NULL,
+    -- The credential is gone, so nothing it was observed doing survives it.
+    last_validated_at = NULL,
+    validation_status = NULL,
+    validation_reason = NULL
 FROM remote_session_clients AS c,
      user_session_issuers AS usi
 WHERE s.subject_urn = @subject_urn
@@ -1534,7 +1582,11 @@ SET deleted_at = clock_timestamp(),
     upstream_email = NULL,
     upstream_display_name = NULL,
     identity_source = NULL,
-    enrichment = NULL
+    enrichment = NULL,
+    -- The credential is gone, so nothing it was observed doing survives it.
+    last_validated_at = NULL,
+    validation_status = NULL,
+    validation_reason = NULL
 FROM remote_session_client_user_session_issuers AS link
 JOIN remote_session_clients AS c ON c.id = link.remote_session_client_id
 JOIN user_session_issuers AS usi ON usi.id = link.user_session_issuer_id
@@ -2325,7 +2377,11 @@ SET deleted_at = clock_timestamp(),
     upstream_email = NULL,
     upstream_display_name = NULL,
     identity_source = NULL,
-    enrichment = NULL
+    enrichment = NULL,
+    -- The credential is gone, so nothing it was observed doing survives it.
+    last_validated_at = NULL,
+    validation_status = NULL,
+    validation_reason = NULL
 FROM remote_session_clients AS c, remote_session_issuers AS i
 WHERE s.id = @id
   AND s.remote_session_client_id = c.id
@@ -2720,6 +2776,16 @@ JOIN remote_session_clients AS c
 WHERE link.remote_session_client_id = @remote_session_client_id
   AND c.project_id = @project_id
 ORDER BY link.user_session_issuer_id;
+
+-- TEST FIXTURE ONLY. Redirects the issuer behind a tenant-owned client to a
+-- local token endpoint so refresh behavior can be exercised without raw SQL.
+-- name: ForceRemoteSessionIssuerTokenEndpointFixture :execrows
+UPDATE remote_session_issuers AS i
+SET token_endpoint = @token_endpoint
+FROM remote_session_clients AS c
+WHERE c.id = @remote_session_client_id
+  AND i.id = c.remote_session_issuer_id
+  AND (c.project_id = @project_id::uuid OR (c.project_id IS NULL AND c.organization_id = @organization_id::text));
 
 -- TEST FIXTURE ONLY. Writes a token_endpoint_auth_method the Goa enum does not
 -- accept, which no production path can produce. private_key_jwt arrives with

--- a/server/internal/remotesessions/remotesessionmetrics/validation.go
+++ b/server/internal/remotesessions/remotesessionmetrics/validation.go
@@ -1,0 +1,43 @@
+package remotesessionmetrics
+
+import (
+	"context"
+	"log/slog"
+
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+)
+
+const meterValidation = "gram.remote_session.validation"
+
+// Validation counts live-validation probes by outcome.
+type Validation struct {
+	probes metric.Int64Counter
+}
+
+func NewValidation(logger *slog.Logger, meterProvider metric.MeterProvider) *Validation {
+	meter := meterProvider.Meter(meterScope)
+
+	probes, err := meter.Int64Counter(
+		meterValidation,
+		metric.WithDescription("Live validation probes of stored Remote Session credentials against their upstream MCP server, by outcome and issuer URL."),
+		metric.WithUnit("{probe}"),
+	)
+	if err != nil {
+		logger.ErrorContext(context.Background(), "create metric", attr.SlogMetricName(meterValidation), attr.SlogError(err))
+	}
+
+	return &Validation{probes: probes}
+}
+
+// Record counts one probe by outcome (a remotesessions.ValidationOutcome) and issuer URL.
+func (m *Validation) Record(ctx context.Context, issuerURL string, outcome string) {
+	if m == nil || m.probes == nil {
+		return
+	}
+	m.probes.Add(ctx, 1, metric.WithAttributes(
+		attr.OAuthIssuer(issuerURL),
+		attr.Outcome(outcome),
+	))
+}

--- a/server/internal/remotesessions/remotesessionmetrics/validation_test.go
+++ b/server/internal/remotesessions/remotesessionmetrics/validation_test.go
@@ -1,0 +1,78 @@
+package remotesessionmetrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+)
+
+// Pins the instrument name, its two attribute keys, and that one Record is one count.
+func TestValidationRecord_PinsInstrumentAndDimensions(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	m := NewValidation(testenv.NewLogger(t), provider)
+	m.Record(t.Context(), "https://idp.example.com/tenant-a", "rejected_by_member")
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	require.Len(t, rm.ScopeMetrics, 1)
+	require.Len(t, rm.ScopeMetrics[0].Metrics, 1)
+
+	got := rm.ScopeMetrics[0].Metrics[0]
+	require.Equal(t, "gram.remote_session.validation", got.Name)
+	metricdatatest.AssertHasAttributes(t, got,
+		attr.OAuthIssuer("https://idp.example.com/tenant-a"),
+		attr.Outcome("rejected_by_member"),
+	)
+
+	sum, ok := got.Data.(metricdata.Sum[int64])
+	require.True(t, ok, "validation instrument must be an int64 counter")
+	require.Len(t, sum.DataPoints, 1)
+	require.Equal(t, int64(1), sum.DataPoints[0].Value)
+}
+
+// Every outcome lands on its own series, so a breakdown by outcome accounts for every probe.
+func TestValidationRecord_SeparatesOutcomes(t *testing.T) {
+	t.Parallel()
+
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	m := NewValidation(testenv.NewLogger(t), provider)
+	m.Record(t.Context(), "https://idp.example.com", "valid")
+	m.Record(t.Context(), "https://idp.example.com", "valid")
+	m.Record(t.Context(), "https://idp.example.com", "unknown")
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	sum, ok := rm.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+
+	counts := map[string]int64{}
+	for _, dp := range sum.DataPoints {
+		outcome, found := dp.Attributes.Value(attr.OutcomeKey)
+		require.True(t, found)
+		counts[outcome.AsString()] = dp.Value
+	}
+	require.Equal(t, map[string]int64{"valid": 2, "unknown": 1}, counts)
+}
+
+// A nil receiver and a nil instrument both degrade to no-ops, per the package convention.
+func TestValidationRecord_NilSafe(t *testing.T) {
+	t.Parallel()
+
+	var m *Validation
+	m.Record(t.Context(), "https://idp.example.com", "valid")
+
+	empty := &Validation{probes: nil}
+	empty.Record(t.Context(), "https://idp.example.com", "valid")
+}

--- a/server/internal/remotesessions/repo/queries.sql.go
+++ b/server/internal/remotesessions/repo/queries.sql.go
@@ -1409,6 +1409,37 @@ func (q *Queries) ForceRemoteSessionClientAuthMethodFixture(ctx context.Context,
 	return result.RowsAffected(), nil
 }
 
+const forceRemoteSessionIssuerTokenEndpointFixture = `-- name: ForceRemoteSessionIssuerTokenEndpointFixture :execrows
+UPDATE remote_session_issuers AS i
+SET token_endpoint = $1
+FROM remote_session_clients AS c
+WHERE c.id = $2
+  AND i.id = c.remote_session_issuer_id
+  AND (c.project_id = $3::uuid OR (c.project_id IS NULL AND c.organization_id = $4::text))
+`
+
+type ForceRemoteSessionIssuerTokenEndpointFixtureParams struct {
+	TokenEndpoint         pgtype.Text
+	RemoteSessionClientID uuid.UUID
+	ProjectID             uuid.UUID
+	OrganizationID        string
+}
+
+// TEST FIXTURE ONLY. Redirects the issuer behind a tenant-owned client to a
+// local token endpoint so refresh behavior can be exercised without raw SQL.
+func (q *Queries) ForceRemoteSessionIssuerTokenEndpointFixture(ctx context.Context, arg ForceRemoteSessionIssuerTokenEndpointFixtureParams) (int64, error) {
+	result, err := q.db.Exec(ctx, forceRemoteSessionIssuerTokenEndpointFixture,
+		arg.TokenEndpoint,
+		arg.RemoteSessionClientID,
+		arg.ProjectID,
+		arg.OrganizationID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const getActiveRemoteSession = `-- name: GetActiveRemoteSession :one
 SELECT id, subject_urn, user_session_issuer_id, remote_session_client_id, access_token_encrypted, access_expires_at, refresh_token_encrypted, authorization_expires_at, refresh_expires_at, scopes, resource, auto_refresh, last_refresh_attempt_at, last_used_at, upstream_subject, upstream_email, upstream_display_name, identity_source, enrichment, last_validated_at, validation_status, validation_reason, created_at, updated_at, deleted_at, deleted
 FROM remote_sessions
@@ -4621,6 +4652,11 @@ SELECT
   s.upstream_email,
   s.upstream_display_name,
   s.identity_source,
+  s.id,
+  s.updated_at,
+  s.last_validated_at,
+  s.validation_status,
+  s.validation_reason,
   (s.refresh_token_encrypted IS NOT NULL
     AND (s.authorization_expires_at IS NULL OR s.authorization_expires_at > now())
     AND (s.refresh_expires_at IS NULL OR s.refresh_expires_at > now()))::boolean AS can_refresh,
@@ -4665,6 +4701,11 @@ type ListRemoteSessionStatusesForSubjectRow struct {
 	UpstreamEmail          pgtype.Text
 	UpstreamDisplayName    pgtype.Text
 	IdentitySource         pgtype.Text
+	ID                     uuid.UUID
+	UpdatedAt              pgtype.Timestamptz
+	LastValidatedAt        pgtype.Timestamptz
+	ValidationStatus       pgtype.Text
+	ValidationReason       pgtype.Text
 	CanRefresh             bool
 	Status                 string
 }
@@ -4727,6 +4768,11 @@ func (q *Queries) ListRemoteSessionStatusesForSubject(ctx context.Context, arg L
 			&i.UpstreamEmail,
 			&i.UpstreamDisplayName,
 			&i.IdentitySource,
+			&i.ID,
+			&i.UpdatedAt,
+			&i.LastValidatedAt,
+			&i.ValidationStatus,
+			&i.ValidationReason,
 			&i.CanRefresh,
 			&i.Status,
 		); err != nil {
@@ -5244,7 +5290,11 @@ SET deleted_at = clock_timestamp(),
     upstream_email = NULL,
     upstream_display_name = NULL,
     identity_source = NULL,
-    enrichment = NULL
+    enrichment = NULL,
+    -- The credential is gone, so nothing it was observed doing survives it.
+    last_validated_at = NULL,
+    validation_status = NULL,
+    validation_reason = NULL
 FROM remote_session_clients AS c, remote_session_issuers AS i
 WHERE s.id = $1
   AND s.remote_session_client_id = c.id
@@ -5338,7 +5388,11 @@ SET deleted_at = clock_timestamp(),
     upstream_email = NULL,
     upstream_display_name = NULL,
     identity_source = NULL,
-    enrichment = NULL
+    enrichment = NULL,
+    -- The credential is gone, so nothing it was observed doing survives it.
+    last_validated_at = NULL,
+    validation_status = NULL,
+    validation_reason = NULL
 FROM remote_session_clients AS c, user_session_issuers AS usi
 WHERE s.id = $1
   AND s.remote_session_client_id = c.id
@@ -5729,6 +5783,60 @@ func (q *Queries) SetRemoteSessionUpdatedAt(ctx context.Context, arg SetRemoteSe
 	return err
 }
 
+const setRemoteSessionValidation = `-- name: SetRemoteSessionValidation :execrows
+UPDATE remote_sessions AS s
+SET
+    last_validated_at = $1,
+    validation_status = $2::text,
+    validation_reason = $3::text
+WHERE s.id = $4
+  AND s.subject_urn = $5
+  AND s.remote_session_client_id = $6
+  AND s.deleted IS FALSE
+  AND s.updated_at = $7
+  AND (s.last_validated_at IS NULL OR s.last_validated_at <= $1)
+  AND ($2::text <> 'unknown' OR s.validation_status IS DISTINCT FROM 'valid')
+  AND EXISTS (
+    SELECT 1 FROM remote_session_clients AS c
+    WHERE c.id = s.remote_session_client_id
+      AND c.deleted IS FALSE
+      AND (c.project_id = $8::uuid OR (c.project_id IS NULL AND (c.organization_id IS NULL OR c.organization_id = $9::text)))
+  )
+`
+
+type SetRemoteSessionValidationParams struct {
+	LastValidatedAt       pgtype.Timestamptz
+	ValidationStatus      string
+	ValidationReason      pgtype.Text
+	ID                    uuid.UUID
+	SubjectUrn            urn.SessionSubject
+	RemoteSessionClientID uuid.UUID
+	ExpectedUpdatedAt     pgtype.Timestamptz
+	ProjectID             uuid.UUID
+	OrganizationID        string
+}
+
+// Records the last probe verdict for the grant the probe presented; updated_at is the CAS token and is left alone.
+// Bound to the challenge's tenant through the client row. Older observations never overwrite newer ones,
+// and an unknown never overwrites a stored valid.
+func (q *Queries) SetRemoteSessionValidation(ctx context.Context, arg SetRemoteSessionValidationParams) (int64, error) {
+	result, err := q.db.Exec(ctx, setRemoteSessionValidation,
+		arg.LastValidatedAt,
+		arg.ValidationStatus,
+		arg.ValidationReason,
+		arg.ID,
+		arg.SubjectUrn,
+		arg.RemoteSessionClientID,
+		arg.ExpectedUpdatedAt,
+		arg.ProjectID,
+		arg.OrganizationID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const softDeleteRemoteSessionBySubjectAndClient = `-- name: SoftDeleteRemoteSessionBySubjectAndClient :many
 UPDATE remote_sessions AS s
 SET deleted_at = clock_timestamp(),
@@ -5737,7 +5845,11 @@ SET deleted_at = clock_timestamp(),
     upstream_email = NULL,
     upstream_display_name = NULL,
     identity_source = NULL,
-    enrichment = NULL
+    enrichment = NULL,
+    -- The credential is gone, so nothing it was observed doing survives it.
+    last_validated_at = NULL,
+    validation_status = NULL,
+    validation_reason = NULL
 FROM remote_session_client_user_session_issuers AS link
 JOIN remote_session_clients AS c ON c.id = link.remote_session_client_id
 JOIN user_session_issuers AS usi ON usi.id = link.user_session_issuer_id
@@ -5816,7 +5928,11 @@ SET deleted_at = clock_timestamp(),
     upstream_email = NULL,
     upstream_display_name = NULL,
     identity_source = NULL,
-    enrichment = NULL
+    enrichment = NULL,
+    -- The credential is gone, so nothing it was observed doing survives it.
+    last_validated_at = NULL,
+    validation_status = NULL,
+    validation_reason = NULL
 WHERE remote_session_client_id = $1 AND deleted IS FALSE
 RETURNING remote_session_client_id, access_token_encrypted, refresh_token_encrypted
 `
@@ -5856,7 +5972,11 @@ SET deleted_at = clock_timestamp(),
     upstream_email = NULL,
     upstream_display_name = NULL,
     identity_source = NULL,
-    enrichment = NULL
+    enrichment = NULL,
+    -- The credential is gone, so nothing it was observed doing survives it.
+    last_validated_at = NULL,
+    validation_status = NULL,
+    validation_reason = NULL
 WHERE remote_session_client_id = ANY($1::uuid[]) AND deleted IS FALSE
 RETURNING remote_session_client_id, access_token_encrypted, refresh_token_encrypted
 `
@@ -5898,7 +6018,11 @@ SET deleted_at = COALESCE(s.deleted_at, $1::timestamptz, clock_timestamp()),
     upstream_email = NULL,
     upstream_display_name = NULL,
     identity_source = NULL,
-    enrichment = NULL
+    enrichment = NULL,
+    -- The credential is gone, so nothing it was observed doing survives it.
+    last_validated_at = NULL,
+    validation_status = NULL,
+    validation_reason = NULL
 FROM remote_session_clients AS c,
      user_session_issuers AS usi
 WHERE s.subject_urn = $2
@@ -7180,6 +7304,10 @@ SET
     refresh_expires_at = $5,
     scopes = $6,
     resource = COALESCE(resource, NULLIF($7::text, '')),
+    -- A refreshed token has not been presented anywhere yet.
+    last_validated_at = NULL,
+    validation_status = NULL,
+    validation_reason = NULL,
     updated_at = clock_timestamp()
 WHERE subject_urn = $8
   AND remote_session_client_id = $9

--- a/server/internal/remotesessions/tokenservice.go
+++ b/server/internal/remotesessions/tokenservice.go
@@ -216,9 +216,11 @@ func (m *ChallengeManager) resolveUpstreamToken(
 	}
 
 	return UpstreamToken{
-		Token:                 tok,
-		Resource:              conv.FromPGTextOrEmpty[string](sess.Resource),
-		RemoteSessionClientID: clientID,
+		Token:                  tok,
+		Resource:               conv.FromPGTextOrEmpty[string](sess.Resource),
+		RemoteSessionClientID:  clientID,
+		RemoteSessionID:        sess.ID,
+		RemoteSessionUpdatedAt: sess.UpdatedAt.Time,
 	}, nil
 }
 
@@ -307,6 +309,12 @@ type UpstreamToken struct {
 	// RemoteSessionClientID is the remote_session_client the credential
 	// belongs to.
 	RemoteSessionClientID uuid.UUID
+
+	// RemoteSessionID and RemoteSessionUpdatedAt identify the exact grant row
+	// this token came from. Callers use the pair as a CAS snapshot when
+	// persisting outcomes from work performed with this credential.
+	RemoteSessionID        uuid.UUID
+	RemoteSessionUpdatedAt time.Time
 }
 
 // ResolveAccessTokens is the variant the MCP serving path calls. It
@@ -508,6 +516,7 @@ func refreshFailureAttrs(sess remotesessions_repo.RemoteSession, err error) []an
 		code = refreshErr.UpstreamCode()
 	}
 	args := []any{
+		attr.SlogRemoteSessionID(sess.ID.String()),
 		attr.SlogRemoteSessionClientID(sess.RemoteSessionClientID.String()),
 		attr.SlogUserSessionIssuerID(sess.UserSessionIssuerID.String()),
 		attr.SlogOAuthFailureReason(reason),

--- a/server/internal/remotesessions/tokenservice_attrs_internal_test.go
+++ b/server/internal/remotesessions/tokenservice_attrs_internal_test.go
@@ -1,0 +1,38 @@
+package remotesessions
+
+import (
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+// A refresh-failure log line names the session row itself, so one failing credential is findable.
+func TestRefreshFailureAttrs_CarriesRemoteSessionID(t *testing.T) {
+	t.Parallel()
+
+	sess := remotesessions_repo.RemoteSession{
+		ID:                    uuid.New(),
+		SubjectUrn:            urn.NewUserSubject("user-1"),
+		UserSessionIssuerID:   uuid.New(),
+		RemoteSessionClientID: uuid.New(),
+	}
+
+	attrs := refreshFailureAttrs(sess, errors.New("upstream said no"))
+
+	keys := map[string]string{}
+	for _, a := range attrs {
+		if sa, ok := a.(slog.Attr); ok {
+			keys[sa.Key] = sa.Value.String()
+		}
+	}
+	require.Equal(t, sess.ID.String(), keys[string(attr.RemoteSessionIDKey)])
+	require.Equal(t, sess.RemoteSessionClientID.String(), keys[string(attr.RemoteSessionClientIDKey)])
+	require.Equal(t, "gram.remote_session.id", string(attr.RemoteSessionIDKey))
+}

--- a/server/internal/remotesessions/tokenservice_resolve_test.go
+++ b/server/internal/remotesessions/tokenservice_resolve_test.go
@@ -97,6 +97,20 @@ func seedActiveClient(t *testing.T, ctx context.Context, conn *pgxpool.Pool, pro
 	return client.ID, issuer.ID
 }
 
+func tokenCredentials(tokens map[uuid.UUID]remotesessions.UpstreamToken) map[uuid.UUID]remotesessions.UpstreamToken {
+	result := make(map[uuid.UUID]remotesessions.UpstreamToken, len(tokens))
+	for issuerID, token := range tokens {
+		result[issuerID] = tokenCredential(token)
+	}
+	return result
+}
+
+func tokenCredential(token remotesessions.UpstreamToken) remotesessions.UpstreamToken {
+	token.RemoteSessionID = uuid.Nil
+	token.RemoteSessionUpdatedAt = time.Time{}
+	return token
+}
+
 func TestResolveAccessTokens_SingleClientHappyPath(t *testing.T) {
 	t.Parallel()
 
@@ -114,7 +128,7 @@ func TestResolveAccessTokens_SingleClientHappyPath(t *testing.T) {
 	subject := urn.NewUserSubject("resolve-happy-subject")
 	accessEnc, err := enc.Encrypt([]byte("upstream-access-token"))
 	require.NoError(t, err)
-	_, err = repo.New(ti.conn).UpsertRemoteSession(ctx, repo.UpsertRemoteSessionParams{
+	session, err := repo.New(ti.conn).UpsertRemoteSession(ctx, repo.UpsertRemoteSessionParams{
 		SubjectUrn:            subject,
 		UserSessionIssuerID:   userIssuerID,
 		RemoteSessionClientID: clientID,
@@ -126,7 +140,9 @@ func TestResolveAccessTokens_SingleClientHappyPath(t *testing.T) {
 
 	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject)
 	require.NoError(t, err)
-	require.Equal(t, map[uuid.UUID]remotesessions.UpstreamToken{remoteIssuerID: {Token: "upstream-access-token", Resource: "", RemoteSessionClientID: clientID}}, tokens)
+	require.Equal(t, map[uuid.UUID]remotesessions.UpstreamToken{remoteIssuerID: {Token: "upstream-access-token", Resource: "", RemoteSessionClientID: clientID}}, tokenCredentials(tokens))
+	require.Equal(t, session.ID, tokens[remoteIssuerID].RemoteSessionID)
+	require.Equal(t, session.UpdatedAt.Time, tokens[remoteIssuerID].RemoteSessionUpdatedAt)
 }
 
 func TestResolveAuthorization_InvalidRequestIsNotReportedAsMissingAuthorization(t *testing.T) {
@@ -299,7 +315,7 @@ func TestResolveAccessTokens_TenantClientOnPlatformIssuer(t *testing.T) {
 
 	tokens, err := mgr.ResolveAccessTokens(ctx, *authCtx.ProjectID, authCtx.ActiveOrganizationID, userIssuerID, subject)
 	require.NoError(t, err)
-	require.Equal(t, map[uuid.UUID]remotesessions.UpstreamToken{platformID: {Token: "platform-upstream-token", Resource: "", RemoteSessionClientID: uuid.MustParse(clientID)}}, tokens)
+	require.Equal(t, map[uuid.UUID]remotesessions.UpstreamToken{platformID: {Token: "platform-upstream-token", Resource: "", RemoteSessionClientID: uuid.MustParse(clientID)}}, tokenCredentials(tokens))
 }
 
 // Two clients on distinct remote issuers bound to one user_session_issuer —
@@ -349,7 +365,7 @@ func TestResolveAccessTokens_MultipleUpstreamsCarryQualifiedResources(t *testing
 	require.Equal(t, map[uuid.UUID]remotesessions.UpstreamToken{
 		remoteIssuerA: {Token: "token-a", Resource: "https://a.example.com/mcp", RemoteSessionClientID: clientA},
 		remoteIssuerB: {Token: "token-b", Resource: "https://b.example.com/mcp", RemoteSessionClientID: clientB},
-	}, tokens)
+	}, tokenCredentials(tokens))
 }
 
 // The partial variant the meta MCP gate calls: a bound client the subject
@@ -388,7 +404,7 @@ func TestResolveAvailableAccessTokens_SkipsUnlinkedClients(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, map[uuid.UUID]remotesessions.UpstreamToken{
 		remoteIssuerA: {Token: "token-a", Resource: "https://a.example.com/mcp", RemoteSessionClientID: clientA},
-	}, tokens)
+	}, tokenCredentials(tokens))
 
 	// The strict variant still refuses the same shape, pinning that partial
 	// resolution changed nothing for direct-endpoint callers.

--- a/server/internal/remotesessions/tokenservice_resource_backfill_test.go
+++ b/server/internal/remotesessions/tokenservice_resource_backfill_test.go
@@ -264,9 +264,9 @@ func TestResolveAccessTokens_RefreshingRequestCarriesBackfilledResource(t *testi
 	require.NoError(t, spy.handlerErr)
 	require.Equal(t, derived, spy.form.Get("resource"), "the refresh grant must have carried the derived resource")
 
-	require.Equal(t, remotesessions.UpstreamToken{Token: "refreshed-access", Resource: derived, RemoteSessionClientID: clientID}, tokens[refreshedClient.RemoteSessionIssuerID],
+	require.Equal(t, remotesessions.UpstreamToken{Token: "refreshed-access", Resource: derived, RemoteSessionClientID: clientID}, tokenCredential(tokens[refreshedClient.RemoteSessionIssuerID]),
 		"the request that backfills the resource must itself carry it, not the pre-refresh empty value")
-	require.Equal(t, remotesessions.UpstreamToken{Token: "second-token", Resource: "https://second.example.com/mcp", RemoteSessionClientID: secondClient}, tokens[secondIssuer])
+	require.Equal(t, remotesessions.UpstreamToken{Token: "second-token", Resource: "https://second.example.com/mcp", RemoteSessionClientID: secondClient}, tokenCredential(tokens[secondIssuer]))
 
 	sess := getRemoteSessionRow(t, ctx, ti, clientID, subject)
 	require.Equal(t, derived, conv.FromPGTextOrEmpty[string](sess.Resource), "the backfill must also have been persisted")
@@ -369,8 +369,8 @@ func TestResolveAccessTokens_BackfillStampsTheRefreshedClientsOwnResource(t *tes
 	sess := getRemoteSessionRow(t, ctx, ti, clientID, subject)
 	require.Equal(t, derived, conv.FromPGTextOrEmpty[string](sess.Resource), "the backfill must stamp the refreshed client's own resource, never a sibling's")
 
-	require.Equal(t, remotesessions.UpstreamToken{Token: "refreshed-access", Resource: derived, RemoteSessionClientID: clientID}, tokens[refreshedClient.RemoteSessionIssuerID])
-	require.Equal(t, remotesessions.UpstreamToken{Token: "sibling-token", Resource: siblingResource, RemoteSessionClientID: siblingClient}, tokens[siblingIssuer])
+	require.Equal(t, remotesessions.UpstreamToken{Token: "refreshed-access", Resource: derived, RemoteSessionClientID: clientID}, tokenCredential(tokens[refreshedClient.RemoteSessionIssuerID]))
+	require.Equal(t, remotesessions.UpstreamToken{Token: "sibling-token", Resource: siblingResource, RemoteSessionClientID: siblingClient}, tokenCredential(tokens[siblingIssuer]))
 
 	siblingSess := getRemoteSessionRow(t, ctx, ti, siblingClient, subject)
 	require.Equal(t, siblingResource, conv.FromPGTextOrEmpty[string](siblingSess.Resource), "the sibling's own binding must survive a neighbour's backfill")

--- a/server/internal/remotesessions/validation.go
+++ b/server/internal/remotesessions/validation.go
@@ -1,0 +1,74 @@
+// Storage for live-validation verdicts; the probe itself lives with the MCP runtime.
+
+package remotesessions
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+// RemoteSessionRef names the exact grant a probe presented, so a verdict lands on that grant or not at all.
+type RemoteSessionRef struct {
+	// ID is the remote_sessions row.
+	ID uuid.UUID
+
+	// Subject is the session subject the grant belongs to.
+	Subject urn.SessionSubject
+
+	// ClientID is the remote_session_client the grant was minted through.
+	ClientID uuid.UUID
+
+	// UpdatedAt is the row's CAS token as read before the probe.
+	UpdatedAt time.Time
+
+	// ProjectID is the consent challenge's project; the client row must belong to it.
+	ProjectID uuid.UUID
+
+	// OrganizationID is the consent challenge's organization, binding an org-level client.
+	OrganizationID string
+}
+
+// RemoteSessionValidation is one observed verdict on a stored credential.
+type RemoteSessionValidation struct {
+	// Status is the observed verdict.
+	Status ValidationOutcome
+
+	// Reason is the Gram-authored explanation of a non-valid status; empty when valid.
+	Reason string
+
+	// At is when the credential was presented.
+	At time.Time
+}
+
+// RecordRemoteSessionValidation stores a verdict; false means the grant changed or vanished since ref was read,
+// or an unknown lost the race to a valid already stored.
+func (m *ChallengeManager) RecordRemoteSessionValidation(ctx context.Context, ref RemoteSessionRef, verdict RemoteSessionValidation) (bool, error) {
+	switch verdict.Status {
+	case ValidationOutcomeValid, ValidationOutcomeRejectedByMember, ValidationOutcomeUnknown:
+	default:
+		return false, fmt.Errorf("record remote session validation: %q is not a probe verdict", verdict.Status)
+	}
+	rows, err := remotesessions_repo.New(m.db).SetRemoteSessionValidation(ctx, remotesessions_repo.SetRemoteSessionValidationParams{
+		LastValidatedAt:       pgtype.Timestamptz{Time: verdict.At, Valid: true, InfinityModifier: pgtype.Finite},
+		ValidationStatus:      string(verdict.Status),
+		ValidationReason:      conv.ToPGTextEmpty(verdict.Reason),
+		ID:                    ref.ID,
+		SubjectUrn:            ref.Subject,
+		RemoteSessionClientID: ref.ClientID,
+		ExpectedUpdatedAt:     pgtype.Timestamptz{Time: ref.UpdatedAt, Valid: true, InfinityModifier: pgtype.Finite},
+		ProjectID:             ref.ProjectID,
+		OrganizationID:        ref.OrganizationID,
+	})
+	if err != nil {
+		return false, fmt.Errorf("record remote session validation: %w", err)
+	}
+	return rows > 0, nil
+}

--- a/server/internal/remotesessions/validation_test.go
+++ b/server/internal/remotesessions/validation_test.go
@@ -1,0 +1,330 @@
+package remotesessions_test
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/contextvalues"
+	"github.com/speakeasy-api/gram/server/internal/conv"
+	"github.com/speakeasy-api/gram/server/internal/guardian"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
+	"github.com/speakeasy-api/gram/server/internal/testenv"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+type validationFixture struct {
+	ti        *testInstance
+	mgr       *remotesessions.ChallengeManager
+	projectID uuid.UUID
+	session   repo.RemoteSession
+	ref       remotesessions.RemoteSessionRef
+}
+
+func seedValidationFixture(t *testing.T, prefix string) (context.Context, validationFixture) {
+	t.Helper()
+
+	ctx, ti := newTestService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	require.NotNil(t, authCtx.ProjectID)
+	issuerID := createRemoteIssuer(t, ctx, ti, prefix+"-issuer", "")
+	userIssuerID := createUserSessionIssuer(t, ctx, ti.conn, prefix+"-usi")
+	clientID := createRemoteClient(t, ctx, ti, issuerID, userIssuerID.String(), prefix+"-client")
+	subject := urn.NewUserSubject(prefix + "-subject")
+	session := insertRemoteSession(t, ctx, ti.conn, subject, userIssuerID.String(), clientID)
+
+	policy, err := guardian.NewUnsafePolicy(testenv.NewTracerProvider(t), []string{})
+	require.NoError(t, err)
+	serverURL, err := url.Parse(testServerURL)
+	require.NoError(t, err)
+	mgr := remotesessions.NewChallengeManager(testenv.NewLogger(t), testenv.NewTracerProvider(t), testenv.NewMeterProvider(t), ti.conn, testenv.NewEncryptionClient(t), policy, ti.redisCache, serverURL)
+
+	return ctx, validationFixture{
+		ti:        ti,
+		mgr:       mgr,
+		projectID: *authCtx.ProjectID,
+		session:   session,
+		ref: remotesessions.RemoteSessionRef{
+			ID:             session.ID,
+			Subject:        subject,
+			ClientID:       session.RemoteSessionClientID,
+			UpdatedAt:      session.UpdatedAt.Time,
+			ProjectID:      *authCtx.ProjectID,
+			OrganizationID: authCtx.ActiveOrganizationID,
+		},
+	}
+}
+
+func (fx validationFixture) reload(t *testing.T, ctx context.Context) repo.RemoteSession {
+	t.Helper()
+	row, err := repo.New(fx.ti.conn).GetRemoteSessionByIDIncludingDeleted(ctx, repo.GetRemoteSessionByIDIncludingDeletedParams{
+		ID:        fx.session.ID,
+		ProjectID: conv.ToNullUUID(fx.projectID),
+	})
+	require.NoError(t, err)
+	return row
+}
+
+func (fx validationFixture) recordValidation(t *testing.T, ctx context.Context, ref remotesessions.RemoteSessionRef, status remotesessions.ValidationOutcome, reason string, at time.Time) bool {
+	t.Helper()
+	written, err := fx.mgr.RecordRemoteSessionValidation(ctx, ref, remotesessions.RemoteSessionValidation{Status: status, Reason: reason, At: at})
+	require.NoError(t, err)
+	return written
+}
+
+func TestRecordRemoteSessionValidation_SetsVerdict(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedValidationFixture(t, "aim204-set")
+	require.False(t, fx.session.LastValidatedAt.Valid, "a fresh grant starts never validated")
+	require.False(t, fx.session.ValidationStatus.Valid)
+
+	at := time.Now().Add(-time.Minute).Truncate(time.Microsecond)
+	written := fx.recordValidation(t, ctx, fx.ref, remotesessions.ValidationOutcomeRejectedByMember, "Rejected by linear", at)
+	require.True(t, written)
+
+	row := fx.reload(t, ctx)
+	require.True(t, row.LastValidatedAt.Valid)
+	require.WithinDuration(t, at, row.LastValidatedAt.Time, time.Millisecond)
+	require.Equal(t, "rejected_by_member", row.ValidationStatus.String)
+	require.Equal(t, "Rejected by linear", row.ValidationReason.String)
+	// The CAS token and keepalive clock are not an observation of the credential, so they stay put.
+	require.Equal(t, fx.session.UpdatedAt.Time, row.UpdatedAt.Time)
+
+	// A valid verdict carries no reason; the column is NULL, not "".
+	written = fx.recordValidation(t, ctx, fx.ref, remotesessions.ValidationOutcomeValid, "", time.Now())
+	require.True(t, written)
+	row = fx.reload(t, ctx)
+	require.Equal(t, "valid", row.ValidationStatus.String)
+	require.False(t, row.ValidationReason.Valid)
+	require.Equal(t, fx.session.UpdatedAt.Time, row.UpdatedAt.Time, "a second verdict on the same grant still leaves the CAS token alone")
+}
+
+// The write is keyed on the whole (id, subject, client, updated_at) tuple.
+func TestRecordRemoteSessionValidation_ScopedToSubjectAndClient(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedValidationFixture(t, "aim204-scope")
+	at := time.Now()
+	wrongSubject, wrongClient, wrongID, stale := fx.ref, fx.ref, fx.ref, fx.ref
+	wrongSubject.Subject = urn.NewUserSubject("aim204-scope-other")
+	wrongClient.ClientID = uuid.New()
+	wrongID.ID = uuid.New()
+	stale.UpdatedAt = fx.session.UpdatedAt.Time.Add(-time.Second)
+	for name, ref := range map[string]remotesessions.RemoteSessionRef{
+		"wrong subject": wrongSubject,
+		"wrong client":  wrongClient,
+		"wrong id":      wrongID,
+		"stale CAS":     stale,
+	} {
+		require.False(t, fx.recordValidation(t, ctx, ref, remotesessions.ValidationOutcomeValid, "", at), name)
+	}
+
+	row := fx.reload(t, ctx)
+	require.False(t, row.ValidationStatus.Valid, "no crafted key may reach the row")
+}
+
+// The write is bound to the challenge's tenant through the client row: another project's challenge writes nothing.
+func TestRecordRemoteSessionValidation_ScopedToTenant(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedValidationFixture(t, "aim204-tenant")
+	at := time.Now()
+	otherProject, otherTenant := fx.ref, fx.ref
+	otherProject.ProjectID = uuid.New()
+	otherTenant.ProjectID = uuid.New()
+	otherTenant.OrganizationID = "org_" + uuid.NewString()
+	for name, ref := range map[string]remotesessions.RemoteSessionRef{
+		"other project": otherProject,
+		"other tenant":  otherTenant,
+	} {
+		require.False(t, fx.recordValidation(t, ctx, ref, remotesessions.ValidationOutcomeValid, "", at), name)
+	}
+	require.False(t, fx.reload(t, ctx).ValidationStatus.Valid)
+
+	require.True(t, fx.recordValidation(t, ctx, fx.ref, remotesessions.ValidationOutcomeValid, "", at), "the owning tenant still writes")
+	require.Equal(t, "valid", fx.reload(t, ctx).ValidationStatus.String)
+}
+
+// Platform clients are shared across projects and organizations, just as in the
+// consent status query. The subject/client/CAS tuple still pins the exact grant.
+func TestRecordRemoteSessionValidation_PlatformClient(t *testing.T) {
+	t.Parallel()
+	ctx, fx := seedValidationFixture(t, "validate-platform")
+	issuerID := seedGlobalRemoteIssuer(t, ctx, fx.ti.conn, "validate-platform-issuer")
+	client, err := repo.New(fx.ti.conn).CreateRemoteSessionClient(ctx, repo.CreateRemoteSessionClientParams{
+		ProjectID:             uuid.NullUUID{},
+		OrganizationID:        pgtype.Text{},
+		RemoteSessionIssuerID: issuerID,
+		ClientID:              "validate-platform-client",
+	})
+	require.NoError(t, err)
+	fx.session = insertRemoteSession(t, ctx, fx.ti.conn, fx.ref.Subject, fx.session.UserSessionIssuerID.String(), client.ID.String())
+	fx.ref.ID = fx.session.ID
+	fx.ref.ClientID = client.ID
+	fx.ref.UpdatedAt = fx.session.UpdatedAt.Time
+
+	require.True(t, fx.recordValidation(t, ctx, fx.ref, remotesessions.ValidationOutcomeValid, "", time.Now()))
+	row, err := repo.New(fx.ti.conn).GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            fx.ref.Subject,
+		RemoteSessionClientID: fx.ref.ClientID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "valid", row.ValidationStatus.String)
+
+	wrongSubject := fx.ref
+	wrongSubject.Subject = urn.NewUserSubject("validate-platform-other")
+	require.False(t, fx.recordValidation(t, ctx, wrongSubject, remotesessions.ValidationOutcomeRejectedByMember, "Rejected by test member", time.Now()))
+}
+
+// Only the three probe verdicts are storable; anything else is refused before the write.
+func TestRecordRemoteSessionValidation_RejectsNonProbeStatus(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedValidationFixture(t, "aim204-closed")
+	for _, status := range []remotesessions.ValidationOutcome{"", remotesessions.ValidationOutcomeRevoked, "expired", "VALID"} {
+		written, err := fx.mgr.RecordRemoteSessionValidation(ctx, fx.ref, remotesessions.RemoteSessionValidation{
+			Status: status,
+			Reason: "",
+			At:     time.Now(),
+		})
+		require.Error(t, err, "status %q", status)
+		require.ErrorContains(t, err, "is not a probe verdict")
+		require.False(t, written)
+	}
+	row := fx.reload(t, ctx)
+	require.False(t, row.ValidationStatus.Valid)
+	require.False(t, row.LastValidatedAt.Valid)
+}
+
+// The never-downgrade rule holds in the row itself, so a late unknown from an overlapping probe cannot overwrite a valid.
+func TestRecordRemoteSessionValidation_UnknownNeverOverwritesValid(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedValidationFixture(t, "aim204-race")
+	written := fx.recordValidation(t, ctx, fx.ref, remotesessions.ValidationOutcomeValid, "", time.Now().Add(-time.Second))
+	require.True(t, written)
+	valid := fx.reload(t, ctx)
+
+	// Same ref, same CAS token: the unknown reaches the row after the valid and loses.
+	written = fx.recordValidation(t, ctx, fx.ref, remotesessions.ValidationOutcomeUnknown, "linear did not answer in time", time.Now())
+	require.False(t, written)
+	row := fx.reload(t, ctx)
+	require.Equal(t, "valid", row.ValidationStatus.String)
+	require.False(t, row.ValidationReason.Valid)
+	require.Equal(t, valid.LastValidatedAt.Time, row.LastValidatedAt.Time)
+
+	// A rejection is decisive and still lands.
+	written = fx.recordValidation(t, ctx, fx.ref, remotesessions.ValidationOutcomeRejectedByMember, "Rejected by linear", time.Now())
+	require.True(t, written)
+	require.Equal(t, "rejected_by_member", fx.reload(t, ctx).ValidationStatus.String)
+
+	// And an unknown over a rejection is recorded.
+	written = fx.recordValidation(t, ctx, fx.ref, remotesessions.ValidationOutcomeUnknown, "linear did not answer in time", time.Now())
+	require.True(t, written)
+	require.Equal(t, "unknown", fx.reload(t, ctx).ValidationStatus.String)
+}
+
+// Conclusive overlapping probes are ordered by when they started, not when they finish.
+func TestRecordRemoteSessionValidation_OlderConclusiveVerdictCannotOverwriteNewer(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedValidationFixture(t, "aim204-order")
+	newerAt := time.Now()
+	written := fx.recordValidation(t, ctx, fx.ref, remotesessions.ValidationOutcomeValid, "", newerAt)
+	require.True(t, written)
+	newer := fx.reload(t, ctx)
+
+	written = fx.recordValidation(t, ctx, fx.ref, remotesessions.ValidationOutcomeRejectedByMember, "Rejected by upstream", newerAt.Add(-time.Second))
+	require.False(t, written)
+
+	row := fx.reload(t, ctx)
+	require.Equal(t, "valid", row.ValidationStatus.String)
+	require.False(t, row.ValidationReason.Valid)
+	require.Equal(t, newer.LastValidatedAt.Time, row.LastValidatedAt.Time)
+	require.Equal(t, fx.session.UpdatedAt.Time, row.UpdatedAt.Time, "validation ordering leaves the grant CAS token unchanged")
+}
+
+// Tombstones and re-established grants forget the last verdict.
+func TestRemoteSessionValidation_ClearedByDeleteAndNewGrant(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedValidationFixture(t, "aim204-clear")
+	written := fx.recordValidation(t, ctx, fx.ref, remotesessions.ValidationOutcomeValid, "", time.Now())
+	require.True(t, written)
+
+	// A new grant on the same (subject, client) replaces the row in place and resets the verdict.
+	insertRemoteSession(t, ctx, fx.ti.conn, fx.ref.Subject, fx.session.UserSessionIssuerID.String(), fx.ref.ClientID.String())
+	row := fx.reload(t, ctx)
+	require.False(t, row.Deleted)
+	require.False(t, row.LastValidatedAt.Valid)
+	require.False(t, row.ValidationStatus.Valid)
+	require.True(t, row.UpdatedAt.Time.After(fx.session.UpdatedAt.Time))
+
+	// The verdict read before the reconnect no longer lands.
+	written = fx.recordValidation(t, ctx, fx.ref, remotesessions.ValidationOutcomeRejectedByMember, "Rejected by linear", time.Now())
+	require.False(t, written, "a reconnect mid-probe leaves the new grant unvalidated")
+	require.False(t, fx.reload(t, ctx).ValidationStatus.Valid)
+
+	fx.ref.UpdatedAt = row.UpdatedAt.Time
+	written = fx.recordValidation(t, ctx, fx.ref, remotesessions.ValidationOutcomeRejectedByMember, "Rejected by linear", time.Now())
+	require.True(t, written)
+
+	tombstoned, err := repo.New(fx.ti.conn).SoftDeleteRemoteSessionsByClientID(ctx, fx.ref.ClientID)
+	require.NoError(t, err)
+	require.Len(t, tombstoned, 1)
+	row = fx.reload(t, ctx)
+	require.True(t, row.Deleted)
+	require.False(t, row.LastValidatedAt.Valid)
+	require.False(t, row.ValidationStatus.Valid)
+	require.False(t, row.ValidationReason.Valid)
+
+	// A tombstone is out of reach of the writer.
+	written = fx.recordValidation(t, ctx, fx.ref, remotesessions.ValidationOutcomeValid, "", time.Now())
+	require.False(t, written)
+}
+
+// A refreshed token has not been presented anywhere, so the refresh forgets the verdict.
+func TestRemoteSessionValidation_ClearedByRefresh(t *testing.T) {
+	t.Parallel()
+
+	var spy upstreamSpy
+	ctx, mgr, ti, clientID, subject := setupRefreshFixtureWithHandler(t, "aim204-refresh", pgtype.Text{String: "", Valid: false}, spyRefreshHandler(&spy))
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+	before := getRemoteSessionRow(t, ctx, ti, clientID, subject)
+
+	written, err := mgr.RecordRemoteSessionValidation(ctx, remotesessions.RemoteSessionRef{
+		ID:             before.ID,
+		Subject:        subject,
+		ClientID:       clientID,
+		UpdatedAt:      before.UpdatedAt.Time,
+		ProjectID:      *authCtx.ProjectID,
+		OrganizationID: authCtx.ActiveOrganizationID,
+	}, remotesessions.RemoteSessionValidation{
+		Status: remotesessions.ValidationOutcomeValid,
+		Reason: "",
+		At:     time.Now(),
+	})
+	require.NoError(t, err)
+	require.True(t, written)
+	require.Equal(t, "valid", getRemoteSessionRow(t, ctx, ti, clientID, subject).ValidationStatus.String)
+
+	tok, err := mgr.ResolveAccessToken(ctx, clientID, subject, "")
+	require.NoError(t, err)
+	require.NoError(t, spy.handlerErr)
+	require.Equal(t, "refreshed-access", tok)
+
+	after := getRemoteSessionRow(t, ctx, ti, clientID, subject)
+	require.True(t, after.UpdatedAt.Time.After(before.UpdatedAt.Time), "the refresh rotates the CAS token")
+	require.False(t, after.LastValidatedAt.Valid)
+	require.False(t, after.ValidationStatus.Valid)
+	require.False(t, after.ValidationReason.Valid)
+}

--- a/server/internal/remotesessions/validation_test.go
+++ b/server/internal/remotesessions/validation_test.go
@@ -72,6 +72,16 @@ func (fx validationFixture) reload(t *testing.T, ctx context.Context) repo.Remot
 	return row
 }
 
+func (fx validationFixture) reloadActive(t *testing.T, ctx context.Context) repo.RemoteSession {
+	t.Helper()
+	row, err := repo.New(fx.ti.conn).GetActiveRemoteSession(ctx, repo.GetActiveRemoteSessionParams{
+		SubjectUrn:            fx.ref.Subject,
+		RemoteSessionClientID: fx.ref.ClientID,
+	})
+	require.NoError(t, err)
+	return row
+}
+
 func (fx validationFixture) recordValidation(t *testing.T, ctx context.Context, ref remotesessions.RemoteSessionRef, status remotesessions.ValidationOutcome, reason string, at time.Time) bool {
 	t.Helper()
 	written, err := fx.mgr.RecordRemoteSessionValidation(ctx, ref, remotesessions.RemoteSessionValidation{Status: status, Reason: reason, At: at})
@@ -131,26 +141,44 @@ func TestRecordRemoteSessionValidation_ScopedToSubjectAndClient(t *testing.T) {
 	require.False(t, row.ValidationStatus.Valid, "no crafted key may reach the row")
 }
 
-// The write is bound to the challenge's tenant through the client row: another project's challenge writes nothing.
-func TestRecordRemoteSessionValidation_ScopedToTenant(t *testing.T) {
+// A project-owned client only accepts the project that owns it.
+func TestRecordRemoteSessionValidation_ScopedToProject(t *testing.T) {
 	t.Parallel()
 
 	ctx, fx := seedValidationFixture(t, "aim204-tenant")
 	at := time.Now()
-	otherProject, otherTenant := fx.ref, fx.ref
+	otherProject := fx.ref
 	otherProject.ProjectID = uuid.New()
-	otherTenant.ProjectID = uuid.New()
-	otherTenant.OrganizationID = "org_" + uuid.NewString()
-	for name, ref := range map[string]remotesessions.RemoteSessionRef{
-		"other project": otherProject,
-		"other tenant":  otherTenant,
-	} {
-		require.False(t, fx.recordValidation(t, ctx, ref, remotesessions.ValidationOutcomeValid, "", at), name)
-	}
+	require.False(t, fx.recordValidation(t, ctx, otherProject, remotesessions.ValidationOutcomeValid, "", at))
 	require.False(t, fx.reload(t, ctx).ValidationStatus.Valid)
 
-	require.True(t, fx.recordValidation(t, ctx, fx.ref, remotesessions.ValidationOutcomeValid, "", at), "the owning tenant still writes")
+	require.True(t, fx.recordValidation(t, ctx, fx.ref, remotesessions.ValidationOutcomeValid, "", at), "the owning project still writes")
 	require.Equal(t, "valid", fx.reload(t, ctx).ValidationStatus.String)
+}
+
+// An organization-owned client accepts any project reference from its organization,
+// but rejects a reference carrying another organization.
+func TestRecordRemoteSessionValidation_ScopedToOrganization(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedValidationFixture(t, "aim204-org-tenant")
+	issuerID := seedGlobalRemoteIssuer(t, ctx, fx.ti.conn, "aim204-org-tenant-issuer")
+	clientID := seedOrgLevelRemoteClient(t, ctx, fx.ti.conn, fx.ref.OrganizationID, issuerID, "aim204-org-tenant-client", fx.session.UserSessionIssuerID)
+	fx.session = insertRemoteSession(t, ctx, fx.ti.conn, fx.ref.Subject, fx.session.UserSessionIssuerID.String(), clientID.String())
+	fx.ref.ID = fx.session.ID
+	fx.ref.ClientID = clientID
+	fx.ref.UpdatedAt = fx.session.UpdatedAt.Time
+
+	at := time.Now()
+	otherOrganization := fx.ref
+	otherOrganization.OrganizationID = "org_" + uuid.NewString()
+	require.False(t, fx.recordValidation(t, ctx, otherOrganization, remotesessions.ValidationOutcomeValid, "", at))
+	require.False(t, fx.reloadActive(t, ctx).ValidationStatus.Valid)
+
+	otherProject := fx.ref
+	otherProject.ProjectID = uuid.New()
+	require.True(t, fx.recordValidation(t, ctx, otherProject, remotesessions.ValidationOutcomeValid, "", at), "another project in the owning organization still writes")
+	require.Equal(t, "valid", fx.reloadActive(t, ctx).ValidationStatus.String)
 }
 
 // Platform clients are shared across projects and organizations, just as in the

--- a/server/internal/remotesessions/validationoutcome.go
+++ b/server/internal/remotesessions/validationoutcome.go
@@ -1,0 +1,18 @@
+package remotesessions
+
+// ValidationOutcome is the closed set remote_sessions.validation_status stores.
+type ValidationOutcome string
+
+const (
+	// ValidationOutcomeValid: the upstream accepted the credential and listed its tools.
+	ValidationOutcomeValid ValidationOutcome = "valid"
+
+	// ValidationOutcomeRejectedByMember: the upstream answered 401 or 403.
+	ValidationOutcomeRejectedByMember ValidationOutcome = "rejected_by_member"
+
+	// ValidationOutcomeUnknown: no verdict (transport failure, timeout, non-auth status); never replaces valid.
+	ValidationOutcomeUnknown ValidationOutcome = "unknown"
+
+	// ValidationOutcomeRevoked is reserved for provider-side revocation; nothing writes it yet.
+	ValidationOutcomeRevoked ValidationOutcome = "revoked"
+)


### PR DESCRIPTION
AIM-204, part 3 of 5, stacked on #6292.

- `remotesessions.RecordRemoteSessionValidation` / `SetRemoteSessionValidation`: writes `last_validated_at`, `validation_status`, `validation_reason` (columns from #6104) with a compare-and-swap on `updated_at`, tenant-bound through the client row; `unknown` never overwrites a stored `valid`, enforced in the UPDATE.
- Verdicts are cleared on every soft delete and on refresh: a new or gone token was never presented.
- `RemoteSessionState` gains the row id, CAS token and verdict fields; `UpstreamToken` gains the `RemoteSessionID`/`RemoteSessionUpdatedAt` CAS pair.
- `ValidationOutcome` lives in `remotesessions` next to `RemoteSessionValidation`; `remotesessions` already imports `remotesessionmetrics`, so the metric records the outcome as a string rather than importing it back.
- Metric `gram.remote_session.validation` by outcome and issuer; `gram.remote_session.id` on refresh-failure logs.
- No caller yet; the probe lands in part 4.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stores live validation verdicts for remote session credentials so the consent page can show whether a stored token still works upstream. Part 3 of AIM-204; the probe that produces these verdicts lands in part 4.

- Adds `RecordRemoteSessionValidation`, a tenant-bound writer with compare-and-swap on `updated_at`; the client row's project or organization scopes the write.
- `unknown` never overwrites a stored `valid`, enforced in the UPDATE.
- Clears verdicts on soft delete and refresh, since the new credential was never presented.
- `RemoteSessionState` and `UpstreamToken` carry the row ID and CAS token.
- Adds metric `gram.remote_session.validation` by outcome and issuer.
- Adds `gram.remote_session.id` attribute to refresh-failure logs.

<sup>Written for commit e4f17da5daafe494a8843daf1e472d0823fb96dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

