### PR TITLE
fix: show a policy's stored detection scope when its category has no recommendation

### DIFF
--- a/client/dashboard/src/pages/security/PolicyDetail.scope-rows.test.tsx
+++ b/client/dashboard/src/pages/security/PolicyDetail.scope-rows.test.tsx
@@ -1,0 +1,207 @@
+import { useSdkClient } from "@/contexts/Sdk";
+import type { RiskCategoryDefinition } from "@gram/client/models/components/riskcategorydefinition.js";
+import type { RiskPolicy } from "@gram/client/models/components/riskpolicy.js";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/Tooltip";
+import { StandardPolicyEditor } from "./PolicyDetail";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/contexts/Auth", () => ({
+  useProject: () => ({ id: "project-1" }),
+}));
+
+vi.mock("@/components/page-layout", () => ({
+  Page: Object.assign(({ children }: { children?: ReactNode }) => children, {
+    Header: Object.assign(
+      ({ children }: { children?: ReactNode }) => children,
+      { Breadcrumbs: () => null },
+    ),
+    Body: ({ children }: { children?: ReactNode }) => children,
+  }),
+}));
+
+vi.mock("@/components/require-scope", () => ({
+  RequireScope: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock("@/contexts/Sdk", () => ({
+  useSdkClient: vi.fn(),
+}));
+
+vi.mock("@/routes", () => ({
+  useRoutes: () => ({ policyCenter: { goTo: vi.fn() } }),
+}));
+
+vi.mock("nuqs", () => ({
+  useQueryState: (name: string) =>
+    name === "step" ? ["scope", vi.fn()] : [null, vi.fn()],
+}));
+
+vi.mock("@/components/shadow-mcp/ShadowMCPPolicyServerSelector", () => ({
+  ShadowMCPPolicyServerSelector: () => null,
+}));
+
+vi.mock("@gram/client/react-query/riskCreatePolicy.js", () => ({
+  useRiskCreatePolicyMutation: () => ({ isPending: false, mutate: vi.fn() }),
+}));
+
+vi.mock("@gram/client/react-query/riskPoliciesUpdate.js", () => ({
+  useRiskPoliciesUpdateMutation: () => ({ isPending: false, mutate: vi.fn() }),
+}));
+
+vi.mock("@gram/client/react-query/riskCategories.js", () => ({
+  useRiskCategories: () => ({
+    data: { categories: CATEGORIES },
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock("./detection-rules-data", () => ({
+  useDetectionRulesStore: () => ({ customRules: [] }),
+}));
+
+vi.mock("./use-cel-status", () => ({
+  useCelStatus: () => ({ kind: "valid" }),
+}));
+
+vi.mock("./use-cel-engine", () => ({
+  useCelEngine: () => ({ status: "loading" }),
+}));
+
+vi.mock("./PolicyCenter", () => ({
+  ActionPicker: () => null,
+  CustomizeRulesSheet: () => null,
+  PolicyAudiencePicker: () => null,
+  RuleSelectList: () => null,
+  ScopeCard: () => null,
+}));
+
+vi.mock("./DetectorCard", () => ({
+  DetectorCard: () => null,
+}));
+
+vi.mock("@/pages/chatLogs/ChatTranscript", () => ({
+  ChatTranscript: () => null,
+}));
+
+vi.mock("@/pages/chatLogs/transcript", () => ({
+  buildDisplayItems: () => [],
+  buildTranscript: () => [],
+}));
+
+vi.mock("@/pages/chatLogs/useChatTranscript", () => ({
+  useChatTranscript: () => ({ messages: [] }),
+}));
+
+vi.mock("@/pages/chatLogs/claudeUsage", () => ({
+  formatUsageCost: () => "$0.00",
+}));
+
+function category(
+  key: string,
+  label: string,
+  overrides: Partial<RiskCategoryDefinition> = {},
+): RiskCategoryDefinition {
+  return {
+    key,
+    label,
+    recommendedScopeApplicable: true,
+    recommendedScopeInclude: "",
+    recommendedScopeExempt: "",
+    recommendedScopeRationale: "",
+    ...overrides,
+  } as RiskCategoryDefinition;
+}
+
+// Three selected categories: one with a registry recommendation, one with
+// neither a recommendation nor a stored scope, and custom rules, which the
+// registry synthesises as applicable-but-empty.
+const CATEGORIES: RiskCategoryDefinition[] = [
+  category("secrets", "Secrets", {
+    recommendedScopeInclude: 'kind == "tool_response"',
+  }),
+  category("shadow_mcp", "Shadow MCP"),
+  category("custom", "Custom rules"),
+];
+
+function policy(overrides: Partial<RiskPolicy> = {}): RiskPolicy {
+  return {
+    name: "Policy",
+    action: "flag",
+    audiencePrincipalUrns: ["user:all"],
+    audienceType: "everyone",
+    autoName: false,
+    createdAt: new Date("2026-01-01T10:00:00Z"),
+    enabled: true,
+    id: "policy-1",
+    messageTypes: [],
+    pendingMessages: 0,
+    policyType: "standard",
+    projectId: "project-1",
+    score: 5,
+    sources: ["gitleaks", "shadow_mcp"],
+    customRuleIds: ["rule-1"],
+    totalMessages: 0,
+    updatedAt: new Date("2026-01-01T10:00:00Z"),
+    version: 1,
+    ...overrides,
+  };
+}
+
+function renderEditor(p: RiskPolicy) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <StandardPolicyEditor policy={p} />
+      </TooltipProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("StandardPolicyEditor scope rows", () => {
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    vi.mocked(useSdkClient).mockReturnValue({
+      access: { listShadowMCPInventory: vi.fn() },
+    } as unknown as ReturnType<typeof useSdkClient>);
+  });
+
+  it("renders a row for a stored custom scope with no recommendation", () => {
+    renderEditor(
+      policy({
+        detectionScopes: [
+          { category: "custom", scopeInclude: 'kind in ["tool_request"]' },
+        ],
+      }),
+    );
+
+    expect(screen.getByText("Custom rules")).toBeTruthy();
+    expect(screen.getByText("Custom")).toBeTruthy();
+  });
+
+  it("still renders a category with a non-empty recommendation", () => {
+    renderEditor(policy());
+
+    expect(screen.getByText("Secrets")).toBeTruthy();
+    expect(screen.getByText("Recommended")).toBeTruthy();
+  });
+
+  it("hides a category with neither a recommendation nor a stored scope", () => {
+    renderEditor(policy());
+
+    expect(screen.queryByText("Shadow MCP")).toBeNull();
+    expect(screen.queryByText("Custom rules")).toBeNull();
+  });
+});

--- a/client/dashboard/src/pages/security/PolicyDetail.tsx
+++ b/client/dashboard/src/pages/security/PolicyDetail.tsx
@@ -1199,8 +1199,10 @@ function RecommendedScopesPanel({
       .filter((category) =>
         selectedCategories.has(category.key as RuleCategory),
       )
-      .filter((category) => hasDisplayableRecommendedScope(category));
-  }, [categoriesQuery.data?.categories, selectedCategories]);
+      .filter((category) =>
+        hasDisplayableScope(category, scopeOverrides.get(category.key)),
+      );
+  }, [categoriesQuery.data?.categories, selectedCategories, scopeOverrides]);
 
   if (categoriesQuery.isLoading) {
     return (
@@ -1736,9 +1738,13 @@ function RecommendedScopeCodeLine({
   );
 }
 
-function hasDisplayableRecommendedScope(
+// A category with an empty recommendation (e.g. custom rules) still gets a
+// row when the policy carries its own scope for it.
+function hasDisplayableScope(
   category: RiskCategoryDefinition,
+  override: ScopeOverride | undefined,
 ): boolean {
+  if (override !== undefined) return true;
   if (!category.recommendedScopeApplicable) return true;
   return (
     category.recommendedScopeInclude.trim() !== "" ||


### PR DESCRIPTION
## Summary

- The scope-row visibility predicate in `PolicyDetail` now also shows a row when the policy carries a stored detection scope for the category, not only when the registry has a non-empty recommendation.
- Adds `PolicyDetail.scope-rows.test.tsx` covering the three cases: stored custom scope renders, non-empty recommendation still renders, neither still hides.

## Motivation

The `custom` category has no recommended-scope registry entry, so the API synthesises an applicable-but-empty recommendation. The editor filtered rows purely on the recommendation, so a policy with a real stored `custom` scope (e.g. `kind in ["tool_request"]`) showed no row in the Scope step. The scope was still stored, enforced, and preserved across a save; it was only invisible and uneditable. The legacy-policy-scope migration writes exactly these scopes onto enforcing policies with custom rules, so this became common.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a policy's stored detection scope in the Scope step even when the category has no recommended scope, so custom-scope policies are visible and editable again. Previously, rows were filtered purely on the registry recommendation, hiding stored scopes for categories like `custom` (the API synthesizes an empty recommendation for them). Adds tests covering stored custom scope, non-empty recommendation, and neither.

<sup>Written for commit 381f51ce1855d0ed86669b4e8705334bdc876ec2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

