### PR TITLE
feat: verify remote sessions automatically on connect

### DIFF
--- a/.changeset/aim-204-auto-verify.md
+++ b/.changeset/aim-204-auto-verify.md
@@ -1,0 +1,5 @@
+---
+"server": minor
+---
+
+Verify a remote session automatically when its grant is connected or reconnected, show the card as Verifying until the verdict lands, and drain in-flight verifications on shutdown.

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -297,6 +297,10 @@ func restoreLocalPluginRepositories(
 // value for the full window to be honored.
 const shutdownDrainTimeout = 60 * time.Second
 
+// probeDrainTimeout bounds the wait for automatic remote-session verifications
+// after the HTTP drain; each probe is already bounded by its ValidationTimeout.
+const probeDrainTimeout = 20 * time.Second
+
 func newStartCommand() *cli.Command {
 	var shutdownFuncs []func(context.Context) error
 	dbClose := func() {}
@@ -1213,6 +1217,7 @@ func newStartCommand() *cli.Command {
 				mcp.MetaRuntimeConfig{
 					MemberCallTimeout: c.Duration("meta-member-call-timeout"),
 					ValidationTimeout: 0,
+					AutoVerifyWait:    0,
 				},
 			)
 			if err != nil {
@@ -2099,6 +2104,17 @@ func newStartCommand() *cli.Command {
 					})
 				}
 				shutdownGroup.Wait()
+
+				// The callbacks that start automatic remote-session verifications are
+				// drained; the probes they detached still write verdicts and close
+				// upstream sessions, so drain them before runShutdown closes the pool.
+				// On its own budget: an HTTP drain that used up graceCtx must not
+				// turn the probe drain into a no-op.
+				drainCtx, cancelDrain := context.WithTimeout(context.WithoutCancel(ctx), probeDrainTimeout)
+				if err := mcpService.Shutdown(drainCtx); err != nil {
+					logger.ErrorContext(ctx, "drain automatic remote session verifications", attr.SlogError(err))
+				}
+				cancelDrain()
 
 				// A successful Shutdown has quiesced the HTTP handlers that produce
 				// realtime recordings. Closing scanner admission here also makes the

--- a/server/cmd/gram/start.go
+++ b/server/cmd/gram/start.go
@@ -2105,19 +2105,8 @@ func newStartCommand() *cli.Command {
 				}
 				shutdownGroup.Wait()
 
-				// The callbacks that start automatic remote-session verifications are
-				// drained; the probes they detached still write verdicts and close
-				// upstream sessions, so drain them before runShutdown closes the pool.
-				// On its own budget: an HTTP drain that used up graceCtx must not
-				// turn the probe drain into a no-op.
-				drainCtx, cancelDrain := context.WithTimeout(context.WithoutCancel(ctx), probeDrainTimeout)
-				if err := mcpService.Shutdown(drainCtx); err != nil {
-					logger.ErrorContext(ctx, "drain automatic remote session verifications", attr.SlogError(err))
-				}
-				cancelDrain()
-
-				// A successful Shutdown has quiesced the HTTP handlers that produce
-				// realtime recordings. Closing scanner admission here also makes the
+				// HTTP shutdown has quiesced handlers that produce realtime
+				// recordings. Closing scanner admission here also makes the
 				// timeout path safe, then drains recordings before runShutdown stops
 				// the shared meter publisher.
 				if err := riskScanner.Shutdown(graceCtx); err != nil {
@@ -2142,6 +2131,17 @@ func newStartCommand() *cli.Command {
 				if err := identityMapRefreshSignaler.Shutdown(graceCtx); err != nil {
 					logger.ErrorContext(ctx, "flush pending identity map refresh triggers", attr.SlogError(err))
 				}
+
+				// The callbacks that start automatic remote-session verifications are
+				// drained; the probes they detached still write verdicts and close
+				// upstream sessions, so drain them before runShutdown closes the pool.
+				// Keep their separate budget after graceCtx users so probe waiting
+				// cannot consume time reserved for realtime recording flushes.
+				drainCtx, cancelDrain := context.WithTimeout(context.WithoutCancel(ctx), probeDrainTimeout)
+				if err := mcpService.Shutdown(drainCtx); err != nil {
+					logger.ErrorContext(ctx, "drain automatic remote session verifications", attr.SlogError(err))
+				}
+				cancelDrain()
 			})
 
 			tlsEnabled := c.String("ssl-key-file") != "" && c.String("ssl-cert-file") != ""

--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -156,8 +156,8 @@ type consentTemplateData struct {
 	// ConsentToolsPrefill is the subject's stored selection serialized for
 	// the island bootstrap; empty when there is no restrictive prefill.
 	ConsentToolsPrefill string
-	// ValidationBudgetMS is how long a pending verification can run, so the page stops refreshing once no verdict can still land.
-	ValidationBudgetMS int64
+	// ValidationDeadlineMS is the callback probe's absolute deadline. Only first-party pages poll because reloading interactive consent would discard unsaved tool choices.
+	ValidationDeadlineMS int64
 	// ConnectedCardCount is the number of RemoteSessionCards already linked,
 	// rendered as the "n of m connected" summary above the service list.
 	ConnectedCardCount int
@@ -438,6 +438,24 @@ func (s *Service) serveConsentGet(w http.ResponseWriter, r *http.Request, endpoi
 	if err != nil {
 		return oops.E(oops.CodeUnexpected, err, "build remote session cards").LogError(ctx, logger)
 	}
+	validationDeadlineMS := int64(0)
+	if deadlineMS, parseErr := strconv.ParseInt(r.URL.Query().Get("verifying_until"), 10, 64); parseErr == nil {
+		now := time.Now()
+		deadline := time.UnixMilli(deadlineMS)
+		maxDeadline := now.Add(s.metaRuntime.ValidationTimeout)
+		if deadline.After(now) && !deadline.After(maxDeadline) {
+			clientID := r.URL.Query().Get("verifying_client")
+			for i := range cards {
+				if cards[i].ClientID == clientID && cards[i].Connected && cards[i].ValidatedAt == "" {
+					cards[i].Pending = true
+					if challengeState.FirstParty {
+						validationDeadlineMS = deadlineMS
+					}
+					break
+				}
+			}
+		}
+	}
 	if limited := r.URL.Query().Get("validate_limited"); limited != "" {
 		for i := range cards {
 			if cards[i].ClientID == limited {
@@ -569,7 +587,7 @@ func (s *Service) serveConsentGet(w http.ResponseWriter, r *http.Request, endpoi
 		ConsentToolsURL:         fmt.Sprintf("/%s/%s/connect/mcp", endpoint.RouteBase, endpoint.Slug),
 		ConsentToolsScriptURL:   consentToolsScriptURL,
 		ConsentToolsPrefill:     prefillAttr,
-		ValidationBudgetMS:      s.metaRuntime.ValidationTimeout.Milliseconds(),
+		ValidationDeadlineMS:    validationDeadlineMS,
 		ConnectedCardCount:      connectedCardCount,
 		Styles:                  consentPageStyles,
 		SelectedSessionDuration: selectedSessionDuration(durationOptions),
@@ -1251,7 +1269,7 @@ func (s *Service) buildRemoteSessionCards(
 			ValidationReason:       state.ValidationReason,
 			ValidationNotice:       "",
 			CanValidate:            routing.canValidate(c, state.Resource),
-			Pending:                connected && s.autoVerifications.isPending(c.ID),
+			Pending:                false,
 		})
 	}
 	return cards, nil

--- a/server/internal/mcp/authnchallenge_consent.go
+++ b/server/internal/mcp/authnchallenge_consent.go
@@ -156,6 +156,8 @@ type consentTemplateData struct {
 	// ConsentToolsPrefill is the subject's stored selection serialized for
 	// the island bootstrap; empty when there is no restrictive prefill.
 	ConsentToolsPrefill string
+	// ValidationBudgetMS is how long a pending verification can run, so the page stops refreshing once no verdict can still land.
+	ValidationBudgetMS int64
 	// ConnectedCardCount is the number of RemoteSessionCards already linked,
 	// rendered as the "n of m connected" summary above the service list.
 	ConnectedCardCount int
@@ -252,6 +254,8 @@ type remoteSessionCard struct {
 	ValidationNotice string
 	// CanValidate marks a card whose credential this endpoint forwards upstream, so a check has a target.
 	CanValidate bool
+	// Pending marks a card whose automatic verification is still running, so the page refreshes until its verdict lands.
+	Pending bool
 }
 
 // autoRefreshPolicy is an organization's policy for automatic remote-session
@@ -565,6 +569,7 @@ func (s *Service) serveConsentGet(w http.ResponseWriter, r *http.Request, endpoi
 		ConsentToolsURL:         fmt.Sprintf("/%s/%s/connect/mcp", endpoint.RouteBase, endpoint.Slug),
 		ConsentToolsScriptURL:   consentToolsScriptURL,
 		ConsentToolsPrefill:     prefillAttr,
+		ValidationBudgetMS:      s.metaRuntime.ValidationTimeout.Milliseconds(),
 		ConnectedCardCount:      connectedCardCount,
 		Styles:                  consentPageStyles,
 		SelectedSessionDuration: selectedSessionDuration(durationOptions),
@@ -1022,7 +1027,7 @@ func shouldAutoCloseFirstParty(firstParty bool, cards []remoteSessionCard) bool 
 	for _, c := range cards {
 		// Keep actionable reconnect and verification states visible instead of
 		// closing the tab before the person can act on them.
-		if !c.Connected || c.IdentityReconnect || c.Rejected || (c.CanValidate && !c.Verified) {
+		if !c.Connected || c.IdentityReconnect || c.Rejected || c.Pending || (c.CanValidate && !c.Verified) {
 			return false
 		}
 	}
@@ -1246,6 +1251,7 @@ func (s *Service) buildRemoteSessionCards(
 			ValidationReason:       state.ValidationReason,
 			ValidationNotice:       "",
 			CanValidate:            routing.canValidate(c, state.Resource),
+			Pending:                connected && s.autoVerifications.isPending(c.ID),
 		})
 	}
 	return cards, nil

--- a/server/internal/mcp/authnchallenge_consent_autoverify.go
+++ b/server/internal/mcp/authnchallenge_consent_autoverify.go
@@ -1,0 +1,171 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/speakeasy-api/gram/server/internal/attr"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+)
+
+// autoVerifications admits the probes committed grants start off the request
+// path, remembers which client each one is for while it runs, and drains them
+// once on shutdown. Admission and registration share one lock, so a probe is
+// never admitted after the drain has started.
+type autoVerifications struct {
+	mu      sync.Mutex
+	wg      sync.WaitGroup
+	closed  bool
+	pending map[uuid.UUID]int
+}
+
+func newAutoVerifications() *autoVerifications {
+	return &autoVerifications{mu: sync.Mutex{}, wg: sync.WaitGroup{}, closed: false, pending: map[uuid.UUID]int{}}
+}
+
+// admit runs fn on its own goroutine; false once admission is closed. The client reads as pending until fn returns.
+func (a *autoVerifications) admit(clientID uuid.UUID, fn func()) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.closed {
+		return false
+	}
+	a.wg.Add(1)
+	a.pending[clientID]++
+	go func() {
+		defer a.wg.Done()
+		defer a.finish(clientID)
+		fn()
+	}()
+	return true
+}
+
+func (a *autoVerifications) finish(clientID uuid.UUID) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.pending[clientID]--; a.pending[clientID] <= 0 {
+		delete(a.pending, clientID)
+	}
+}
+
+// isPending reports whether a probe for the client is still running.
+func (a *autoVerifications) isPending(clientID uuid.UUID) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.pending[clientID] > 0
+}
+
+// shutdown closes admission, then waits for every admitted probe or ctx.
+func (a *autoVerifications) shutdown(ctx context.Context) error {
+	a.mu.Lock()
+	a.closed = true
+	a.mu.Unlock()
+	drained := make(chan struct{})
+	go func() {
+		a.wg.Wait()
+		close(drained)
+	}()
+	select {
+	case <-drained:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err() //nolint:wrapcheck // the caller names the drain
+	}
+}
+
+// Shutdown stops admitting automatic verifications and drains the ones in
+// flight. Run it after the HTTP servers have drained and before the database
+// and cache close: the probes detach from their requests and still write
+// verdicts and close upstream sessions.
+func (s *Service) Shutdown(ctx context.Context) error {
+	if err := s.autoVerifications.shutdown(ctx); err != nil {
+		return fmt.Errorf("drain automatic verifications: %w", err)
+	}
+	return nil
+}
+
+// verifyRemoteGrant probes a grant the remote login callback just committed, so
+// a connect or reconnect carries its own verdict. Everything, placement
+// included, runs off the request path under the probe's own budget; the caller
+// is held for at most AutoVerifyWait so a fast member's verdict is on the first
+// render. Best effort: anything that cannot be placed leaves the card at "Not
+// yet verified" for the manual Verify.
+func (s *Service) verifyRemoteGrant(ctx context.Context, grant remotesessions.RemoteGrant) {
+	logger := s.logger.With(attr.SlogRemoteSessionClientID(grant.RemoteSessionClientID.String()))
+	probeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), s.metaRuntime.ValidationTimeout)
+	done := make(chan struct{})
+	admitted := s.autoVerifications.admit(grant.RemoteSessionClientID, func() {
+		defer cancel()
+		defer close(done)
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				logger.ErrorContext(probeCtx, "verify new remote grant panicked", attr.SlogError(fmt.Errorf("%v", recovered)))
+			}
+		}()
+		endpoint, challengeState, ok := s.placeRemoteGrant(probeCtx, logger, grant)
+		if ok {
+			s.probeRemoteGrant(probeCtx, logger, endpoint, challengeState, grant)
+		}
+	})
+	if !admitted {
+		cancel()
+		logger.InfoContext(ctx, "new remote grant not verified: shutting down")
+		return
+	}
+	wait := time.NewTimer(s.metaRuntime.AutoVerifyWait)
+	defer wait.Stop()
+	select {
+	case <-done:
+	case <-wait.C:
+		logger.InfoContext(ctx, "new remote grant still verifying")
+	}
+}
+
+// placeRemoteGrant finds the consent challenge the grant belongs to and the
+// endpoint it was minted for, the same resolution the IdP callback trusts.
+func (s *Service) placeRemoteGrant(ctx context.Context, logger *slog.Logger, grant remotesessions.RemoteGrant) (*ResolvedMcpEndpoint, AuthnChallengeState, bool) {
+	var none AuthnChallengeState
+	challengeState, err := s.authnChallengeCache.Get(ctx, "authnChallenge:"+grant.ParentChallengeID)
+	if err != nil {
+		logger.InfoContext(ctx, "new remote grant not verified: consent challenge not found", attr.SlogError(err))
+		return nil, none, false
+	}
+	if challengeState.UserSessionIssuerID != grant.UserSessionIssuerID ||
+		challengeState.Subject == nil || challengeState.Subject.String() != grant.Subject.String() {
+		logger.InfoContext(ctx, "new remote grant not verified: grant does not belong to the consent challenge")
+		return nil, none, false
+	}
+	endpoint, err := s.loadResolvedMcpEndpointByRef(ctx, challengeState.Endpoint)
+	if err != nil {
+		logger.InfoContext(ctx, "new remote grant not verified: endpoint not resolved", attr.SlogError(err))
+		return nil, none, false
+	}
+	if err := endpoint.ValidateGlobalChallenge(ctx, s.db, challengeState.Endpoint, challengeState.UserSessionIssuerID); err != nil {
+		logger.InfoContext(ctx, "new remote grant not verified: challenge no longer valid for its endpoint", attr.SlogError(err))
+		return nil, none, false
+	}
+	return endpoint, challengeState, true
+}
+
+// probeRemoteGrant runs the probe for the grant's card on the endpoint.
+func (s *Service) probeRemoteGrant(ctx context.Context, logger *slog.Logger, endpoint *ResolvedMcpEndpoint, challengeState AuthnChallengeState, grant remotesessions.RemoteGrant) {
+	clients, err := s.remoteChallengeMgr.ListClients(ctx, endpoint.ProjectID, endpoint.OrganizationID, endpoint.UserSessionIssuerID)
+	if err != nil {
+		logger.WarnContext(ctx, "new remote grant not verified: list clients", attr.SlogError(err))
+		return
+	}
+	client := findConsentClient(clients, grant.RemoteSessionClientID)
+	if client == nil {
+		logger.InfoContext(ctx, "new remote grant not verified: client is not bound to this endpoint")
+		return
+	}
+	// The probe logs its own refusals; this only says the verdict did not land.
+	if err := s.probeRemoteSession(ctx, logger, endpoint, challengeState, *client); err != nil {
+		logger.InfoContext(ctx, "new remote grant not verified", attr.SlogError(err))
+	}
+}

