### PR TITLE
chore: build the assistant runtime image on GitHub-hosted runners

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -464,7 +464,12 @@ jobs:
           docker run --rm ${{ steps.build.outputs.image-tag }} --help
 
   assistant-runtime-image:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # TEMPORARY: on GitHub-hosted runners (and so on upstream checkout/buildx/
+    # build-push actions) because Blacksmith runners cannot reach the Ubuntu apt
+    # mirrors, which breaks the musl toolchain install below. Move back to
+    # blacksmith-4vcpu-ubuntu-2404 (and the useblacksmith/* actions) once their
+    # egress is fixed, or once the musl toolchain no longer comes from apt.
+    runs-on: ubuntu-24.04
     needs: [changes]
     if: needs.changes.outputs.server == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]')
     env:
@@ -472,7 +477,7 @@ jobs:
       RUNNER_BINARY_DIR: /tmp/runner-binary
     steps:
       - name: Checkout
-        uses: useblacksmith/checkout@6fd481652155169ed4d2f25ebaf97464f685175f # v1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Mise
         uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
@@ -539,13 +544,7 @@ jobs:
           echo "hash=$hash" >> "$GITHUB_OUTPUT"
 
       - name: Setup Docker builder
-        # Skip on fork PRs: untrusted code must not commit to the shared sticky
-        # disk. The build step below then falls back to the default builder and
-        # simply runs uncached.
-        if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
-        uses: useblacksmith/setup-docker-builder@a5256a73e30f09e37e3eceb8ca36043d17621d24 # v2.1.0
-        with:
-          cache-key: gram/assistant-runtime-image
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to Docker Hub
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -596,10 +595,7 @@ jobs:
             type=sha,format=long
 
       - name: Build and push assistant runtime image to GCR
-        # Blacksmith fork of docker/build-push-action, paired with the
-        # setup-docker-builder step above: buildkit runs on a sticky-disk
-        # cache so the bun/lightpanda/apt layers persist across runs.
-        uses: useblacksmith/build-push-action@9b0579bbec7a6cad2f171596c57e7ac1e7658850 # v2.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           # build-contexts and build-args travel together: the arg switches the

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -475,6 +475,9 @@ jobs:
     env:
       RUNNER_TARGET: x86_64-unknown-linux-musl
       RUNNER_BINARY_DIR: /tmp/runner-binary
+      # This job runs GitHub-hosted, so keep its cache keys out of the
+      # Blacksmith-backed CI namespace (see .mise-tasks/github/pre-cache.mts).
+      CACHE_NAMESPACE: github-v1
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -485,7 +488,7 @@ jobs:
           minimum_release_age: 1d
           install: true
           cache: true
-          cache_key_prefix: mise-blacksmith-v1
+          cache_key_prefix: mise-github-v1
           env: false
 
       - name: Prepare GitHub Actions environment


### PR DESCRIPTION
## Summary

Move the `assistant-runtime-image` job in `pr.yaml` from `blacksmith-4vcpu-ubuntu-2404` to `ubuntu-24.04`, and swap the three Blacksmith actions it used for their upstream equivalents (already pinned elsewhere in this repo):

- `useblacksmith/checkout` → `actions/checkout`
- `useblacksmith/setup-docker-builder` → `docker/setup-buildx-action`
- `useblacksmith/build-push-action` → `docker/build-push-action`

The fork guard on the builder step goes away with it: it existed so untrusted fork code could not write to the shared sticky disk, and there is no shared disk on the upstream buildx builder.

Marked TEMPORARY in a comment on the job, with the revert conditions.

## Motivation

Every run of this job has failed since this morning, on unrelated branches and in the merge queue. The `Install musl toolchain` step cannot reach the Ubuntu apt mirrors from a Blacksmith runner:

```
W: Failed to fetch mirror+file:/etc/apt/blacksmith-ubuntu-mirrors.txt/dists/noble/InRelease  Connection failed
E: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/universe/m/musl/musl-tools_1.2.4-2_amd64.deb  Connection failed
E: Unable to fetch some archives
```

Every later step is skipped, so `CI Gate` fails and nothing merges. GitHub-hosted runners have a different egress path and can install the package.

The toolchain is not optional here: the runtime image is `debian:bookworm-slim` (glibc 2.36) while the runner host is Ubuntu 24.04 (glibc 2.39), so the binary is built static against musl — and `aws-lc-sys` (via `opentelemetry-otlp`'s `tls-aws-lc` feature) needs a musl C cross-toolchain to compile.

Trade-off: this job loses the sticky-disk buildkit cache, so the bun/lightpanda/apt layers rebuild on every run. The cargo cache is unaffected. Revert to Blacksmith once their egress is fixed; the durable fix is to stop sourcing the musl toolchain from apt at all (e.g. zig + `cargo-zigbuild`, or building the binary in the Dockerfile).

https://claude.ai/code/session_01FvK1gKWfQeirDzwC4bDQV7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the `assistant-runtime-image` job from Blacksmith runners to GitHub-hosted runners because Blacksmith runners can't reach Ubuntu apt mirrors, which broke the musl toolchain install and blocked CI.

- Swaps the three `useblacksmith/*` actions for upstream equivalents (`actions/checkout`, `docker/setup-buildx-action`, `docker/build-push-action`).
- Removes the fork guard on the builder step; there's no shared sticky disk on the upstream buildx builder.
- Loses the sticky-disk buildkit cache, so bun/lightpanda/apt layers rebuild each run; cargo cache is unaffected.
- Sets `CACHE_NAMESPACE` to `github-v1` and updates the mise cache key prefix to match, because `mise run github` requires an explicit namespace on GitHub-hosted runners (same pairing as `release.yaml`).
- Marked TEMPORARY with revert conditions documented in the workflow.

<sup>Written for commit 47ec5776d58718d72fea4bbbf62f09c457aa9113. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

