### PR TITLE
fix: risk policy scope editor misrepresents empty and parenthesized scopes

### DIFF
--- a/client/dashboard/src/pages/security/PolicyDetail.scope-rows.test.tsx
+++ b/client/dashboard/src/pages/security/PolicyDetail.scope-rows.test.tsx
@@ -3,6 +3,7 @@ import type { RiskCategoryDefinition } from "@gram/client/models/components/risk
 import type { RiskPolicy } from "@gram/client/models/components/riskpolicy.js";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/Tooltip";
@@ -198,10 +199,126 @@ describe("StandardPolicyEditor scope rows", () => {
     expect(screen.getByText("Recommended")).toBeTruthy();
   });
 
-  it("hides a category with neither a recommendation nor a stored scope", () => {
+  it("renders a row so a category with no recommendation can be authored", () => {
     renderEditor(policy());
 
-    expect(screen.queryByText("Shadow MCP")).toBeNull();
-    expect(screen.queryByText("Custom rules")).toBeNull();
+    expect(screen.getByText("Shadow MCP")).toBeTruthy();
+    expect(screen.getByText("Custom rules")).toBeTruthy();
+    expect(screen.getByText("Recommended")).toBeTruthy();
+  });
+});
+
+function secretsOnlyPolicy(overrides: Partial<RiskPolicy> = {}): RiskPolicy {
+  return policy({
+    sources: ["gitleaks"],
+    customRuleIds: [],
+    ...overrides,
+  });
+}
+
+describe("StandardPolicyEditor scope chip fidelity", () => {
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    vi.mocked(useSdkClient).mockReturnValue({
+      access: { listShadowMCPInventory: vi.fn() },
+    } as unknown as ReturnType<typeof useSdkClient>);
+  });
+
+  it("does not highlight every surface for a scope that matches none", () => {
+    renderEditor(
+      secretsOnlyPolicy({
+        detectionScopes: [{ category: "secrets", scopeInclude: "kind in []" }],
+      }),
+    );
+
+    for (const label of [
+      "User",
+      "Tool requests",
+      "Tool responses",
+      "Assistant",
+    ]) {
+      expect(
+        screen
+          .getByRole("button", { name: label })
+          .getAttribute("aria-pressed"),
+      ).toBe("false");
+    }
+    expect(
+      screen.getByText("This category scans no message surfaces."),
+    ).toBeTruthy();
+  });
+
+  it("decodes parenthesised membership into the same surface chips", () => {
+    renderEditor(
+      secretsOnlyPolicy({
+        detectionScopes: [
+          {
+            category: "secrets",
+            scopeInclude: '(kind in ["tool_request"])',
+          },
+        ],
+      }),
+    );
+
+    expect(
+      screen
+        .getByRole("button", { name: "Tool requests" })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(
+      screen.getByRole("button", { name: "User" }).getAttribute("aria-pressed"),
+    ).toBe("false");
+    expect(screen.queryByText(/kind in \[/)).toBeNull();
+  });
+
+  it("warns when a kind conjunction can never match", () => {
+    renderEditor(
+      secretsOnlyPolicy({
+        detectionScopes: [
+          {
+            category: "secrets",
+            scopeInclude: 'kind == "user_message" && kind == "tool_request"',
+          },
+        ],
+      }),
+    );
+
+    expect(
+      screen.getByText("This category scans no message surfaces."),
+    ).toBeTruthy();
+    for (const label of [
+      "User",
+      "Tool requests",
+      "Tool responses",
+      "Assistant",
+    ]) {
+      expect(
+        screen
+          .getByRole("button", { name: label })
+          .getAttribute("aria-pressed"),
+      ).toBe("false");
+    }
+  });
+
+  it("lets the last surface be deselected and shows the empty-scope state", async () => {
+    const user = userEvent.setup();
+    renderEditor(
+      secretsOnlyPolicy({
+        detectionScopes: [
+          { category: "secrets", scopeInclude: 'kind == "user_message"' },
+        ],
+      }),
+    );
+
+    const userChip = screen.getByRole("button", { name: "User" });
+    expect(userChip.getAttribute("aria-pressed")).toBe("true");
+
+    await user.click(userChip);
+
+    expect(userChip.getAttribute("aria-pressed")).toBe("false");
+    expect(
+      screen.getByText("This category scans no message surfaces."),
+    ).toBeTruthy();
   });
 });

