### PR TITLE
fix: explain conflicting role blocks and restore annotation narrowing on MCP team access

### DIFF
--- a/client/dashboard/src/pages/mcp/MCPTeamAccessTab.tsx
+++ b/client/dashboard/src/pages/mcp/MCPTeamAccessTab.tsx
@@ -330,10 +330,11 @@ export function MCPTeamAccessTab({
                 <Heading variant="h4">Conflicting roles</Heading>
               </div>
               <Text muted small className="mt-1">
-                These people are granted access through one role and blocked by
-                another role they are also in. A block outranks every grant, so
-                they cannot reach this server. To fix it, remove them from the
-                role that blocks access on that role&rsquo;s page.
+                These people are granted access through one rule and blocked by
+                another. A block outranks every grant, so they cannot reach this
+                server. To fix it, remove the block: on the blocking
+                role&rsquo;s page, or from the list above when it names the
+                person directly.
               </Text>
             </div>
             <Table columns={conflictColumns}>

--- a/client/dashboard/src/pages/mcp/MCPTeamAccessTab.tsx
+++ b/client/dashboard/src/pages/mcp/MCPTeamAccessTab.tsx
@@ -11,6 +11,7 @@ import { Column, Table } from "@/components/ui/Table";
 import { Text } from "@/components/ui/Text";
 import type { ToolAnnotation } from "@/components/tool-selection/ToolSelectionPanel";
 import type { Tool } from "@/lib/toolTypes";
+import { TriangleAlert } from "lucide-react";
 import type { AccessMember } from "@gram/client/models/components/accessmember.js";
 import type { ResourceAudienceEntry } from "@gram/client/models/components/resourceaudienceentry.js";
 import { useMembers } from "@gram/client/react-query/members.js";
@@ -318,7 +319,16 @@ export function MCPTeamAccessTab({
         {!audienceFailed && conflicts.length > 0 && (
           <>
             <div className="mt-10 mb-4">
-              <Heading variant="h4">Conflicting roles</Heading>
+              {/* The one section on this page reporting something wrong
+                  rather than something configured, so it is marked as such
+                  before the heading is read. */}
+              <div className="flex items-center gap-2">
+                <TriangleAlert
+                  className="h-4 w-4 shrink-0 text-amber-500"
+                  aria-hidden
+                />
+                <Heading variant="h4">Conflicting roles</Heading>
+              </div>
               <Text muted small className="mt-1">
                 These people are granted access through one role and blocked by
                 another role they are also in. A block outranks every grant, so

--- a/client/dashboard/src/pages/mcp/MCPTeamAccessTab.tsx
+++ b/client/dashboard/src/pages/mcp/MCPTeamAccessTab.tsx
@@ -17,7 +17,9 @@ import { useMembers } from "@gram/client/react-query/members.js";
 import { useResourceAudience } from "@gram/client/react-query/resourceAudience.js";
 import { useMemo, type ReactElement } from "react";
 import { ManageAccess } from "./access/ManageAccess";
+import { RoleLink } from "./access/RoleLink";
 import {
+  blockingRules,
   effectiveReach,
   LEVEL_VERB,
   type AudienceLevel,
@@ -48,6 +50,23 @@ function getInitials(name: string) {
 interface MemberAccess {
   member: AccessMember;
   reach: EffectiveReach;
+}
+
+/** A rule named on a row, linked when it is a role someone can go and edit. */
+interface NamedRule {
+  principalUrn: string;
+  displayName: string;
+}
+
+/**
+ * Someone two rules disagree about: a role gives them the server and another
+ * role they are also in takes it away. A block outranks every grant, so the
+ * grant does nothing — which is invisible from either role's own page.
+ */
+interface MemberConflict {
+  member: AccessMember;
+  grantedBy: NamedRule[];
+  blockedBy: NamedRule[];
 }
 
 // MCPTeamAccessTab renders who can use one MCP server, for any server
@@ -123,36 +142,61 @@ export function MCPTeamAccessTab({
       .sort((a, b) => a.member.name.localeCompare(b.member.name));
   }, [membersData?.members, entries, toolCatalog]);
 
+  // The people two rules disagree about. They are not in the list above —
+  // nothing they were given survives — and an absence explains nothing, so
+  // they get a section that names both rules and says how to resolve it.
+  const conflicts = useMemo((): MemberConflict[] => {
+    const members = membersData?.members ?? [];
+    const reaching = new Map<string, ResourceAudienceEntry[]>();
+    for (const entry of entries) {
+      for (const memberId of entry.memberIds ?? []) {
+        reaching.set(memberId, [...(reaching.get(memberId) ?? []), entry]);
+      }
+    }
+
+    const named = (rules: ResourceAudienceEntry[]): NamedRule[] => {
+      const byUrn = new Map<string, NamedRule>();
+      for (const rule of rules) {
+        byUrn.set(rule.principalUrn, {
+          principalUrn: rule.principalUrn,
+          displayName: rule.displayName,
+        });
+      }
+      return [...byUrn.values()];
+    };
+
+    return members
+      .map((member) => {
+        const rules = reaching.get(member.id) ?? [];
+        const blocks = blockingRules(rules);
+        // A grant they never had is not a conflict, it is just no access.
+        if (blocks.length === 0) return null;
+        const blockedBy = named(blocks);
+        const blocking = new Set(blockedBy.map((rule) => rule.principalUrn));
+        // Only the roles the conflict is with. A role that both grants the
+        // server organization-wide and blocks it here is arguing with itself,
+        // not with another role, and naming it on both sides of the row would
+        // read as a contradiction rather than a thing to go and fix.
+        const grantedBy = named(
+          rules.filter(
+            (rule) =>
+              !rule.level.startsWith("blocked") &&
+              !blocking.has(rule.principalUrn),
+          ),
+        );
+        if (grantedBy.length === 0) return null;
+        return { member, grantedBy, blockedBy };
+      })
+      .filter((row): row is MemberConflict => row !== null)
+      .sort((a, b) => a.member.name.localeCompare(b.member.name));
+  }, [membersData?.members, entries]);
+
   const memberColumns: Column<MemberAccess>[] = [
     {
       key: "member",
       header: "Person",
       width: "300px",
-      render: (row) => (
-        <div className="flex items-center gap-3">
-          <Avatar className="h-8 w-8">
-            {row.member.photoUrl && (
-              <AvatarImage src={row.member.photoUrl} alt={row.member.name} />
-            )}
-            <AvatarFallback className="text-xs">
-              {getInitials(row.member.name)}
-            </AvatarFallback>
-          </Avatar>
-          <div className="min-w-0">
-            <IdentityLink identifier={{ userId: row.member.id }}>
-              <Text variant="body" className="truncate font-medium">
-                {row.member.name}
-              </Text>
-            </IdentityLink>
-            <Text
-              variant="body"
-              className="text-muted-foreground truncate text-xs"
-            >
-              {row.member.email}
-            </Text>
-          </div>
-        </div>
-      ),
+      render: (row) => <PersonCell member={row.member} />,
     },
     {
       key: "platform",
@@ -176,56 +220,40 @@ export function MCPTeamAccessTab({
       // Tool access is about connect: view and manage are server-level, and
       // both satisfy a connect check, so an unnarrowed rule at any level
       // reaches every tool.
-      render: (row) => (
-        <div className="min-w-0 space-y-0.5">
-          {row.reach.reachableTools.length > 0 ? (
-            // The count is the answer; the names are what someone hovers to
-            // check, and there is no room for them in the cell.
-            <Tooltip delayDuration={0}>
-              <TooltipTrigger asChild>
-                <Text
-                  variant="body"
-                  className="cursor-help text-sm underline decoration-dotted underline-offset-4"
-                >
-                  {row.reach.toolsLabel}
-                </Text>
-              </TooltipTrigger>
-              <TooltipContent>
-                {row.reach.reachableTools.join(", ")}
-              </TooltipContent>
-            </Tooltip>
-          ) : (
-            <Text variant="body" className="text-sm">
-              {row.reach.toolsLabel}
-            </Text>
-          )}
-          {row.reach.scopedLevels.map((scoped) => (
-            <Text key={scoped.id} muted small>
-              {scoped.label}
-            </Text>
-          ))}
-          {row.reach.excluded.map((excluded) => (
-            <Text key={excluded.id} muted small>
-              except {excluded.label}
-            </Text>
-          ))}
-        </div>
-      ),
+      render: (row) => <MCPAccessCell reach={row.reach} />,
     },
     {
       key: "via",
       header: "Granted by",
       width: "200px",
-      render: (row) => {
-        const names = row.reach.grantedBy.join(", ");
-        // Roles wrap rather than truncate: which role opened a server is the
-        // answer someone came to this table for.
-        return (
-          <Text variant="body" className="text-sm break-words">
-            {names}
-          </Text>
-        );
-      },
+      // Roles wrap rather than truncate: which role opened a server is the
+      // answer someone came to this table for.
+      render: (row) => (
+        <Text variant="body" className="text-sm break-words">
+          {row.reach.grantedBy.join(", ")}
+        </Text>
+      ),
+    },
+  ];
+
+  const conflictColumns: Column<MemberConflict>[] = [
+    {
+      key: "member",
+      header: "Person",
+      width: "300px",
+      render: (row) => <PersonCell member={row.member} />,
+    },
+    {
+      key: "granted",
+      header: "Granted by",
+      width: "1fr",
+      render: (row) => <RuleNames rules={row.grantedBy} />,
+    },
+    {
+      key: "blocked",
+      header: "Blocked by",
+      width: "1fr",
+      render: (row) => <RuleNames rules={row.blockedBy} />,
     },
   ];
 
@@ -283,8 +311,116 @@ export function MCPTeamAccessTab({
             )}
           </Table>
         )}
+
+        {/* Two rules disagreeing about the same person. They are missing from
+            the list above and nothing there says why, so the pair is named
+            here along with the only place either can be changed. */}
+        {!audienceFailed && conflicts.length > 0 && (
+          <>
+            <div className="mt-10 mb-4">
+              <Heading variant="h4">Conflicting roles</Heading>
+              <Text muted small className="mt-1">
+                These people are granted access through one role and blocked by
+                another role they are also in. A block outranks every grant, so
+                they cannot reach this server. To fix it, remove them from the
+                role that blocks access on that role&rsquo;s page.
+              </Text>
+            </div>
+            <Table columns={conflictColumns}>
+              <Table.Header columns={conflictColumns} />
+              <Table.Body
+                columns={conflictColumns}
+                data={conflicts}
+                rowKey={(row) => row.member.id}
+              />
+            </Table>
+          </>
+        )}
       </Page.Section.Body>
     </Page.Section>
+  );
+}
+
+/** The person a row is about: avatar, name, and the address that identifies them. */
+function PersonCell({ member }: { member: AccessMember }): ReactElement {
+  return (
+    <div className="flex items-center gap-3">
+      <Avatar className="h-8 w-8">
+        {member.photoUrl && (
+          <AvatarImage src={member.photoUrl} alt={member.name} />
+        )}
+        <AvatarFallback className="text-xs">
+          {getInitials(member.name)}
+        </AvatarFallback>
+      </Avatar>
+      <div className="min-w-0">
+        <IdentityLink identifier={{ userId: member.id }}>
+          <Text variant="body" className="truncate font-medium">
+            {member.name}
+          </Text>
+        </IdentityLink>
+        <Text variant="body" className="text-muted-foreground truncate text-xs">
+          {member.email}
+        </Text>
+      </div>
+    </div>
+  );
+}
+
+/** Rules named on a conflict row, linked when the rule lives on a role. */
+function RuleNames({ rules }: { rules: NamedRule[] }): ReactElement {
+  return (
+    <Text variant="body" className="text-sm break-words">
+      {rules.map((rule, index) => (
+        <span key={rule.principalUrn}>
+          {index > 0 && ", "}
+          {rule.principalUrn.startsWith("role:") ? (
+            <RoleLink principalUrn={rule.principalUrn}>
+              {rule.displayName}
+            </RoleLink>
+          ) : (
+            rule.displayName
+          )}
+        </span>
+      ))}
+    </Text>
+  );
+}
+
+/** How far one person's connect access reaches inside the server. */
+function MCPAccessCell({ reach }: { reach: EffectiveReach }): ReactElement {
+  return (
+    <div className="min-w-0 space-y-0.5">
+      {reach.reachableTools.length > 0 ? (
+        // The count is the answer; the names are what someone hovers to
+        // check, and there is no room for them in the cell.
+        <Tooltip delayDuration={0}>
+          <TooltipTrigger asChild>
+            <Text
+              variant="body"
+              className="cursor-help text-sm underline decoration-dotted underline-offset-4"
+            >
+              {reach.toolsLabel}
+            </Text>
+          </TooltipTrigger>
+          <TooltipContent>{reach.reachableTools.join(", ")}</TooltipContent>
+        </Tooltip>
+      ) : (
+        <Text variant="body" className="text-sm">
+          {reach.toolsLabel}
+        </Text>
+      )}
+      {reach.scopedLevels.map((scoped) => (
+        <Text key={scoped.id} muted small>
+          {scoped.label}
+        </Text>
+      ))}
+      {reach.excluded.map((excluded) => (
+        <Text key={excluded.id} muted small>
+          except {excluded.label}
+        </Text>
+      ))}
+    </div>
   );
 }
 

--- a/client/dashboard/src/pages/mcp/access/ManageAccess.tsx
+++ b/client/dashboard/src/pages/mcp/access/ManageAccess.tsx
@@ -20,7 +20,7 @@ import {
 import { SkeletonTable } from "@/components/ui/Skeleton";
 import { Text } from "@/components/ui/Text";
 import { useOrgRoutes } from "@/routes";
-import { Link, useNavigate } from "react-router";
+import { useNavigate } from "react-router";
 import type { SetResourceAudienceEntry } from "@gram/client/models/components/setresourceaudienceentry.js";
 import type { ResourceAudienceEntry } from "@gram/client/models/components/resourceaudienceentry.js";
 import { invalidateAllResourceAudience } from "@gram/client/react-query/resourceAudience.js";
@@ -36,13 +36,7 @@ import {
   Trash2,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import {
-  useMemo,
-  useState,
-  type ComponentProps,
-  type JSX,
-  type ReactNode,
-} from "react";
+import { useMemo, useState, type ComponentProps, type JSX } from "react";
 import { toast } from "sonner";
 import { AddAudienceDialog } from "./AddAudienceDialog";
 import { RemoveAudienceDialog } from "./RemoveAudienceDialog";
@@ -61,13 +55,16 @@ import {
 } from "./accessRows";
 import {
   addPrincipalsWrite,
+  allowDestructiveWrite,
   allowWrite,
+  blockDestructiveWrite,
   narrowingSeed,
   narrowWrite,
   revokeRowWrite,
   revokeScopeWrite,
   type AudienceWrite,
 } from "./accessWrites";
+import { RoleLink } from "./RoleLink";
 import { ownRules, LEVEL_VERB } from "./serverAudience";
 
 /** Narrowing the tool dialog is currently editing, and the row it belongs to. */
@@ -325,7 +322,6 @@ export function ManageAccess({
                   .map((id) => facesById.get(id))
                   .filter((member) => member !== undefined)}
                 catalog={toolCatalog ?? []}
-                hasCatalog={Boolean(toolCatalog)}
                 onAllow={(scope) =>
                   applyWrite(allowWrite(direct, row, scope, resourceName))
                 }
@@ -333,6 +329,12 @@ export function ManageAccess({
                   applyWrite(revokeScopeWrite(direct, row, scope, resourceName))
                 }
                 onNarrow={() => openNarrowing(row)}
+                onBlockDestructive={() =>
+                  applyWrite(blockDestructiveWrite(direct, row, resourceName))
+                }
+                onAllowDestructive={() =>
+                  applyWrite(allowDestructiveWrite(direct, row, resourceName))
+                }
                 onRevoke={() => removeRow(row)}
                 onEditRole={() => editRole(row)}
                 canManage={canManage}
@@ -441,10 +443,11 @@ function PrincipalRow({
   row,
   faces,
   catalog,
-  hasCatalog,
   onAllow,
   onRevokeScope,
   onNarrow,
+  onBlockDestructive,
+  onAllowDestructive,
   onRevoke,
   onEditRole,
   canManage,
@@ -455,10 +458,11 @@ function PrincipalRow({
   faces: FacepileMember[];
   /** The server's tools, for resolving what a rule and a block leave. */
   catalog: ToolSelectionTool[];
-  hasCatalog: boolean;
   onAllow: (scope: ScopeKey) => void;
   onRevokeScope: (scope: ScopeKey) => void;
   onNarrow: () => void;
+  onBlockDestructive: () => void;
+  onAllowDestructive: () => void;
   onRevoke: () => void;
   onEditRole: () => void;
   canManage: boolean;
@@ -557,10 +561,11 @@ function PrincipalRow({
                   row={row}
                   scope={key}
                   catalog={catalog}
-                  hasCatalog={hasCatalog}
                   onAllow={() => onAllow(key)}
                   onRevoke={() => onRevokeScope(key)}
                   onNarrow={onNarrow}
+                  onBlockDestructive={onBlockDestructive}
+                  onAllowDestructive={onAllowDestructive}
                   pending={pending}
                 />
               ))}
@@ -592,10 +597,11 @@ function ScopeLine({
   row,
   scope,
   catalog,
-  hasCatalog,
   onAllow,
   onRevoke,
   onNarrow,
+  onBlockDestructive,
+  onAllowDestructive,
   pending,
 }: {
   label: string;
@@ -605,10 +611,11 @@ function ScopeLine({
   scope: ScopeKey;
   /** The server's tools, for resolving what a rule and a block leave. */
   catalog: ToolSelectionTool[];
-  hasCatalog: boolean;
   onAllow: () => void;
   onRevoke: () => void;
   onNarrow: () => void;
+  onBlockDestructive: () => void;
+  onAllowDestructive: () => void;
   pending: boolean;
 }): JSX.Element {
   const state = scopeState(row, scope, catalog);
@@ -616,10 +623,11 @@ function ScopeLine({
     row,
     scope,
     catalog,
-    hasCatalog,
     onAllow,
     onRevoke,
     onNarrow,
+    onBlockDestructive,
+    onAllowDestructive,
   });
 
   return (
@@ -677,18 +685,20 @@ function scopeOptions({
   row,
   scope,
   catalog,
-  hasCatalog,
   onAllow,
   onRevoke,
   onNarrow,
+  onBlockDestructive,
+  onAllowDestructive,
 }: {
   row: AccessRow;
   scope: ScopeKey;
   catalog: ToolSelectionTool[];
-  hasCatalog: boolean;
   onAllow: () => void;
   onRevoke: () => void;
   onNarrow: () => void;
+  onBlockDestructive: () => void;
+  onAllowDestructive: () => void;
 }): InlineChoiceOption[] {
   const state = scopeState(row, scope, catalog);
   // A block this row cannot lift closes the line, and nothing granted here
@@ -708,15 +718,45 @@ function scopeOptions({
   const options: InlineChoiceOption[] = state.capped
     ? []
     : [{ label: "All tools", onSelect: onAllow }];
-  // Narrowing an organization-wide rule has to name the tools it takes away,
-  // so a server that does not publish a catalogue cannot offer it.
-  if (!state.subtracts || hasCatalog) {
-    options.push({ label: "Specific tools\u2026", onSelect: onNarrow });
+  options.push({ label: "Specific tools\u2026", onSelect: onNarrow });
+  // Keeping someone off the destructive tools is the common restriction, and
+  // an annotation expresses it without a catalogue: it keeps covering tools
+  // added later, so it is offered on every server rather than only the ones
+  // that publish their tools.
+  if (state.granted) {
+    if (ownDestructiveBlock(row)) {
+      options.push({
+        label: "Allow destructive tools",
+        onSelect: onAllowDestructive,
+      });
+    } else if (!destructiveBlock(row)) {
+      options.push({
+        label: "Block destructive tools",
+        onSelect: onBlockDestructive,
+      });
+    }
   }
   if (state.canRevoke) {
     options.push({ label: "No access", onSelect: onRevoke });
   }
   return options;
+}
+
+/** A block on this row's connect line that names the destructive annotation. */
+function destructiveBlock(row: AccessRow) {
+  return row.cells.use.blocks.find((block) =>
+    (block.dispositions ?? []).includes("destructive"),
+  );
+}
+
+/** That block, when it is the rule this page owns and can therefore lift. */
+function ownDestructiveBlock(row: AccessRow) {
+  const block = destructiveBlock(row);
+  return block &&
+    block.principalUrn === row.principalUrn &&
+    block.appliesTo === "resource"
+    ? block
+    : undefined;
 }
 
 /** What kind of thing a row names, so a role does not read as a person. */
@@ -790,23 +830,3 @@ function IconAction({
  * A role name that goes to the role. The rule behind a line often lives on a
  * role, and the name is what a reader reaches for to go and change it.
  */
-function RoleLink({
-  principalUrn,
-  children,
-}: {
-  principalUrn: string;
-  children: ReactNode;
-}): JSX.Element {
-  const orgRoutes = useOrgRoutes();
-  const roleId = principalUrn.split(":").pop();
-  if (!roleId) return <>{children}</>;
-  return (
-    <Link
-      to={`${orgRoutes.access.roles.href()}/${roleId}/edit`}
-      className="underline decoration-dotted underline-offset-4 hover:decoration-solid"
-      onClick={(event) => event.stopPropagation()}
-    >
-      {children}
-    </Link>
-  );
-}

--- a/client/dashboard/src/pages/mcp/access/ManageAccess.tsx
+++ b/client/dashboard/src/pages/mcp/access/ManageAccess.tsx
@@ -723,13 +723,16 @@ function scopeOptions({
   // an annotation expresses it without a catalogue: it keeps covering tools
   // added later, so it is offered on every server rather than only the ones
   // that publish their tools.
+  // Both forms rewrite the whole block, so neither is offered while another
+  // restriction is standing there — the shortcut would take that restriction
+  // away without saying so. "Specific tools…" edits those rows instead.
   if (state.granted) {
-    if (ownDestructiveBlock(row)) {
+    if (ownDestructiveBlockOnly(row)) {
       options.push({
         label: "Allow destructive tools",
         onSelect: onAllowDestructive,
       });
-    } else if (!destructiveBlock(row)) {
+    } else if (!destructiveBlock(row) && !row.cells.use.ownBlock) {
       options.push({
         label: "Block destructive tools",
         onSelect: onBlockDestructive,
@@ -749,14 +752,20 @@ function destructiveBlock(row: AccessRow) {
   );
 }
 
-/** That block, when it is the rule this page owns and can therefore lift. */
-function ownDestructiveBlock(row: AccessRow) {
-  const block = destructiveBlock(row);
-  return block &&
-    block.principalUrn === row.principalUrn &&
-    block.appliesTo === "resource"
-    ? block
-    : undefined;
+/**
+ * Whether this row's own block is exactly "no destructive tools" and nothing
+ * else. A principal holds one block per level, so lifting it lifts everything
+ * it names — fine when destructive is all it names, and a silent widening when
+ * it names anything more.
+ */
+function ownDestructiveBlockOnly(row: AccessRow): boolean {
+  const own = row.cells.use.ownBlock;
+  if (!own) return false;
+  return (
+    (own.tools ?? []).length === 0 &&
+    (own.dispositions ?? []).length === 1 &&
+    (own.dispositions ?? []).includes("destructive")
+  );
 }
 
 /** What kind of thing a row names, so a role does not read as a person. */

--- a/client/dashboard/src/pages/mcp/access/RoleLink.tsx
+++ b/client/dashboard/src/pages/mcp/access/RoleLink.tsx
@@ -1,0 +1,29 @@
+import { useOrgRoutes } from "@/routes";
+import type { JSX, ReactNode } from "react";
+import { Link } from "react-router";
+
+/**
+ * A role named on an access surface, linked to the page that edits it. The
+ * rule behind the name lives on the role, not on the server being read, so the
+ * fix for what the name is saying is always one click away.
+ */
+export function RoleLink({
+  principalUrn,
+  children,
+}: {
+  principalUrn: string;
+  children: ReactNode;
+}): JSX.Element {
+  const orgRoutes = useOrgRoutes();
+  const roleId = principalUrn.split(":").pop();
+  if (!roleId) return <>{children}</>;
+  return (
+    <Link
+      to={`${orgRoutes.access.roles.href()}/${roleId}/edit`}
+      className="underline decoration-dotted underline-offset-4 hover:decoration-solid"
+      onClick={(event) => event.stopPropagation()}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/client/dashboard/src/pages/mcp/access/accessRows.ts
+++ b/client/dashboard/src/pages/mcp/access/accessRows.ts
@@ -1,6 +1,10 @@
 import type { ToolSelectionTool } from "@/components/tool-selection/ToolSelectionPanel";
 import type { ResourceAudienceEntry } from "@gram/client/models/components/resourceaudienceentry.js";
-import { narrowingLabel, type AudienceLevel } from "./serverAudience";
+import {
+  isUnnarrowed,
+  narrowingLabel,
+  type AudienceLevel,
+} from "./serverAudience";
 
 /**
  * One row per principal, with a line for each of the three things it can be
@@ -49,15 +53,9 @@ export const BLOCK_LEVEL: Record<ScopeKey, AudienceLevel> = {
   manage: "blocked_manage",
 };
 
-/** A rule that grants rather than subtracts, and covers the whole server. */
-export function isUnnarrowed(entry: {
-  tools?: string[];
-  dispositions?: string[];
-}): boolean {
-  return (
-    (entry.tools ?? []).length === 0 && (entry.dispositions ?? []).length === 0
-  );
-}
+// Defined next to the reach resolution it is part of, and re-exported here so
+// the two surfaces cannot drift when the selector fields change.
+export { isUnnarrowed } from "./serverAudience";
 
 /** The scope a block level was written for, or null if it is not a block. */
 function blockedScope(level: AudienceLevel): ScopeKey | null {

--- a/client/dashboard/src/pages/mcp/access/accessWrites.test.ts
+++ b/client/dashboard/src/pages/mcp/access/accessWrites.test.ts
@@ -641,3 +641,31 @@ describe("an annotation choice is stored as a block", () => {
     ]);
   });
 });
+
+describe("subtracting by name without a catalogue", () => {
+  // An empty catalogue makes the complement unknowable. Computing it anyway
+  // gave an empty block, which read as "block nothing" and fell through to an
+  // allow — lifting the block that was the only thing restricting the row.
+  it("leaves the standing block alone rather than widening to every tool", () => {
+    const { direct, rows } = state([
+      role({ level: "use", memberIds: ["1"] }),
+      entry({ principalUrn: "user:1", level: "use", tools: ["search"] }),
+      entry({ principalUrn: "user:1", level: "blocked", tools: ["delete"] }),
+    ]);
+    const person = rows.find((r) => r.principalUrn === "user:1")!;
+
+    const written = narrowWrite(
+      direct,
+      person,
+      { tools: ["search"], dispositions: [] },
+      undefined,
+    ).entries;
+
+    expect(written).toContainEqual(
+      expect.objectContaining({ level: "blocked", tools: ["delete"] }),
+    );
+    expect(
+      written.some((e) => e.level === "use" && (e.tools ?? []).length === 0),
+    ).toBe(false);
+  });
+});

--- a/client/dashboard/src/pages/mcp/access/accessWrites.test.ts
+++ b/client/dashboard/src/pages/mcp/access/accessWrites.test.ts
@@ -4,7 +4,9 @@ import type { ToolSelectionTool } from "@/components/tool-selection/ToolSelectio
 import { buildAccessRows } from "./accessRows";
 import {
   addPrincipalsWrite,
+  allowDestructiveWrite,
   allowWrite,
+  blockDestructiveWrite,
   narrowWrite,
   revokeRowWrite,
   revokeScopeWrite,
@@ -428,5 +430,88 @@ describe("a stronger scope cannot outrun a trim", () => {
           written.principalUrn === "user:u1" && written.level === "use",
       ),
     ).toBe(true);
+  });
+});
+
+describe("destructive tools", () => {
+  // The restriction people actually reach for. It has to survive a server that
+  // publishes no catalogue, which is every gateway and every remote server.
+  it("blocks them by annotation rather than by name", () => {
+    const { direct, rows } = state([
+      entry({ principalUrn: "user:1", level: "use" }),
+    ]);
+
+    expect(blockDestructiveWrite(direct, rows[0]!, "Acme Ops").entries).toEqual(
+      [
+        {
+          principalUrn: "user:1",
+          level: "use",
+          tools: undefined,
+          dispositions: undefined,
+        },
+        {
+          principalUrn: "user:1",
+          level: "blocked",
+          tools: [],
+          dispositions: ["destructive"],
+        },
+      ],
+    );
+  });
+
+  it("lifts its own block and leaves the grant standing", () => {
+    const { direct, rows } = state([
+      entry({ principalUrn: "user:1", level: "use" }),
+      entry({
+        principalUrn: "user:1",
+        level: "blocked",
+        dispositions: ["destructive"],
+      }),
+    ]);
+
+    expect(allowDestructiveWrite(direct, rows[0]!).entries).toEqual([
+      { principalUrn: "user:1", level: "use" },
+    ]);
+  });
+});
+
+describe("narrowing a rule this page does not own", () => {
+  // Gateways and remote servers resolve their tools per caller and publish no
+  // catalogue, so a name list has nothing to be resolved against. The
+  // annotation vocabulary is closed, so "only read-only" is written as a block
+  // on the other three — and keeps covering tools added later.
+  it("subtracts by annotation when the choice names no tools", () => {
+    const { direct, rows } = state([
+      role({ level: "use", memberIds: ["1"] }),
+      entry({ principalUrn: "user:1", level: "use" }),
+    ]);
+    const person = rows.find((r) => r.principalUrn === "user:1")!;
+
+    const written = narrowWrite(
+      direct,
+      person,
+      { tools: [], dispositions: ["read_only"] },
+      undefined,
+    ).entries.find((e) => e.level === "blocked");
+
+    expect(written?.dispositions).toEqual([
+      "destructive",
+      "idempotent",
+      "open_world",
+    ]);
+    expect(written?.tools).toEqual([]);
+  });
+
+  it("closes the line when the choice is empty", () => {
+    const { direct, rows } = state([
+      role({ level: "use", memberIds: ["1"] }),
+      entry({ principalUrn: "user:1", level: "use" }),
+    ]);
+    const person = rows.find((r) => r.principalUrn === "user:1")!;
+
+    expect(
+      narrowWrite(direct, person, { tools: [], dispositions: [] }, undefined)
+        .entries,
+    ).toEqual(revokeScopeWrite(direct, person, "use").entries);
   });
 });

--- a/client/dashboard/src/pages/mcp/access/accessWrites.test.ts
+++ b/client/dashboard/src/pages/mcp/access/accessWrites.test.ts
@@ -716,3 +716,61 @@ describe("a tool choice cannot lift an annotation block", () => {
     );
   });
 });
+
+describe("a name write never replaces an annotation rule", () => {
+  // The subtraction is stored at the block level, so writing it replaces the
+  // block already there. Converting an annotation block into the names it
+  // covers today would stop it covering the ones added tomorrow.
+  it("keeps an annotation block when the choice takes away exactly what it does", () => {
+    const { direct, rows } = state([
+      role({ level: "use", memberIds: ["1"] }),
+      entry({
+        principalUrn: "user:1",
+        level: "blocked",
+        dispositions: ["destructive"],
+      }),
+    ]);
+    const person = rows.find((r) => r.principalUrn === "user:1")!;
+
+    // Everything the catalogue leaves once destructive is taken away.
+    const written = narrowWrite(
+      direct,
+      person,
+      { tools: ["search", "fetch"], dispositions: [] },
+      catalog,
+    ).entries;
+
+    expect(written).toContainEqual(
+      expect.objectContaining({
+        level: "blocked",
+        dispositions: ["destructive"],
+      }),
+    );
+    expect(
+      written.some((e) => e.level === "blocked" && (e.tools ?? []).length > 0),
+    ).toBe(false);
+  });
+
+  it("leaves an annotation grant alone when there is no catalogue", () => {
+    const { direct, rows } = state([
+      role({ level: "use", tools: ["search"], memberIds: ["1"] }),
+      entry({
+        principalUrn: "user:1",
+        level: "use",
+        dispositions: ["read_only"],
+      }),
+    ]);
+    const person = rows.find((r) => r.principalUrn === "user:1")!;
+
+    expect(
+      narrowWrite(
+        direct,
+        person,
+        { tools: ["search"], dispositions: [] },
+        undefined,
+      ).entries,
+    ).toContainEqual(
+      expect.objectContaining({ level: "use", dispositions: ["read_only"] }),
+    );
+  });
+});

--- a/client/dashboard/src/pages/mcp/access/accessWrites.test.ts
+++ b/client/dashboard/src/pages/mcp/access/accessWrites.test.ts
@@ -7,6 +7,7 @@ import {
   allowDestructiveWrite,
   allowWrite,
   blockDestructiveWrite,
+  narrowingSeed,
   narrowWrite,
   revokeRowWrite,
   revokeScopeWrite,
@@ -513,5 +514,66 @@ describe("narrowing a rule this page does not own", () => {
       narrowWrite(direct, person, { tools: [], dispositions: [] }, undefined)
         .entries,
     ).toEqual(revokeScopeWrite(direct, person, "use").entries);
+  });
+});
+
+describe("narrowingSeed", () => {
+  // Opening the dialog on a row reading "all tools except destructive tools"
+  // has to show the other three chosen. Seeding from the grant alone showed
+  // nothing chosen, and saving that revoked the line.
+  it("seeds from the grants minus the annotations a block takes away", () => {
+    const { rows } = state([
+      entry({ principalUrn: "user:1", level: "use" }),
+      entry({
+        principalUrn: "user:1",
+        level: "blocked",
+        dispositions: ["destructive"],
+      }),
+    ]);
+
+    expect(narrowingSeed(rows[0]!, undefined)).toEqual({
+      tools: [],
+      dispositions: ["read_only", "idempotent", "open_world"],
+    });
+  });
+
+  it("keeps a rule's own tool names", () => {
+    const { rows } = state([
+      entry({ principalUrn: "user:1", level: "use", tools: ["search"] }),
+    ]);
+
+    expect(narrowingSeed(rows[0]!, undefined)).toEqual({
+      tools: ["search"],
+      dispositions: [],
+    });
+  });
+});
+
+describe("choosing every annotation", () => {
+  // Four dispositions is "all tools" said the long way. Storing it as four
+  // selectors would drop the tools that carry no annotation at all.
+  it("writes an unnarrowed rule rather than four selectors", () => {
+    const { direct, rows } = state([
+      entry({ principalUrn: "user:1", level: "use" }),
+    ]);
+
+    expect(
+      narrowWrite(
+        direct,
+        rows[0]!,
+        {
+          tools: [],
+          dispositions: [
+            "read_only",
+            "destructive",
+            "idempotent",
+            "open_world",
+          ],
+        },
+        undefined,
+      ).entries,
+    ).toEqual([
+      { principalUrn: "user:1", level: "use", tools: [], dispositions: [] },
+    ]);
   });
 });

--- a/client/dashboard/src/pages/mcp/access/accessWrites.test.ts
+++ b/client/dashboard/src/pages/mcp/access/accessWrites.test.ts
@@ -577,3 +577,67 @@ describe("choosing every annotation", () => {
     ]);
   });
 });
+
+describe("narrowingSeed against a catalogue", () => {
+  // The common path, and the one the dialog opens on for a toolset-backed
+  // server: the seed is what the row reaches once every block is applied.
+  it("seeds the tools left after a block trims the catalogue", () => {
+    const { rows } = state([
+      entry({ principalUrn: "user:1", level: "use" }),
+      entry({
+        principalUrn: "user:1",
+        level: "blocked",
+        dispositions: ["destructive"],
+      }),
+    ]);
+
+    expect(narrowingSeed(rows[0]!, catalog)).toEqual({
+      tools: ["search", "fetch"],
+      dispositions: [],
+    });
+  });
+
+  it("drops the names its own block takes away when there is no catalogue", () => {
+    const { rows } = state([
+      entry({
+        principalUrn: "user:1",
+        level: "use",
+        tools: ["search", "delete"],
+      }),
+      entry({ principalUrn: "user:1", level: "blocked", tools: ["delete"] }),
+    ]);
+
+    expect(narrowingSeed(rows[0]!, undefined)).toEqual({
+      tools: ["search"],
+      dispositions: [],
+    });
+  });
+});
+
+describe("an annotation choice is stored as a block", () => {
+  // A dispositions grant reaches only the tools carrying one of its
+  // annotations, so writing one would drop every tool annotated with nothing
+  // at all. The block leaves those alone.
+  it("blocks the complement even when the row's own rule is the only grant", () => {
+    const { direct, rows } = state([
+      entry({ principalUrn: "user:1", level: "use" }),
+    ]);
+
+    expect(
+      narrowWrite(
+        direct,
+        rows[0]!,
+        { tools: [], dispositions: ["read_only"] },
+        undefined,
+      ).entries,
+    ).toEqual([
+      { principalUrn: "user:1", level: "use" },
+      {
+        principalUrn: "user:1",
+        level: "blocked",
+        tools: [],
+        dispositions: ["destructive", "idempotent", "open_world"],
+      },
+    ]);
+  });
+});

--- a/client/dashboard/src/pages/mcp/access/accessWrites.test.ts
+++ b/client/dashboard/src/pages/mcp/access/accessWrites.test.ts
@@ -669,3 +669,50 @@ describe("subtracting by name without a catalogue", () => {
     ).toBe(false);
   });
 });
+
+describe("seeding a row whose grant lives on another rule", () => {
+  // An organization-wide rule can be narrowed to names too. Seeding from the
+  // row's own rule alone left nothing chosen, and saving that revoked the
+  // inherited access on this server.
+  it("seeds the names an inherited rule grants", () => {
+    const { rows } = state([
+      role({ level: "use", tools: ["search"], memberIds: ["1"] }),
+      entry({ principalUrn: "user:1", level: "use", tools: [] }),
+    ]);
+    const person = rows.find((r) => r.principalUrn === "user:1")!;
+
+    expect(narrowingSeed(person, undefined)).toEqual({
+      tools: ["search"],
+      dispositions: [],
+    });
+  });
+});
+
+describe("a tool choice cannot lift an annotation block", () => {
+  // The choice says nothing about annotations, so lifting a block naming them
+  // would hand back every tool it was subtracting.
+  it("keeps a standing destructive block when the choice names tools", () => {
+    const { direct, rows } = state([
+      entry({ principalUrn: "user:1", level: "use", tools: ["search"] }),
+      entry({
+        principalUrn: "user:1",
+        level: "blocked",
+        dispositions: ["destructive"],
+      }),
+    ]);
+
+    expect(
+      narrowWrite(
+        direct,
+        rows[0]!,
+        { tools: ["search"], dispositions: [] },
+        catalog,
+      ).entries,
+    ).toContainEqual(
+      expect.objectContaining({
+        level: "blocked",
+        dispositions: ["destructive"],
+      }),
+    );
+  });
+});

--- a/client/dashboard/src/pages/mcp/access/accessWrites.ts
+++ b/client/dashboard/src/pages/mcp/access/accessWrites.ts
@@ -77,6 +77,29 @@ function withoutOwnBlock(
 }
 
 /**
+ * The rules a narrowing is written onto, with this row's own connect block
+ * lifted only when the choice can speak for it. A choice naming tools says
+ * nothing about annotations, so a block naming annotations has to survive it —
+ * lifting it would hand back every tool that block was subtracting, which is
+ * a widening nobody asked for.
+ */
+function narrowingBase(
+  direct: AudienceRule[],
+  row: AccessRow,
+  next: Narrowing,
+): AudienceRule[] {
+  const ownBlock = row.cells.use.ownBlock;
+  if (
+    ownBlock &&
+    (ownBlock.dispositions ?? []).length > 0 &&
+    next.tools.length > 0
+  ) {
+    return direct;
+  }
+  return withoutOwnBlock(direct, row, "use");
+}
+
+/**
  * What a write did, said as the change an administrator just made. The rule
  * it was stored as — a grant here, a block against a role's own rule — is an
  * implementation detail of this server's access, so the sentence names the
@@ -160,7 +183,7 @@ export function narrowWrite(
   toolCatalog: ToolSelectionTool[] | undefined,
   resourceName?: string,
 ): AudienceWrite {
-  const base = withoutOwnBlock(direct, row, "use");
+  const base = narrowingBase(direct, row, next);
   const server = serverLabel(resourceName);
   const label = narrowingLabel(next).toLowerCase();
 
@@ -215,6 +238,8 @@ export function narrowWrite(
   // row's own grant is rewritten, which cannot widen anything.
   if ((toolCatalog ?? []).length === 0) {
     return {
+      // `direct`, not `base`: without a catalogue the subtraction cannot be
+      // recomputed, so no block on this line may be lifted, whatever it names.
       entries: withRule(direct, row.principalUrn, "use", {
         tools: next.tools,
         dispositions: [],
@@ -329,16 +354,19 @@ export function narrowingSeed(
   const reachable = reachableTools(cell, toolCatalog ?? []);
   if (reachable) return { tools: reachable, dispositions: [] };
 
-  // A rule naming tools says what it reaches, once the names a block takes
-  // away are removed. Reading the grant alone would re-open them the moment
-  // the dialog was saved without being touched.
+  // Names come from every grant reaching this row, not only the rule it owns
+  // here: a rule covering every server can be narrowed to names too, and it is
+  // just as much what this row reaches. Seeding from the own rule alone left
+  // an inherited name list with nothing chosen, and saving that revoked it.
+  // The names a block takes away come off, or saving an untouched dialog would
+  // hand them straight back.
   const blockedTools = new Set(
     cell.blocks.flatMap((block) => block.tools ?? []),
   );
-  const ownTools = (cell.own?.tools ?? []).filter(
-    (tool) => !blockedTools.has(tool),
-  );
-  if (ownTools.length > 0) return { tools: ownTools, dispositions: [] };
+  const grantedTools = [
+    ...new Set(cell.grants.flatMap((grant) => grant.tools ?? [])),
+  ].filter((tool) => !blockedTools.has(tool));
+  if (grantedTools.length > 0) return { tools: grantedTools, dispositions: [] };
 
   // No catalogue to resolve against, so the seed is said in the vocabulary the
   // blocks are written in: everything the grants open, minus every annotation a

--- a/client/dashboard/src/pages/mcp/access/accessWrites.ts
+++ b/client/dashboard/src/pages/mcp/access/accessWrites.ts
@@ -208,6 +208,21 @@ export function narrowWrite(
     };
   }
 
+  // Subtracting by name needs the catalogue to say what to take away, and
+  // without one the complement is unknowable — an empty one would read as
+  // "block nothing" and fall through to an allow, lifting whatever block is
+  // already standing. So the block is left exactly as it is and only this
+  // row's own grant is rewritten, which cannot widen anything.
+  if ((toolCatalog ?? []).length === 0) {
+    return {
+      entries: withRule(direct, row.principalUrn, "use", {
+        tools: next.tools,
+        dispositions: [],
+      }),
+      message: reachMessage(row, server, `call ${label} on`),
+    };
+  }
+
   // Subtracting by name. A block with nothing named would take the whole
   // server away, so a choice covering everything reachable is the same as
   // asking for all tools.

--- a/client/dashboard/src/pages/mcp/access/accessWrites.ts
+++ b/client/dashboard/src/pages/mcp/access/accessWrites.ts
@@ -164,48 +164,26 @@ export function narrowWrite(
   const server = serverLabel(resourceName);
   const label = narrowingLabel(next).toLowerCase();
 
-  // Every annotation chosen is "all tools" said the long way, and storing it
-  // as four dispositions would quietly drop the tools that carry none.
-  if (
-    next.tools.length === 0 &&
-    DISPOSITIONS.every((disposition) => next.dispositions.includes(disposition))
-  ) {
-    return allowWrite(direct, row, "use", resourceName);
-  }
-
-  if (foreignGrants(row, "use").length === 0) {
-    return {
-      // A rule stores tools or annotations, never both — the endpoint
-      // refuses the pair — so an explicit list of names wins over the
-      // annotations that would have covered them.
-      entries: withRule(base, row.principalUrn, "use", {
-        tools: next.tools,
-        // The annotation values and the stored dispositions are the same
-        // strings; the generated union just types them more tightly.
-        dispositions: next.tools.length
-          ? []
-          : (next.dispositions as SetResourceAudienceEntryDispositions[]),
-      }),
-      message: reachMessage(row, server, `call ${label} on`),
-    };
-  }
-
-  // Subtracting, and nothing was chosen: the line reaches nothing, which is
-  // the revoke this page already knows how to write. Falling through would
-  // block no tools at all and read as a widening.
+  // Nothing chosen: the line reaches nothing, which is the revoke this page
+  // already knows how to write. Falling through would store a rule that names
+  // nothing, which reads as the opposite.
   if (next.tools.length === 0 && next.dispositions.length === 0) {
     return revokeScopeWrite(direct, row, "use", resourceName);
   }
 
-  // Subtracting by annotation. The vocabulary is closed, so "only these" is
-  // expressible as a block on the rest — and unlike a list of names it keeps
-  // covering tools added later, which is the reason to restrict by annotation
-  // at all. It needs no catalogue, so it is the form gateways and remote
-  // servers use, since they resolve their tools per caller and publish none.
+  // An annotation choice is always stored as a block on the annotations left
+  // out, never as a grant naming the ones kept. The two are not the same: a
+  // grant reaches only the tools carrying one of its annotations, so a tool
+  // annotated with nothing at all would silently stop being reachable, while
+  // the block leaves it alone. The block also keeps covering tools added
+  // later, which is the reason to restrict by annotation rather than by name,
+  // and it needs no catalogue — the form gateways and remote servers depend
+  // on, since they resolve their tools per caller and publish none.
   if (next.tools.length === 0) {
     const blockedDispositions = DISPOSITIONS.filter(
       (disposition) => !next.dispositions.includes(disposition),
     );
+    // Every annotation chosen is "all tools" said the long way.
     if (blockedDispositions.length === 0) {
       return allowWrite(direct, row, "use", resourceName);
     }
@@ -214,6 +192,19 @@ export function narrowWrite(
         dispositions: blockedDispositions,
       }),
       message: `${reachMessage(row, server, `call ${label} on`)} Other servers are unchanged.`,
+    };
+  }
+
+  if (foreignGrants(row, "use").length === 0) {
+    return {
+      // A rule stores tools or annotations, never both — the endpoint refuses
+      // the pair — and an annotation choice never reaches here, so this is
+      // always the list of names.
+      entries: withRule(base, row.principalUrn, "use", {
+        tools: next.tools,
+        dispositions: [],
+      }),
+      message: reachMessage(row, server, `call ${label} on`),
     };
   }
 
@@ -323,10 +314,16 @@ export function narrowingSeed(
   const reachable = reachableTools(cell, toolCatalog ?? []);
   if (reachable) return { tools: reachable, dispositions: [] };
 
-  // A rule naming tools says what it reaches on its own.
-  if ((cell.own?.tools ?? []).length > 0) {
-    return { tools: cell.own?.tools ?? [], dispositions: [] };
-  }
+  // A rule naming tools says what it reaches, once the names a block takes
+  // away are removed. Reading the grant alone would re-open them the moment
+  // the dialog was saved without being touched.
+  const blockedTools = new Set(
+    cell.blocks.flatMap((block) => block.tools ?? []),
+  );
+  const ownTools = (cell.own?.tools ?? []).filter(
+    (tool) => !blockedTools.has(tool),
+  );
+  if (ownTools.length > 0) return { tools: ownTools, dispositions: [] };
 
   // No catalogue to resolve against, so the seed is said in the vocabulary the
   // blocks are written in: everything the grants open, minus every annotation a

--- a/client/dashboard/src/pages/mcp/access/accessWrites.ts
+++ b/client/dashboard/src/pages/mcp/access/accessWrites.ts
@@ -48,6 +48,18 @@ export interface Narrowing {
   dispositions: string[];
 }
 
+/**
+ * Every annotation a rule can name, mirroring validDispositions in
+ * authz/selector.go. The set is closed, which is what makes "only these" and
+ * "everything but these" two ways of writing the same restriction.
+ */
+const DISPOSITIONS: SetResourceAudienceEntryDispositions[] = [
+  "read_only",
+  "destructive",
+  "idempotent",
+  "open_world",
+];
+
 function serverLabel(resourceName?: string): string {
   return resourceName ?? "this server";
 }
@@ -169,9 +181,36 @@ export function narrowWrite(
     };
   }
 
-  // Subtracting. A block with nothing named would take the whole server
-  // away, so a choice covering everything reachable is the same as asking
-  // for all tools.
+  // Subtracting, and nothing was chosen: the line reaches nothing, which is
+  // the revoke this page already knows how to write. Falling through would
+  // block no tools at all and read as a widening.
+  if (next.tools.length === 0 && next.dispositions.length === 0) {
+    return revokeScopeWrite(direct, row, "use", resourceName);
+  }
+
+  // Subtracting by annotation. The vocabulary is closed, so "only these" is
+  // expressible as a block on the rest — and unlike a list of names it keeps
+  // covering tools added later, which is the reason to restrict by annotation
+  // at all. It needs no catalogue, so it is the form gateways and remote
+  // servers use, since they resolve their tools per caller and publish none.
+  if (next.tools.length === 0) {
+    const blockedDispositions = DISPOSITIONS.filter(
+      (disposition) => !next.dispositions.includes(disposition),
+    );
+    if (blockedDispositions.length === 0) {
+      return allowWrite(direct, row, "use", resourceName);
+    }
+    return {
+      entries: withRule(base, row.principalUrn, BLOCK_LEVEL.use, {
+        dispositions: blockedDispositions,
+      }),
+      message: `${reachMessage(row, server, `call ${label} on`)} Other servers are unchanged.`,
+    };
+  }
+
+  // Subtracting by name. A block with nothing named would take the whole
+  // server away, so a choice covering everything reachable is the same as
+  // asking for all tools.
   const blocked = complementTools(toolCatalog ?? [], next);
   if (blocked.length === 0) return allowWrite(direct, row, "use", resourceName);
 
@@ -180,6 +219,41 @@ export function narrowWrite(
       tools: blocked,
     }),
     message: `${reachMessage(row, server, `call ${label} on`)} Other servers are unchanged.`,
+  };
+}
+
+/**
+ * Keep a principal off this server's destructive tools, and let it back on.
+ *
+ * Stored as a block naming the annotation rather than the tools carrying it
+ * today: a name list stops covering a destructive tool added next week, which
+ * is the whole reason to restrict by annotation. It also needs no catalogue, so
+ * it works on gateways and remote servers, which resolve their tools per
+ * caller and publish none.
+ */
+export function blockDestructiveWrite(
+  direct: AudienceRule[],
+  row: AccessRow,
+  resourceName?: string,
+): AudienceWrite {
+  return {
+    entries: withRule(direct, row.principalUrn, BLOCK_LEVEL.use, {
+      dispositions: ["destructive"],
+    }),
+    message: `${row.displayName} can no longer call destructive tools on ${serverLabel(resourceName)}.`,
+  };
+}
+
+export function allowDestructiveWrite(
+  direct: AudienceRule[],
+  row: AccessRow,
+  resourceName?: string,
+): AudienceWrite {
+  return {
+    entries: withoutRules(direct, [
+      ruleId({ principalUrn: row.principalUrn, level: BLOCK_LEVEL.use }),
+    ]),
+    message: `${row.displayName} can call destructive tools on ${serverLabel(resourceName)} again.`,
   };
 }
 

--- a/client/dashboard/src/pages/mcp/access/accessWrites.ts
+++ b/client/dashboard/src/pages/mcp/access/accessWrites.ts
@@ -164,6 +164,15 @@ export function narrowWrite(
   const server = serverLabel(resourceName);
   const label = narrowingLabel(next).toLowerCase();
 
+  // Every annotation chosen is "all tools" said the long way, and storing it
+  // as four dispositions would quietly drop the tools that carry none.
+  if (
+    next.tools.length === 0 &&
+    DISPOSITIONS.every((disposition) => next.dispositions.includes(disposition))
+  ) {
+    return allowWrite(direct, row, "use", resourceName);
+  }
+
   if (foreignGrants(row, "use").length === 0) {
     return {
       // A rule stores tools or annotations, never both — the endpoint
@@ -313,9 +322,27 @@ export function narrowingSeed(
   const cell = row.cells.use;
   const reachable = reachableTools(cell, toolCatalog ?? []);
   if (reachable) return { tools: reachable, dispositions: [] };
-  // No catalogue to resolve against: the row's own rule is all there is.
+
+  // A rule naming tools says what it reaches on its own.
+  if ((cell.own?.tools ?? []).length > 0) {
+    return { tools: cell.own?.tools ?? [], dispositions: [] };
+  }
+
+  // No catalogue to resolve against, so the seed is said in the vocabulary the
+  // blocks are written in: everything the grants open, minus every annotation a
+  // block takes away. Reading the grant alone would open the dialog with
+  // nothing chosen on a row whose line plainly reads "all tools except
+  // destructive tools" — and saving that would revoke the line.
+  const blocked = new Set(
+    cell.blocks.flatMap((block) => block.dispositions ?? []),
+  );
+  const granted = cell.grants.some(isUnnarrowed)
+    ? DISPOSITIONS
+    : [...new Set(cell.grants.flatMap((grant) => grant.dispositions ?? []))];
   return {
-    tools: cell.own?.tools ?? [],
-    dispositions: cell.own?.dispositions ?? [],
+    tools: [],
+    dispositions: granted.filter(
+      (disposition) => !blocked.has(disposition),
+    ) as string[],
   };
 }

--- a/client/dashboard/src/pages/mcp/access/accessWrites.ts
+++ b/client/dashboard/src/pages/mcp/access/accessWrites.ts
@@ -109,6 +109,37 @@ function reachMessage(row: AccessRow, server: string, reach: string): string {
   return `${row.displayName} can now ${reach} ${server}.`;
 }
 
+/** The catalogue's tools carrying any of these annotations. */
+function toolsCarrying(
+  catalog: ToolSelectionTool[],
+  dispositions: string[],
+): string[] {
+  const wanted = new Set(dispositions);
+  return catalog
+    .filter((tool) => tool.annotations.some((a) => wanted.has(a)))
+    .map((tool) => tool.name);
+}
+
+function sameNames(left: string[], right: string[]): boolean {
+  if (left.length !== right.length) return false;
+  const seen = new Set(left);
+  return right.every((name) => seen.has(name));
+}
+
+/**
+ * A write that changes nothing, for the choices this form cannot store without
+ * losing something already written. A principal holds one rule per level and a
+ * rule names tools or annotations but never both, so the two vocabularies
+ * cannot be merged — and replacing one with the other is a change nobody asked
+ * for. Leaving the rules alone is the honest answer.
+ */
+function unchangedWrite(direct: AudienceRule[], server: string): AudienceWrite {
+  return {
+    entries: withoutRules(direct, []),
+    message: `Access to ${server} is unchanged.`,
+  };
+}
+
 /** Open one scope over the whole server. */
 export function allowWrite(
   direct: AudienceRule[],
@@ -237,6 +268,13 @@ export function narrowWrite(
   // already standing. So the block is left exactly as it is and only this
   // row's own grant is rewritten, which cannot widen anything.
   if ((toolCatalog ?? []).length === 0) {
+    // This row's own rule may be written in annotations while another grant
+    // names tools. With no catalogue there is nothing to translate between the
+    // two, so rewriting this rule as names would drop the annotations it holds
+    // without saying so.
+    if ((row.cells.use.own?.dispositions ?? []).length > 0) {
+      return unchangedWrite(direct, server);
+    }
     return {
       // `direct`, not `base`: without a catalogue the subtraction cannot be
       // recomputed, so no block on this line may be lifted, whatever it names.
@@ -253,6 +291,20 @@ export function narrowWrite(
   // asking for all tools.
   const blocked = complementTools(toolCatalog ?? [], next);
   if (blocked.length === 0) return allowWrite(direct, row, "use", resourceName);
+
+  // The subtraction is stored at the block level, so writing it replaces any
+  // block already there. Replacing an annotation block with the names it
+  // happens to cover today would quietly stop it covering the ones added
+  // tomorrow, which is the whole reason it was written as an annotation. When
+  // the choice takes away exactly what the annotation already takes away — an
+  // untouched dialog, saved — the annotation stays.
+  const ownAnnotations = row.cells.use.ownBlock?.dispositions ?? [];
+  if (
+    ownAnnotations.length > 0 &&
+    sameNames(blocked, toolsCarrying(toolCatalog ?? [], ownAnnotations))
+  ) {
+    return unchangedWrite(direct, server);
+  }
 
   return {
     entries: withRule(base, row.principalUrn, BLOCK_LEVEL.use, {

--- a/client/dashboard/src/pages/mcp/access/serverAudience.test.ts
+++ b/client/dashboard/src/pages/mcp/access/serverAudience.test.ts
@@ -1,0 +1,63 @@
+import type { ResourceAudienceEntry } from "@gram/client/models/components/resourceaudienceentry.js";
+import { describe, expect, it } from "vitest";
+import { blockingRules, effectiveReach } from "./serverAudience";
+
+function entry(
+  overrides: Partial<ResourceAudienceEntry> & { principalUrn: string },
+): ResourceAudienceEntry {
+  return {
+    kind: "role",
+    displayName: "GTM",
+    level: "use",
+    appliesTo: "all_resources",
+    ...overrides,
+  } as ResourceAudienceEntry;
+}
+
+const gtmGrant = entry({ principalUrn: "role:organization:gtm", level: "use" });
+const adminBlock = entry({
+  principalUrn: "role:global:admin",
+  displayName: "Admin",
+  level: "blocked",
+  appliesTo: "resource",
+});
+
+describe("blockingRules", () => {
+  // The shape that made a role of eleven show four people underneath it: the
+  // seven missing were administrators too, and a block on that role outranks
+  // the grant that put them in the list.
+  it("names the block that cancelled every capability", () => {
+    const reaching = [gtmGrant, adminBlock];
+
+    expect(effectiveReach(reaching)).toBeNull();
+    expect(blockingRules(reaching).map((rule) => rule.displayName)).toEqual([
+      "Admin",
+    ]);
+  });
+
+  it("says nothing about someone the rules still reach", () => {
+    expect(blockingRules([gtmGrant])).toEqual([]);
+  });
+
+  it("says nothing about someone no rule names", () => {
+    expect(blockingRules([])).toEqual([]);
+  });
+
+  // A block narrowed to some tools leaves the rest reachable, so it is not
+  // what took someone off the server and must not be named as if it were.
+  it("ignores a block that only trims tools", () => {
+    const reaching = [
+      gtmGrant,
+      entry({
+        principalUrn: "role:global:admin",
+        displayName: "Admin",
+        level: "blocked",
+        appliesTo: "resource",
+        dispositions: ["destructive"],
+      }),
+    ];
+
+    expect(effectiveReach(reaching)).not.toBeNull();
+    expect(blockingRules(reaching)).toEqual([]);
+  });
+});

--- a/client/dashboard/src/pages/mcp/access/serverAudience.test.ts
+++ b/client/dashboard/src/pages/mcp/access/serverAudience.test.ts
@@ -61,3 +61,25 @@ describe("blockingRules", () => {
     expect(blockingRules(reaching)).toEqual([]);
   });
 });
+
+describe("blockingRules names only the blocks that took something away", () => {
+  // The mcp:blocked_* scopes are independent. A block on a capability nobody
+  // was granted changed nothing, and naming it sends an administrator to a
+  // role that is not the reason.
+  it("ignores a block on a capability the grants never opened", () => {
+    const reaching = [
+      gtmGrant,
+      adminBlock,
+      entry({
+        principalUrn: "role:organization:ops",
+        displayName: "Ops",
+        level: "blocked_manage",
+        appliesTo: "resource",
+      }),
+    ];
+
+    expect(blockingRules(reaching).map((rule) => rule.displayName)).toEqual([
+      "Admin",
+    ]);
+  });
+});

--- a/client/dashboard/src/pages/mcp/access/serverAudience.ts
+++ b/client/dashboard/src/pages/mcp/access/serverAudience.ts
@@ -104,13 +104,21 @@ function isBlock(entry: { level: AudienceLevel }): boolean {
   return BLOCKED_CAPABILITY[entry.level] !== undefined;
 }
 
-function isNarrowedRule(entry: {
+/** A rule covering the whole server rather than a slice of it. */
+export function isUnnarrowed(entry: {
   tools?: string[];
   dispositions?: string[];
 }): boolean {
   return (
-    (entry.tools ?? []).length > 0 || (entry.dispositions ?? []).length > 0
+    (entry.tools ?? []).length === 0 && (entry.dispositions ?? []).length === 0
   );
+}
+
+function isNarrowedRule(entry: {
+  tools?: string[];
+  dispositions?: string[];
+}): boolean {
+  return !isUnnarrowed(entry);
 }
 
 /**
@@ -119,12 +127,27 @@ function isNarrowedRule(entry: {
  * `effectiveReach`, and an absence explains nothing: a reader counting eleven
  * faces on a role and four people underneath needs the rule that took the other
  * seven away, by name.
+ *
+ * Only the blocks that took something away are named. The mcp:blocked_* scopes
+ * are independent, so a block on a capability nobody was granted changed
+ * nothing, and naming it sends an administrator to a role that is not the
+ * reason.
  */
 export function blockingRules(
   reaching: ResourceAudienceEntry[],
 ): ResourceAudienceEntry[] {
   if (reaching.length === 0 || effectiveReach(reaching) !== null) return [];
-  return reaching.filter((entry) => isBlock(entry) && !isNarrowedRule(entry));
+  const granted = new Set(
+    reaching
+      .filter((entry) => !isBlock(entry))
+      .flatMap((entry) => capabilitiesOf(entry.level)),
+  );
+  return reaching.filter(
+    (entry) =>
+      isBlock(entry) &&
+      !isNarrowedRule(entry) &&
+      granted.has(BLOCKED_CAPABILITY[entry.level]!),
+  );
 }
 
 export function effectiveReach(

--- a/client/dashboard/src/pages/mcp/access/serverAudience.ts
+++ b/client/dashboard/src/pages/mcp/access/serverAudience.ts
@@ -104,6 +104,29 @@ function isBlock(entry: { level: AudienceLevel }): boolean {
   return BLOCKED_CAPABILITY[entry.level] !== undefined;
 }
 
+function isNarrowedRule(entry: {
+  tools?: string[];
+  dispositions?: string[];
+}): boolean {
+  return (
+    (entry.tools ?? []).length > 0 || (entry.dispositions ?? []).length > 0
+  );
+}
+
+/**
+ * The blocks that leave a principal reaching nothing at all. Someone a role
+ * reaches but a block cancels is absent from every list resolved through
+ * `effectiveReach`, and an absence explains nothing: a reader counting eleven
+ * faces on a role and four people underneath needs the rule that took the other
+ * seven away, by name.
+ */
+export function blockingRules(
+  reaching: ResourceAudienceEntry[],
+): ResourceAudienceEntry[] {
+  if (reaching.length === 0 || effectiveReach(reaching) !== null) return [];
+  return reaching.filter((entry) => isBlock(entry) && !isNarrowedRule(entry));
+}
+
 export function effectiveReach(
   reaching: ResourceAudienceEntry[],
   /** The server's tools, when it publishes a catalogue. */
@@ -112,8 +135,7 @@ export function effectiveReach(
   const granting = reaching.filter((entry) => !isBlock(entry));
   if (granting.length === 0) return null;
 
-  const isNarrowed = (entry: ResourceAudienceEntry) =>
-    (entry.tools ?? []).length > 0 || (entry.dispositions ?? []).length > 0;
+  const isNarrowed = isNarrowedRule;
 
   // Blocks are independent of one another, so each takes away just the
   // capability it names — and only an unnarrowed one takes it away whole. A

--- a/server/internal/access/resource_audience.go
+++ b/server/internal/access/resource_audience.go
@@ -58,6 +58,17 @@ var audienceLevelScopes = map[string]authz.Scope{
 // connect or manage leaves the page readable, so neither needs a guard.
 var audienceLockoutLevels = []string{audienceLevelBlockedView}
 
+// Every block level. Blocking the administrator role is guarded at all three:
+// the caller guard above only protects whoever is writing, and an administrator
+// is not usually the one restricting a server. Blocking the role that exists to
+// undo such a rule leaves nobody who can, so it is refused whichever capability
+// it names.
+var audienceBlockLevels = []string{
+	audienceLevelBlocked,
+	audienceLevelBlockedView,
+	audienceLevelBlockedManage,
+}
+
 // Widest first: a principal holding several scopes is reported at its highest
 // level, and a block outranks every grant.
 var audienceLevelOrder = []string{
@@ -191,6 +202,14 @@ func (s *Service) SetResourceAudience(ctx context.Context, payload *gen.SetResou
 			Principal: principal,
 			Selectors: selectors,
 		})
+	}
+
+	// Lockout guardrail: the administrator role is what undoes a rule written
+	// here, so a block naming it takes the server's access away from everyone
+	// who could give it back. The caller guard below does not catch this — the
+	// person restricting a server is rarely an administrator themselves.
+	if err := s.rejectAdminRoleBlocks(ctx, ac.ActiveOrganizationID, principalsByLevel); err != nil {
+		return nil, err
 	}
 
 	// Lockout guardrail: a block on view subtracts the read that renders this
@@ -483,6 +502,40 @@ func audienceSelectors(scope authz.Scope, resourceID string, tools, dispositions
 	}
 
 	return selectors, nil
+}
+
+// rejectAdminRoleBlocks refuses a save that would block the administrator role
+// on this resource. Restricting a server to one team is normally written as
+// "everyone else: no access", which stores a block — and a block outranks every
+// grant, so naming the administrator role there locks every administrator out
+// of the page that could undo it. Roles other than admin are left alone: taking
+// a team off a server is the point of this surface.
+func (s *Service) rejectAdminRoleBlocks(ctx context.Context, organizationID string, principalsByLevel map[string][]authz.PrincipalSelectors) error {
+	blocked := make(map[string]struct{})
+	for _, level := range audienceBlockLevels {
+		for _, entry := range principalsByLevel[level] {
+			if entry.Principal.Type == urn.PrincipalTypeRole {
+				blocked[entry.Principal.String()] = struct{}{}
+			}
+		}
+	}
+	if len(blocked) == 0 {
+		return nil
+	}
+
+	roles, err := accessrepo.New(s.db).ListActiveOrganizationRoles(ctx, organizationID)
+	if err != nil {
+		return oops.E(oops.CodeUnexpected, err, "list roles for lockout guard").LogError(ctx, s.logger)
+	}
+	for _, role := range roles {
+		if role.WorkosSlug != authz.SystemRoleAdmin {
+			continue
+		}
+		if _, ok := blocked[role.RoleUrn]; ok {
+			return oops.E(oops.CodeInvalid, nil, "blocking the %s role would take this server away from every administrator, including the ones who could give it back; remove its access instead of blocking it", role.WorkosName)
+		}
+	}
+	return nil
 }
 
 // audienceReach maps every principal an audience row can name to the

--- a/server/internal/access/resource_audience_test.go
+++ b/server/internal/access/resource_audience_test.go
@@ -648,6 +648,73 @@ func TestService_SetResourceAudience_RefusesBlockingEveryonesView(t *testing.T) 
 	require.Equal(t, oops.CodeInvalid, oopsErr.Code)
 }
 
+// Restricting a server to one team is written as "everyone else: no access",
+// which stores a block — and a block outranks every grant. Naming the
+// administrator role there takes the server's own access page away from every
+// administrator, including the ones who would undo it, so it is refused at all
+// three block levels rather than only the one covering the caller.
+func TestService_SetResourceAudience_RefusesBlockingTheAdminRole(t *testing.T) {
+	t.Parallel()
+
+	for _, level := range []string{"blocked", "blocked_view", "blocked_manage"} {
+		t.Run(level, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, ti := newTestAccessService(t)
+			authCtx, ok := contextvalues.GetAuthContext(ctx)
+			require.True(t, ok)
+
+			seedRole(t, ctx, ti.conn, authCtx.ActiveOrganizationID, mockSystemRole("role_admin", "Admin", authz.SystemRoleAdmin))
+			adminPrincipal := seededRolePrincipal(t, ctx, ti.conn, authCtx.ActiveOrganizationID, authz.SystemRoleAdmin)
+			serverID := seedMCPServer(t, ctx, ti.conn, authCtx.ActiveOrganizationID)
+
+			_, err := ti.service.SetResourceAudience(ctx, &gen.SetResourceAudiencePayload{
+				ResourceKind: "mcp",
+				ResourceID:   serverID,
+				Entries: []*gen.SetResourceAudienceEntry{
+					{PrincipalUrn: adminPrincipal.String(), Level: level},
+				},
+				ExpectedVersion: currentAudienceVersion(t, ctx, ti, serverID),
+				SessionToken:    nil,
+				ApikeyToken:     nil,
+			})
+			require.Error(t, err)
+
+			var oopsErr *oops.ShareableError
+			require.ErrorAs(t, err, &oopsErr)
+			require.Equal(t, oops.CodeInvalid, oopsErr.Code)
+		})
+	}
+}
+
+// Taking a team off a server is what this surface is for, so every role other
+// than admin is still blockable.
+func TestService_SetResourceAudience_AllowsBlockingANonAdminRole(t *testing.T) {
+	t.Parallel()
+
+	ctx, ti := newTestAccessService(t)
+	authCtx, ok := contextvalues.GetAuthContext(ctx)
+	require.True(t, ok)
+
+	seedRole(t, ctx, ti.conn, authCtx.ActiveOrganizationID, mockRole("role_gtm", "GTM", "gtm", "Go to market"))
+	gtmPrincipal := seededRolePrincipal(t, ctx, ti.conn, authCtx.ActiveOrganizationID, "gtm")
+	serverID := seedMCPServer(t, ctx, ti.conn, authCtx.ActiveOrganizationID)
+
+	result, err := ti.service.SetResourceAudience(ctx, &gen.SetResourceAudiencePayload{
+		ResourceKind: "mcp",
+		ResourceID:   serverID,
+		Entries: []*gen.SetResourceAudienceEntry{
+			{PrincipalUrn: gtmPrincipal.String(), Level: "blocked"},
+		},
+		ExpectedVersion: currentAudienceVersion(t, ctx, ti, serverID),
+		SessionToken:    nil,
+		ApikeyToken:     nil,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Entries, 1)
+	require.Equal(t, "blocked", result.Entries[0].Level)
+}
+
 func TestService_SetResourceAudience_NarrowsToTools(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Three fixes to the MCP server Team Access surface, plus a guardrail on the endpoint behind it.

**A "Conflicting roles" section explains people a block removed.** Someone a role grants the server but another of their roles blocks resolves to no reach at all, so they were silently absent from "People this reaches". A role showing eleven faces above a list of four read as a bug in the count. Those people now get their own section under the table — marked with a warning icon — naming the granting role, the blocking role, and how to resolve it, with both roles linked to their edit pages. "Granted by" omits any role that also appears under "Blocked by": a role that both grants organization-wide and blocks here is arguing with itself, not with another role, and reads as a contradiction rather than something to go and fix.

**Annotation narrowing works again on servers with no tool catalogue.** `#6246` gated "Specific tools…" behind `hasCatalog`, because subtracting from a rule this page does not own was written as a block naming every tool left out — which needs a catalogue to enumerate. Gateways and remote servers resolve their tools per caller and publish none, so the option disappeared from exactly the servers where restricting by annotation is the only form available. `narrowWrite` now subtracts by annotation when the choice names no tools: the disposition vocabulary is closed, so "only read-only" is stored as a block on the other three. That needs no catalogue and keeps covering tools added later, which is the point of restricting by annotation rather than by name. An empty choice now routes to the existing revoke instead of falling through to a block that names nothing, which previously widened access to every tool.

**"Block destructive tools" is a one-click option** on the Connect line, writing `mcp:blocked_connect` with `dispositions: ["destructive"]` and lifted by "Allow destructive tools". It is the restriction people reach for most, and it works the same on every kind of server.

**The endpoint refuses a block naming the admin role**, at all three block levels. Restricting a server to one team is written as "everyone else: no access", which stores a block — and a block outranks every grant. Naming the administrator role there takes the server's own access page away from every administrator, including the ones who could undo it. The existing lockout guard only covers the caller's own principals, and whoever restricts a server is rarely an administrator themselves. Every other role stays blockable; taking a team off a server is what this surface is for.

## Motivation

Reported from internal use: a gateway restricted to one team showed that team's role reaching eleven people while only four appeared underneath, and the admins of the organization lost the Team Access tab on that server entirely (the nav hides it when `mcp:read` is blocked, with no explanation). Both follow from the same mechanic — a block outranks every grant, per-person — which the page had no way of saying. The third report, that the option to restrict destructive actions had disappeared, turned out to be the `hasCatalog` gate.

`RoleLink` moved out of `ManageAccess.tsx` into its own module so both surfaces share it.


https://claude.ai/code/session_0162kYLnbnxXXktCYkW3buo2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the MCP Team Access surface: people silently missing because a role block cancelled their grant are now explained, and annotation narrowing plus destructive-tool restrictions work again on servers that publish no tool catalogue.

- People whose grant is cancelled by a role block now appear under a "Conflicting roles" section naming both the granting and blocking roles, each linked to its edit page; a role that both grants and blocks appears only under "Blocked by".
- Annotation narrowing and the new "Block destructive tools" option write blocks by disposition rather than tool name, so they work without a catalogue and keep covering tools added later. Since these shortcuts rewrite the whole block, they are only offered when no other restriction is standing; "Allow destructive tools" likewise only lifts a block that names destructive and nothing else.
- The narrowing dialog seeds from every grant a row reaches — inherited ones included — minus what its blocks take away, so rows like "all tools except destructive tools" open pre-selected. An empty save revokes instead of widening, name-only edits keep a standing annotation block rather than converting it to the tool names it covers today, picking every annotation restores an unnarrowed grant, and name subtraction without a catalogue leaves existing blocks in place.
- The endpoint refuses a block on the administrator role at all three block levels: restricting a server to one team is written as "everyone else: no access", and blocking admin would lock out everyone who could undo it.

<sup>Written for commit ee5d88ab6049e8e8dd396ee5769459b343cb66ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