--- a/server/internal/mcp/authnchallenge_consent_autoverify.go
+++ b/server/internal/mcp/authnchallenge_consent_autoverify.go
@@ -7,8 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
-
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 )
@@ -18,46 +16,26 @@ import (
 // once on shutdown. Admission and registration share one lock, so a probe is
 // never admitted after the drain has started.
 type autoVerifications struct {
-	mu      sync.Mutex
-	wg      sync.WaitGroup
-	closed  bool
-	pending map[uuid.UUID]int
+	mu     sync.Mutex
+	wg     sync.WaitGroup
+	closed bool
 }
 
 func newAutoVerifications() *autoVerifications {
-	return &autoVerifications{mu: sync.Mutex{}, wg: sync.WaitGroup{}, closed: false, pending: map[uuid.UUID]int{}}
+	return &autoVerifications{mu: sync.Mutex{}, wg: sync.WaitGroup{}, closed: false}
 }
 
-// admit runs fn on its own goroutine; false once admission is closed. The client reads as pending until fn returns.
-func (a *autoVerifications) admit(clientID uuid.UUID, fn func()) bool {
+// admit runs fn on its own goroutine; false once admission is closed.
+func (a *autoVerifications) admit(fn func()) bool {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if a.closed {
 		return false
 	}
-	a.wg.Add(1)
-	a.pending[clientID]++
-	go func() {
-		defer a.wg.Done()
-		defer a.finish(clientID)
+	a.wg.Go(func() {
 		fn()
-	}()
+	})
 	return true
-}
-
-func (a *autoVerifications) finish(clientID uuid.UUID) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if a.pending[clientID]--; a.pending[clientID] <= 0 {
-		delete(a.pending, clientID)
-	}
-}
-
-// isPending reports whether a probe for the client is still running.
-func (a *autoVerifications) isPending(clientID uuid.UUID) bool {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	return a.pending[clientID] > 0
 }
 
 // shutdown closes admission, then waits for every admitted probe or ctx.
@@ -95,11 +73,12 @@ func (s *Service) Shutdown(ctx context.Context) error {
 // is held for at most AutoVerifyWait so a fast member's verdict is on the first
 // render. Best effort: anything that cannot be placed leaves the card at "Not
 // yet verified" for the manual Verify.
-func (s *Service) verifyRemoteGrant(ctx context.Context, grant remotesessions.RemoteGrant) {
+func (s *Service) verifyRemoteGrant(ctx context.Context, grant remotesessions.RemoteGrant) time.Time {
 	logger := s.logger.With(attr.SlogRemoteSessionClientID(grant.RemoteSessionClientID.String()))
 	probeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), s.metaRuntime.ValidationTimeout)
+	deadline, _ := probeCtx.Deadline()
 	done := make(chan struct{})
-	admitted := s.autoVerifications.admit(grant.RemoteSessionClientID, func() {
+	admitted := s.autoVerifications.admit(func() {
 		defer cancel()
 		defer close(done)
 		defer func() {
@@ -115,14 +94,16 @@ func (s *Service) verifyRemoteGrant(ctx context.Context, grant remotesessions.Re
 	if !admitted {
 		cancel()
 		logger.InfoContext(ctx, "new remote grant not verified: shutting down")
-		return
+		return time.Time{}
 	}
 	wait := time.NewTimer(s.metaRuntime.AutoVerifyWait)
 	defer wait.Stop()
 	select {
 	case <-done:
+		return time.Time{}
 	case <-wait.C:
 		logger.InfoContext(ctx, "new remote grant still verifying")
+		return deadline
 	}
 }
 
@@ -165,7 +146,7 @@ func (s *Service) probeRemoteGrant(ctx context.Context, logger *slog.Logger, end
 		return
 	}
 	// The probe logs its own refusals; this only says the verdict did not land.
-	if err := s.probeRemoteSession(ctx, logger, endpoint, challengeState, *client); err != nil {
+	if err := s.probeRemoteSession(ctx, logger, endpoint, challengeState, *client, &grant); err != nil {
 		logger.InfoContext(ctx, "new remote grant not verified", attr.SlogError(err))
 	}
 }

--- a/server/internal/mcp/authnchallenge_consent_autoverify_test.go
+++ b/server/internal/mcp/authnchallenge_consent_autoverify_test.go
@@ -1,0 +1,200 @@
+package mcp_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/mcp"
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+	"github.com/speakeasy-api/gram/server/internal/urn"
+)
+
+// A committed grant is probed without a click: the consent page renders Verified on its first view.
+func TestConsentAutoVerify_FreshGrantIsProbedOnCommit(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedStandaloneValidationFixture(t, "aim204-auto")
+	require.Contains(t, renderConsent(t, fx), "Not yet verified")
+	require.Empty(t, fx.member.drain(), "rendering alone never probes")
+
+	fx.ti.service.VerifyRemoteGrantOn(ctx, fx.endpoint, remotesessions.RemoteGrant{
+		ParentChallengeID:     fx.stateID,
+		UserSessionIssuerID:   fx.endpoint.UserSessionIssuerID,
+		RemoteSessionClientID: fx.clientID,
+		Subject:               fx.subject,
+	})
+	require.NoError(t, fx.ti.service.Shutdown(ctx))
+
+	requireProbe(t, fx.member.drain(), "token-aim204-auto", true, true)
+	sess := storedSession(t, ctx, fx)
+	require.Equal(t, string(remotesessions.ValidationOutcomeValid), sess.ValidationStatus.String)
+	require.Contains(t, renderConsent(t, fx), `data-validation="valid"`)
+	require.Equal(t, map[string]int64{"valid": 1}, validationCounts(t, fx.reader))
+}
+
+// A rejecting member is recorded as such on commit, with the Reconnect control ready on the first view.
+func TestConsentAutoVerify_RejectedGrantShowsReconnect(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedStandaloneValidationFixture(t, "aim204-auto-401")
+	fx.member.set(memberForbids)
+
+	fx.ti.service.VerifyRemoteGrantOn(ctx, fx.endpoint, remotesessions.RemoteGrant{
+		ParentChallengeID:     fx.stateID,
+		UserSessionIssuerID:   fx.endpoint.UserSessionIssuerID,
+		RemoteSessionClientID: fx.clientID,
+		Subject:               fx.subject,
+	})
+	require.NoError(t, fx.ti.service.Shutdown(ctx))
+
+	sess := storedSession(t, ctx, fx)
+	require.Equal(t, string(remotesessions.ValidationOutcomeRejectedByMember), sess.ValidationStatus.String)
+	page := renderConsent(t, fx)
+	require.Contains(t, page, "Rejected by "+fx.name+", reconnect")
+	require.Contains(t, page, `data-connect-link > Reconnect`)
+}
+
+// A grant that does not belong to its consent challenge, or that the endpoint does not bind, is left alone: no probe, no verdict, the manual Verify still works.
+func TestConsentAutoVerify_UnplaceableGrantIsSkipped(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedStandaloneValidationFixture(t, "aim204-auto-skip")
+	other := urn.NewUserSubject("someone-else-" + uuid.NewString())
+
+	fx.ti.service.VerifyRemoteGrant(ctx, remotesessions.RemoteGrant{ParentChallengeID: uuid.NewString(), UserSessionIssuerID: fx.endpoint.UserSessionIssuerID, RemoteSessionClientID: fx.clientID, Subject: fx.subject})
+	fx.ti.service.VerifyRemoteGrant(ctx, remotesessions.RemoteGrant{ParentChallengeID: fx.stateID, UserSessionIssuerID: uuid.New(), RemoteSessionClientID: fx.clientID, Subject: fx.subject})
+	fx.ti.service.VerifyRemoteGrant(ctx, remotesessions.RemoteGrant{ParentChallengeID: fx.stateID, UserSessionIssuerID: fx.endpoint.UserSessionIssuerID, RemoteSessionClientID: fx.clientID, Subject: other})
+	fx.ti.service.VerifyRemoteGrantOn(ctx, fx.endpoint, remotesessions.RemoteGrant{ParentChallengeID: fx.stateID, UserSessionIssuerID: fx.endpoint.UserSessionIssuerID, RemoteSessionClientID: uuid.New(), Subject: fx.subject})
+	require.NoError(t, fx.ti.service.Shutdown(ctx))
+
+	require.Empty(t, fx.member.drain())
+	require.False(t, storedSession(t, ctx, fx).ValidationStatus.Valid)
+	require.Empty(t, validationCounts(t, fx.reader))
+}
+
+// heldProbeFixture is a standalone fixture whose member holds initialize until release is called, with a callback wait far shorter than the probe.
+func heldProbeFixture(t *testing.T, prefix string) (context.Context, validationFixture, remotesessions.RemoteGrant, chan struct{}, func()) {
+	t.Helper()
+	ctx, fx := seedStandaloneValidationFixtureWith(t, prefix, mcp.MetaRuntimeConfig{MemberCallTimeout: 0, ValidationTimeout: 10 * time.Second, AutoVerifyWait: 50 * time.Millisecond})
+	reached := make(chan struct{})
+	released := make(chan struct{})
+	var reachOnce, releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(released) }) }
+	t.Cleanup(release)
+	fx.member.onInitialize = func() error {
+		reachOnce.Do(func() { close(reached) })
+		<-released
+		return nil
+	}
+	grant := remotesessions.RemoteGrant{
+		ParentChallengeID:     fx.stateID,
+		UserSessionIssuerID:   fx.endpoint.UserSessionIssuerID,
+		RemoteSessionClientID: fx.clientID,
+		Subject:               fx.subject,
+	}
+	return ctx, fx, grant, reached, release
+}
+
+func requireReached(t *testing.T, reached <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-reached:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the probe never reached the member")
+	}
+}
+
+// The callback redirects before a slow probe finishes: the page it lands on
+// reads Verifying… and declares the budget its script refreshes under, stays
+// open, and reads Verified once the probe is done, without a click.
+func TestConsentAutoVerify_PendingUntilProbeFinishes(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx, grant, reached, release := heldProbeFixture(t, "aim204-auto-pending")
+
+	// What HandleRemoteLoginCallback runs between committing the grant and redirecting.
+	fx.ti.service.VerifyRemoteGrant(ctx, grant)
+	requireReached(t, reached)
+
+	page := renderConsent(t, fx)
+	require.Contains(t, page, `data-validation="pending"`)
+	require.Contains(t, page, `Connected · <span class="text-muted-foreground" data-validation="pending" >Verifying…`)
+	require.Contains(t, page, `data-verify-budget-ms="10000"`)
+	require.NotContains(t, page, "Not yet verified")
+	require.NotContains(t, page, "data-auto-close", "a first-party tab stays open while a verdict is pending")
+
+	release()
+	require.NoError(t, fx.ti.service.Shutdown(ctx))
+
+	page = renderConsent(t, fx)
+	require.NotContains(t, page, `data-validation="pending"`)
+	require.Contains(t, page, `data-validation="valid"`)
+	require.Contains(t, page, "data-auto-close", "the verdict completes the first-party connection")
+	require.Equal(t, "valid", storedSession(t, ctx, fx).ValidationStatus.String)
+}
+
+// Shutdown waits for a probe in flight and admits none after it.
+func TestConsentAutoVerify_ShutdownDrainsAndClosesAdmission(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx, grant, reached, release := heldProbeFixture(t, "aim204-auto-shutdown")
+	fx.ti.service.VerifyRemoteGrant(ctx, grant)
+	requireReached(t, reached)
+
+	stopped := make(chan error, 1)
+	go func() { stopped <- fx.ti.service.Shutdown(ctx) }()
+	select {
+	case err := <-stopped:
+		t.Fatalf("shutdown returned while the probe was still held: %v", err)
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	release()
+	select {
+	case err := <-stopped:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("shutdown did not return once the probe finished")
+	}
+	requireProbe(t, fx.member.drain(), "token-aim204-auto-shutdown", true, true)
+
+	fx.ti.service.VerifyRemoteGrant(ctx, grant)
+	require.Empty(t, fx.member.drain(), "nothing is admitted after shutdown")
+	require.NotContains(t, renderConsent(t, fx), `data-validation="pending"`)
+	require.Equal(t, map[string]int64{"valid": 1}, validationCounts(t, fx.reader))
+}
+
+// Placement can consume part of the callback's budget; the verdict is still written inside what is left, even when a leg hangs.
+func TestConsentAutoVerify_PreservesRemainingBudgetForVerdict(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		mode validationMemberMode
+		want string
+	}{
+		{mode: memberHangsAck, want: "unknown"},
+		{mode: memberHangsClose, want: "valid"},
+	} {
+		t.Run(string(tc.mode), func(t *testing.T) {
+			t.Parallel()
+			ctx, fx := seedStandaloneValidationFixture(t, "auto-budget-"+string(tc.mode))
+			fx.member.set(tc.mode)
+			// Model placement having consumed half of the configured two-second probe budget.
+			remaining, cancel := context.WithTimeout(ctx, time.Second)
+			defer cancel()
+			fx.ti.service.VerifyRemoteGrantOn(remaining, fx.endpoint, remotesessions.RemoteGrant{
+				ParentChallengeID:     fx.stateID,
+				UserSessionIssuerID:   fx.endpoint.UserSessionIssuerID,
+				RemoteSessionClientID: fx.clientID,
+				Subject:               fx.subject,
+			})
+			require.NoError(t, remaining.Err(), "cleanup must leave time to persist the verdict")
+			requireProbe(t, fx.member.drain(), "token-auto-budget-"+string(tc.mode), true, true)
+			require.Equal(t, tc.want, storedSession(t, ctx, fx).ValidationStatus.String)
+		})
+	}
+}

--- a/server/internal/mcp/authnchallenge_consent_autoverify_test.go
+++ b/server/internal/mcp/authnchallenge_consent_autoverify_test.go
@@ -2,16 +2,22 @@ package mcp_test
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/mcp"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+	remotesessions_repo "github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
 	"github.com/speakeasy-api/gram/server/internal/urn"
 )
 
@@ -142,24 +148,156 @@ func TestConsentAutoVerify_PendingUntilProbeFinishes(t *testing.T) {
 	require.Equal(t, "valid", storedSession(t, ctx, fx).ValidationStatus.String)
 }
 
-// A detached verifier must not probe a replacement credential committed after
-// the callback grant it was admitted for.
-func TestConsentAutoVerify_ChangedGrantIsSkipped(t *testing.T) {
+// Token resolution may refresh a just-committed near-expiry grant. The rotated
+// CAS token must receive the automatic probe verdict without looking like a
+// different callback grant.
+func TestConsentAutoVerify_RefreshesGrantBeforeProbe(t *testing.T) {
 	t.Parallel()
 
-	ctx, fx := seedStandaloneValidationFixture(t, "aim204-auto-stale")
-	sess := storedSession(t, ctx, fx)
+	ctx, fx := seedStandaloneValidationFixture(t, "aim204-auto-refresh")
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "invalid form", http.StatusBadRequest)
+			return
+		}
+		if r.Form.Get("grant_type") != "refresh_token" {
+			http.Error(w, "unexpected grant type", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"access_token":"refreshed-auto-token","token_type":"Bearer","expires_in":3600,"refresh_token":"rotated-auto-refresh-token"}`)
+	}))
+	t.Cleanup(tokenServer.Close)
+
+	grant := configureAutoRefreshGrant(t, ctx, fx, tokenServer.URL)
+
 	fx.ti.service.VerifyRemoteGrantOn(ctx, fx.endpoint, remotesessions.RemoteGrant{
 		ParentChallengeID:      fx.stateID,
 		UserSessionIssuerID:    fx.endpoint.UserSessionIssuerID,
 		RemoteSessionClientID:  fx.clientID,
 		Subject:                fx.subject,
-		RemoteSessionID:        uuid.New(),
-		RemoteSessionUpdatedAt: sess.UpdatedAt.Time,
+		RemoteSessionID:        grant.ID,
+		RemoteSessionUpdatedAt: grant.UpdatedAt.Time,
 	})
 
-	require.Empty(t, fx.member.drain())
+	requireProbe(t, fx.member.drain(), "refreshed-auto-token", true, true)
+	after := storedSession(t, ctx, fx)
+	require.True(t, after.UpdatedAt.Time.After(grant.UpdatedAt.Time), "refresh rotates the grant CAS token")
+	require.Equal(t, "valid", after.ValidationStatus.String)
+}
+
+// A refresh loser may adopt a concurrently reconnected credential on the same
+// row. Automatic verification must not present that unrelated winner.
+func TestConsentAutoVerify_AdoptedRefreshWinnerIsSkipped(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedStandaloneValidationFixture(t, "aim204-auto-adopted")
+	reached := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	unblock := func() { releaseOnce.Do(func() { close(release) }) }
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(reached)
+		<-release
+		http.Error(w, "refresh failed", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(tokenServer.Close)
+	t.Cleanup(unblock)
+	grant := configureAutoRefreshGrant(t, ctx, fx, tokenServer.URL)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fx.ti.service.VerifyRemoteGrantOn(ctx, fx.endpoint, remotesessions.RemoteGrant{
+			ParentChallengeID:      fx.stateID,
+			UserSessionIssuerID:    fx.endpoint.UserSessionIssuerID,
+			RemoteSessionClientID:  fx.clientID,
+			Subject:                fx.subject,
+			RemoteSessionID:        grant.ID,
+			RemoteSessionUpdatedAt: grant.UpdatedAt.Time,
+		})
+	}()
+	requireReached(t, reached)
+	insertQualifiedRemoteSessionToken(t, ctx, fx.ti, fx.endpoint.UserSessionIssuerID, fx.clientID, fx.subject, "replacement-token", fx.member.url)
+	unblock()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("automatic verifier did not finish")
+	}
+
+	require.Empty(t, fx.member.drain(), "the adopted replacement must not be probed")
 	require.False(t, storedSession(t, ctx, fx).ValidationStatus.Valid)
+}
+
+func configureAutoRefreshGrant(t *testing.T, ctx context.Context, fx validationFixture, tokenEndpoint string) remotesessions_repo.RemoteSession {
+	t.Helper()
+	projectID, orgID := consentTestTenant(t, ctx)
+	rows, err := remotesessions_repo.New(fx.ti.conn).ForceRemoteSessionIssuerTokenEndpointFixture(ctx, remotesessions_repo.ForceRemoteSessionIssuerTokenEndpointFixtureParams{
+		TokenEndpoint:         conv.ToPGText(tokenEndpoint),
+		RemoteSessionClientID: fx.clientID,
+		ProjectID:             projectID,
+		OrganizationID:        orgID,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rows)
+
+	accessEncrypted, err := fx.ti.enc.Encrypt([]byte("stale-auto-token"))
+	require.NoError(t, err)
+	refreshEncrypted, err := fx.ti.enc.Encrypt([]byte("auto-refresh-token"))
+	require.NoError(t, err)
+	grant, err := remotesessions_repo.New(fx.ti.conn).UpsertRemoteSession(ctx, remotesessions_repo.UpsertRemoteSessionParams{
+		SubjectUrn:            fx.subject,
+		UserSessionIssuerID:   fx.endpoint.UserSessionIssuerID,
+		RemoteSessionClientID: fx.clientID,
+		AccessTokenEncrypted:  accessEncrypted,
+		AccessExpiresAt:       pgtype.Timestamptz{Time: time.Now().Add(5 * time.Second), Valid: true, InfinityModifier: pgtype.Finite},
+		RefreshTokenEncrypted: conv.ToPGText(refreshEncrypted),
+		RefreshExpiresAt:      pgtype.Timestamptz{Time: time.Now().Add(time.Hour), Valid: true, InfinityModifier: pgtype.Finite},
+		Scopes:                []string{},
+		Resource:              conv.ToPGText(fx.member.url),
+	})
+	require.NoError(t, err)
+	return grant
+}
+
+// A detached verifier must not probe a replacement credential committed after
+// the callback grant it was admitted for.
+func TestConsentAutoVerify_ChangedGrantIsSkipped(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name          string
+		replacementID bool
+	}{
+		{name: "different session ID", replacementID: true},
+		{name: "different session timestamp"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, fx := seedStandaloneValidationFixture(t, "aim204-auto-stale-"+uuid.NewString()[:8])
+			sess := storedSession(t, ctx, fx)
+			expectedID := sess.ID
+			expectedUpdatedAt := sess.UpdatedAt.Time
+			if tc.replacementID {
+				expectedID = uuid.New()
+			} else {
+				insertQualifiedRemoteSessionToken(t, ctx, fx.ti, fx.endpoint.UserSessionIssuerID, fx.clientID, fx.subject, "replacement-token", fx.member.url)
+				require.True(t, storedSession(t, ctx, fx).UpdatedAt.Time.After(expectedUpdatedAt))
+			}
+			fx.ti.service.VerifyRemoteGrantOn(ctx, fx.endpoint, remotesessions.RemoteGrant{
+				ParentChallengeID:      fx.stateID,
+				UserSessionIssuerID:    fx.endpoint.UserSessionIssuerID,
+				RemoteSessionClientID:  fx.clientID,
+				Subject:                fx.subject,
+				RemoteSessionID:        expectedID,
+				RemoteSessionUpdatedAt: expectedUpdatedAt,
+			})
+
+			require.Empty(t, fx.member.drain())
+			require.False(t, storedSession(t, ctx, fx).ValidationStatus.Valid)
+		})
+	}
 }
 
 // Shutdown waits for a probe in flight and admits none after it.

--- a/server/internal/mcp/authnchallenge_consent_autoverify_test.go
+++ b/server/internal/mcp/authnchallenge_consent_autoverify_test.go
@@ -2,6 +2,7 @@ package mcp_test
 
 import (
 	"context"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -118,13 +119,16 @@ func TestConsentAutoVerify_PendingUntilProbeFinishes(t *testing.T) {
 	ctx, fx, grant, reached, release := heldProbeFixture(t, "aim204-auto-pending")
 
 	// What HandleRemoteLoginCallback runs between committing the grant and redirecting.
-	fx.ti.service.VerifyRemoteGrant(ctx, grant)
+	deadline := fx.ti.service.VerifyRemoteGrant(ctx, grant)
 	requireReached(t, reached)
 
-	page := renderConsent(t, fx)
+	target := "/mcp/" + fx.endpoint.Slug + "/connect?state=" + fx.stateID +
+		"&verifying_client=" + fx.clientID.String() +
+		"&verifying_until=" + strconv.FormatInt(deadline.UnixMilli(), 10)
+	page := renderConsentAt(t, fx, target)
 	require.Contains(t, page, `data-validation="pending"`)
 	require.Contains(t, page, `Connected · <span class="text-muted-foreground" data-validation="pending" >Verifying…`)
-	require.Contains(t, page, `data-verify-budget-ms="10000"`)
+	require.Contains(t, page, `data-verify-deadline-ms="`+strconv.FormatInt(deadline.UnixMilli(), 10)+`"`)
 	require.NotContains(t, page, "Not yet verified")
 	require.NotContains(t, page, "data-auto-close", "a first-party tab stays open while a verdict is pending")
 
@@ -136,6 +140,26 @@ func TestConsentAutoVerify_PendingUntilProbeFinishes(t *testing.T) {
 	require.Contains(t, page, `data-validation="valid"`)
 	require.Contains(t, page, "data-auto-close", "the verdict completes the first-party connection")
 	require.Equal(t, "valid", storedSession(t, ctx, fx).ValidationStatus.String)
+}
+
+// A detached verifier must not probe a replacement credential committed after
+// the callback grant it was admitted for.
+func TestConsentAutoVerify_ChangedGrantIsSkipped(t *testing.T) {
+	t.Parallel()
+
+	ctx, fx := seedStandaloneValidationFixture(t, "aim204-auto-stale")
+	sess := storedSession(t, ctx, fx)
+	fx.ti.service.VerifyRemoteGrantOn(ctx, fx.endpoint, remotesessions.RemoteGrant{
+		ParentChallengeID:      fx.stateID,
+		UserSessionIssuerID:    fx.endpoint.UserSessionIssuerID,
+		RemoteSessionClientID:  fx.clientID,
+		Subject:                fx.subject,
+		RemoteSessionID:        uuid.New(),
+		RemoteSessionUpdatedAt: sess.UpdatedAt.Time,
+	})
+
+	require.Empty(t, fx.member.drain())
+	require.False(t, storedSession(t, ctx, fx).ValidationStatus.Valid)
 }
 
 // Shutdown waits for a probe in flight and admits none after it.

--- a/server/internal/mcp/authnchallenge_consent_probe_internal_test.go
+++ b/server/internal/mcp/authnchallenge_consent_probe_internal_test.go
@@ -1,0 +1,20 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/speakeasy-api/gram/server/internal/remotemcp/proxy"
+)
+
+func TestProbeProxyBuilderDisablesTrafficMetrics(t *testing.T) {
+	t.Parallel()
+
+	built, err := probeProxyBuilder(func(context.Context) (*proxy.Proxy, error) {
+		return &proxy.Proxy{Metrics: &proxy.Metrics{}}, nil
+	})(t.Context())
+	require.NoError(t, err)
+	require.Nil(t, built.Metrics)
+}

--- a/server/internal/mcp/authnchallenge_consent_script_test.go
+++ b/server/internal/mcp/authnchallenge_consent_script_test.go
@@ -14,9 +14,7 @@ func TestConsentScriptVerificationPolling(t *testing.T) {
 	t.Parallel()
 
 	node, err := exec.LookPath("node")
-	if err != nil {
-		t.Skip("node is required to exercise the consent script")
-	}
+	require.NoError(t, err, "node is required to exercise the consent script")
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, node, "-e", `

--- a/server/internal/mcp/authnchallenge_consent_script_test.go
+++ b/server/internal/mcp/authnchallenge_consent_script_test.go
@@ -1,0 +1,62 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsentScriptVerificationPolling(t *testing.T) {
+	t.Parallel()
+
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is required to exercise the consent script")
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, node, "-e", `
+const assert = require('node:assert/strict');
+const vm = require('node:vm');
+const source = require('node:fs').readFileSync(0, 'utf8');
+const serverNow = 1700000000000;
+for (const skew of [-60000, 0, 60000]) {
+  for (const [hasDeadline, pending] of [[true, true], [false, true], [true, false]]) {
+    const timers = [];
+    let reloads = 0;
+    vm.runInNewContext(source, {
+      Date: { now: () => serverNow + skew },
+      document: {
+        body: { hasAttribute: () => false },
+        querySelector(selector) {
+          if (selector === '[data-verify-deadline-ms]' && hasDeadline) {
+            return { getAttribute: () => String(serverNow + 12000) };
+          }
+          if (selector === '[data-validation="pending"]' && pending) return {};
+          return null;
+        },
+        querySelectorAll: () => [],
+      },
+      window: {
+        setTimeout: (callback, delay) => timers.push({ callback, delay }),
+        location: { reload: () => reloads++ },
+      },
+    });
+    const expected = hasDeadline && pending ? 1 : 0;
+    assert.equal(timers.length, expected, JSON.stringify({ skew, hasDeadline, pending }));
+    if (expected) {
+      assert.equal(timers[0].delay, 2000);
+      timers[0].callback();
+      assert.equal(reloads, 1);
+    }
+  }
+}
+`)
+	cmd.Stdin = bytes.NewReader(consentScriptData)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "consent script polling: %s", out)
+}

