### PR TITLE
fix: make setup wizard rail rows non-interactive while a completion settles

### DIFF
--- a/.changeset/setup-wizard-rail-disabled.md
+++ b/.changeset/setup-wizard-rail-disabled.md
@@ -1,0 +1,5 @@
+---
+"dashboard": patch
+---
+
+Setup wizard rail rows are no longer focusable or announced as buttons while a card's completion is settling.

--- a/client/dashboard/src/pages/setup/SetupWizard.test.tsx
+++ b/client/dashboard/src/pages/setup/SetupWizard.test.tsx
@@ -305,9 +305,11 @@ describe("SetupWizard", () => {
     expect(skip.hasAttribute("disabled")).toBe(true);
     fireEvent.click(previous);
     fireEvent.click(skip);
-    fireEvent.click(
-      screen.getByRole("button", { name: /Set up identity provider/ }),
-    );
+    // Rail rows stop presenting as buttons rather than ignoring clicks.
+    expect(
+      screen.queryByRole("button", { name: /Set up identity provider/ }),
+    ).toBeNull();
+    fireEvent.click(screen.getByText("Set up identity provider"));
     // The nested sub-step list holds too.
     const subStep = screen.getByRole("button", { name: /Confirm traffic/ });
     expect(subStep.hasAttribute("disabled")).toBe(true);
@@ -334,9 +336,10 @@ describe("SetupWizard", () => {
     const skip = screen.getByRole("button", { name: "Skip task" });
     expect(skip.hasAttribute("disabled")).toBe(true);
     fireEvent.click(skip);
-    fireEvent.click(
-      screen.getByRole("button", { name: /Set up identity provider/ }),
-    );
+    expect(
+      screen.queryByRole("button", { name: /Set up identity provider/ }),
+    ).toBeNull();
+    fireEvent.click(screen.getByText("Set up identity provider"));
     expect(mocks.setSearchParams).not.toHaveBeenCalled();
 
     finishInvalidate();

--- a/client/dashboard/src/pages/setup/SetupWizard.tsx
+++ b/client/dashboard/src/pages/setup/SetupWizard.tsx
@@ -129,6 +129,7 @@ function WizardRail({
       <OnboardingStepper
         steps={railSteps}
         currentStep={currentStep === -1 ? 0 : currentStep}
+        disabled={disabled}
         onStepClick={(position) => {
           const task = tasks[position];
           if (task) onPick(task);

--- a/client/dashboard/src/pages/setup/components/onboarding-stepper.tsx
+++ b/client/dashboard/src/pages/setup/components/onboarding-stepper.tsx
@@ -25,12 +25,19 @@ interface OnboardingStepperProps {
   steps: Step[];
   currentStep: number;
   onStepClick: (index: number) => void;
+  /**
+   * Rows stop being interactive: no button role, no tab stop, no click.
+   * The wizard sets this while a completion is settling, when a jump would
+   * be overwritten a moment later.
+   */
+  disabled?: boolean;
 }
 
 export function OnboardingStepper({
   steps,
   currentStep,
   onStepClick,
+  disabled = false,
 }: OnboardingStepperProps): JSX.Element {
   return (
     <nav className="flex flex-col" aria-label="Progress">
@@ -39,7 +46,7 @@ export function OnboardingStepper({
         const isCompleted = step.status === "done";
         const isUpcoming = !isCurrent && !isCompleted;
         const isLast = index === steps.length - 1;
-        const canJump = !isCurrent;
+        const canJump = !isCurrent && !disabled;
 
         return (
           // The whole row is the single interactive control for the step. The


### PR DESCRIPTION
## Summary

Follow-up to #6296. While a card's completion is settling, the setup wizard already ignores rail clicks, but the rows still carried a button role and a tab stop, so keyboard and screen-reader users were offered a control that did nothing.

- `OnboardingStepper` gains an optional `disabled` prop, off by default. When set, rows drop the button role, tab stop, click and key handlers, so they are presentational until the completion and refetch land. The task page passes nothing and is unchanged.
- `SetupWizard` passes its settling state through to the rail alongside the Previous, Skip and nested sub-step controls it already disables.
- Tests assert the rows no longer present as buttons while settling, rather than that clicks are ignored.

## Motivation

Raised by cubic on #6296 after the PR had entered the merge queue, where the branch could no longer be updated. The change is small and self-contained, so it lands on its own rather than dequeuing a green PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoD6WScBss9ETeHs6JaTyy


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes setup wizard rail rows non-interactive while a completion is settling, so keyboard and screen-reader users no longer tab to a control that does nothing. Rows previously kept a button role and tab stop even though clicks were ignored; they now drop the role, tab stop, and click handlers until the completion and refetch land.

<sup>Written for commit 54d57c55e34ea2fac2926054c551895920d5e771. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