--- a/client/dashboard/src/pages/security/PolicyDetail.tsx
+++ b/client/dashboard/src/pages/security/PolicyDetail.tsx
@@ -120,7 +120,12 @@ import {
   pinnedHiddenRuleIds,
   policyToCategories,
 } from "./policy-form";
-import { decodeKindScope, encodeKindScope } from "./policy-scope";
+import {
+  decodeKindScope,
+  encodeKindScope,
+  kindScopeForMessageTypes,
+  scopeScansNoSurfaces,
+} from "./policy-scope";
 import { SeverityBadge } from "./risk-ui";
 import { CelExpressionField } from "./cel-field";
 import { CelReferenceSheet } from "./cel-reference";
@@ -1195,14 +1200,10 @@ function RecommendedScopesPanel({
 
   const rows = useMemo(() => {
     if (!categoriesQuery.data?.categories) return [];
-    return categoriesQuery.data.categories
-      .filter((category) =>
-        selectedCategories.has(category.key as RuleCategory),
-      )
-      .filter((category) =>
-        hasDisplayableScope(category, scopeOverrides.get(category.key)),
-      );
-  }, [categoriesQuery.data?.categories, selectedCategories, scopeOverrides]);
+    return categoriesQuery.data.categories.filter((category) =>
+      selectedCategories.has(category.key as RuleCategory),
+    );
+  }, [categoriesQuery.data?.categories, selectedCategories]);
 
   if (categoriesQuery.isLoading) {
     return (
@@ -1294,7 +1295,8 @@ function kindsFromExpr(expr: string): Set<ScopeSurfaceKind> | null {
 }
 
 // The surfaces a scope admits, or null when it is not a pure surface
-// expression. An empty include means every surface.
+// expression. An empty include string is unrestricted (every surface);
+// a decoded empty list (`kind in []`, exclusive conjunctions) is none.
 function surfacesFromScope(
   include: string,
   exempt: string,
@@ -1303,7 +1305,7 @@ function surfacesFromScope(
   const exempted = kindsFromExpr(exempt);
   if (included === null || exempted === null) return null;
   const base =
-    included.size === 0
+    include.trim() === ""
       ? new Set<ScopeSurfaceKind>(ALL_SURFACE_KINDS)
       : included;
   return new Set([...base].filter((kind) => !exempted.has(kind)));
@@ -1396,9 +1398,17 @@ function scopeWithSurface(
   };
 }
 
-// Canonical scope for a surface set: every surface = unrestricted, one
-// missing = exempt it, otherwise include the chosen surfaces.
+// Canonical scope for a surface set: every surface = unrestricted, none =
+// `kind in []`, one missing = exempt it, otherwise include the chosen
+// surfaces.
 function scopeFromSurfaces(surfaces: Set<ScopeSurfaceKind>): ScopeOverride {
+  if (surfaces.size === 0) {
+    const empty = kindScopeForMessageTypes([]);
+    return {
+      scopeInclude: empty.scopeInclude ?? "",
+      scopeExempt: empty.scopeExempt ?? "",
+    };
+  }
   if (surfaces.size >= ALL_SURFACE_KINDS.length) {
     return { scopeInclude: "", scopeExempt: "" };
   }
@@ -1412,6 +1422,17 @@ function scopeFromSurfaces(surfaces: Set<ScopeSurfaceKind>): ScopeOverride {
     ),
     scopeExempt: "",
   };
+}
+
+const SCANS_NOTHING_COPY = "This category scans no message surfaces.";
+
+function ScansNothingWarning(): JSX.Element {
+  return (
+    <p className="text-warning mt-2 flex items-start gap-1.5 text-xs">
+      <TriangleAlert className="mt-0.5 size-3.5 shrink-0" />
+      {SCANS_NOTHING_COPY}
+    </p>
+  );
 }
 
 function RecommendedScopeRow({
@@ -1451,12 +1472,17 @@ function RecommendedScopeRow({
   );
   const granularChips = !celOpen && activeSurfaces === null;
   const editorsOpen = celOpen && override !== undefined;
+  const hasRecommendation =
+    category.recommendedScopeInclude.trim() !== "" ||
+    category.recommendedScopeExempt.trim() !== "";
+  const scansNothing =
+    (activeSurfaces !== null && activeSurfaces.size === 0) ||
+    scopeScansNoSurfaces(activeScope);
 
   const toggleSurface = (kind: ScopeSurfaceKind) => {
     if (!activeSurfaces) return;
     const next = new Set(activeSurfaces);
     if (next.has(kind)) {
-      if (next.size === 1) return;
       next.delete(kind);
     } else {
       next.add(kind);
@@ -1474,9 +1500,11 @@ function RecommendedScopeRow({
           <ScopeRationaleHint rationale={category.recommendedScopeRationale} />
         </div>
         <div className="flex shrink-0 items-center gap-2">
-          <Badge variant="neutral">
-            {override === undefined ? "Recommended" : "Custom"}
-          </Badge>
+          {override !== undefined ? (
+            <Badge variant="neutral">Custom</Badge>
+          ) : hasRecommendation ? (
+            <Badge variant="neutral">Recommended</Badge>
+          ) : null}
           {override !== undefined && (
             <button
               type="button"
@@ -1530,6 +1558,8 @@ function RecommendedScopeRow({
           </SimpleTooltip>
         </div>
       )}
+
+      {!celOpen && activeSurfaces && scansNothing && <ScansNothingWarning />}
 
       {granularChips && (
         <GranularRecommendationChips
@@ -1585,6 +1615,7 @@ function RecommendedScopeRow({
               mode="scope"
             />
           </div>
+          {scansNothing && <ScansNothingWarning />}
         </div>
       )}
     </div>
@@ -1611,9 +1642,10 @@ function GranularRecommendationChips({
   const states = engine
     ? surfaceStatesFromProbes(engine, scope.scopeInclude, scope.scopeExempt)
     : null;
-  const scannedCount = states
-    ? Object.values(states).filter((s) => s !== "out").length
-    : 0;
+  const scansNothing =
+    scopeScansNoSurfaces(scope) ||
+    (states !== null &&
+      ALL_SURFACE_KINDS.every((kind) => states[kind] === "out"));
 
   return (
     <div className="mt-2 space-y-2">
@@ -1622,16 +1654,15 @@ function GranularRecommendationChips({
           {SCOPE_SURFACES.map(({ kind, label }) => {
             const state = states[kind];
             // Tri-state checkbox semantics: out and conditional click to
-            // fully in; in clicks to out (unless it is the last surface).
+            // fully in; in clicks to out, including the last surface (that
+            // writes an empty scope and surfaces the scans-nothing warning).
             const nextOn = state !== "in";
-            const lastSurface = state !== "out" && scannedCount <= 1;
             const chip = (
               <button
                 key={kind}
                 type="button"
                 aria-pressed={state !== "out"}
                 onClick={() => {
-                  if (!nextOn && lastSurface) return;
                   onToggleSurface(kind, nextOn);
                 }}
                 className={cn(
@@ -1685,6 +1716,7 @@ function GranularRecommendationChips({
           </button>
         </div>
       )}
+      {scansNothing && <ScansNothingWarning />}
     </div>
   );
 }
@@ -1735,20 +1767,6 @@ function RecommendedScopeCodeLine({
         {expr}
       </pre>
     </div>
-  );
-}
-
-// A category with an empty recommendation (e.g. custom rules) still gets a
-// row when the policy carries its own scope for it.
-function hasDisplayableScope(
-  category: RiskCategoryDefinition,
-  override: ScopeOverride | undefined,
-): boolean {
-  if (override !== undefined) return true;
-  if (!category.recommendedScopeApplicable) return true;
-  return (
-    category.recommendedScopeInclude.trim() !== "" ||
-    category.recommendedScopeExempt.trim() !== ""
   );
 }
 

--- a/client/dashboard/src/pages/security/policy-scope.test.ts
+++ b/client/dashboard/src/pages/security/policy-scope.test.ts
@@ -10,6 +10,7 @@ import {
   kindScopeForMessageTypes,
   narrowScopeToKinds,
   replaceCategoryDetectionScope,
+  scopeScansNoSurfaces,
 } from "./policy-scope";
 
 const PROMPT_INJECTION_EXEMPT =
@@ -81,6 +82,29 @@ describe("policy scope codec", () => {
     ]);
   });
 
+  it("decodes parenthesised membership the same as the unwrapped form", () => {
+    expect(
+      decodeKindScope('(kind in ["user_message","tool_request"])'),
+    ).toEqual(["user_message", "tool_request"]);
+    expect(decodeKindScope('(kind in ["tool_request"])')).toEqual([
+      "tool_request",
+    ]);
+    expect(decodeKindScope('( kind in [ "tool_request" ] )')).toEqual([
+      "tool_request",
+    ]);
+  });
+
+  it("decodes a conjunction of kind predicates as their intersection", () => {
+    expect(
+      decodeKindScope('kind == "user_message" && kind == "tool_request"'),
+    ).toEqual([]);
+    expect(
+      decodeKindScope(
+        'kind in ["user_message","tool_request"] && kind == "tool_request"',
+      ),
+    ).toEqual(["tool_request"]);
+  });
+
   it("decodes parenthesised and unspaced OR scopes", () => {
     expect(
       decodeKindScope('(kind == "user_message")||(kind == "tool_request")'),
@@ -134,6 +158,36 @@ describe("policy scope codec", () => {
       kinds: new Set(ALL_POLICY_MESSAGE_TYPES),
       custom: true,
     });
+  });
+
+  it("treats mutually exclusive kind conjuncts as an empty scope", () => {
+    expect(
+      effectiveScopeKinds({
+        scopeInclude: 'kind == "user_message" && kind == "tool_request"',
+      }),
+    ).toEqual({ kinds: new Set(), custom: false });
+  });
+});
+
+describe("scopeScansNoSurfaces", () => {
+  it("is false for an unrestricted scope", () => {
+    expect(scopeScansNoSurfaces({})).toBe(false);
+    expect(scopeScansNoSurfaces({ scopeInclude: "" })).toBe(false);
+  });
+
+  it("is true for a decoded empty kind list", () => {
+    expect(scopeScansNoSurfaces({ scopeInclude: "kind in []" })).toBe(true);
+    expect(
+      scopeScansNoSurfaces({
+        scopeInclude: 'kind == "user_message" && kind == "tool_request"',
+      }),
+    ).toBe(true);
+  });
+
+  it("is false for a custom predicate that may still match", () => {
+    expect(scopeScansNoSurfaces({ scopeExempt: PROMPT_INJECTION_EXEMPT })).toBe(
+      false,
+    );
   });
 });
 

--- a/client/dashboard/src/pages/security/policy-scope.ts
+++ b/client/dashboard/src/pages/security/policy-scope.ts
@@ -90,11 +90,13 @@ function decodeKindEquality(cel: string): EffectivePolicyMessageType | null {
 }
 
 /** `kind in [...]` in any order, with or without duplicates — the server and
- *  hand-written policies are under no obligation to emit our canonical form. */
+ *  hand-written policies are under no obligation to emit our canonical form.
+ *  Optional wrapping parentheses match `decodeKindEquality`, so a purely
+ *  cosmetic `(kind in […])` still decodes to the same surface list. */
 function decodeKindMembership(
   cel: string,
 ): EffectivePolicyMessageType[] | null {
-  const list = /^\s*kind\s+in\s+(\[[\s\S]*\])\s*$/.exec(cel)?.[1];
+  const list = /^\(?\s*kind\s+in\s+(\[[\s\S]*\])\s*\)?$/.exec(cel.trim())?.[1];
   if (!list) return null;
 
   let parsed: unknown;
@@ -114,7 +116,7 @@ function decodeKindMembership(
     : null;
 }
 
-function decodeEffectiveKindScope(
+function decodeKindDisjunction(
   cel: string,
 ): EffectivePolicyMessageType[] | null {
   const membership = decodeKindMembership(cel);
@@ -136,6 +138,37 @@ function decodeEffectiveKindScope(
   }
 
   return null;
+}
+
+/** Intersection of kind-only conjuncts. Mutually exclusive terms decode to
+ *  an empty list rather than falling through to "custom" — that empty list
+ *  is the signal that the category scans nothing. */
+function decodeKindConjunction(
+  cel: string,
+): EffectivePolicyMessageType[] | null {
+  const terms = cel.split("&&");
+  if (terms.length < 2) return null;
+
+  let intersection: Set<EffectivePolicyMessageType> | undefined;
+  for (const term of terms) {
+    const decoded = decodeKindDisjunction(term.trim());
+    if (!decoded) return null;
+    const next = new Set(decoded);
+    if (!intersection) {
+      intersection = next;
+      continue;
+    }
+    for (const kind of intersection) {
+      if (!next.has(kind)) intersection.delete(kind);
+    }
+  }
+  return intersection ? [...intersection] : null;
+}
+
+function decodeEffectiveKindScope(
+  cel: string,
+): EffectivePolicyMessageType[] | null {
+  return decodeKindConjunction(cel) ?? decodeKindDisjunction(cel);
 }
 
 export function decodeKindScope(cel: string): PolicyMessageType[] | null {
@@ -195,6 +228,14 @@ export function effectiveScopeKinds({ scopeInclude, scopeExempt }: Scope): {
   // Both predicates can only ever narrow, so an undecodable one tells us
   // nothing once the scope is already empty.
   return { kinds, custom: custom && kinds.size > 0 };
+}
+
+/** True when every kind predicate in the scope is decodable and their
+ *  intersection admits no message surface. Undecodable (custom) predicates
+ *  return false — they may still match nothing, but that needs evaluation. */
+export function scopeScansNoSurfaces(scope: Scope): boolean {
+  const { kinds, custom } = effectiveScopeKinds(scope);
+  return !custom && kinds.size === 0;
 }
 
 /** The recommended scope for a category, or undefined when the category has no


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [AIS-693](https://linear.app/speakeasy/issue/AIS-693/risk-policy-scope-authoring-scope-editor-misrepresents-what-a-saved).

The Scope step of the risk policy editor could show the opposite of a saved category scope. Expressions still round-tripped correctly; the bugs were display, decode, and validation.

## What changed

- **Empty scope no longer looks like “every surface.”** `kind in []` (and an include/exempt pair that admits no kinds) now renders as no surfaces selected, with a warning: “This category scans no message surfaces.” Deselecting the last surface writes `kind in []` instead of a silent no-op.
- **Impossible kind conjunctions warn.** `kind == "user_message" && kind == "tool_request"` decodes to an empty surface set instead of a raw “Custom” expression with no signal that the category scans nothing.
- **Parenthesized membership decodes like equality.** `(kind in ["tool_request"])` shows the same surface chips as the unwrapped form.
- **Categories without a recommendation can be authored.** A selected category with no centrally recommended scope now always gets a row, not only when a scope is already stored.

Client-side CEL compile errors reaching Save with a generic message is left as unconfirmed (the issue asked to reproduce against a deployed environment first).

## Tests

- `policy-scope.test.ts` — parenthesized membership, kind conjunctions, `scopeScansNoSurfaces`
- `PolicyDetail.scope-rows.test.tsx` — empty-scope chips, last-surface deselection, parenthesized membership, impossible conjunction warning, authoring rows for categories with no recommendation
- Browser: emptied a category’s surfaces on the Scope step and confirmed the warning; opened a custom-only policy and confirmed its scope row is authorable.

![Secrets category with no surfaces selected and scans-nothing warning](https://cursor.com/artifacts/c/art-030c2a55-ca73-4b1b-98c3-4beb6cd1fffc)
![Scope step showing empty Secrets scope versus recommended sibling categories](https://cursor.com/artifacts/c/art-9485986f-41b2-474a-b3eb-b94a7b32a558)
![Custom Patterns category visible with surface chips so a scope can be authored](https://cursor.com/artifacts/c/art-b85ebfdf-99fa-441c-b12e-e73f20250ae6)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AIS-693](https://linear.app/speakeasy/issue/AIS-693/risk-policy-scope-authoring-scope-editor-misrepresents-what-a-saved)

<div><a href="https://cursor.com/agents/bc-ef8734b9-c27e-4812-bfb3-8afe3562ba1b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef8734b9-c27e-4812-bfb3-8afe3562ba1b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the risk policy scope editor so empty, impossible, and parenthesized scopes display what they actually scan instead of misrepresenting the saved scope (AIS-693).

- Empty scopes (`kind in []`) now render as no surfaces selected with a scans-nothing warning.
- Deselecting the last surface writes `kind in []` instead of silently keeping the previous selection.
- Kind conjunctions that can never match decode to an empty surface set and show the same warning.
- Parenthesized membership expressions decode to the same surface chips as the unwrapped form.
- Selected categories with no recommended scope now always get an editor row.

<sup>Written for commit 9d1de0727586e04ac263598efa63c707150d6bd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