--- a/server/internal/mcp/authnchallenge_consent_template_test.go
+++ b/server/internal/mcp/authnchallenge_consent_template_test.go
@@ -107,15 +107,15 @@ func TestConsentTemplateRendersPendingVerification(t *testing.T) {
 			CanValidate: true,
 			Pending:     true,
 		}},
-		ValidationBudgetMS: 15000,
-		ConsentEnabled:     true,
-		FirstParty:         true,
-		AutoClose:          false,
+		ValidationDeadlineMS: 15000,
+		ConsentEnabled:       true,
+		FirstParty:           true,
+		AutoClose:            false,
 	})
 	require.NoError(t, err)
 
 	html := normalizeWhitespace(page.String())
-	require.Contains(t, html, `data-verify-budget-ms="15000"`)
+	require.Contains(t, html, `data-verify-deadline-ms="15000"`)
 	require.Contains(t, html, `data-validation="pending"`)
 	require.Contains(t, html, "Verifying…")
 	require.NotContains(t, html, "Not yet verified")

--- a/server/internal/mcp/authnchallenge_consent_template_test.go
+++ b/server/internal/mcp/authnchallenge_consent_template_test.go
@@ -87,6 +87,41 @@ func TestConsentTemplateIncompleteFirstPartyConnectionStaysOpen(t *testing.T) {
 	require.NotContains(t, page.String(), "Connection complete")
 }
 
