### PR TITLE
mig: retain accepted risk meter envelopes

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -6897,6 +6897,8 @@ WHERE processed_at IS NULL AND dead_lettered IS FALSE;
 -- Retained first-accepted risk meter envelopes. The complete protobuf includes
 -- reporting attribution and commits atomically with its publication outbox row.
 -- Delivery cleanup must never remove these idempotency receipts.
+-- Soft deletion retains the project reference. Physical deletion detaches only
+-- that reference, preserving the organization and original envelope for replay.
 CREATE TABLE IF NOT EXISTS risk_meter_reading_acceptances (
   id uuid NOT NULL,
   organization_id TEXT NOT NULL,
@@ -6908,6 +6910,9 @@ CREATE TABLE IF NOT EXISTS risk_meter_reading_acceptances (
   CONSTRAINT risk_meter_reading_acceptances_pkey PRIMARY KEY (id),
   CONSTRAINT risk_meter_reading_acceptances_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE SET NULL
 );
+
+CREATE INDEX IF NOT EXISTS risk_meter_reading_acceptances_project_id_idx
+ON risk_meter_reading_acceptances (project_id);
 
 -- General-purpose transactional outbox. A row says "publish these bytes to this
 -- Pub/Sub topic" and nothing more: the relay never inspects the payload, so any

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -6894,6 +6894,21 @@ CREATE INDEX IF NOT EXISTS outbox_relays_pending_idx
 ON outbox_relays (outbox_id)
 WHERE processed_at IS NULL AND dead_lettered IS FALSE;
 
+-- Retained first-accepted risk meter envelopes. The complete protobuf includes
+-- reporting attribution and commits atomically with its publication outbox row.
+-- Delivery cleanup must never remove these idempotency receipts.
+CREATE TABLE IF NOT EXISTS risk_meter_reading_acceptances (
+  id uuid NOT NULL,
+  organization_id TEXT NOT NULL,
+  project_id uuid,
+  envelope bytea NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+
+  CONSTRAINT risk_meter_reading_acceptances_pkey PRIMARY KEY (id),
+  CONSTRAINT risk_meter_reading_acceptances_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE SET NULL
+);
+
 -- General-purpose transactional outbox. A row says "publish these bytes to this
 -- Pub/Sub topic" and nothing more: the relay never inspects the payload, so any
 -- component can enqueue a message atomically with its own database writes

--- a/server/migrations/20260911153515_risk_meter_reading_acceptances.sql
+++ b/server/migrations/20260911153515_risk_meter_reading_acceptances.sql
@@ -1,0 +1,11 @@
+-- Create "risk_meter_reading_acceptances" table
+CREATE TABLE "risk_meter_reading_acceptances" (
+  "id" uuid NOT NULL,
+  "organization_id" text NOT NULL,
+  "project_id" uuid NULL,
+  "envelope" bytea NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  "updated_at" timestamptz NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY ("id"),
+  CONSTRAINT "risk_meter_reading_acceptances_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects" ("id") ON UPDATE NO ACTION ON DELETE SET NULL
+);

--- a/server/migrations/20260911163118_index_risk_meter_receipt_projects.sql
+++ b/server/migrations/20260911163118_index_risk_meter_receipt_projects.sql
@@ -1,0 +1,4 @@
+-- atlas:txmode none
+
+-- Create index "risk_meter_reading_acceptances_project_id_idx" to table: "risk_meter_reading_acceptances"
+CREATE INDEX CONCURRENTLY "risk_meter_reading_acceptances_project_id_idx" ON "risk_meter_reading_acceptances" ("project_id");

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:ddjd76fkhGKlyWDT7inWoy/dE4qIh04BL/3ebSV5p+c=
+h1:QyQA5N9LH/qH1A2o4qECHxOf0PrBG5x5kfznCIuzk/s=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -400,3 +400,4 @@ h1:ddjd76fkhGKlyWDT7inWoy/dE4qIh04BL/3ebSV5p+c=
 20260910185215_add_workload_identity_admissions.sql h1:RoBbWHsyGZxnR5a+04dSoe5T9xjpJEd61v6CakRJK9w=
 20260910213144_user-session-issuer-trusted-remote-issuer.sql h1:pqfLDrzOYI3IiCow5/HpUL9DbDxKE1caOW3T7fF4QU0=
 20260911153515_risk_meter_reading_acceptances.sql h1:Hd5GchTb4ztJi+lDr/bJl6NnHuo6Z4RYdeC3nIwpwlg=
+20260911163118_index_risk_meter_receipt_projects.sql h1:ETO1BQfWUeyYowGf9EhjOjJyR6vKw2JpQiLi/b9MTlQ=

--- a/server/migrations/atlas.sum
+++ b/server/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:aREcIjzCaCcCw8zeXl6DpNcWqUiECGrhWQpYUf3ts2o=
+h1:ddjd76fkhGKlyWDT7inWoy/dE4qIh04BL/3ebSV5p+c=
 20250502122425_initial-tables.sql h1:Hu3O60/bB4fjZpUay8FzyOjw6vngp087zU+U/wVKn7k=
 20250502130852_initial-indexes.sql h1:oYbnwi9y9PPTqu7uVbSPSALhCY8XF3rv03nDfG4b7mo=
 20250502154250_relax-http-security-fields.sql h1:0+OYIDq7IHmx7CP5BChVwfpF2rOSrRDxnqawXio2EVo=
@@ -399,3 +399,4 @@ h1:aREcIjzCaCcCw8zeXl6DpNcWqUiECGrhWQpYUf3ts2o=
 20260910185039_add_workload_issuers.sql h1:KzKMWOvQ4KyGsZP2E8LKR8tVbCfUdQ0Ix94PfVYsjqQ=
 20260910185215_add_workload_identity_admissions.sql h1:RoBbWHsyGZxnR5a+04dSoe5T9xjpJEd61v6CakRJK9w=
 20260910213144_user-session-issuer-trusted-remote-issuer.sql h1:pqfLDrzOYI3IiCow5/HpUL9DbDxKE1caOW3T7fF4QU0=
+20260911153515_risk_meter_reading_acceptances.sql h1:Hd5GchTb4ztJi+lDr/bJl6NnHuo6Z4RYdeC3nIwpwlg=


### PR DESCRIPTION
## Summary

Add retained PostgreSQL receipts keyed by deterministic risk meter reading ID. Each receipt stores the complete accepted protobuf envelope, including reporting attribution. Soft deletion retains the project reference. Physical deletion nulls that reference without discarding the original organization, envelope, or idempotency identity. A project-reference index keeps physical deletion from scanning the retained receipt table.

## Motivation

The publication outbox removes delivered rows, so it cannot permanently prevent a retry from publishing a different fact under the same reading ID. These receipts provide the persistence required for atomic first acceptance and outbox enqueue.

Schema-only prerequisite for the risk-meter acceptance fix. Apply this migration before deploying code that uses the receipts. No backfill or historical conflict reconciliation is included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a table that retains the first-accepted risk meter envelope per reading ID so a retry cannot publish a different fact under the same ID. Because the outbox deletes delivered rows, these receipts are the persisted idempotency identity. Deleting a project nulls its reference without discarding the envelope or organization, with a concurrent index covering that lookup. Apply this migration before deploying code that uses the receipts; no backfill is included.

<sup>Written for commit 1151d9155cd1f3a5af5f94928223b180cfa05581. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

