### PR TITLE
fix: improve catalog branding in dark mode

### DIFF
--- a/client/dashboard/src/components/ui/DotRow/index.tsx
+++ b/client/dashboard/src/components/ui/DotRow/index.tsx
@@ -4,6 +4,8 @@ import { Link } from "react-router";
 
 interface DotRowProps extends React.ComponentPropsWithoutRef<"tr"> {
   icon?: React.ReactNode;
+  iconRailClassName?: string;
+  iconTileClassName?: string;
   /**
    * When set, the whole row becomes a real navigation link. A stretched anchor
    * covers the row so browser semantics (open-in-new-tab, copy link, the
@@ -27,7 +29,16 @@ interface DotRowProps extends React.ComponentPropsWithoutRef<"tr"> {
  */
 export const DotRow = forwardRef<HTMLTableRowElement, DotRowProps>(
   function DotRow(
-    { children, icon, className, href, ariaLabel, ...rest },
+    {
+      children,
+      icon,
+      iconRailClassName,
+      iconTileClassName,
+      className,
+      href,
+      ariaLabel,
+      ...rest
+    },
     ref,
   ): JSX.Element {
     return (
@@ -51,7 +62,12 @@ export const DotRow = forwardRef<HTMLTableRowElement, DotRowProps>(
               className="absolute inset-0 z-10"
             />
           )}
-          <div className="bg-muted/30 text-muted-foreground/20 relative size-17 overflow-hidden">
+          <div
+            className={cn(
+              "bg-muted/30 text-muted-foreground/20 relative size-17 overflow-hidden",
+              iconRailClassName,
+            )}
+          >
             <div
               className="scroll-dots-target absolute inset-0"
               style={{
@@ -62,7 +78,12 @@ export const DotRow = forwardRef<HTMLTableRowElement, DotRowProps>(
             />
             {icon && (
               <div className="absolute inset-0 flex items-center justify-center">
-                <div className="bg-background/90 p-1.5 shadow-sm backdrop-blur-sm dark:bg-neutral-800 dark:backdrop-blur-none">
+                <div
+                  className={cn(
+                    "bg-background/90 p-1.5 shadow-sm backdrop-blur-sm dark:bg-neutral-800 dark:backdrop-blur-none",
+                    iconTileClassName,
+                  )}
+                >
                   {icon}
                 </div>
               </div>

--- a/client/dashboard/src/pages/catalog/AddServerDialog.tsx
+++ b/client/dashboard/src/pages/catalog/AddServerDialog.tsx
@@ -1,3 +1,4 @@
+import { catalogLogoClassName } from "./logo";
 import { Checkbox } from "@/components/ui/Checkbox";
 import { Label } from "@/components/ui/Label";
 import { Text } from "@/components/ui/Text";
@@ -549,7 +550,10 @@ function SelectRemotesPhaseContent({
               <img
                 src={currentConfig.server.iconUrl}
                 alt=""
-                className="h-6 w-6"
+                className={cn(
+                  "h-6 w-6",
+                  catalogLogoClassName(currentConfig.server.registrySpecifier),
+                )}
               />
             ) : (
               <ServerIcon className="text-muted-foreground h-5 w-5" />
@@ -851,7 +855,14 @@ function BatchServerConfig({
             <div className="flex items-center gap-3">
               <div className="bg-primary/10 flex h-6 w-6 shrink-0 items-center justify-center">
                 {config.server.iconUrl ? (
-                  <img src={config.server.iconUrl} alt="" className="h-4 w-4" />
+                  <img
+                    src={config.server.iconUrl}
+                    alt=""
+                    className={cn(
+                      "h-4 w-4",
+                      catalogLogoClassName(config.server.registrySpecifier),
+                    )}
+                  />
                 ) : (
                   <ServerIcon className="text-muted-foreground h-3 w-3" />
                 )}

--- a/client/dashboard/src/pages/catalog/CatalogDetail.tsx
+++ b/client/dashboard/src/pages/catalog/CatalogDetail.tsx
@@ -1,3 +1,5 @@
+import { catalogLogoClassName } from "./logo";
+import { cn } from "@/lib/utils";
 import { Page } from "@/components/page-layout";
 import { Card } from "@/components/ui/Card";
 import { Skeleton } from "@/components/ui/Skeleton";
@@ -257,12 +259,15 @@ export default function CatalogDetail(): JSX.Element {
             <div className="space-y-6 @3xl:col-span-2">
               {/* Header */}
               <div className="flex items-start gap-6">
-                <div className="bg-primary/5 flex h-24 w-24 shrink-0 items-center justify-center dark:bg-neutral-800">
+                <div className="bg-card flex h-24 w-24 shrink-0 items-center justify-center border">
                   {server.iconUrl ? (
                     <img
                       src={server.iconUrl}
                       alt={displayName}
-                      className="h-16 w-16 object-contain"
+                      className={cn(
+                        "h-16 w-16 object-contain",
+                        catalogLogoClassName(server.registrySpecifier),
+                      )}
                     />
                   ) : (
                     <ServerIcon className="text-muted-foreground h-12 w-12" />

--- a/client/dashboard/src/pages/catalog/ServerCard.tsx
+++ b/client/dashboard/src/pages/catalog/ServerCard.tsx
@@ -1,3 +1,5 @@
+import { catalogLogoClassName } from "./logo";
+import { cn } from "@/lib/utils";
 import { ToolCollectionBadge } from "@/components/tool-collection-badge";
 import { Card } from "@/components/ui/Card";
 import { useIconConfetti } from "@/components/icon-confetti";
@@ -60,7 +62,10 @@ export function ServerCard({
             <img
               src={server.iconUrl}
               alt={displayName}
-              className="h-12 w-12 object-contain"
+              className={cn(
+                "h-12 w-12 object-contain",
+                catalogLogoClassName(server.registrySpecifier),
+              )}
             />
           ) : undefined
         }

--- a/client/dashboard/src/pages/catalog/ServerTableRow.tsx
+++ b/client/dashboard/src/pages/catalog/ServerTableRow.tsx
@@ -1,3 +1,5 @@
+import { catalogLogoClassName } from "./logo";
+import { cn } from "@/lib/utils";
 import { ToolCollectionBadge } from "@/components/tool-collection-badge";
 import { DotRow } from "@/components/ui/DotRow";
 import { Text } from "@/components/ui/Text";
@@ -39,12 +41,17 @@ export function ServerTableRow({
     <DotRow
       href={detailHref}
       ariaLabel={`View ${displayName}`}
+      iconRailClassName="bg-surface-secondary-default"
+      iconTileClassName="bg-card dark:bg-card"
       icon={
         server.iconUrl ? (
           <img
             src={server.iconUrl}
             alt={displayName}
-            className="h-6 w-6 object-contain"
+            className={cn(
+              "h-6 w-6 object-contain",
+              catalogLogoClassName(server.registrySpecifier),
+            )}
           />
         ) : undefined
       }

--- a/client/dashboard/src/pages/catalog/logo.ts
+++ b/client/dashboard/src/pages/catalog/logo.ts
@@ -1,0 +1,15 @@
+// These catalog servers use dark logos that need inversion on dark surfaces.
+const DARK_MODE_INVERTED_LOGOS = new Set([
+  "app.linear/linear",
+  "com.pulsemcp.mirror/gram-ordinal-api",
+  "com.pulsemcp.mirror/intercom",
+  "com.pulsemcp.mirror/launchdarkly-mcp-server",
+  "com.pulsemcp.mirror/mercury",
+  "com.pulsemcp.mirror/xdevplatform-xmcp",
+  "com.vercel/vercel-mcp",
+  "io.github.github/github-mcp-server",
+]);
+
+export function catalogLogoClassName(registrySpecifier: string): string {
+  return DARK_MODE_INVERTED_LOGOS.has(registrySpecifier) ? "dark:invert" : "";
+}


### PR DESCRIPTION
GRW-84

## Summary
- Invert an explicit allowlist of eight catalog logos in dark mode, leaving other logos and light mode unchanged.
- Match catalog row logo backgrounds to the newer card styling without changing other tables.
- Match the detail-page logo background and border to the card tile.

## Motivation
Dark catalog logos disappear against dark surfaces, and logo containers differ between catalog views. Use a small exact-ID allowlist and shared theme tokens rather than changing assets or detecting logo colors automatically.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dark catalog logos disappearing on dark surfaces by inverting an exact allowlist of eight logos in dark mode and aligning logo-container styling across catalog views.

- Inverts Linear, Vercel, Launch Darkly, GitHub, Mercury, Intercom, X, and Ordinal API logos only in dark mode; light mode and all other logos are unchanged.
- Matches the catalog table-row logo rail and tile backgrounds to the newer card styling without affecting other tables.
- Matches the detail-page logo background and border to the card tile.

<sup>Written for commit 614c3e154e8fbba00c2a610f6259f2fe35f0bacc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