+func TestConsentTemplateRendersPendingVerification(t *testing.T) {
+	t.Parallel()
+
+	var page bytes.Buffer
+	err := consentTemplate.Execute(&page, consentTemplateData{
+		ClientName:     "Gram",
+		MCPSlug:        "example",
+		MCPRouteBase:   "x/mcp",
+		State:          "state",
+		CSRFToken:      "csrf",
+		SubjectDisplay: "user@example.com",
+		RedirectURI:    "",
+		ScriptURL:      "/mcp/consent-page-test.js",
+		RemoteSessionCards: []remoteSessionCard{{
+			ClientID:    "client-id",
+			IssuerSlug:  "example-issuer",
+			Connected:   true,
+			CanValidate: true,
+			Pending:     true,
+		}},
+		ValidationBudgetMS: 15000,
+		ConsentEnabled:     true,
+		FirstParty:         true,
+		AutoClose:          false,
+	})
+	require.NoError(t, err)
+
+	html := normalizeWhitespace(page.String())
+	require.Contains(t, html, `data-verify-budget-ms="15000"`)
+	require.Contains(t, html, `data-validation="pending"`)
+	require.Contains(t, html, "Verifying…")
+	require.NotContains(t, html, "Not yet verified")
+	require.NotContains(t, html, "data-auto-close")
+}
+
 func TestShouldAutoCloseFirstParty(t *testing.T) {
 	t.Parallel()
 
@@ -111,6 +146,7 @@ func TestShouldAutoCloseFirstParty(t *testing.T) {
 		{Connected: true, CanValidate: true, Unverified: true},
 		{Connected: true, CanValidate: true, Rejected: true},
 		{Connected: true, Rejected: true},
+		{Connected: true, Pending: true},
 	} {
 		require.False(t, shouldAutoCloseFirstParty(true, []remoteSessionCard{connected, card}), "pending, unknown, and rejected verifications keep the page open")
 	}

--- a/server/internal/mcp/authnchallenge_consent_validate.go
+++ b/server/internal/mcp/authnchallenge_consent_validate.go
@@ -96,7 +96,7 @@ func (s *Service) probeRemoteSession(
 		return oops.E(oops.CodeBadRequest, nil, "Connect this service before verifying it.").LogWarn(ctx, logger)
 	}
 	if expectedGrant != nil && expectedGrant.RemoteSessionID != uuid.Nil &&
-		(entry.RemoteSessionID != expectedGrant.RemoteSessionID || !entry.RemoteSessionUpdatedAt.Equal(expectedGrant.RemoteSessionUpdatedAt)) {
+		(entry.RemoteSessionID != expectedGrant.RemoteSessionID || !entry.RemoteSessionResolvedFromUpdatedAt.Equal(expectedGrant.RemoteSessionUpdatedAt)) {
 		logger.InfoContext(ctx, "new remote grant not verified: credential changed before probe")
 		return nil
 	}

--- a/server/internal/mcp/authnchallenge_consent_validate.go
+++ b/server/internal/mcp/authnchallenge_consent_validate.go
@@ -70,7 +70,7 @@ func (s *Service) validateRemoteSession(
 			return errValidationRateLimited
 		}
 	}
-	return s.probeRemoteSession(ctx, logger, endpoint, challengeState, client)
+	return s.probeRemoteSession(ctx, logger, endpoint, challengeState, client, nil)
 }
 
 // probeRemoteSession presents the card's credential to its upstream and records
@@ -82,6 +82,7 @@ func (s *Service) probeRemoteSession(
 	endpoint *ResolvedMcpEndpoint,
 	challengeState AuthnChallengeState,
 	client remotesessions.Client,
+	expectedGrant *remotesessions.RemoteGrant,
 ) error {
 	subject := *challengeState.Subject
 	logger = logger.With(attr.SlogRemoteSessionClientID(client.ID.String()))
@@ -93,6 +94,11 @@ func (s *Service) probeRemoteSession(
 	entry, usable := tokens[client.RemoteSessionIssuerID]
 	if !usable || entry.RemoteSessionClientID != client.ID {
 		return oops.E(oops.CodeBadRequest, nil, "Connect this service before verifying it.").LogWarn(ctx, logger)
+	}
+	if expectedGrant != nil && expectedGrant.RemoteSessionID != uuid.Nil &&
+		(entry.RemoteSessionID != expectedGrant.RemoteSessionID || !entry.RemoteSessionUpdatedAt.Equal(expectedGrant.RemoteSessionUpdatedAt)) {
+		logger.InfoContext(ctx, "new remote grant not verified: credential changed before probe")
+		return nil
 	}
 	// Route the complete credential set, just as serving does. The target resolver
 	// separately proves that this card is the credential selected for the target.
@@ -332,7 +338,8 @@ func (s *Service) standaloneValidationTarget(
 	})}, nil
 }
 
-// probeProxyBuilder strips client-session and census interceptors so a probe is not counted as traffic.
+// probeProxyBuilder strips client-session and census interceptors and proxy
+// metrics so a synthetic validation handshake is not counted as user traffic.
 func probeProxyBuilder(build memberProxyBuilder) memberProxyBuilder {
 	return func(ctx context.Context) (*proxy.Proxy, error) {
 		p, err := build(ctx)
@@ -341,6 +348,7 @@ func probeProxyBuilder(build memberProxyBuilder) memberProxyBuilder {
 		}
 		p.InitializeRequestInterceptors = nil
 		p.UserRequestObservationInterceptors = nil
+		p.Metrics = nil
 		return p, nil
 	}
 }

--- a/server/internal/mcp/consent_script.js
+++ b/server/internal/mcp/consent_script.js
@@ -28,6 +28,59 @@
     }, 3000);
   }
 
