### PR TITLE
feat: bring back the linear setup wizard at /setup/wizard

### DIFF
--- a/.changeset/setup-wizard-route.md
+++ b/.changeset/setup-wizard-route.md
@@ -1,0 +1,5 @@
+---
+"dashboard": minor
+---
+
+Bring back the linear setup wizard at /setup/wizard, walking the board's cards in order, with a header button that swaps between the board and the wizard.

--- a/client/dashboard/src/pages/setup/SetupBoard.tsx
+++ b/client/dashboard/src/pages/setup/SetupBoard.tsx
@@ -34,7 +34,7 @@ type FailedInvite = { email: string; roleId: string };
 
 function BoardPage({ children }: { children: React.ReactNode }): JSX.Element {
   return (
-    <SetupShell>
+    <SetupShell view="board">
       <main className="flex min-h-0 flex-1 overflow-hidden">
         <div className="@container/main mx-auto flex h-full min-h-0 w-full max-w-7xl flex-col gap-4 px-4 py-6 sm:px-6 lg:px-8 [&>div]:mb-0 [&>div]:min-h-0 [&>div]:flex-1">
           <Page.Section>

--- a/client/dashboard/src/pages/setup/SetupTaskPage.tsx
+++ b/client/dashboard/src/pages/setup/SetupTaskPage.tsx
@@ -229,7 +229,7 @@ function SetupTaskPageInner(): JSX.Element {
   }
 
   return (
-    <SetupShell>
+    <SetupShell view="board">
       <JourneyLayout
         rail={
           <StepsRail

--- a/client/dashboard/src/pages/setup/SetupWizard.test.tsx
+++ b/client/dashboard/src/pages/setup/SetupWizard.test.tsx
@@ -293,6 +293,25 @@ describe("SetupWizard", () => {
     await waitFor(() => expect(mocks.navigate).toHaveBeenCalledWith("/org"));
   });
 
+  it("holds the reader's own moves while a completion is settling", () => {
+    mocks.updatePending = true;
+    render(<SetupWizard />);
+
+    // Completing advances once its mutation lands; a move made in that
+    // window would be overwritten a moment later, so none is taken.
+    const previous = screen.getByRole("button", { name: "Previous task" });
+    const skip = screen.getByRole("button", { name: "Skip task" });
+    expect(previous.hasAttribute("disabled")).toBe(true);
+    expect(skip.hasAttribute("disabled")).toBe(true);
+    fireEvent.click(previous);
+    fireEvent.click(skip);
+    fireEvent.click(
+      screen.getByRole("button", { name: /Set up identity provider/ }),
+    );
+
+    expect(mocks.setSearchParams).not.toHaveBeenCalled();
+  });
+
   it("stays put when completing fails", async () => {
     mocks.update.mockRejectedValueOnce(new Error("nope"));
     render(<SetupWizard />);

--- a/client/dashboard/src/pages/setup/SetupWizard.test.tsx
+++ b/client/dashboard/src/pages/setup/SetupWizard.test.tsx
@@ -1,0 +1,354 @@
+import type { ReactNode } from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SetupTask } from "@gram/client/models/components/setuptask.js";
+import SetupWizard from "./SetupWizard";
+import { StepSection } from "./components/step-section";
+
+const mocks = vi.hoisted(() => ({
+  setupQuery: vi.fn(),
+  update: vi.fn(),
+  updatePending: false,
+  invalidate: vi.fn(),
+  goToBoard: vi.fn(),
+  showPylonChat: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+  navigate: vi.fn(),
+  searchParams: new URLSearchParams(),
+  setSearchParams: vi.fn(),
+}));
+
+vi.mock("react-router", () => ({
+  useParams: () => ({ orgSlug: "org" }),
+  useSearchParams: () => [mocks.searchParams, mocks.setSearchParams],
+  useNavigate: () => mocks.navigate,
+}));
+vi.mock("@/routes", () => ({
+  useOrgRoutes: () => ({
+    setup: { goTo: mocks.goToBoard, href: () => "/org/setup" },
+  }),
+}));
+vi.mock("@/components/require-scope", () => ({
+  RequireScope: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock("./components/setup-shell", () => ({
+  SetupShell: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+// A stand-in card with two real StepSections, so the rail is fed the same
+// way the real cards feed it.
+vi.mock("./components/setup-task-content", () => ({
+  SetupTaskContent: ({
+    taskKey,
+    onComplete,
+    onSupport,
+  }: {
+    taskKey: string;
+    onComplete: () => void;
+    onSupport: () => void;
+  }) => (
+    <div>
+      <p>Content for {taskKey}</p>
+      {taskKey !== "anthropic-observability" ? null : (
+        <>
+          <StepSection
+            index={1}
+            slug="publish-marketplace"
+            title="Publish plugin marketplace"
+          >
+            <span>marketplace body</span>
+          </StepSection>
+          <StepSection index={2} slug="confirm-traffic" title="Confirm traffic">
+            <span>traffic body</span>
+          </StepSection>
+        </>
+      )}
+      <button onClick={onComplete}>Complete</button>
+      <button onClick={onSupport}>Get support</button>
+    </div>
+  ),
+}));
+vi.mock("@/hooks/useOrganizationSetupTasks", () => ({
+  useOrganizationSetupTasks: (...args: unknown[]) => mocks.setupQuery(...args),
+}));
+vi.mock("@/contexts/Auth", () => ({
+  useOrganization: () => ({ id: "org-one" }),
+}));
+vi.mock("@tanstack/react-query", () => ({ useQueryClient: () => ({}) }));
+vi.mock("@gram/client/react-query/listSetupTasks.js", () => ({
+  invalidateAllListSetupTasks: (...args: unknown[]) =>
+    mocks.invalidate(...args),
+}));
+vi.mock("@gram/client/react-query/updateSetupTask.js", () => ({
+  useUpdateSetupTaskMutation: () => ({
+    mutateAsync: mocks.update,
+    isPending: mocks.updatePending,
+  }),
+}));
+vi.mock("@/lib/pylon", () => ({ showPylonChat: mocks.showPylonChat }));
+vi.mock("sonner", () => ({
+  toast: { success: mocks.toastSuccess, error: mocks.toastError },
+}));
+
+function task(
+  key: string,
+  title: string,
+  status: SetupTask["status"] = "todo",
+): SetupTask {
+  return {
+    key,
+    title,
+    description: `${title} description`,
+    status,
+    completedByFact: false,
+    blockedBy: [],
+    hidden: false,
+  };
+}
+
+const tasks: SetupTask[] = [
+  task("identity-provider", "Set up identity provider", "done"),
+  task("anthropic-observability", "Set up Anthropic observability"),
+  task("instrument-agents", "Set up observability in other platforms"),
+];
+
+function loaded(list: SetupTask[] = tasks) {
+  return {
+    data: { tasks: list },
+    isPending: false,
+    isSuccess: true,
+    isError: false,
+    refetch: vi.fn(),
+  };
+}
+
+function rail(): HTMLElement {
+  return screen.getByRole("navigation", { name: "Progress" });
+}
+
+/** The ?task= / ?step= the last navigation would have written. */
+function lastParams(): URLSearchParams {
+  const calls = mocks.setSearchParams.mock.calls;
+  const [updater] = calls[calls.length - 1]!;
+  return updater(new URLSearchParams("step=confirm-traffic"));
+}
+
+afterEach(cleanup);
+beforeEach(() => {
+  mocks.updatePending = false;
+  mocks.searchParams = new URLSearchParams();
+  mocks.setSearchParams.mockReset();
+  mocks.navigate.mockReset();
+  mocks.setupQuery.mockReset().mockReturnValue(loaded());
+  mocks.update.mockReset().mockResolvedValue(tasks[1]);
+  mocks.invalidate.mockReset();
+  mocks.goToBoard.mockReset();
+  mocks.showPylonChat.mockReset();
+  mocks.toastSuccess.mockReset();
+  mocks.toastError.mockReset();
+});
+
+describe("SetupWizard", () => {
+  it("lists every card in the rail and opens on the first one still open", () => {
+    render(<SetupWizard />);
+
+    expect(rail().textContent).toContain("Set up identity provider");
+    expect(rail().textContent).toContain("Set up Anthropic observability");
+    expect(rail().textContent).toContain(
+      "Set up observability in other platforms",
+    );
+    expect(screen.getByText("1 of 3 tasks complete")).toBeTruthy();
+    expect(
+      screen.getByText("Content for anthropic-observability"),
+    ).toBeTruthy();
+  });
+
+  it("walks the board's default list, without hidden cards", () => {
+    render(<SetupWizard />);
+
+    expect(mocks.setupQuery).toHaveBeenCalledWith("org-one", false, {
+      retry: false,
+    });
+  });
+
+  it("nests the open card's own sub-steps under it in the rail", () => {
+    render(<SetupWizard />);
+
+    const steps = screen.getByRole("list", { name: "Steps in this task" });
+    expect(steps.textContent).toContain("Publish plugin marketplace");
+    expect(steps.textContent).toContain("Confirm traffic");
+    expect(rail().contains(steps)).toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: /Confirm traffic/ }));
+
+    expect(screen.getByText("traffic body").closest("section")?.hidden).toBe(
+      false,
+    );
+  });
+
+  it("opens on the card named by ?task=, by its URL slug", () => {
+    mocks.searchParams = new URLSearchParams("task=other-platforms");
+    render(<SetupWizard />);
+
+    expect(screen.getByText("Content for instrument-agents")).toBeTruthy();
+  });
+
+  it("falls back to the first open card when ?task= names nothing here", () => {
+    mocks.searchParams = new URLSearchParams("task=no-such-card");
+    render(<SetupWizard />);
+
+    expect(
+      screen.getByText("Content for anthropic-observability"),
+    ).toBeTruthy();
+  });
+
+  it("lands on the last card once every card is done", () => {
+    mocks.setupQuery.mockReturnValue(
+      loaded(tasks.map((t) => ({ ...t, status: "done" }))),
+    );
+    render(<SetupWizard />);
+
+    expect(screen.getByText("Content for instrument-agents")).toBeTruthy();
+    expect(screen.getByText("3 of 3 tasks complete")).toBeTruthy();
+  });
+
+  it("moves between cards from the rail, dropping the outgoing card's step", () => {
+    render(<SetupWizard />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Set up identity provider/ }),
+    );
+
+    const params = lastParams();
+    expect(params.get("task")).toBe("idp");
+    expect(params.get("step")).toBeNull();
+    const [, options] = mocks.setSearchParams.mock.calls.at(-1)!;
+    expect(options).toEqual({ replace: true });
+  });
+
+  it("skips to the next card without touching its status", () => {
+    render(<SetupWizard />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Skip task" }));
+
+    expect(lastParams().get("task")).toBe("other-platforms");
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it("steps back to the previous card", () => {
+    render(<SetupWizard />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Previous task" }));
+
+    expect(lastParams().get("task")).toBe("idp");
+  });
+
+  it("has no previous on the first card and skips to the dashboard from the last", () => {
+    mocks.searchParams = new URLSearchParams("task=idp");
+    const view = render(<SetupWizard />);
+    expect(screen.queryByRole("button", { name: "Previous task" })).toBeNull();
+
+    mocks.searchParams = new URLSearchParams("task=other-platforms");
+    view.rerender(<SetupWizard />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Skip to dashboard" }));
+    expect(mocks.navigate).toHaveBeenCalledWith("/org");
+  });
+
+  it("completes the card and moves on to the next one", async () => {
+    render(<SetupWizard />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Complete" }));
+
+    await waitFor(() =>
+      expect(mocks.update).toHaveBeenCalledWith({
+        request: {
+          updateSetupTaskRequestBody: {
+            taskKey: "anthropic-observability",
+            status: "done",
+          },
+        },
+      }),
+    );
+    await waitFor(() =>
+      expect(lastParams().get("task")).toBe("other-platforms"),
+    );
+    expect(mocks.invalidate).toHaveBeenCalled();
+    expect(mocks.toastSuccess).toHaveBeenCalled();
+    expect(mocks.goToBoard).not.toHaveBeenCalled();
+  });
+
+  it("completes the last card and leaves for the dashboard", async () => {
+    mocks.searchParams = new URLSearchParams("task=other-platforms");
+    render(<SetupWizard />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Complete" }));
+
+    await waitFor(() => expect(mocks.navigate).toHaveBeenCalledWith("/org"));
+  });
+
+  it("stays put when completing fails", async () => {
+    mocks.update.mockRejectedValueOnce(new Error("nope"));
+    render(<SetupWizard />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Complete" }));
+
+    await waitFor(() => expect(mocks.toastError).toHaveBeenCalledWith("nope"));
+    expect(mocks.setSearchParams).not.toHaveBeenCalled();
+    expect(mocks.navigate).not.toHaveBeenCalled();
+  });
+
+  it("persists awaiting support before opening chat and stays on the card", async () => {
+    let finishUpdate = (_value: SetupTask) => {};
+    mocks.update.mockReturnValueOnce(
+      new Promise<SetupTask>((resolve) => {
+        finishUpdate = resolve;
+      }),
+    );
+    render(<SetupWizard />);
+
+    const support = screen.getByRole("button", { name: "Get support" });
+    fireEvent.click(support);
+    fireEvent.click(support);
+
+    expect(mocks.update).toHaveBeenCalledOnce();
+    expect(mocks.showPylonChat).not.toHaveBeenCalled();
+
+    finishUpdate(tasks[1]!);
+    await waitFor(() => expect(mocks.showPylonChat).toHaveBeenCalledOnce());
+    expect(
+      screen.getByText("Content for anthropic-observability"),
+    ).toBeTruthy();
+    expect(mocks.setSearchParams).not.toHaveBeenCalled();
+  });
+
+  it("points at the board when every card is hidden", () => {
+    mocks.setupQuery.mockReturnValue(loaded([]));
+    render(<SetupWizard />);
+
+    expect(screen.getByText("Nothing to set up")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Setup board" }));
+    expect(mocks.goToBoard).toHaveBeenCalledOnce();
+  });
+
+  it("offers a retry when the list fails to load", () => {
+    const refetch = vi.fn();
+    mocks.setupQuery.mockReturnValue({
+      data: undefined,
+      isPending: false,
+      isSuccess: false,
+      isError: true,
+      refetch,
+    });
+    render(<SetupWizard />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(refetch).toHaveBeenCalledOnce();
+  });
+});

--- a/client/dashboard/src/pages/setup/SetupWizard.test.tsx
+++ b/client/dashboard/src/pages/setup/SetupWizard.test.tsx
@@ -308,8 +308,42 @@ describe("SetupWizard", () => {
     fireEvent.click(
       screen.getByRole("button", { name: /Set up identity provider/ }),
     );
+    // The nested sub-step list holds too.
+    const subStep = screen.getByRole("button", { name: /Confirm traffic/ });
+    expect(subStep.hasAttribute("disabled")).toBe(true);
+    fireEvent.click(subStep);
 
     expect(mocks.setSearchParams).not.toHaveBeenCalled();
+  });
+
+  it("keeps holding after the mutation resolves until the refetch lands", async () => {
+    let finishInvalidate = () => {};
+    mocks.invalidate.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        finishInvalidate = resolve;
+      }),
+    );
+    render(<SetupWizard />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Complete" }));
+    await waitFor(() => expect(mocks.invalidate).toHaveBeenCalled());
+
+    // The mutation is done (isPending is false in this suite) but the
+    // completion is still awaiting the refetch before it advances, so a
+    // move now would be overwritten a moment later.
+    const skip = screen.getByRole("button", { name: "Skip task" });
+    expect(skip.hasAttribute("disabled")).toBe(true);
+    fireEvent.click(skip);
+    fireEvent.click(
+      screen.getByRole("button", { name: /Set up identity provider/ }),
+    );
+    expect(mocks.setSearchParams).not.toHaveBeenCalled();
+
+    finishInvalidate();
+    await waitFor(() =>
+      expect(lastParams().get("task")).toBe("other-platforms"),
+    );
+    expect(mocks.setSearchParams).toHaveBeenCalledOnce();
   });
 
   it("stays put when completing fails", async () => {

--- a/client/dashboard/src/pages/setup/SetupWizard.tsx
+++ b/client/dashboard/src/pages/setup/SetupWizard.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router";
 import type {
   SetupTask,
@@ -47,7 +47,11 @@ export default function SetupWizard(): JSX.Element {
 
 // The current card's own sub-steps, nested under it in the rail. Cards with a
 // single section have nothing to walk, so they show nothing extra.
-function CurrentTaskSteps(): JSX.Element | null {
+function CurrentTaskSteps({
+  disabled,
+}: {
+  disabled: boolean;
+}): JSX.Element | null {
   const { steps, activeIndex, setActiveIndex } = useJourneyView();
   if (steps.length < 2) return null;
 
@@ -60,9 +64,10 @@ function CurrentTaskSteps(): JSX.Element | null {
             <button
               type="button"
               aria-current={active ? "step" : undefined}
+              disabled={disabled}
               onClick={() => setActiveIndex(step.index)}
               className={cn(
-                "flex w-full items-center gap-2 text-left text-sm leading-snug",
+                "flex w-full items-center gap-2 text-left text-sm leading-snug disabled:cursor-not-allowed",
                 active
                   ? "text-foreground font-medium"
                   : "text-muted-foreground hover:text-foreground",
@@ -94,10 +99,13 @@ function CurrentTaskSteps(): JSX.Element | null {
 function WizardRail({
   tasks,
   currentKey,
+  disabled,
   onPick,
 }: {
   tasks: SetupTask[];
   currentKey: string | undefined;
+  /** Mirrors WizardNav: no moves while a completion is settling. */
+  disabled: boolean;
   onPick: (task: SetupTask) => void;
 }): JSX.Element {
   const railSteps: Step[] = tasks.map((task) => ({
@@ -105,7 +113,10 @@ function WizardRail({
     title: task.title,
     description: task.description,
     status: task.status === "done" ? "done" : undefined,
-    detail: task.key === currentKey ? <CurrentTaskSteps /> : undefined,
+    detail:
+      task.key === currentKey ? (
+        <CurrentTaskSteps disabled={disabled} />
+      ) : undefined,
   }));
   const currentStep = tasks.findIndex((task) => task.key === currentKey);
   const doneCount = tasks.filter((task) => task.status === "done").length;
@@ -187,8 +198,12 @@ function SetupWizardInner(): JSX.Element {
   });
   const updateTask = useUpdateSetupTaskMutation();
   // Complete and support await a round trip; a second click while the first
-  // is in flight must not fire it again.
+  // is in flight must not fire it again. The ref blocks re-entry within a
+  // render; the state is what the controls read, and it spans the whole
+  // action — mutation and the refetch after it — where `isPending` alone
+  // clears as soon as the mutation resolves.
   const actionInFlight = useRef(false);
+  const [actionSettling, setActionSettling] = useState(false);
 
   const tasks = setupTasks.data?.tasks ?? [];
 
@@ -228,7 +243,7 @@ function SetupWizardInner(): JSX.Element {
   // Completing a card advances once its mutation and refetch land. A
   // reader's own move in that window (Previous, Skip, a rail click) would be
   // overwritten a moment later, so those wait until it has settled.
-  const settling = updateTask.isPending;
+  const settling = actionSettling || updateTask.isPending;
   const pick = (task: SetupTask) => {
     if (settling) return;
     goToTask(task);
@@ -251,10 +266,12 @@ function SetupWizardInner(): JSX.Element {
   const guarded = async (action: () => Promise<void>) => {
     if (updateTask.isPending || actionInFlight.current) return;
     actionInFlight.current = true;
+    setActionSettling(true);
     try {
       await action();
     } finally {
       actionInFlight.current = false;
+      setActionSettling(false);
     }
   };
 
@@ -364,7 +381,12 @@ function SetupWizardInner(): JSX.Element {
       <JourneyStepsProvider key={current?.key ?? "none"}>
         <JourneyLayout
           rail={
-            <WizardRail tasks={tasks} currentKey={current?.key} onPick={pick} />
+            <WizardRail
+              tasks={tasks}
+              currentKey={current?.key}
+              disabled={settling}
+              onPick={pick}
+            />
           }
           loading={setupTasks.isPending}
           skeletonRows={6}

--- a/client/dashboard/src/pages/setup/SetupWizard.tsx
+++ b/client/dashboard/src/pages/setup/SetupWizard.tsx
@@ -1,0 +1,363 @@
+import { useRef } from "react";
+import { useNavigate, useParams, useSearchParams } from "react-router";
+import type {
+  SetupTask,
+  SetupTaskStatus,
+} from "@gram/client/models/components/setuptask.js";
+import type { UpdateSetupTaskRequestBody } from "@gram/client/models/components/updatesetuptaskrequestbody.js";
+import { invalidateAllListSetupTasks } from "@gram/client/react-query/listSetupTasks.js";
+import { useUpdateSetupTaskMutation } from "@gram/client/react-query/updateSetupTask.js";
+import { useQueryClient } from "@tanstack/react-query";
+import { ArrowLeft, ArrowRight, Check } from "lucide-react";
+import { toast } from "sonner";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/Alert";
+import { Button } from "@/components/ui/Button";
+import { RequireScope } from "@/components/require-scope";
+import { useOrganization } from "@/contexts/Auth";
+import { useOrganizationSetupTasks } from "@/hooks/useOrganizationSetupTasks";
+import { showPylonChat } from "@/lib/pylon";
+import { cn } from "@/lib/utils";
+import { useOrgRoutes } from "@/routes";
+import { JourneyLayout } from "./components/journey-layout";
+import { JourneyStepsProvider } from "./components/journey-steps-provider";
+import { useJourneyView } from "./components/journey-steps";
+import { OnboardingStepper, type Step } from "./components/onboarding-stepper";
+import { SetupShell } from "./components/setup-shell";
+import { SetupTaskContent } from "./components/setup-task-content";
+import { setupTaskKeyForSlug, setupTaskSlug } from "./task-slugs";
+
+/** Query parameter naming the card on screen, e.g. ?task=idp. */
+const TASK_PARAM = "task";
+/** The card's own sub-step parameter, owned by JourneyStepsProvider. */
+const STEP_PARAM = "step";
+
+// The linear way through setup: every board card in order, one on screen at
+// a time, for the single owner who wants to do it all in a sitting. The board
+// at /setup stays the default and the map; this page is the same cards walked
+// front to back. Nothing here is a second copy of a card — each one renders
+// through SetupTaskContent exactly as it does on its own page, and only what
+// "done" leads to changes: the next card rather than the board.
+export default function SetupWizard(): JSX.Element {
+  return (
+    <RequireScope scope="org:admin" level="page">
+      <SetupWizardInner />
+    </RequireScope>
+  );
+}
+
+// The current card's own sub-steps, nested under it in the rail. Cards with a
+// single section have nothing to walk, so they show nothing extra.
+function CurrentTaskSteps(): JSX.Element | null {
+  const { steps, activeIndex, setActiveIndex } = useJourneyView();
+  if (steps.length < 2) return null;
+
+  return (
+    <ol className="flex flex-col gap-1.5" aria-label="Steps in this task">
+      {steps.map((step) => {
+        const active = step.index === activeIndex;
+        return (
+          <li key={step.slug}>
+            <button
+              type="button"
+              aria-current={active ? "step" : undefined}
+              onClick={() => setActiveIndex(step.index)}
+              className={cn(
+                "flex w-full items-center gap-2 text-left text-sm leading-snug",
+                active
+                  ? "text-foreground font-medium"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {step.complete ? (
+                <Check
+                  className="text-default-success h-3.5 w-3.5 flex-shrink-0"
+                  strokeWidth={3}
+                  aria-label="Done"
+                />
+              ) : (
+                <span
+                  aria-hidden="true"
+                  className="w-3.5 flex-shrink-0 text-center font-mono text-xs"
+                >
+                  {step.index}
+                </span>
+              )}
+              {step.title}
+            </button>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+function WizardRail({
+  tasks,
+  currentKey,
+  onPick,
+}: {
+  tasks: SetupTask[];
+  currentKey: string | undefined;
+  onPick: (task: SetupTask) => void;
+}): JSX.Element {
+  const railSteps: Step[] = tasks.map((task) => ({
+    id: task.key,
+    title: task.title,
+    description: task.description,
+    status: task.status === "done" ? "done" : undefined,
+    detail: task.key === currentKey ? <CurrentTaskSteps /> : undefined,
+  }));
+  const currentStep = tasks.findIndex((task) => task.key === currentKey);
+  const doneCount = tasks.filter((task) => task.status === "done").length;
+
+  return (
+    <div>
+      <p className="text-eyebrow mb-4">
+        {doneCount} of {tasks.length} tasks complete
+      </p>
+      <OnboardingStepper
+        steps={railSteps}
+        currentStep={currentStep === -1 ? 0 : currentStep}
+        onStepClick={(position) => {
+          const task = tasks[position];
+          if (task) onPick(task);
+        }}
+      />
+    </div>
+  );
+}
+
+// Previous / Skip sit above the card rather than in its footer: the footer
+// belongs to the card (Next step, Mark done, Get support) and is shared with
+// the task page, so the wizard's own moves stay out of it.
+function WizardNav({
+  previous,
+  isLast,
+  onPrevious,
+  onSkip,
+}: {
+  previous: SetupTask | undefined;
+  isLast: boolean;
+  onPrevious: () => void;
+  onSkip: () => void;
+}): JSX.Element {
+  return (
+    <div className="mb-6 flex items-center justify-between gap-3">
+      {previous ? (
+        <Button
+          variant="tertiary"
+          size="sm"
+          onClick={onPrevious}
+          className="text-muted-foreground hover:text-foreground gap-1.5"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Previous task
+        </Button>
+      ) : (
+        <span />
+      )}
+      <Button
+        variant="tertiary"
+        size="sm"
+        onClick={onSkip}
+        className="text-muted-foreground hover:text-foreground gap-1.5"
+      >
+        {isLast ? "Skip to dashboard" : "Skip task"}
+        <ArrowRight className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}
+
+function SetupWizardInner(): JSX.Element {
+  const { orgSlug } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const orgRoutes = useOrgRoutes();
+  const organization = useOrganization();
+  const queryClient = useQueryClient();
+  // Same list the board shows by default: hidden cards stay out of the walk.
+  const setupTasks = useOrganizationSetupTasks(organization.id, false, {
+    retry: false,
+  });
+  const updateTask = useUpdateSetupTaskMutation();
+  // Complete and support await a round trip; a second click while the first
+  // is in flight must not fire it again.
+  const actionInFlight = useRef(false);
+
+  const tasks = setupTasks.data?.tasks ?? [];
+
+  // ?task= names the card on screen, as a URL slug so the address bar reads
+  // like the card's own page. Without one — or with one that names nothing
+  // here — resume at the first card still open; every card done lands on the
+  // last so the reader can see they are finished.
+  const requestedKey = setupTaskKeyForSlug(searchParams.get(TASK_PARAM) ?? "");
+  const requested = tasks.find((task) => task.key === requestedKey);
+  const firstOpen = tasks.find((task) => task.status !== "done");
+  const current = requested ?? firstOpen ?? tasks[tasks.length - 1];
+  const currentIndex = current
+    ? tasks.findIndex((task) => task.key === current.key)
+    : -1;
+  const previous = currentIndex > 0 ? tasks[currentIndex - 1] : undefined;
+  const next =
+    currentIndex >= 0 && currentIndex < tasks.length - 1
+      ? tasks[currentIndex + 1]
+      : undefined;
+
+  // Moving between cards rewrites ?task= and drops the outgoing card's
+  // ?step=, which would otherwise be read as a link into the next card. It
+  // replaces rather than pushes: Back belongs to wherever the reader came
+  // from, not to each card passed through.
+  const goToTask = (task: SetupTask) => {
+    setSearchParams(
+      (prev) => {
+        const params = new URLSearchParams(prev);
+        params.set(TASK_PARAM, setupTaskSlug(task.key));
+        params.delete(STEP_PARAM);
+        return params;
+      },
+      { replace: true },
+    );
+  };
+
+  const leave = () => void navigate(`/${orgSlug}`);
+
+  const advance = () => {
+    if (next) goToTask(next);
+    else leave();
+  };
+
+  const mutate = async (body: UpdateSetupTaskRequestBody) => {
+    await updateTask.mutateAsync({
+      request: { updateSetupTaskRequestBody: body },
+    });
+    await invalidateAllListSetupTasks(queryClient);
+  };
+
+  const guarded = async (action: () => Promise<void>) => {
+    if (updateTask.isPending || actionInFlight.current) return;
+    actionInFlight.current = true;
+    try {
+      await action();
+    } finally {
+      actionInFlight.current = false;
+    }
+  };
+
+  const setStatus = async (
+    status: SetupTaskStatus,
+    fallback: string,
+  ): Promise<boolean> => {
+    if (!current) return false;
+    try {
+      await mutate({ taskKey: current.key, status });
+      return true;
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : fallback);
+      return false;
+    }
+  };
+
+  const complete = () =>
+    guarded(async () => {
+      if (!current) return;
+      if (await setStatus("done", "Failed to complete setup task")) {
+        toast.success(`${current.title} completed`);
+        advance();
+      }
+    });
+
+  const requestSupport = () =>
+    guarded(async () => {
+      if (await setStatus("awaiting_support", "Failed to request support")) {
+        showPylonChat();
+      }
+    });
+
+  let content: JSX.Element | null = null;
+  if (setupTasks.isError) {
+    content = (
+      <Alert variant="error">
+        <div>
+          <AlertTitle>Could not load setup tasks</AlertTitle>
+          <AlertDescription>
+            Try again, or return to the board.
+          </AlertDescription>
+          <div className="mt-3 flex gap-2">
+            <Button
+              variant="secondary"
+              onClick={() => void setupTasks.refetch()}
+            >
+              Retry
+            </Button>
+            <Button variant="tertiary" onClick={() => orgRoutes.setup.goTo()}>
+              Setup board
+            </Button>
+          </div>
+        </div>
+      </Alert>
+    );
+  } else if (setupTasks.isSuccess && !current) {
+    content = (
+      <Alert variant="info">
+        <div>
+          <AlertTitle>Nothing to set up</AlertTitle>
+          <AlertDescription>
+            Every setup task is hidden. Restore one from the board to walk it
+            here.
+          </AlertDescription>
+          <Button
+            className="mt-3"
+            variant="secondary"
+            onClick={() => orgRoutes.setup.goTo()}
+          >
+            Setup board
+          </Button>
+        </div>
+      </Alert>
+    );
+  } else if (current) {
+    content = (
+      <>
+        <WizardNav
+          previous={previous}
+          isLast={!next}
+          onPrevious={() => {
+            if (previous) goToTask(previous);
+          }}
+          onSkip={advance}
+        />
+        <SetupTaskContent
+          taskKey={current.key}
+          projectSlug="default"
+          onComplete={() => void complete()}
+          onSupport={() => void requestSupport()}
+        />
+      </>
+    );
+  }
+
+  return (
+    <SetupShell view="wizard">
+      {/* Keyed by the card: each one has its own sub-steps, so carrying the
+          previous card's active step into the next would land the reader on
+          an unrelated section. The rail lives inside the provider too, so it
+          can nest the current card's sub-steps under it. */}
+      <JourneyStepsProvider key={current?.key ?? "none"}>
+        <JourneyLayout
+          rail={
+            <WizardRail
+              tasks={tasks}
+              currentKey={current?.key}
+              onPick={goToTask}
+            />
+          }
+          loading={setupTasks.isPending}
+          skeletonRows={6}
+        >
+          {content}
+        </JourneyLayout>
+      </JourneyStepsProvider>
+    </SetupShell>
+  );
+}

--- a/client/dashboard/src/pages/setup/SetupWizard.tsx
+++ b/client/dashboard/src/pages/setup/SetupWizard.tsx
@@ -133,11 +133,14 @@ function WizardRail({
 function WizardNav({
   previous,
   isLast,
+  disabled,
   onPrevious,
   onSkip,
 }: {
   previous: SetupTask | undefined;
   isLast: boolean;
+  /** While a completion is in flight its own advance is about to land. */
+  disabled: boolean;
   onPrevious: () => void;
   onSkip: () => void;
 }): JSX.Element {
@@ -148,6 +151,7 @@ function WizardNav({
           variant="tertiary"
           size="sm"
           onClick={onPrevious}
+          disabled={disabled}
           className="text-muted-foreground hover:text-foreground gap-1.5"
         >
           <ArrowLeft className="h-4 w-4" />
@@ -160,6 +164,7 @@ function WizardNav({
         variant="tertiary"
         size="sm"
         onClick={onSkip}
+        disabled={disabled}
         className="text-muted-foreground hover:text-foreground gap-1.5"
       >
         {isLast ? "Skip to dashboard" : "Skip task"}
@@ -218,6 +223,15 @@ function SetupWizardInner(): JSX.Element {
       },
       { replace: true },
     );
+  };
+
+  // Completing a card advances once its mutation and refetch land. A
+  // reader's own move in that window (Previous, Skip, a rail click) would be
+  // overwritten a moment later, so those wait until it has settled.
+  const settling = updateTask.isPending;
+  const pick = (task: SetupTask) => {
+    if (settling) return;
+    goToTask(task);
   };
 
   const leave = () => void navigate(`/${orgSlug}`);
@@ -322,10 +336,14 @@ function SetupWizardInner(): JSX.Element {
         <WizardNav
           previous={previous}
           isLast={!next}
+          disabled={settling}
           onPrevious={() => {
-            if (previous) goToTask(previous);
+            if (previous) pick(previous);
           }}
-          onSkip={advance}
+          onSkip={() => {
+            if (settling) return;
+            advance();
+          }}
         />
         <SetupTaskContent
           taskKey={current.key}
@@ -346,11 +364,7 @@ function SetupWizardInner(): JSX.Element {
       <JourneyStepsProvider key={current?.key ?? "none"}>
         <JourneyLayout
           rail={
-            <WizardRail
-              tasks={tasks}
-              currentKey={current?.key}
-              onPick={goToTask}
-            />
+            <WizardRail tasks={tasks} currentKey={current?.key} onPick={pick} />
           }
           loading={setupTasks.isPending}
           skeletonRows={6}

--- a/client/dashboard/src/pages/setup/components/journey-steps.ts
+++ b/client/dashboard/src/pages/setup/components/journey-steps.ts
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect } from "react";
+import { createContext, useContext, useEffect, useLayoutEffect } from "react";
 
 export interface JourneyStep {
   index: number;
@@ -38,7 +38,10 @@ export function useRegisterJourneyStep(id: string, step: JourneyStep): void {
   const registry = useContext(RegistryContext);
   const { index, slug, title, complete, badge } = step;
 
-  useEffect(() => {
+  // A layout effect so the provider knows every section before the first
+  // paint. With a passive effect the initial mount painted once with no steps
+  // registered: every section hidden and the footer reading "Mark done".
+  useLayoutEffect(() => {
     if (!registry) return;
     registry.register(id, { index, slug, title, complete, badge });
   }, [registry, id, index, slug, title, complete, badge]);

--- a/client/dashboard/src/pages/setup/components/onboarding-header.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-header.tsx
@@ -24,6 +24,7 @@ export function OnboardingHeader({
           </span>
         </div>
         <div className="flex items-center gap-2">
+          {children}
           <Button
             asChild
             variant="tertiary"
@@ -58,7 +59,6 @@ export function OnboardingHeader({
             <span className="hidden lg:inline">Go to dashboard</span>
             <ArrowRight className="h-4 w-4" />
           </Button>
-          {children}
         </div>
       </div>
     </header>

--- a/client/dashboard/src/pages/setup/components/onboarding-stepper.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-stepper.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -13,6 +14,11 @@ export interface Step {
    * this signal, never the step's position relative to the current one.
    */
   status?: "done";
+  /**
+   * Rendered under the description, inside the step's row. The wizard nests
+   * the current card's own sub-steps here so the rail reads as one outline.
+   */
+  detail?: ReactNode;
 }
 
 interface OnboardingStepperProps {
@@ -126,6 +132,7 @@ export function OnboardingStepper({
               >
                 {step.description}
               </p>
+              {step.detail ? <div className="mt-3">{step.detail}</div> : null}
             </div>
           </div>
         );

--- a/client/dashboard/src/pages/setup/components/setup-shell.tsx
+++ b/client/dashboard/src/pages/setup/components/setup-shell.tsx
@@ -2,14 +2,23 @@ import type { ReactNode } from "react";
 import { useNavigate, useParams } from "react-router";
 import { OnboardingFooter } from "./onboarding-footer";
 import { OnboardingHeader } from "./onboarding-header";
+import { SetupViewButton, type SetupView } from "./setup-view-button";
 
-export function SetupShell({ children }: { children: ReactNode }): JSX.Element {
+export function SetupShell({
+  view,
+  children,
+}: {
+  view: SetupView;
+  children: ReactNode;
+}): JSX.Element {
   const navigate = useNavigate();
   const { orgSlug } = useParams();
 
   return (
     <div className="bg-background flex h-screen max-h-dvh flex-col overflow-hidden supports-[height:100dvh]:h-dvh">
-      <OnboardingHeader onLeave={() => void navigate(`/${orgSlug}`)} />
+      <OnboardingHeader onLeave={() => void navigate(`/${orgSlug}`)}>
+        <SetupViewButton view={view} />
+      </OnboardingHeader>
       {children}
       <OnboardingFooter />
     </div>

--- a/client/dashboard/src/pages/setup/components/setup-view-button.test.tsx
+++ b/client/dashboard/src/pages/setup/components/setup-view-button.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/contexts/Sdk", () => ({
+  useSlugs: () => ({ orgSlug: "org", projectSlug: "project" }),
+}));
+
+// The footer's ThemeSwitcher needs a ConfigProvider; this suite is about the
+// header, so stub it out rather than dragging in app-wide context.
+vi.mock("./onboarding-footer", () => ({
+  OnboardingFooter: () => null,
+}));
+
+import { SetupShell } from "./setup-shell";
+import { SetupViewButton } from "./setup-view-button";
+
+function renderAt(path: string, element: JSX.Element) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/:orgSlug/setup" element={element} />
+        <Route path="/:orgSlug/setup/wizard" element={element} />
+        <Route path="/:orgSlug/setup/:taskSlug" element={element} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+afterEach(cleanup);
+
+describe("SetupViewButton", () => {
+  it("offers the wizard from the board", () => {
+    renderAt("/org/setup", <SetupViewButton view="board" />);
+
+    const link = screen.getByRole("link", { name: "Wizard" });
+    expect(link.getAttribute("href")).toBe("/org/setup/wizard");
+  });
+
+  it("carries the open card into the wizard from its page", () => {
+    renderAt("/org/setup/idp", <SetupViewButton view="board" />);
+
+    expect(
+      screen.getByRole("link", { name: "Wizard" }).getAttribute("href"),
+    ).toBe("/org/setup/wizard?task=idp");
+  });
+
+  it("offers the board from the wizard", () => {
+    renderAt("/org/setup/wizard", <SetupViewButton view="wizard" />);
+
+    expect(
+      screen.getByRole("link", { name: "Board" }).getAttribute("href"),
+    ).toBe("/org/setup");
+  });
+});
+
+describe("SetupShell", () => {
+  it("puts the view button in the setup header", () => {
+    renderAt(
+      "/org/setup",
+      <SetupShell view="board">
+        <div>content</div>
+      </SetupShell>,
+    );
+
+    expect(screen.getByRole("banner").textContent).toContain("Wizard");
+    expect(screen.getByText("content")).toBeTruthy();
+  });
+});

--- a/client/dashboard/src/pages/setup/components/setup-view-button.tsx
+++ b/client/dashboard/src/pages/setup/components/setup-view-button.tsx
@@ -1,0 +1,38 @@
+import { LayoutGrid, ListChecks } from "lucide-react";
+import { useParams } from "react-router";
+import { Button } from "@/components/ui/Button";
+import { useOrgRoutes } from "@/routes";
+
+export type SetupView = "board" | "wizard";
+
+// A single discreet control in the setup header that swaps between the two
+// ways through setup: the board (assign and track cards) and the wizard (walk
+// them in order). It always names the view you are not on. From a card's own
+// page it carries that card into the wizard so the reader lands where they
+// were.
+export function SetupViewButton({ view }: { view: SetupView }): JSX.Element {
+  const routes = useOrgRoutes();
+  const { taskSlug } = useParams<{ taskSlug?: string }>();
+  const className =
+    "text-muted-foreground hover:text-foreground inline-flex gap-1.5 hover:no-underline";
+
+  if (view === "wizard") {
+    return (
+      <Button asChild variant="tertiary" size="sm" className={className}>
+        <routes.setup.Link>
+          <LayoutGrid className="h-4 w-4" />
+          Board
+        </routes.setup.Link>
+      </Button>
+    );
+  }
+
+  return (
+    <Button asChild variant="tertiary" size="sm" className={className}>
+      <routes.setupWizard.Link queryParams={taskSlug ? { task: taskSlug } : {}}>
+        <ListChecks className="h-4 w-4" />
+        Wizard
+      </routes.setupWizard.Link>
+    </Button>
+  );
+}

--- a/client/dashboard/src/routes.tsx
+++ b/client/dashboard/src/routes.tsx
@@ -155,6 +155,7 @@ import {
 
 const SetupBoard = React.lazy(() => import("./pages/setup/SetupBoard"));
 const SetupTaskPage = React.lazy(() => import("./pages/setup/SetupTaskPage"));
+const SetupWizard = React.lazy(() => import("./pages/setup/SetupWizard"));
 
 type AppRouteBasic = {
   title: string;
@@ -1476,6 +1477,16 @@ const ORG_ROUTE_STRUCTURE = {
     url: "setup",
     icon: "settings",
     component: SetupBoard,
+    outsideMainLayout: true,
+  },
+  // The linear wizard walks every board card in order, one owner in one
+  // sitting; the board at /setup stays the default. The header's view button
+  // swaps between the two. Static, so it wins over setup/:taskSlug below.
+  setupWizard: {
+    title: "Setup wizard",
+    url: "setup/wizard",
+    icon: "list-checks",
+    component: SetupWizard,
     outsideMainLayout: true,
   },
   // Each board card opens as its own page at a short slug (setup/idp,


### PR DESCRIPTION
## Summary

Brings back a linear way through organization setup at `/setup/wizard`, next to the board at `/setup`, which stays the default.

- **New route and page.** `setupWizard` (`setup/wizard`, org-admin gated, outside the main layout) renders `SetupWizard`, which walks the board's visible cards in order, one on screen at a time. Each card renders through the existing `SetupTaskContent`, so no step component changes and nothing is built twice. The only new semantic is what "Mark done" leads to: the next card rather than the board. Finishing or skipping the last card leaves for the dashboard.
- **Rail.** Lists the cards with their done state and a "N of M tasks complete" count. The current card's own sub-steps nest under it, so the rail reads as one outline. `OnboardingStepper` gains an optional `detail` slot per row for this; nothing else about it changes.
- **Navigation.** `?task=<slug>` names the card on screen using the same slugs as `/setup/<slug>`; without one the wizard resumes at the first card still open. Moving between cards drops the outgoing card's `?step=` so it isn't read as a link into the next one. Previous task and Skip task sit above the card rather than in the shared card footer.
- **Header view button.** A discreet tertiary button in the setup header, styled like Docs and Get support, reads "Wizard" on the board and task pages and "Board" on the wizard. From a card's page it deep-links the wizard to that card. Wired through a `view` prop on `SetupShell`.
- Error and empty states mirror the task page: a retry alert when the list fails, and a pointer back to the board when every card is hidden.

## Motivation

#6202 reshaped setup around outcomes and removed the wizard added in #6098, along with the step components it rendered and the Back/Skip/Continue footer. The board is the right default for an organization where setup is assigned and picked up piecemeal, but a single owner doing it all in a sitting still wants to be walked front to back.

Restoring the old wizard verbatim would have meant resurrecting deleted steps and a second copy of every card, which is the drift #6202 removed. Instead this reuses the task page's machinery: the journey provider already derives a rail from whatever sections a card renders and owns `?step=`, and the shared `StepContainer` footer already routes "Mark done" through a callback. The wizard is a thin driver over those pieces, so the board and wizard cannot disagree about what a card is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoD6WScBss9ETeHs6JaTyy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings back a linear setup wizard at `/setup/wizard` that walks the board's setup cards in order, for a single owner doing setup in one sitting. The board at `/setup` stays the default; both views render cards through the same `SetupTaskContent`, so the wizard adds no second copy of any step — only the "done" action differs, advancing to the next card instead of returning to the board.

**New Features**
- The rail lists every card with its done state and a "N of M tasks complete" count, with the current card's sub-steps nested underneath.
- `?task=<slug>` opens a specific card by its URL slug; without it, the wizard resumes at the first card still open.
- A tertiary header button toggles between "Wizard" and "Board" labels and deep-links the open task page's card into the wizard.
- Previous task and Skip task sit above the card; completing or skipping the last card leaves for the dashboard.

**Bug Fixes**
- Previous, Skip, and rail (including the nested sub-step list) clicks are ignored until a completion fully settles — mutation and refetch — so the completion's own advance is never overwritten.
- Journey sections now register before first paint, so the initial mount never renders with every section hidden and the footer reading "Mark done".

<sup>Written for commit 2ca9cc037e008e82f31d1da62308b9d1700bdca6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