+  // A card whose automatic verification was still running when the callback
+  // redirected reads "Connected · Verifying…". Reload every two seconds until
+  // no card is pending, for at most the probe budget the list declares; the
+  // first-party auto-close above only arrives on a render with nothing pending.
+  var cardList = document.querySelector("[data-verify-budget-ms]");
+  var verifyingSinceKey = "consent-verifying-since:" + window.location.href;
+  function readVerifyingSince() {
+    try {
+      return parseInt(window.sessionStorage.getItem(verifyingSinceKey), 10);
+    } catch (e) {
+      return NaN;
+    }
+  }
+  // Returns whether the value was persisted; the reload loop is only safe
+  // while its deadline survives a reload.
+  function writeVerifyingSince(value) {
+    try {
+      if (value === null) {
+        window.sessionStorage.removeItem(verifyingSinceKey);
+      } else {
+        window.sessionStorage.setItem(verifyingSinceKey, String(value));
+        return (
+          window.sessionStorage.getItem(verifyingSinceKey) === String(value)
+        );
+      }
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+  if (cardList && document.querySelector('[data-validation="pending"]')) {
+    var budget =
+      parseInt(cardList.getAttribute("data-verify-budget-ms"), 10) || 15000;
+    var since = readVerifyingSince();
+    var persisted = true;
+    if (isNaN(since)) {
+      since = Date.now();
+      persisted = writeVerifyingSince(since);
+    }
+    if (!persisted) {
+      // Without storage each render would restart the budget: one render,
+      // no reload; the verdict shows on the next visit or Verify.
+    } else if (Date.now() - since < budget) {
+      window.setTimeout(function () {
+        window.location.reload();
+      }, 2000);
+    } else {
+      writeVerifyingSince(null);
+    }
+  } else {
+    writeVerifyingSince(null);
+  }
+
   // Replace an element's contents with a spinner + label.
   function showPending(el, label) {
     el.textContent = "";
@@ -121,8 +174,7 @@
     });
   }
 
-  // Connect / Reconnect and Refresh each make an upstream request. Guard both
-  // against repeat clicks and make their pending state visible.
+  // Connect / Reconnect, Refresh and Re-check each make an upstream request; guard repeat clicks and show pending.
   function guardActionButtons(selector, pendingLabel) {
     var buttons = document.querySelectorAll(selector);
     Array.prototype.forEach.call(buttons, function (actionButton) {
@@ -143,6 +195,7 @@
   }
   guardActionButtons("button[data-connect-link]", "Connecting…");
   guardActionButtons("button[data-refresh-link]", "Refreshing…");
+  guardActionButtons("button[data-validate-link]", "Checking…");
 
   // Session length is stated on the summary line so it is visible without
   // opening the configuration disclosure; keep the two in step when the

--- a/server/internal/mcp/consent_script.js
+++ b/server/internal/mcp/consent_script.js
@@ -29,56 +29,20 @@
   }
 
   // A card whose automatic verification was still running when the callback
-  // redirected reads "Connected · Verifying…". Reload every two seconds until
-  // no card is pending, for at most the probe budget the list declares; the
-  // first-party auto-close above only arrives on a render with nothing pending.
-  var cardList = document.querySelector("[data-verify-budget-ms]");
-  var verifyingSinceKey = "consent-verifying-since:" + window.location.href;
-  function readVerifyingSince() {
-    try {
-      return parseInt(window.sessionStorage.getItem(verifyingSinceKey), 10);
-    } catch (e) {
-      return NaN;
-    }
-  }
-  // Returns whether the value was persisted; the reload loop is only safe
-  // while its deadline survives a reload.
-  function writeVerifyingSince(value) {
-    try {
-      if (value === null) {
-        window.sessionStorage.removeItem(verifyingSinceKey);
-      } else {
-        window.sessionStorage.setItem(verifyingSinceKey, String(value));
-        return (
-          window.sessionStorage.getItem(verifyingSinceKey) === String(value)
-        );
-      }
-      return true;
-    } catch (e) {
-      return false;
-    }
-  }
+  // redirected reads "Connected · Verifying…". First-party pages can
+  // safely reload until the callback probe's absolute deadline; interactive
+  // consent pages do not poll because a reload would discard tool selections.
+  var cardList = document.querySelector("[data-verify-deadline-ms]");
   if (cardList && document.querySelector('[data-validation="pending"]')) {
-    var budget =
-      parseInt(cardList.getAttribute("data-verify-budget-ms"), 10) || 15000;
-    var since = readVerifyingSince();
-    var persisted = true;
-    if (isNaN(since)) {
-      since = Date.now();
-      persisted = writeVerifyingSince(since);
-    }
-    if (!persisted) {
-      // Without storage each render would restart the budget: one render,
-      // no reload; the verdict shows on the next visit or Verify.
-    } else if (Date.now() - since < budget) {
+    var deadline = parseInt(
+      cardList.getAttribute("data-verify-deadline-ms"),
+      10,
+    );
+    if (!isNaN(deadline) && Date.now() < deadline) {
       window.setTimeout(function () {
         window.location.reload();
       }, 2000);
-    } else {
-      writeVerifyingSince(null);
     }
-  } else {
-    writeVerifyingSince(null);
   }
 
   // Replace an element's contents with a spinner + label.

--- a/server/internal/mcp/consent_script.js
+++ b/server/internal/mcp/consent_script.js
@@ -34,15 +34,11 @@
   // consent pages do not poll because a reload would discard tool selections.
   var cardList = document.querySelector("[data-verify-deadline-ms]");
   if (cardList && document.querySelector('[data-validation="pending"]')) {
-    var deadline = parseInt(
-      cardList.getAttribute("data-verify-deadline-ms"),
-      10,
-    );
-    if (!isNaN(deadline) && Date.now() < deadline) {
-      window.setTimeout(function () {
-        window.location.reload();
-      }, 2000);
-    }
+    // The server only renders this attribute while its deadline is live.
+    // Let the next render stop polling: the browser's clock may be skewed.
+    window.setTimeout(function () {
+      window.location.reload();
+    }, 2000);
   }
 
   // Replace an element's contents with a spinner + label.

--- a/server/internal/mcp/consent_template.html
+++ b/server/internal/mcp/consent_template.html
@@ -175,7 +175,10 @@
               {{.ConnectedCardCount}} of {{len .RemoteSessionCards}} connected
             </p>
           </div>
-          <ul class="m-0 flex list-none flex-col border p-0">
+          <ul
+            class="m-0 flex list-none flex-col border p-0"
+            data-verify-budget-ms="{{.ValidationBudgetMS}}"
+          >
             {{range .RemoteSessionCards}}
             <li
               class="flex items-center justify-between gap-3 px-4 py-3 not-first:border-t"
@@ -194,7 +197,10 @@
                   {{if .Connected}}
                   <span class="text-xs text-default-success"
                     >Connected{{if .AutoRefreshChecked}} · auto refresh
-                    on{{end}}</span
+                    on{{end}}{{if .Pending}} ·
+                    <span class="text-muted-foreground" data-validation="pending"
+                      >Verifying…</span
+                    >{{end}}</span
                   >
                   {{if .ConnectedAs}}
                   <span
@@ -203,8 +209,9 @@
                     >Connected as {{.ConnectedAs}}</span
                   >
                   {{end}}
-                  {{/* The last probe's verdict; a rejected card keeps its Connected line and gains a reconnect prompt. */}}
-                  {{if .Verified}}
+                  {{/* The last probe's verdict; a rejected card keeps its Connected line and gains a reconnect prompt. A pending automatic verification shows on the Connected line instead, until the page refreshes with its verdict. */}}
+                  {{if .Pending}}
+                  {{else if .Verified}}
                   <span class="text-xs text-muted-foreground" data-validation="valid"
                     >Verified
                     <time datetime="{{.ValidatedAt}}">{{.ValidatedAgo}}</time></span

--- a/server/internal/mcp/consent_template.html
+++ b/server/internal/mcp/consent_template.html
@@ -177,7 +177,7 @@
           </div>
           <ul
             class="m-0 flex list-none flex-col border p-0"
-            data-verify-budget-ms="{{.ValidationBudgetMS}}"
+            {{if .ValidationDeadlineMS}}data-verify-deadline-ms="{{.ValidationDeadlineMS}}"{{end}}
           >
             {{range .RemoteSessionCards}}
             <li

--- a/server/internal/mcp/export_test.go
+++ b/server/internal/mcp/export_test.go
@@ -2,13 +2,14 @@ package mcp
 
 import (
 	"context"
+	"time"
 
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 )
 
 // VerifyRemoteGrant exposes the grant hook to tests.
-func (s *Service) VerifyRemoteGrant(ctx context.Context, grant remotesessions.RemoteGrant) {
-	s.verifyRemoteGrant(ctx, grant)
+func (s *Service) VerifyRemoteGrant(ctx context.Context, grant remotesessions.RemoteGrant) time.Time {
+	return s.verifyRemoteGrant(ctx, grant)
 }
 
 // VerifyRemoteGrantOn runs the probe step against an endpoint the test resolved itself.

--- a/server/internal/mcp/export_test.go
+++ b/server/internal/mcp/export_test.go
@@ -1,0 +1,28 @@
+package mcp
+
+import (
+	"context"
+
+	"github.com/speakeasy-api/gram/server/internal/remotesessions"
+)
+
+// VerifyRemoteGrant exposes the grant hook to tests.
+func (s *Service) VerifyRemoteGrant(ctx context.Context, grant remotesessions.RemoteGrant) {
+	s.verifyRemoteGrant(ctx, grant)
+}
+
+// VerifyRemoteGrantOn runs the probe step against an endpoint the test resolved itself.
+// It preserves ctx, including its deadline; unlike VerifyRemoteGrant it does not
+// start detached work with a fresh callback budget.
+func (s *Service) VerifyRemoteGrantOn(ctx context.Context, endpoint *ResolvedMcpEndpoint, grant remotesessions.RemoteGrant) {
+	challengeState, err := s.authnChallengeCache.Get(ctx, "authnChallenge:"+grant.ParentChallengeID)
+	if err != nil {
+		return
+	}
+	s.probeRemoteGrant(ctx, s.logger, endpoint, challengeState, grant)
+}
+
+// RemoteChallengeManager is the manager the service registered its grant hook on.
+func (s *Service) RemoteChallengeManager() *remotesessions.ChallengeManager {
+	return s.remoteChallengeMgr
+}

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -185,6 +185,8 @@ type Service struct {
 	validationMetrics *remotesessionmetrics.Validation
 	// validationLimiter paces verifies per consent challenge; nil without Redis.
 	validationLimiter *ratelimit.Limiter
+	// autoVerifications admits and drains the probes a committed grant starts off the request path.
+	autoVerifications *autoVerifications
 	// remoteProxyManager builds configured remotemcp proxies wired with the
 	// MCP-aware interceptor stack. Only consulted by ServeMCPEndpoint's
 	// remote-backed branch; may be nil in non-HTTP contexts (e.g. the
@@ -484,6 +486,7 @@ func NewService(
 		remoteChallengeMgr: remoteChallengeMgr,
 		validationMetrics:  remotesessionmetrics.NewValidation(logger, meterProvider),
 		validationLimiter:  newValidationLimiter(redisClient, meterProvider),
+		autoVerifications:  newAutoVerifications(),
 		remoteProxyManager: remoteProxyManager,
 		tunnelManager:      newTunnelManager(tunnelRoutes, tunnelForwardToken, remoteProxyManager, tunnelGatewayCIDRs),
 		tunnelPublic:       newTunnelPublicRuntime(redisClient, meterProvider, metrics, tunnelPublicConfig),
@@ -621,7 +624,15 @@ func Attach(mux goahttp.Muxer, service *Service, metadataService *mcpmetadata.Se
 // same handler via the public method instead of reaching into the
 // unexported manager field.
 func (s *Service) HandleRemoteLoginCallback(w http.ResponseWriter, r *http.Request) error {
-	return s.remoteChallengeMgr.HandleRemoteLoginCallback(w, r) //nolint:wrapcheck // thin passthrough; the inner handler already writes the HTTP response.
+	result, err := s.remoteChallengeMgr.CompleteRemoteLogin(r)
+	if err != nil {
+		return err //nolint:wrapcheck // the manager's errors already carry the response
+	}
+	if result.Grant != nil {
+		s.verifyRemoteGrant(r.Context(), *result.Grant)
+	}
+	http.Redirect(w, r, result.RedirectURL, http.StatusSeeOther)
+	return nil
 }
 
 // HandleLegacyProxyCallback is the chi handler at `GET /oauth/callback`. Thin

--- a/server/internal/mcp/impl.go
+++ b/server/internal/mcp/impl.go
@@ -629,7 +629,17 @@ func (s *Service) HandleRemoteLoginCallback(w http.ResponseWriter, r *http.Reque
 		return err //nolint:wrapcheck // the manager's errors already carry the response
 	}
 	if result.Grant != nil {
-		s.verifyRemoteGrant(r.Context(), *result.Grant)
+		if deadline := s.verifyRemoteGrant(r.Context(), *result.Grant); !deadline.IsZero() {
+			redirect, parseErr := url.Parse(result.RedirectURL)
+			if parseErr != nil {
+				return fmt.Errorf("parse remote login redirect: %w", parseErr)
+			}
+			query := redirect.Query()
+			query.Set("verifying_client", result.Grant.RemoteSessionClientID.String())
+			query.Set("verifying_until", strconv.FormatInt(deadline.UnixMilli(), 10))
+			redirect.RawQuery = query.Encode()
+			result.RedirectURL = redirect.String()
+		}
 	}
 	http.Redirect(w, r, result.RedirectURL, http.StatusSeeOther)
 	return nil

--- a/server/internal/mcp/serve_meta_config.go
+++ b/server/internal/mcp/serve_meta_config.go
@@ -9,8 +9,11 @@ type MetaRuntimeConfig struct {
 	// timeouts so this deadline, not the proxy's, is what a slow member hits.
 	MemberCallTimeout time.Duration
 
-	// ValidationTimeout bounds a consent-page probe end to end, session close and verdict write included.
+	// ValidationTimeout bounds a consent-page probe's handshake and session close.
 	ValidationTimeout time.Duration
+
+	// AutoVerifyWait is how long a remote login callback holds its redirect for the probe a fresh grant starts, so a fast member's verdict is on the first render.
+	AutoVerifyWait time.Duration
 }
 
 func (c MetaRuntimeConfig) withDefaults() MetaRuntimeConfig {
@@ -19,6 +22,9 @@ func (c MetaRuntimeConfig) withDefaults() MetaRuntimeConfig {
 	}
 	if c.ValidationTimeout <= 0 {
 		c.ValidationTimeout = 15 * time.Second
+	}
+	if c.AutoVerifyWait <= 0 {
+		c.AutoVerifyWait = 3 * time.Second
 	}
 	return c
 }

--- a/server/internal/mcp/setup_test.go
+++ b/server/internal/mcp/setup_test.go
@@ -142,7 +142,7 @@ func newTestMCPServiceWithoutTemporal(t *testing.T) (context.Context, *testInsta
 		nil,
 		nil,
 		false,
-		mcp.MetaRuntimeConfig{MemberCallTimeout: 0, ValidationTimeout: 0},
+		mcp.MetaRuntimeConfig{MemberCallTimeout: 0, ValidationTimeout: 0, AutoVerifyWait: 0},
 	)
 }
 
@@ -300,7 +300,7 @@ func newTestMCPServiceWithTunnelPublicConfigAndCacheWrapper(
 // newTestMCPServiceWithValidationTimeout shortens the probe deadline so a hanging upstream fails fast.
 func newTestMCPServiceWithValidationTimeout(t *testing.T, meterProvider metric.MeterProvider, validationTimeout time.Duration) (context.Context, *testInstance) {
 	t.Helper()
-	return newTestMCPServiceWithMetaRuntime(t, meterProvider, mcp.MetaRuntimeConfig{MemberCallTimeout: 0, ValidationTimeout: validationTimeout})
+	return newTestMCPServiceWithMetaRuntime(t, meterProvider, mcp.MetaRuntimeConfig{MemberCallTimeout: 0, ValidationTimeout: validationTimeout, AutoVerifyWait: 0})
 }
 
 func newTestMCPServiceWithMetaRuntime(t *testing.T, meterProvider metric.MeterProvider, metaRuntime mcp.MetaRuntimeConfig) (context.Context, *testInstance) {

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -209,6 +209,26 @@ type ChallengeManager struct {
 	issuerMetadata *IssuerMetadataRefresher
 }
 
+// RemoteGrant is a grant the remote login callback committed, keyed to the
+// consent challenge it belongs to.
+type RemoteGrant struct {
+	// ParentChallengeID is the consent challenge the login was started from.
+	ParentChallengeID string
+	// UserSessionIssuerID is the issuer that challenge was minted for.
+	UserSessionIssuerID uuid.UUID
+	// RemoteSessionClientID is the client the grant was stored against.
+	RemoteSessionClientID uuid.UUID
+	// Subject is who holds the grant.
+	Subject urn.SessionSubject
+}
+
+// RemoteLoginResult is where the callback sends the browser next.
+type RemoteLoginResult struct {
+	RedirectURL string
+	// Grant is the committed grant, nil while the login is being retried upstream.
+	Grant *RemoteGrant
+}
+
 // PrivateAuthorityValidator revalidates a private endpoint without introducing
 // a remotesessions -> mcp dependency.
 type PrivateAuthorityValidator func(context.Context, RemoteLoginState) error
@@ -799,10 +819,23 @@ func (m *ChallengeManager) mintAuthorization(
 // /mcp/remote_login_callback. Bound by mcp/ at route-mount time. The legacy
 // /mcp/{mcpSlug}/remote_login_callback route is still accepted, but the MCP
 // slug is resolved from the stored RemoteLoginState.
-// Coordinates code → token exchange at the upstream token endpoint and
-// persists the result in remote_sessions; on success redirects back to
-// /mcp/{slug}/connect?state={parent_challenge_id}.
+// Completes the login through CompleteRemoteLogin and redirects the browser.
 func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *http.Request) error {
+	result, err := m.CompleteRemoteLogin(r)
+	if err != nil {
+		return err
+	}
+	http.Redirect(w, r, result.RedirectURL, http.StatusSeeOther)
+	return nil
+}
+
+// CompleteRemoteLogin exchanges the upstream code, persists the result in
+// remote_sessions, and returns where the browser goes next: the consent page
+// /{route}/{slug}/connect?state={parent_challenge_id}, or the upstream
+// authorize URL again when the login is retried without a resource. It writes
+// nothing itself.
+func (m *ChallengeManager) CompleteRemoteLogin(r *http.Request) (RemoteLoginResult, error) {
+	var none RemoteLoginResult
 	ctx := r.Context()
 	routeMcpSlug := chi.URLParam(r, "mcpSlug")
 	logger := m.logger
@@ -813,14 +846,14 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 	stateID := q.Get("state")
 	if stateID == "" {
 		if errCode != "" {
-			return denied(ctx, logger, q)
+			return none, denied(ctx, logger, q)
 		}
-		return oops.E(oops.CodeBadRequest, nil, "state is required").LogError(ctx, logger)
+		return none, oops.E(oops.CodeBadRequest, nil, "state is required").LogError(ctx, logger)
 	}
 	// Checked before the state is consumed so a bare ?state= prefetch does not
 	// burn a pending login.
 	if code == "" && errCode == "" {
-		return oops.E(oops.CodeBadRequest, nil, "code is required").LogError(ctx, logger)
+		return none, oops.E(oops.CodeBadRequest, nil, "code is required").LogError(ctx, logger)
 	}
 
 	// Single-use state: GETDEL so a duplicate callback can't double-exchange
@@ -830,22 +863,22 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 	state, err := m.cache.GetAndDelete(ctx, "remoteLogin:"+stateID)
 	if err != nil {
 		if errCode != "" {
-			return denied(ctx, logger, q)
+			return none, denied(ctx, logger, q)
 		}
-		return oops.E(oops.CodeUnauthorized, err, "remote login state not found or expired").LogError(ctx, logger)
+		return none, oops.E(oops.CodeUnauthorized, err, "remote login state not found or expired").LogError(ctx, logger)
 	}
 	mcpSlug := state.McpSlug
 	if mcpSlug == "" {
 		mcpSlug = routeMcpSlug
 	}
 	if mcpSlug == "" {
-		return oops.E(oops.CodeBadRequest, nil, "mcp slug is missing from remote login state").LogError(ctx, logger)
+		return none, oops.E(oops.CodeBadRequest, nil, "mcp slug is missing from remote login state").LogError(ctx, logger)
 	}
 	if routeMcpSlug != "" && routeMcpSlug != mcpSlug {
-		return oops.E(oops.CodeUnauthorized, nil, "remote login state does not match this MCP server").LogError(ctx, logger)
+		return none, oops.E(oops.CodeUnauthorized, nil, "remote login state does not match this MCP server").LogError(ctx, logger)
 	}
 	if state.McpSlug != "" && state.McpSlug != mcpSlug {
-		return oops.E(oops.CodeUnauthorized, nil, "remote login state does not match this MCP server").LogError(ctx, logger)
+		return none, oops.E(oops.CodeUnauthorized, nil, "remote login state does not match this MCP server").LogError(ctx, logger)
 	}
 
 	logger = logger.With(
@@ -859,7 +892,7 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 	// RFC 9207 §2.4: iss must be present and match before anything in the
 	// response is trusted, denial included.
 	if state.ExpectedIssuer != "" && q.Get("iss") != state.ExpectedIssuer {
-		return oops.E(oops.CodeUnauthorized, nil, "remote login callback did not identify the expected issuer").LogWarn(ctx, logger,
+		return none, oops.E(oops.CodeUnauthorized, nil, "remote login callback did not identify the expected issuer").LogWarn(ctx, logger,
 			attr.SlogOAuthIssuer(state.ExpectedIssuer),
 		)
 	}
@@ -871,9 +904,9 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 				Description: truncateForMessage(q.Get("error_description")),
 				URI:         truncateForMessage(q.Get("error_uri")),
 			}
-			return m.retryWithoutResource(ctx, w, r, logger, state, cause)
+			return m.retryWithoutResource(ctx, logger, state, cause)
 		}
-		return denied(ctx, logger, q)
+		return none, denied(ctx, logger, q)
 	}
 
 	// Hoisted above the DB lookup + upstream code exchange so a state with a
@@ -881,17 +914,17 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 	// upstream authorization code on a request that can't produce a
 	// remote_sessions row anyway.
 	if state.Subject == nil || state.Subject.IsZero() {
-		return oops.E(oops.CodeUnauthorized, nil, "remote login requires a stamped subject on the parent challenge").LogError(ctx, logger)
+		return none, oops.E(oops.CodeUnauthorized, nil, "remote login requires a stamped subject on the parent challenge").LogError(ctx, logger)
 	}
 	if err := state.Authority.ValidateLive(ctx, m.db); err != nil {
-		return oops.E(oops.CodeUnauthorized, err, "private OAuth authority is no longer valid").LogError(ctx, logger)
+		return none, oops.E(oops.CodeUnauthorized, err, "private OAuth authority is no longer valid").LogError(ctx, logger)
 	}
 	if state.Authority.IsPrivate() {
 		if m.privateAuthorityValidator == nil {
-			return oops.E(oops.CodeUnauthorized, nil, "private MCP endpoint authority validator is unavailable").LogError(ctx, logger)
+			return none, oops.E(oops.CodeUnauthorized, nil, "private MCP endpoint authority validator is unavailable").LogError(ctx, logger)
 		}
 		if err := m.privateAuthorityValidator(ctx, state); err != nil {
-			return oops.E(oops.CodeUnauthorized, err, "private MCP endpoint authority is no longer valid").LogError(ctx, logger)
+			return none, oops.E(oops.CodeUnauthorized, err, "private MCP endpoint authority is no longer valid").LogError(ctx, logger)
 		}
 	}
 
@@ -902,7 +935,7 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 		OrganizationID: state.OrganizationID,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "load remote session client").LogError(ctx, logger)
+		return none, oops.E(oops.CodeUnexpected, err, "load remote session client").LogError(ctx, logger)
 	}
 	client := clientRow.RemoteSessionClient
 
@@ -910,23 +943,23 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 	if client.ClientSecretEncrypted.Valid {
 		decoded, derr := m.enc.Decrypt(client.ClientSecretEncrypted.String)
 		if derr != nil {
-			return oops.E(oops.CodeUnexpected, derr, "decrypt client secret").LogError(ctx, logger)
+			return none, oops.E(oops.CodeUnexpected, derr, "decrypt client secret").LogError(ctx, logger)
 		}
 		clientSecret = decoded
 	}
 
 	authMethod, err := ResolveTokenEndpointAuthMethod(client.TokenEndpointAuthMethod.String, clientSecret)
 	if err != nil {
-		return oops.E(oops.CodeUnauthorized, err, "the remote session client is misconfigured").LogError(ctx, logger)
+		return none, oops.E(oops.CodeUnauthorized, err, "the remote session client is misconfigured").LogError(ctx, logger)
 	}
 	audience := conv.FromPGTextOrEmpty[string](client.Audience)
 	tok, err := m.exchangeCode(ctx, state, client.ClientID, clientSecret, authMethod, audience, code)
 	if err != nil {
 		var oauthErr oautherr.RFC6749Error
 		if errors.As(err, &oauthErr) && oauthErr.Code == oautherr.CodeInvalidTarget {
-			return m.retryWithoutResource(ctx, w, r, logger, state, err)
+			return m.retryWithoutResource(ctx, logger, state, err)
 		}
-		return oops.E(oops.CodeUnauthorized, err, "upstream token exchange failed").LogError(ctx, logger)
+		return none, oops.E(oops.CodeUnauthorized, err, "upstream token exchange failed").LogError(ctx, logger)
 	}
 	// The pair is live upstream from this line on, and every path out of here
 	// that does not store it strands it: unreachable through Gram, and outside
@@ -951,13 +984,13 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 
 	accessEnc, err := m.enc.Encrypt([]byte(tok.AccessToken))
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "encrypt access token").LogError(ctx, logger)
+		return none, oops.E(oops.CodeUnexpected, err, "encrypt access token").LogError(ctx, logger)
 	}
 	var refreshEnc *string
 	if tok.RefreshToken != "" {
 		v, eerr := m.enc.Encrypt([]byte(tok.RefreshToken))
 		if eerr != nil {
-			return oops.E(oops.CodeUnexpected, eerr, "encrypt refresh token").LogError(ctx, logger)
+			return none, oops.E(oops.CodeUnexpected, eerr, "encrypt refresh token").LogError(ctx, logger)
 		}
 		refreshEnc = &v
 	}
@@ -981,7 +1014,7 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 	// is the one the request path refreshes at, and the armed revocation
 	// above returns the pair to the provider.
 	if tok.RefreshToken == "" && accessExpires != nil && !accessExpires.After(now.Add(AccessTokenExpirySkew)) {
-		return oops.E(oops.CodeUnauthorized, nil, "the identity provider issued an access token that is expired or about to expire, and no refresh token to renew it").LogWarn(ctx, logger,
+		return none, oops.E(oops.CodeUnauthorized, nil, "the identity provider issued an access token that is expired or about to expire, and no refresh token to renew it").LogWarn(ctx, logger,
 			attr.SlogRemoteSessionAccessExpiresAt(*accessExpires),
 		)
 	}
@@ -1017,7 +1050,7 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 	// callback leaves the revocation armed above still standing.
 	dbtx, err := m.db.Begin(ctx)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "begin remote session transaction").LogError(ctx, logger)
+		return none, oops.E(oops.CodeUnexpected, err, "begin remote session transaction").LogError(ctx, logger)
 	}
 	defer o11y.NoLogDefer(func() error { return dbtx.Rollback(ctx) })
 	txQueries := remotesessions_repo.New(dbtx)
@@ -1025,7 +1058,7 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 	// No row means the client itself is gone, which the binding recheck below
 	// rejects on its own — there is nothing left to serialize against.
 	if _, err := txQueries.LockRemoteSessionClientForSessionWrite(ctx, state.RemoteSessionClientID); err != nil && !errors.Is(err, pgx.ErrNoRows) {
-		return oops.E(oops.CodeUnexpected, err, "lock remote session client").LogError(ctx, logger)
+		return none, oops.E(oops.CodeUnexpected, err, "lock remote session client").LogError(ctx, logger)
 	}
 
 	// Deliberately the issuer this login started from, not "any live binding
@@ -1040,10 +1073,10 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 		OrganizationID:        state.OrganizationID,
 	})
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "recheck remote session client binding").LogError(ctx, logger)
+		return none, oops.E(oops.CodeUnexpected, err, "recheck remote session client binding").LogError(ctx, logger)
 	}
 	if !bound {
-		return oops.E(oops.CodeUnauthorized, nil, "the connection this login was started from no longer exists").LogWarn(ctx, logger)
+		return none, oops.E(oops.CodeUnauthorized, nil, "the connection this login was started from no longer exists").LogWarn(ctx, logger)
 	}
 
 	if _, err := txQueries.UpsertRemoteSession(ctx, remotesessions_repo.UpsertRemoteSessionParams{
@@ -1066,11 +1099,11 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 		IdentitySource:      identityCols.Source,
 		Enrichment:          enrichment,
 	}); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "store remote session").LogError(ctx, logger)
+		return none, oops.E(oops.CodeUnexpected, err, "store remote session").LogError(ctx, logger)
 	}
 
 	if err := dbtx.Commit(ctx); err != nil {
-		return oops.E(oops.CodeUnexpected, err, "commit remote session").LogError(ctx, logger)
+		return none, oops.E(oops.CodeUnexpected, err, "commit remote session").LogError(ctx, logger)
 	}
 	stranded = false
 
@@ -1093,8 +1126,15 @@ func (m *ChallengeManager) HandleRemoteLoginCallback(w http.ResponseWriter, r *h
 	if state.FinalRedirectURI != "" {
 		redirect = state.FinalRedirectURI
 	}
-	http.Redirect(w, r, redirect, http.StatusSeeOther)
-	return nil
+	return RemoteLoginResult{
+		RedirectURL: redirect,
+		Grant: &RemoteGrant{
+			ParentChallengeID:     state.ParentChallengeID,
+			UserSessionIssuerID:   state.UserSessionIssuerID,
+			RemoteSessionClientID: client.ID,
+			Subject:               *state.Subject,
+		},
+	}, nil
 }
 
 // denied rejects the callback; the public message echoes only IETF-registered error codes.
@@ -1114,19 +1154,20 @@ func denied(ctx context.Context, logger *slog.Logger, q url.Values) error {
 // invalid_target. Refused when the leg already omitted the resource or is the
 // retry itself, so an issuer cannot loop the user. Persists nothing: the
 // rejection may be of this resource alone, so it stays scoped to this login.
-func (m *ChallengeManager) retryWithoutResource(ctx context.Context, w http.ResponseWriter, r *http.Request, logger *slog.Logger, state RemoteLoginState, cause error) error {
+func (m *ChallengeManager) retryWithoutResource(ctx context.Context, logger *slog.Logger, state RemoteLoginState, cause error) (RemoteLoginResult, error) {
+	var none RemoteLoginResult
 	logger = logger.With(attr.SlogOAuthError(oautherr.CodeInvalidTarget))
 	if state.Resource == "" || state.OmitResource || state.ResourceRetried {
-		return oops.E(oops.CodeUnauthorized, cause, "the identity provider rejected the requested resource").LogWarn(ctx, logger)
+		return none, oops.E(oops.CodeUnauthorized, cause, "the identity provider rejected the requested resource").LogWarn(ctx, logger)
 	}
 
 	clients, err := m.ListClients(ctx, state.ProjectID, state.OrganizationID, state.UserSessionIssuerID)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "load remote session client for retry").LogError(ctx, logger)
+		return none, oops.E(oops.CodeUnexpected, err, "load remote session client for retry").LogError(ctx, logger)
 	}
 	idx := slices.IndexFunc(clients, func(c Client) bool { return c.ID == state.RemoteSessionClientID })
 	if idx < 0 {
-		return oops.E(oops.CodeUnauthorized, cause, "the connection this login was started from no longer exists").LogWarn(ctx, logger)
+		return none, oops.E(oops.CodeUnauthorized, cause, "the connection this login was started from no longer exists").LogWarn(ctx, logger)
 	}
 	client := clients[idx]
 
@@ -1140,10 +1181,9 @@ func (m *ChallengeManager) retryWithoutResource(ctx context.Context, w http.Resp
 	client.IssuerResourceIndicatorSupported = &unsupported
 	authURL, err := m.mintAuthorization(ctx, state.parent(), client, true)
 	if err != nil {
-		return oops.E(oops.CodeUnexpected, err, "build authorization url for retry").LogError(ctx, logger)
+		return none, oops.E(oops.CodeUnexpected, err, "build authorization url for retry").LogError(ctx, logger)
 	}
-	http.Redirect(w, r, authURL, http.StatusSeeOther)
-	return nil
+	return RemoteLoginResult{RedirectURL: authURL, Grant: nil}, nil
 }
 
 // canonicalCallbackRouteBase is the route base the outbound remote-login

--- a/server/internal/remotesessions/challenge.go
+++ b/server/internal/remotesessions/challenge.go
@@ -220,6 +220,9 @@ type RemoteGrant struct {
 	RemoteSessionClientID uuid.UUID
 	// Subject is who holds the grant.
 	Subject urn.SessionSubject
+	// RemoteSessionID and RemoteSessionUpdatedAt identify the exact stored credential committed by the callback.
+	RemoteSessionID        uuid.UUID
+	RemoteSessionUpdatedAt time.Time
 }
 
 // RemoteLoginResult is where the callback sends the browser next.
@@ -1079,7 +1082,7 @@ func (m *ChallengeManager) CompleteRemoteLogin(r *http.Request) (RemoteLoginResu
 		return none, oops.E(oops.CodeUnauthorized, nil, "the connection this login was started from no longer exists").LogWarn(ctx, logger)
 	}
 
-	if _, err := txQueries.UpsertRemoteSession(ctx, remotesessions_repo.UpsertRemoteSessionParams{
+	storedSession, err := txQueries.UpsertRemoteSession(ctx, remotesessions_repo.UpsertRemoteSessionParams{
 		SubjectUrn:            *state.Subject,
 		UserSessionIssuerID:   state.UserSessionIssuerID,
 		RemoteSessionClientID: state.RemoteSessionClientID,
@@ -1098,7 +1101,8 @@ func (m *ChallengeManager) CompleteRemoteLogin(r *http.Request) (RemoteLoginResu
 		UpstreamDisplayName: identityCols.DisplayName,
 		IdentitySource:      identityCols.Source,
 		Enrichment:          enrichment,
-	}); err != nil {
+	})
+	if err != nil {
 		return none, oops.E(oops.CodeUnexpected, err, "store remote session").LogError(ctx, logger)
 	}
 
@@ -1129,10 +1133,12 @@ func (m *ChallengeManager) CompleteRemoteLogin(r *http.Request) (RemoteLoginResu
 	return RemoteLoginResult{
 		RedirectURL: redirect,
 		Grant: &RemoteGrant{
-			ParentChallengeID:     state.ParentChallengeID,
-			UserSessionIssuerID:   state.UserSessionIssuerID,
-			RemoteSessionClientID: client.ID,
-			Subject:               *state.Subject,
+			ParentChallengeID:      state.ParentChallengeID,
+			UserSessionIssuerID:    state.UserSessionIssuerID,
+			RemoteSessionClientID:  client.ID,
+			Subject:                *state.Subject,
+			RemoteSessionID:        storedSession.ID,
+			RemoteSessionUpdatedAt: storedSession.UpdatedAt.Time,
 		},
 	}, nil
 }

--- a/server/internal/remotesessions/challenge_complete_test.go
+++ b/server/internal/remotesessions/challenge_complete_test.go
@@ -1,0 +1,35 @@
+package remotesessions_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// CompleteRemoteLogin returns the committed grant addressed the way the consent page is, alongside the redirect.
+func TestCompleteRemoteLogin_ReturnsTheCommittedGrant(t *testing.T) {
+	t.Parallel()
+
+	var spy upstreamSpy
+	ctx, fx := setupResourceDanceFixture(t, "https://mcp.example.com/mcp", "set", &spy)
+
+	authURL, err := fx.mgr.BuildAuthorizationUrl(ctx, fx.parent, fx.clients[0])
+	require.NoError(t, err)
+	parsed, err := url.Parse(authURL)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/mcp/remote_login_callback?code=fake-code&state="+url.QueryEscape(parsed.Query().Get("state")), nil)
+	result, err := fx.mgr.CompleteRemoteLogin(req.WithContext(ctx))
+	require.NoError(t, err)
+	require.NoError(t, spy.handlerErr)
+
+	require.Contains(t, result.RedirectURL, "/mcp/"+fx.parent.McpSlug+"/connect?state="+url.QueryEscape(fx.parent.ID))
+	require.NotNil(t, result.Grant)
+	require.Equal(t, fx.parent.ID, result.Grant.ParentChallengeID)
+	require.Equal(t, fx.parent.UserSessionIssuerID, result.Grant.UserSessionIssuerID)
+	require.Equal(t, fx.clients[0].ID, result.Grant.RemoteSessionClientID)
+	require.Equal(t, *fx.parent.Subject, result.Grant.Subject)
+}

--- a/server/internal/remotesessions/refreshservice.go
+++ b/server/internal/remotesessions/refreshservice.go
@@ -40,6 +40,10 @@ type RefreshResult struct {
 	Session     remotesessions_repo.RemoteSession
 	AccessToken string
 
+	// SourceUpdatedAt is the session snapshot this caller actually refreshed.
+	// Adopted concurrent winners identify their final snapshot instead.
+	SourceUpdatedAt time.Time
+
 	// Outcome is the same closed set the upstream-refresh metric records, so
 	// a caller's log line and the metric series always agree.
 	Outcome remotesessionmetrics.RefreshOutcome
@@ -340,7 +344,7 @@ func (s *RefreshService) refresh(
 		// Revoked while we were acquiring. Refreshing anyway would rotate
 		// tokens upstream that nothing will ever hold.
 		var inactive remotesessions_repo.RemoteSession
-		return RefreshResult{Session: inactive, AccessToken: "", Outcome: remotesessionmetrics.RefreshOutcomeSessionInactive, IssuerURL: ""}, "", nil, nil
+		return RefreshResult{Session: inactive, AccessToken: "", SourceUpdatedAt: time.Time{}, Outcome: remotesessionmetrics.RefreshOutcomeSessionInactive, IssuerURL: ""}, "", nil, nil
 	case currentErr != nil:
 		// Whatever broke this read breaks the write below too, and a refresh we
 		// cannot persist leaves the stored token dead upstream.
@@ -355,7 +359,7 @@ func (s *RefreshService) refresh(
 			if err != nil {
 				return zero, "", nil, fmt.Errorf("decrypt concurrently refreshed access token: %w", err)
 			}
-			return RefreshResult{Session: current, AccessToken: plain, Outcome: remotesessionmetrics.RefreshOutcomeAdoptedConcurrentWinner, IssuerURL: ""}, "", nil, nil
+			return RefreshResult{Session: current, AccessToken: plain, SourceUpdatedAt: current.UpdatedAt.Time, Outcome: remotesessionmetrics.RefreshOutcomeAdoptedConcurrentWinner, IssuerURL: ""}, "", nil, nil
 		}
 	}
 	if !hasRefreshToken(current) {
@@ -402,7 +406,7 @@ func (s *RefreshService) refresh(
 				attr.SlogOAuthResource(updated.Resource.String),
 			)
 		}
-		return RefreshResult{Session: updated, AccessToken: accessToken, Outcome: remotesessionmetrics.RefreshOutcomeRefreshed, IssuerURL: ""}, client.IssuerUrl, &identityRestatement{client: client, tok: tok}, nil
+		return RefreshResult{Session: updated, AccessToken: accessToken, SourceUpdatedAt: sess.UpdatedAt.Time, Outcome: remotesessionmetrics.RefreshOutcomeRefreshed, IssuerURL: ""}, client.IssuerUrl, &identityRestatement{client: client, tok: tok}, nil
 	}
 
 	var tokenRefreshErr *TokenRefreshError
@@ -445,7 +449,7 @@ func (s *RefreshService) refresh(
 		return zero, client.IssuerUrl, nil, refreshErr
 	}
 
-	return RefreshResult{Session: latest, AccessToken: plain, Outcome: remotesessionmetrics.RefreshOutcomeAdoptedConcurrentWinner, IssuerURL: ""}, client.IssuerUrl, nil, nil
+	return RefreshResult{Session: latest, AccessToken: plain, SourceUpdatedAt: latest.UpdatedAt.Time, Outcome: remotesessionmetrics.RefreshOutcomeAdoptedConcurrentWinner, IssuerURL: ""}, client.IssuerUrl, nil, nil
 }
 
 // AccessTokenExpirySkew is the window before access_expires_at within which a
@@ -542,6 +546,6 @@ func (s *RefreshService) awaitRefreshedSession(
 			return zero, false
 		}
 
-		return RefreshResult{Session: latest, AccessToken: plain, Outcome: remotesessionmetrics.RefreshOutcomeAdoptedConcurrentWinner, IssuerURL: ""}, true
+		return RefreshResult{Session: latest, AccessToken: plain, SourceUpdatedAt: latest.UpdatedAt.Time, Outcome: remotesessionmetrics.RefreshOutcomeAdoptedConcurrentWinner, IssuerURL: ""}, true
 	}
 }

--- a/server/internal/remotesessions/refreshservice_metrics_test.go
+++ b/server/internal/remotesessions/refreshservice_metrics_test.go
@@ -3,7 +3,9 @@ package remotesessions_test
 import (
 	"net/http"
 	"testing"
+	"time"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
@@ -11,6 +13,7 @@ import (
 
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/cache"
+	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions/remotesessionmetrics"
 	"github.com/speakeasy-api/gram/server/internal/remotesessions/repo"
@@ -103,9 +106,25 @@ func TestRefreshNow_RecordsRefreshed(t *testing.T) {
 	reader := sdkmetric.NewManualReader()
 	env.refresher = env.newRefresher(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)), cache.NoopCache)
 
+	// Model a replacement landing after the caller loaded its snapshot but
+	// before RefreshNow's post-lock re-read. The replacement is still expired,
+	// so this caller refreshes it rather than adopting it as already live.
+	replacementUpdatedAt := env.session.UpdatedAt.Time.Add(time.Second)
+	require.NoError(t, env.q.SetRemoteSessionUpdatedAt(ctx, repo.SetRemoteSessionUpdatedAtParams{
+		UpdatedAt: pgtype.Timestamptz{Time: replacementUpdatedAt, Valid: true, InfinityModifier: pgtype.Finite},
+		ID:        env.session.ID,
+		ProjectID: conv.ToNullUUID(env.projectID),
+	}))
+	require.NoError(t, env.q.SetRemoteSessionAccessExpiresAt(ctx, repo.SetRemoteSessionAccessExpiresAtParams{
+		AccessExpiresAt: pgtype.Timestamptz{Time: time.Now().Add(-time.Minute), Valid: true, InfinityModifier: pgtype.Finite},
+		ID:              env.session.ID,
+		ProjectID:       conv.ToNullUUID(env.projectID),
+	}))
+
 	result, err := env.refresher.RefreshNow(ctx, env.session, "", remotesessionmetrics.RefreshTriggerRequest)
 	require.NoError(t, err)
 	require.Equal(t, remotesessionmetrics.RefreshOutcomeRefreshed, result.Outcome)
+	require.Equal(t, replacementUpdatedAt, result.SourceUpdatedAt)
 	require.Equal(t, "fresh-access", result.AccessToken)
 	require.Equal(t, "https://idp.example.com", result.IssuerURL)
 

--- a/server/internal/remotesessions/tokenservice.go
+++ b/server/internal/remotesessions/tokenservice.go
@@ -178,8 +178,9 @@ func (m *ChallengeManager) resolveUpstreamToken(
 	}
 
 	// Rebinds sess to the row the token came from, so a refresh that backfilled
-	// a legacy NULL resource routes on this same request.
-	tok, sess, err := m.validateAndRefresh(ctx, sess, resource)
+	// a legacy NULL resource routes on this same request. resolvedFromUpdatedAt
+	// remains the original snapshot only when this resolution won the refresh.
+	tok, sess, resolvedFromUpdatedAt, err := m.validateAndRefresh(ctx, sess, resource)
 	if err != nil {
 		// A known-expired access token with no usable refresh grant is the
 		// ordinary reconnect path. The downstream 401 carries the challenge;
@@ -216,11 +217,12 @@ func (m *ChallengeManager) resolveUpstreamToken(
 	}
 
 	return UpstreamToken{
-		Token:                  tok,
-		Resource:               conv.FromPGTextOrEmpty[string](sess.Resource),
-		RemoteSessionClientID:  clientID,
-		RemoteSessionID:        sess.ID,
-		RemoteSessionUpdatedAt: sess.UpdatedAt.Time,
+		Token:                              tok,
+		Resource:                           conv.FromPGTextOrEmpty[string](sess.Resource),
+		RemoteSessionClientID:              clientID,
+		RemoteSessionID:                    sess.ID,
+		RemoteSessionUpdatedAt:             sess.UpdatedAt.Time,
+		RemoteSessionResolvedFromUpdatedAt: resolvedFromUpdatedAt,
 	}, nil
 }
 
@@ -315,6 +317,10 @@ type UpstreamToken struct {
 	// persisting outcomes from work performed with this credential.
 	RemoteSessionID        uuid.UUID
 	RemoteSessionUpdatedAt time.Time
+
+	// RemoteSessionResolvedFromUpdatedAt identifies the grant snapshot loaded
+	// before token resolution refreshed it.
+	RemoteSessionResolvedFromUpdatedAt time.Time
 }
 
 // ResolveAccessTokens is the variant the MCP serving path calls. It
@@ -454,10 +460,10 @@ func (m *ChallengeManager) validateAndRefresh(
 	ctx context.Context,
 	sess remotesessions_repo.RemoteSession,
 	resource string,
-) (string, remotesessions_repo.RemoteSession, error) {
+) (string, remotesessions_repo.RemoteSession, time.Time, error) {
 	now := time.Now()
 	if !authorizationUsable(sess, now) {
-		return "", sess, ErrNoValidToken
+		return "", sess, sess.UpdatedAt.Time, ErrNoValidToken
 	}
 
 	hasRefresh := hasRefreshToken(sess)
@@ -468,13 +474,13 @@ func (m *ChallengeManager) validateAndRefresh(
 	if accessTokenUsable(sess, now) {
 		plain, err := m.enc.Decrypt(sess.AccessTokenEncrypted)
 		if err != nil {
-			return "", sess, fmt.Errorf("decrypt access token: %w", err)
+			return "", sess, sess.UpdatedAt.Time, fmt.Errorf("decrypt access token: %w", err)
 		}
-		return plain, sess, nil
+		return plain, sess, sess.UpdatedAt.Time, nil
 	}
 
 	if !hasRefresh {
-		return "", sess, ErrNoValidToken
+		return "", sess, sess.UpdatedAt.Time, ErrNoValidToken
 	}
 
 	res, err := m.refresher.RefreshNow(ctx, sess, resource, remotesessionmetrics.RefreshTriggerRequest)
@@ -486,18 +492,20 @@ func (m *ChallengeManager) validateAndRefresh(
 		// nobody is sent to reconnect while holding a token that still works.
 		// Past the deadline there is nothing to fall back to.
 		if !accessTokenLive(sess, time.Now()) {
-			return "", sess, err
+			return "", sess, sess.UpdatedAt.Time, err
 		}
 		plain, derr := m.enc.Decrypt(sess.AccessTokenEncrypted)
 		if derr != nil {
-			return "", sess, fmt.Errorf("decrypt access token after failed refresh: %w", derr)
+			return "", sess, sess.UpdatedAt.Time, fmt.Errorf("decrypt access token after failed refresh: %w", derr)
 		}
 		m.logger.WarnContext(ctx, "remote session refresh failed inside the expiry skew; forwarding the stored access token until its deadline", refreshFailureAttrs(sess, err)...)
-		return plain, sess, nil
+		return plain, sess, sess.UpdatedAt.Time, nil
 	}
+	// SourceUpdatedAt comes from the post-lock snapshot actually refreshed. An
+	// adopted concurrent winner instead identifies its final snapshot.
 	// remotesessionmetrics.RefreshOutcomeSessionInactive lands here as an empty token, which the
 	// caller treats the same as "never linked".
-	return res.AccessToken, res.Session, nil
+	return res.AccessToken, res.Session, res.SourceUpdatedAt, nil
 }
 
 // refreshFailureAttrs is the attribute set a failed request-path refresh is

--- a/server/internal/remotesessions/tokenservice_resolve_test.go
+++ b/server/internal/remotesessions/tokenservice_resolve_test.go
@@ -108,6 +108,7 @@ func tokenCredentials(tokens map[uuid.UUID]remotesessions.UpstreamToken) map[uui
 func tokenCredential(token remotesessions.UpstreamToken) remotesessions.UpstreamToken {
 	token.RemoteSessionID = uuid.Nil
 	token.RemoteSessionUpdatedAt = time.Time{}
+	token.RemoteSessionResolvedFromUpdatedAt = time.Time{}
 	return token
 }
 


### PR DESCRIPTION
AIM-204, part 5 of 5, stacked on #6175.

- `ChallengeManager.CompleteRemoteLogin` returns the redirect plus the committed grant; the MCP callback handler probes it off the request path, holding the redirect up to `AutoVerifyWait` (3s) so a fast member reads Verified on the first render.
- While a probe is still running the card reads "Connected · Verifying…" (`data-validation="pending"`); the page reloads every 2s until nothing is pending, bounded by `ValidationTimeout` via `data-verify-budget-ms`, and only while the deadline can be persisted in sessionStorage (cubic).
- `shouldAutoCloseFirstParty` waits for every probe-capable card to be verified, so a first-party tab no longer closes on an unverified or pending connection.
- `Service.Shutdown` closes admission and drains in-flight probes under one mutex; `start.go` runs it after the HTTP drain on its own 20s context, before `runShutdown` closes the pool (cubic).
- Probes are once per committed grant and do not draw on the per-challenge Verify budget.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically probes a remote session's credential against its upstream MCP server when a connect or reconnect commits its grant, so the consent page shows "Connected · Verifying…" until the verdict lands and a first-party tab waits for verification before closing.

**Behavior changes**
- A fast member's verdict renders on the first page load; slower members keep first-party pages reloading every 2s until the probe finishes or the 15s budget expires (interactive consent pages don't poll, to preserve unsaved tool selections).
- First-party auto-close now waits for all probe-capable cards to be verified instead of closing on an unverified connection.
- Shutdown admits no new probes and drains in-flight ones on a separate 20s budget, so verdicts from work already started are still written.
- Auto-probes run once per committed grant, skip when a different credential replaced it before the probe ran, and are not subject to the manual Re-check's 6/min-per-challenge rate limit.

**Supporting changes**
- `complete` returns the committed grant keyed to session ID and updated-at so verification starts off the request path and follows a token refresh while skipping a concurrently adopted replacement; the redirect carries the verifying client and deadline so the landing page knows when to stop polling.
- Probes route through the same member proxy as real dispatch but strip session/census interceptors and metrics so they never count as traffic.
- A verdict of `unknown` never overwrites a stored `valid`, enforced in the SQL update, and token refresh, reconnect, and soft delete clear the stored verdict.
- The consent script's polling behavior is exercised under Node.js, so the test suite now requires Node installed.

<sup>Written for commit a91f4808f9070b41a5b5ac40e8e937b90da35d28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

