### PR TITLE
fix: keep theme and favorites when impersonation logout clears storage

### DIFF
--- a/client/dashboard/src/App.tsx
+++ b/client/dashboard/src/App.tsx
@@ -51,7 +51,10 @@ import { SdkProvider } from "./contexts/SdkProvider.tsx";
 import { TelemetryProvider } from "./contexts/TelemetryProvider.tsx";
 import { usePageTitle } from "./hooks/use-page-title";
 import { PREFERRED_THEME_STORAGE_KEY } from "./lib/local-storage-keys";
-import { restorePreservedStorageBackup } from "./lib/logout-storage";
+import {
+  capturePreservedStorageIfSafe,
+  restorePreservedStorageBackup,
+} from "./lib/logout-storage";
 import CliCallback from "./pages/cli/CliCallback";
 import ShadowMCPRequestAccess from "./pages/shadow-mcp/RequestAccess";
 import RiskPolicyChallengeAcknowledge from "./pages/risk-policy-challenge/Acknowledge";
@@ -87,6 +90,7 @@ export default function App(): JSX.Element {
     root.classList.remove(theme === "dark" ? "light" : "dark");
 
     localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, theme);
+    capturePreservedStorageIfSafe();
 
     setTheme(theme);
   };

--- a/client/dashboard/src/App.tsx
+++ b/client/dashboard/src/App.tsx
@@ -51,6 +51,7 @@ import { SdkProvider } from "./contexts/SdkProvider.tsx";
 import { TelemetryProvider } from "./contexts/TelemetryProvider.tsx";
 import { usePageTitle } from "./hooks/use-page-title";
 import { PREFERRED_THEME_STORAGE_KEY } from "./lib/local-storage-keys";
+import { restorePreservedStorageBackup } from "./lib/logout-storage";
 import CliCallback from "./pages/cli/CliCallback";
 import ShadowMCPRequestAccess from "./pages/shadow-mcp/RequestAccess";
 import RiskPolicyChallengeAcknowledge from "./pages/risk-policy-challenge/Acknowledge";
@@ -60,6 +61,11 @@ import { SharedSkillPage } from "./pages/skills/SharedSkillPage";
 import SwitchOrg from "./pages/demo/SwitchOrg";
 import TrialEnded from "./pages/demo/TrialEnded";
 import { AppRoute, useRoutes, useOrgRoutes } from "./routes";
+
+// Logout may have navigated here after Clear-Site-Data emptied localStorage.
+// theme-init.ts already restores when it can; this covers the module path
+// (tests, and any load that skipped the classic script).
+restorePreservedStorageBackup();
 
 export default function App(): JSX.Element {
   // Initialize from storage so React/Moonshine match the theme the pre-paint

--- a/client/dashboard/src/App.tsx
+++ b/client/dashboard/src/App.tsx
@@ -52,7 +52,7 @@ import { TelemetryProvider } from "./contexts/TelemetryProvider.tsx";
 import { usePageTitle } from "./hooks/use-page-title";
 import { PREFERRED_THEME_STORAGE_KEY } from "./lib/local-storage-keys";
 import {
-  capturePreservedStorageIfSafe,
+  rememberPreservedStorageKey,
   restorePreservedStorageBackup,
 } from "./lib/logout-storage";
 import CliCallback from "./pages/cli/CliCallback";
@@ -90,7 +90,7 @@ export default function App(): JSX.Element {
     root.classList.remove(theme === "dark" ? "light" : "dark");
 
     localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, theme);
-    capturePreservedStorageIfSafe();
+    rememberPreservedStorageKey(PREFERRED_THEME_STORAGE_KEY, theme);
 
     setTheme(theme);
   };

--- a/client/dashboard/src/contexts/AuthProvider.tsx
+++ b/client/dashboard/src/contexts/AuthProvider.tsx
@@ -131,7 +131,12 @@ const AuthHandler = ({ children }: { children: React.ReactNode }) => {
   const isImpersonating =
     Boolean(session?.impersonatorEmail) ||
     Boolean(session?.organizationOverride);
-  setPreservedStorageImpersonating(isImpersonating);
+  // Only classify when a session is present. A disappearing session (401 /
+  // expiry before /login) must not flip the flag to false — that would let
+  // session-expiry cleanup live-capture the impersonated org's keys.
+  if (session?.session) {
+    setPreservedStorageImpersonating(isImpersonating);
+  }
   useEffect(() => {
     if (session?.session && !isImpersonating) {
       capturePreservedStorage();

--- a/client/dashboard/src/contexts/AuthProvider.tsx
+++ b/client/dashboard/src/contexts/AuthProvider.tsx
@@ -19,6 +19,10 @@ import { isGramSessionUnauthorizedError } from "@/lib/route-errors";
 import { useQueryClient } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
 import { useIsPlatformAdminRef } from "@/contexts/Sdk";
+import {
+  capturePreservedStorage,
+  setPreservedStorageImpersonating,
+} from "@/lib/logout-storage";
 import { useEffect, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import {
@@ -119,6 +123,20 @@ const AuthHandler = ({ children }: { children: React.ReactNode }) => {
 
   // Sync isAdmin into the SDK fetcher so it can attach X-Gram-Scope-Override in production.
   isPlatformAdminRef.current = session?.user.isAdmin ?? false;
+
+  // Snapshot theme/favorites only for a normal session. Impersonation and
+  // support access must not refresh it, or logout would restore the
+  // customer org's keys instead of the admin's. The flag is set during
+  // render so child effects (favorites, theme) cannot capture first.
+  const isImpersonating =
+    Boolean(session?.impersonatorEmail) ||
+    Boolean(session?.organizationOverride);
+  setPreservedStorageImpersonating(isImpersonating);
+  useEffect(() => {
+    if (session?.session && !isImpersonating) {
+      capturePreservedStorage();
+    }
+  }, [session?.session, isImpersonating]);
 
   // you need something like this so you don't redirect with empty session too soon
   // isLoading is not synchronized with the session data actually being populated, so we need to wait for the session to actually finish loading

--- a/client/dashboard/src/contexts/SdkProvider.tsx
+++ b/client/dashboard/src/contexts/SdkProvider.tsx
@@ -44,7 +44,10 @@ export const SdkProvider = ({
     // hook below runs, so anything meant to outlive the session has to be read
     // off localStorage before the request is sent. Keyed by request so
     // overlapping logouts — a double-clicked menu item — each restore their own
-    // snapshot rather than racing over one slot.
+    // snapshot rather than racing over one slot. capturePreservedStorage also
+    // writes a window.name backup: impersonation exit / switch-account can
+    // time out and navigate to /login after Clear-Site-Data has already
+    // emptied the store, and this WeakMap does not survive that navigation.
     const preservedAcrossLogout = new WeakMap<Request, PreservedStorage>();
 
     const httpClient = new HTTPClient({

--- a/client/dashboard/src/contexts/SdkProvider.tsx
+++ b/client/dashboard/src/contexts/SdkProvider.tsx
@@ -1,7 +1,7 @@
 import { getRBACScopeOverrideHeader } from "@/components/dev-toolbar-utils";
 import { isProjectOverviewQueryKey } from "@/components/project/projectOverviewQuery";
 import {
-  capturePreservedStorage,
+  capturePreservedStorageIfSafe,
   clearStorageForLogout,
   type PreservedStorage,
 } from "@/lib/logout-storage";
@@ -44,10 +44,10 @@ export const SdkProvider = ({
     // hook below runs, so anything meant to outlive the session has to be read
     // off localStorage before the request is sent. Keyed by request so
     // overlapping logouts — a double-clicked menu item — each restore their own
-    // snapshot rather than racing over one slot. capturePreservedStorage also
-    // writes a window.name backup: impersonation exit / switch-account can
-    // time out and navigate to /login after Clear-Site-Data has already
-    // emptied the store, and this WeakMap does not survive that navigation.
+    // snapshot rather than racing over one slot. capturePreservedStorageIfSafe
+    // refuses to refresh that snapshot while impersonating, and also writes a
+    // window.name backup: impersonation exit can time out and navigate to
+    // /login after Clear-Site-Data has already emptied the store.
     const preservedAcrossLogout = new WeakMap<Request, PreservedStorage>();
 
     const httpClient = new HTTPClient({
@@ -73,7 +73,7 @@ export const SdkProvider = ({
 
     httpClient.addHook("beforeRequest", (request) => {
       if (new URL(request.url).pathname === LOGOUT_PATH) {
-        preservedAcrossLogout.set(request, capturePreservedStorage());
+        preservedAcrossLogout.set(request, capturePreservedStorageIfSafe());
       }
     });
 

--- a/client/dashboard/src/contexts/SdkProvider.tsx
+++ b/client/dashboard/src/contexts/SdkProvider.tsx
@@ -45,9 +45,9 @@ export const SdkProvider = ({
     // off localStorage before the request is sent. Keyed by request so
     // overlapping logouts — a double-clicked menu item — each restore their own
     // snapshot rather than racing over one slot. capturePreservedStorageIfSafe
-    // refuses to refresh that snapshot while impersonating, and also writes a
-    // window.name backup: impersonation exit can time out and navigate to
-    // /login after Clear-Site-Data has already emptied the store.
+    // returns the last safe snapshot while impersonating (it does not write
+    // a new backup). The backup is written by a prior safe capture so
+    // impersonation exit can time out and still restore after Clear-Site-Data.
     const preservedAcrossLogout = new WeakMap<Request, PreservedStorage>();
 
     const httpClient = new HTTPClient({

--- a/client/dashboard/src/hooks/useProjectFavorites.ts
+++ b/client/dashboard/src/hooks/useProjectFavorites.ts
@@ -1,7 +1,8 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 
 import { useLocalStorageState } from "@/hooks/useLocalStorageState";
 import { PROJECT_FAVORITES_STORAGE_PREFIX } from "@/lib/local-storage-keys";
+import { capturePreservedStorageIfSafe } from "@/lib/logout-storage";
 
 export function useProjectFavorites(orgId: string): {
   favoriteIds: string[];
@@ -15,6 +16,10 @@ export function useProjectFavorites(orgId: string): {
   );
 
   const favoriteSet = useMemo(() => new Set(favoriteIds), [favoriteIds]);
+
+  useEffect(() => {
+    capturePreservedStorageIfSafe();
+  }, [favoriteIds]);
 
   const isFavorite = useCallback(
     (projectId: string) => favoriteSet.has(projectId),

--- a/client/dashboard/src/hooks/useProjectFavorites.ts
+++ b/client/dashboard/src/hooks/useProjectFavorites.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo } from "react";
 
 import { useLocalStorageState } from "@/hooks/useLocalStorageState";
 import { PROJECT_FAVORITES_STORAGE_PREFIX } from "@/lib/local-storage-keys";
-import { capturePreservedStorageIfSafe } from "@/lib/logout-storage";
+import { rememberPreservedStorageKey } from "@/lib/logout-storage";
 
 export function useProjectFavorites(orgId: string): {
   favoriteIds: string[];
@@ -18,8 +18,11 @@ export function useProjectFavorites(orgId: string): {
   const favoriteSet = useMemo(() => new Set(favoriteIds), [favoriteIds]);
 
   useEffect(() => {
-    capturePreservedStorageIfSafe();
-  }, [favoriteIds]);
+    rememberPreservedStorageKey(
+      `${PROJECT_FAVORITES_STORAGE_PREFIX}${orgId}`,
+      JSON.stringify(favoriteIds),
+    );
+  }, [favoriteIds, orgId]);
 
   const isFavorite = useCallback(
     (projectId: string) => favoriteSet.has(projectId),

--- a/client/dashboard/src/lib/local-storage-keys.ts
+++ b/client/dashboard/src/lib/local-storage-keys.ts
@@ -6,3 +6,15 @@ export const PROJECT_FAVORITES_STORAGE_PREFIX = "gram:org-favorites:";
 // the values (labels, slugs) still reveal one user's navigation to the next
 // person on a shared machine, so logout clears them; theme and favorites survive.
 export const RECENTS_STORAGE_PREFIX = "gram:recents:";
+
+// Exact keys that outlive logout, impersonation exit, and Clear-Site-Data.
+// Theme is a device preference; favorites are opaque project UUIDs keyed by
+// org, so neither identifies the previous session's user.
+export const PRESERVED_LOCAL_STORAGE_KEYS = [
+  PREFERRED_THEME_STORAGE_KEY,
+] as const;
+
+// Prefixes of keys that outlive logout for the same reason as above.
+export const PRESERVED_LOCAL_STORAGE_PREFIXES = [
+  PROJECT_FAVORITES_STORAGE_PREFIX,
+] as const;

--- a/client/dashboard/src/lib/logout-storage.test.ts
+++ b/client/dashboard/src/lib/logout-storage.test.ts
@@ -462,6 +462,22 @@ describe("clearStorageForLogout", () => {
     ).toBeNull();
   });
 
+  it("does not live-capture while the session is unclassified", () => {
+    resetPreservedStorageCapture();
+    window.localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, "light");
+    window.localStorage.setItem(
+      "gram:org-favorites:<CUSTOMER_ORG_ID>",
+      '["<CUSTOMER_PROJECT_ID>"]',
+    );
+
+    clearStorageForLogout();
+
+    expect(window.localStorage.getItem(PREFERRED_THEME_STORAGE_KEY)).toBeNull();
+    expect(
+      window.localStorage.getItem("gram:org-favorites:<CUSTOMER_ORG_ID>"),
+    ).toBeNull();
+  });
+
   it("does not live-capture impersonated storage when no snapshot exists", () => {
     setPreservedStorageImpersonating(true);
     window.localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, "light");

--- a/client/dashboard/src/lib/logout-storage.test.ts
+++ b/client/dashboard/src/lib/logout-storage.test.ts
@@ -63,9 +63,8 @@ describe("clearStorageForLogout", () => {
     window.localStorage.clear();
     window.sessionStorage.clear();
     window.name = "";
-    setPreservedStorageImpersonating(false);
     resetPreservedStorageCapture();
-    capturePreservedStorage();
+    setPreservedStorageImpersonating(false);
   });
 
   it("keeps theme and favorites on the logout preserve lists", () => {
@@ -370,6 +369,40 @@ describe("clearStorageForLogout", () => {
     expect(
       window.localStorage.getItem("gram:org-favorites:<CUSTOMER_ORG_ID>"),
     ).toBeNull();
+  });
+
+  it("does not recapture on impersonation when the sealed snapshot is empty", () => {
+    expect(capturePreservedStorage()).toEqual([]);
+    expect(window.name.startsWith(LOGOUT_PRESERVE_WINDOW_NAME_PREFIX)).toBe(
+      true,
+    );
+    window.localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, "light");
+    window.localStorage.setItem(
+      "gram:org-favorites:<CUSTOMER_ORG_ID>",
+      '["<CUSTOMER_PROJECT_ID>"]',
+    );
+
+    setPreservedStorageImpersonating(true);
+    clearStorageForLogout(capturePreservedStorageIfSafe());
+
+    expect(window.localStorage.getItem(PREFERRED_THEME_STORAGE_KEY)).toBeNull();
+    expect(
+      window.localStorage.getItem("gram:org-favorites:<CUSTOMER_ORG_ID>"),
+    ).toBeNull();
+  });
+
+  it("does not upsert preserved keys before the session is classified", () => {
+    resetPreservedStorageCapture();
+    window.localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, "dark");
+    capturePreservedStorage();
+
+    rememberPreservedStorageKey(PREFERRED_THEME_STORAGE_KEY, "light");
+    setPreservedStorageImpersonating(true);
+    clearStorageForLogout(capturePreservedStorageIfSafe());
+
+    expect(window.localStorage.getItem(PREFERRED_THEME_STORAGE_KEY)).toBe(
+      "dark",
+    );
   });
 
   it("does not upsert while impersonating", () => {

--- a/client/dashboard/src/lib/logout-storage.test.ts
+++ b/client/dashboard/src/lib/logout-storage.test.ts
@@ -10,10 +10,13 @@ import {
 import {
   LOGOUT_PRESERVE_WINDOW_NAME_PREFIX,
   capturePreservedStorage,
+  capturePreservedStorageIfSafe,
   clearLegacyUserStorage,
   clearStorageForLogout,
+  resetPreservedStorageCapture,
   restorePreservedStorage,
   restorePreservedStorageBackup,
+  setPreservedStorageImpersonating,
 } from "./logout-storage";
 
 function createStorage(): Storage {
@@ -59,6 +62,8 @@ describe("clearStorageForLogout", () => {
     window.localStorage.clear();
     window.sessionStorage.clear();
     window.name = "";
+    setPreservedStorageImpersonating(false);
+    resetPreservedStorageCapture();
     capturePreservedStorage();
   });
 
@@ -234,7 +239,9 @@ describe("clearStorageForLogout", () => {
       '["<PROJECT_ID>"]',
     );
     expect(window.localStorage.getItem("preferredProject")).toBeNull();
-    expect(window.name).toBe("");
+    expect(window.name.startsWith(LOGOUT_PRESERVE_WINDOW_NAME_PREFIX)).toBe(
+      true,
+    );
   });
 
   it("ignores non-preserved keys smuggled in the window.name backup", () => {
@@ -249,7 +256,6 @@ describe("clearStorageForLogout", () => {
       "dark",
     );
     expect(window.localStorage.getItem("pylon_user_email")).toBeNull();
-    expect(window.name).toBe("");
   });
 
   it("does not overwrite an unrelated window.name", () => {
@@ -259,5 +265,102 @@ describe("clearStorageForLogout", () => {
     capturePreservedStorage();
 
     expect(window.name).toBe("other-tab-state");
+  });
+
+  // Platform admins snapshot in their own org. Impersonation must not replace
+  // that snapshot with the customer org's theme or favorites.
+  it("does not refresh the snapshot while impersonating", () => {
+    window.localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, "dark");
+    window.localStorage.setItem(
+      "gram:org-favorites:<ADMIN_ORG_ID>",
+      '["<ADMIN_PROJECT_ID>"]',
+    );
+    capturePreservedStorage();
+
+    setPreservedStorageImpersonating(true);
+    window.localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, "light");
+    window.localStorage.setItem(
+      "gram:org-favorites:<CUSTOMER_ORG_ID>",
+      '["<CUSTOMER_PROJECT_ID>"]',
+    );
+
+    expect(capturePreservedStorageIfSafe()).toEqual([
+      [PREFERRED_THEME_STORAGE_KEY, "dark"],
+      ["gram:org-favorites:<ADMIN_ORG_ID>", '["<ADMIN_PROJECT_ID>"]'],
+    ]);
+
+    window.localStorage.clear();
+    clearStorageForLogout(capturePreservedStorageIfSafe());
+
+    expect(window.localStorage.getItem(PREFERRED_THEME_STORAGE_KEY)).toBe(
+      "dark",
+    );
+    expect(
+      window.localStorage.getItem("gram:org-favorites:<ADMIN_ORG_ID>"),
+    ).toBe('["<ADMIN_PROJECT_ID>"]');
+    expect(
+      window.localStorage.getItem("gram:org-favorites:<CUSTOMER_ORG_ID>"),
+    ).toBeNull();
+  });
+
+  it("refreshes the snapshot on a normal admin session", () => {
+    window.localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, "dark");
+    capturePreservedStorage();
+
+    setPreservedStorageImpersonating(false);
+    window.localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, "light");
+
+    expect(capturePreservedStorageIfSafe()).toEqual([
+      [PREFERRED_THEME_STORAGE_KEY, "light"],
+    ]);
+  });
+
+  it("restores the pre-impersonation snapshot after a new-document load", () => {
+    window.localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, "dark");
+    window.localStorage.setItem(
+      "gram:org-favorites:<ADMIN_ORG_ID>",
+      '["<ADMIN_PROJECT_ID>"]',
+    );
+    capturePreservedStorage();
+
+    // Support-session start is a full navigation: heap is gone, backup remains.
+    window.localStorage.clear();
+    resetPreservedStorageCapture();
+    restorePreservedStorageBackup();
+    setPreservedStorageImpersonating(true);
+    window.localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, "light");
+    window.localStorage.setItem(
+      "gram:org-favorites:<CUSTOMER_ORG_ID>",
+      '["<CUSTOMER_PROJECT_ID>"]',
+    );
+
+    window.localStorage.clear();
+    clearStorageForLogout(capturePreservedStorageIfSafe());
+
+    expect(window.localStorage.getItem(PREFERRED_THEME_STORAGE_KEY)).toBe(
+      "dark",
+    );
+    expect(
+      window.localStorage.getItem("gram:org-favorites:<ADMIN_ORG_ID>"),
+    ).toBe('["<ADMIN_PROJECT_ID>"]');
+    expect(
+      window.localStorage.getItem("gram:org-favorites:<CUSTOMER_ORG_ID>"),
+    ).toBeNull();
+  });
+
+  it("does not live-capture impersonated storage when no snapshot exists", () => {
+    setPreservedStorageImpersonating(true);
+    window.localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, "light");
+    window.localStorage.setItem(
+      "gram:org-favorites:<CUSTOMER_ORG_ID>",
+      '["<CUSTOMER_PROJECT_ID>"]',
+    );
+
+    clearStorageForLogout();
+
+    expect(window.localStorage.getItem(PREFERRED_THEME_STORAGE_KEY)).toBeNull();
+    expect(
+      window.localStorage.getItem("gram:org-favorites:<CUSTOMER_ORG_ID>"),
+    ).toBeNull();
   });
 });

--- a/client/dashboard/src/lib/logout-storage.test.ts
+++ b/client/dashboard/src/lib/logout-storage.test.ts
@@ -13,6 +13,7 @@ import {
   capturePreservedStorageIfSafe,
   clearLegacyUserStorage,
   clearStorageForLogout,
+  rememberPreservedStorageKey,
   resetPreservedStorageCapture,
   restorePreservedStorage,
   restorePreservedStorageBackup,
@@ -301,6 +302,86 @@ describe("clearStorageForLogout", () => {
     expect(
       window.localStorage.getItem("gram:org-favorites:<CUSTOMER_ORG_ID>"),
     ).toBeNull();
+  });
+
+  it("seals the live store on the rising edge of impersonation", () => {
+    resetPreservedStorageCapture();
+    window.name = "";
+    window.localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, "dark");
+    window.localStorage.setItem(
+      "gram:org-favorites:<ADMIN_ORG_ID>",
+      '["<ADMIN_PROJECT_ID>"]',
+    );
+
+    setPreservedStorageImpersonating(true);
+    window.localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, "light");
+    window.localStorage.setItem(
+      "gram:org-favorites:<CUSTOMER_ORG_ID>",
+      '["<CUSTOMER_PROJECT_ID>"]',
+    );
+
+    clearStorageForLogout(capturePreservedStorageIfSafe());
+
+    expect(window.localStorage.getItem(PREFERRED_THEME_STORAGE_KEY)).toBe(
+      "dark",
+    );
+    expect(
+      window.localStorage.getItem("gram:org-favorites:<ADMIN_ORG_ID>"),
+    ).toBe('["<ADMIN_PROJECT_ID>"]');
+    expect(
+      window.localStorage.getItem("gram:org-favorites:<CUSTOMER_ORG_ID>"),
+    ).toBeNull();
+  });
+
+  it("restores the last snapshot on no-arg cleanup while impersonating", () => {
+    window.localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, "dark");
+    capturePreservedStorage();
+    setPreservedStorageImpersonating(true);
+    window.localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, "light");
+    window.localStorage.setItem(
+      "gram:org-favorites:<CUSTOMER_ORG_ID>",
+      '["<CUSTOMER_PROJECT_ID>"]',
+    );
+
+    clearStorageForLogout();
+
+    expect(window.localStorage.getItem(PREFERRED_THEME_STORAGE_KEY)).toBe(
+      "dark",
+    );
+    expect(
+      window.localStorage.getItem("gram:org-favorites:<CUSTOMER_ORG_ID>"),
+    ).toBeNull();
+  });
+
+  it("upserts one preserved key without scanning the rest of the store", () => {
+    window.localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, "dark");
+    capturePreservedStorage();
+    window.localStorage.setItem(
+      "gram:org-favorites:<CUSTOMER_ORG_ID>",
+      '["<CUSTOMER_PROJECT_ID>"]',
+    );
+
+    rememberPreservedStorageKey(PREFERRED_THEME_STORAGE_KEY, "light");
+    clearStorageForLogout();
+
+    expect(window.localStorage.getItem(PREFERRED_THEME_STORAGE_KEY)).toBe(
+      "light",
+    );
+    expect(
+      window.localStorage.getItem("gram:org-favorites:<CUSTOMER_ORG_ID>"),
+    ).toBeNull();
+  });
+
+  it("does not upsert while impersonating", () => {
+    window.localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, "dark");
+    capturePreservedStorage();
+    setPreservedStorageImpersonating(true);
+
+    rememberPreservedStorageKey(PREFERRED_THEME_STORAGE_KEY, "light");
+
+    expect(capturePreservedStorageIfSafe()).toEqual([
+      [PREFERRED_THEME_STORAGE_KEY, "dark"],
+    ]);
   });
 
   it("refreshes the snapshot on a normal admin session", () => {

--- a/client/dashboard/src/lib/logout-storage.test.ts
+++ b/client/dashboard/src/lib/logout-storage.test.ts
@@ -2,12 +2,18 @@
 
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { PREFERRED_THEME_STORAGE_KEY } from "./local-storage-keys";
 import {
+  PRESERVED_LOCAL_STORAGE_KEYS,
+  PRESERVED_LOCAL_STORAGE_PREFIXES,
+  PREFERRED_THEME_STORAGE_KEY,
+} from "./local-storage-keys";
+import {
+  LOGOUT_PRESERVE_WINDOW_NAME_PREFIX,
   capturePreservedStorage,
   clearLegacyUserStorage,
   clearStorageForLogout,
   restorePreservedStorage,
+  restorePreservedStorageBackup,
 } from "./logout-storage";
 
 function createStorage(): Storage {
@@ -52,6 +58,13 @@ describe("clearStorageForLogout", () => {
     });
     window.localStorage.clear();
     window.sessionStorage.clear();
+    window.name = "";
+    capturePreservedStorage();
+  });
+
+  it("keeps theme and favorites on the logout preserve lists", () => {
+    expect(PRESERVED_LOCAL_STORAGE_KEYS).toContain(PREFERRED_THEME_STORAGE_KEY);
+    expect(PRESERVED_LOCAL_STORAGE_PREFIXES).toContain("gram:org-favorites:");
   });
 
   it("preserves theme and favorites while clearing user-scoped local storage", () => {
@@ -170,5 +183,81 @@ describe("clearStorageForLogout", () => {
     expect(() =>
       restorePreservedStorage([[PREFERRED_THEME_STORAGE_KEY, "dark"]]),
     ).not.toThrow();
+  });
+
+  // Impersonation exit and "switch account" call logout, then navigate to
+  // /login. The response hook may never run (timeout, or the Request identity
+  // used as the WeakMap key does not match). The capture taken before the
+  // request is what has to refill the emptied store.
+  it("restores from the last capture when logout is given no snapshot", () => {
+    window.localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, "dark");
+    window.localStorage.setItem(
+      "gram:org-favorites:<ORG_ID>",
+      '["<PROJECT_ID>"]',
+    );
+    window.localStorage.setItem("preferredProject", "project-slug");
+
+    capturePreservedStorage();
+    window.localStorage.clear();
+
+    clearStorageForLogout();
+
+    expect(window.localStorage.getItem(PREFERRED_THEME_STORAGE_KEY)).toBe(
+      "dark",
+    );
+    expect(window.localStorage.getItem("gram:org-favorites:<ORG_ID>")).toBe(
+      '["<PROJECT_ID>"]',
+    );
+    expect(window.localStorage.getItem("preferredProject")).toBeNull();
+  });
+
+  it("survives a post-wipe navigation via the window.name backup", () => {
+    window.localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, "dark");
+    window.localStorage.setItem(
+      "gram:org-favorites:<ORG_ID>",
+      '["<PROJECT_ID>"]',
+    );
+    window.localStorage.setItem("preferredProject", "project-slug");
+
+    capturePreservedStorage();
+    expect(window.name.startsWith(LOGOUT_PRESERVE_WINDOW_NAME_PREFIX)).toBe(
+      true,
+    );
+
+    window.localStorage.clear();
+    restorePreservedStorageBackup();
+
+    expect(window.localStorage.getItem(PREFERRED_THEME_STORAGE_KEY)).toBe(
+      "dark",
+    );
+    expect(window.localStorage.getItem("gram:org-favorites:<ORG_ID>")).toBe(
+      '["<PROJECT_ID>"]',
+    );
+    expect(window.localStorage.getItem("preferredProject")).toBeNull();
+    expect(window.name).toBe("");
+  });
+
+  it("ignores non-preserved keys smuggled in the window.name backup", () => {
+    window.name = `${LOGOUT_PRESERVE_WINDOW_NAME_PREFIX}${JSON.stringify([
+      [PREFERRED_THEME_STORAGE_KEY, "dark"],
+      ["pylon_user_email", "user@example.com"],
+    ])}`;
+
+    restorePreservedStorageBackup();
+
+    expect(window.localStorage.getItem(PREFERRED_THEME_STORAGE_KEY)).toBe(
+      "dark",
+    );
+    expect(window.localStorage.getItem("pylon_user_email")).toBeNull();
+    expect(window.name).toBe("");
+  });
+
+  it("does not overwrite an unrelated window.name", () => {
+    window.name = "other-tab-state";
+    window.localStorage.setItem(PREFERRED_THEME_STORAGE_KEY, "dark");
+
+    capturePreservedStorage();
+
+    expect(window.name).toBe("other-tab-state");
   });
 });

--- a/client/dashboard/src/lib/logout-storage.ts
+++ b/client/dashboard/src/lib/logout-storage.ts
@@ -1,21 +1,24 @@
 import {
-  PREFERRED_THEME_STORAGE_KEY,
-  PROJECT_FAVORITES_STORAGE_PREFIX,
+  PRESERVED_LOCAL_STORAGE_KEYS,
+  PRESERVED_LOCAL_STORAGE_PREFIXES,
 } from "@/lib/local-storage-keys";
 
-const PRESERVED_LOCAL_STORAGE_KEYS = new Set([PREFERRED_THEME_STORAGE_KEY]);
-// Favorites hold only opaque project UUIDs keyed by org id — nothing
-// dereferenceable without an authenticated session — so they survive logout.
-const PRESERVED_LOCAL_STORAGE_PREFIXES = [PROJECT_FAVORITES_STORAGE_PREFIX];
+const PRESERVED_KEY_SET = new Set<string>(PRESERVED_LOCAL_STORAGE_KEYS);
 
 const LEGACY_USER_STORAGE_KEYS = [
   "pylon_user_email",
   "pylon_user_display_name",
 ];
 
+// Survives Clear-Site-Data and the /login navigation that follows logout.
+// localStorage and sessionStorage are both emptied by that header; window.name
+// is not. theme-init.ts reads the same prefix before first paint — keep them
+// in lockstep. Cleared as soon as the entries are written back.
+export const LOGOUT_PRESERVE_WINDOW_NAME_PREFIX = "gram:logout-preserve:";
+
 function shouldPreserveLocalStorageKey(key: string) {
   return (
-    PRESERVED_LOCAL_STORAGE_KEYS.has(key) ||
+    PRESERVED_KEY_SET.has(key) ||
     PRESERVED_LOCAL_STORAGE_PREFIXES.some((prefix) => key.startsWith(prefix))
   );
 }
@@ -57,6 +60,84 @@ export function clearLegacyUserStorage(): void {
 /** localStorage entries that outlive a logout, as key/value pairs. */
 export type PreservedStorage = ReadonlyArray<readonly [string, string]>;
 
+// Last snapshot taken in this document. Used when the logout response hook
+// cannot find the per-request WeakMap entry (cloned Request identity) and
+// when logout times out after Clear-Site-Data has already emptied the store.
+let lastCaptured: PreservedStorage = [];
+
+function persistPreservedStorageBackup(preserved: PreservedStorage): void {
+  if (typeof window === "undefined") return;
+
+  try {
+    const current = window.name;
+    if (
+      current !== "" &&
+      !current.startsWith(LOGOUT_PRESERVE_WINDOW_NAME_PREFIX)
+    ) {
+      return;
+    }
+    window.name =
+      preserved.length === 0
+        ? ""
+        : `${LOGOUT_PRESERVE_WINDOW_NAME_PREFIX}${JSON.stringify(preserved)}`;
+  } catch {
+    // window.name unavailable — same-document restore still works.
+  }
+}
+
+function readPreservedStorageBackup(): PreservedStorage {
+  if (typeof window === "undefined") return [];
+
+  try {
+    const raw = window.name;
+    if (!raw.startsWith(LOGOUT_PRESERVE_WINDOW_NAME_PREFIX)) return [];
+
+    const parsed: unknown = JSON.parse(
+      raw.slice(LOGOUT_PRESERVE_WINDOW_NAME_PREFIX.length),
+    );
+    if (!Array.isArray(parsed)) return [];
+
+    const preserved: Array<readonly [string, string]> = [];
+    for (const entry of parsed) {
+      if (
+        !Array.isArray(entry) ||
+        entry.length !== 2 ||
+        typeof entry[0] !== "string" ||
+        typeof entry[1] !== "string" ||
+        !shouldPreserveLocalStorageKey(entry[0])
+      ) {
+        continue;
+      }
+      preserved.push([entry[0], entry[1]]);
+    }
+    return preserved;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Writes a captured snapshot back into localStorage and drops the
+ * navigation-surviving backup so a later site in this tab cannot read it.
+ */
+export function restorePreservedStorageBackup(): void {
+  const preserved = readPreservedStorageBackup();
+  if (preserved.length === 0) return;
+
+  restorePreservedStorage(preserved);
+  persistPreservedStorageBackup([]);
+}
+
+function snapshotForRestore(preserved?: PreservedStorage): PreservedStorage {
+  if (preserved && preserved.length > 0) return preserved;
+  if (lastCaptured.length > 0) return lastCaptured;
+
+  const backup = readPreservedStorageBackup();
+  if (backup.length > 0) return backup;
+
+  return capturePreservedStorage();
+}
+
 /**
  * Reads the localStorage entries that survive logout.
  *
@@ -66,6 +147,10 @@ export type PreservedStorage = ReadonlyArray<readonly [string, string]>;
  * to preserve by the time a response handler runs. Capturing before the request
  * goes out and handing the result to `clearStorageForLogout` is what keeps the
  * theme and favorites across a logout.
+ *
+ * The snapshot is also written to `window.name` so it still exists if logout
+ * times out and the page navigates to /login after the browser has already
+ * applied Clear-Site-Data — the WeakMap in SdkProvider does not survive that.
  */
 export function capturePreservedStorage(): PreservedStorage {
   if (typeof window === "undefined") return [];
@@ -88,6 +173,8 @@ export function capturePreservedStorage(): PreservedStorage {
     // Storage blocked — nothing persisted, nothing to preserve.
   }
 
+  lastCaptured = preserved;
+  persistPreservedStorageBackup(preserved);
   return preserved;
 }
 
@@ -97,6 +184,7 @@ export function restorePreservedStorage(preserved: PreservedStorage): void {
   try {
     const local = window.localStorage;
     for (const [key, value] of preserved) {
+      if (!shouldPreserveLocalStorageKey(key)) continue;
       local.setItem(key, value);
     }
   } catch {
@@ -112,10 +200,10 @@ export function restorePreservedStorage(preserved: PreservedStorage): void {
  * remaining copy of those entries. Callers clearing an intact store omit it and
  * the entries are read from storage directly.
  */
-export function clearStorageForLogout(
-  preserved: PreservedStorage = capturePreservedStorage(),
-): void {
+export function clearStorageForLogout(preserved?: PreservedStorage): void {
   if (typeof window === "undefined") return;
+
+  const toRestore = snapshotForRestore(preserved);
 
   try {
     window.localStorage.clear();
@@ -123,7 +211,9 @@ export function clearStorageForLogout(
     // Storage blocked — nothing persisted, nothing to clear.
   }
 
-  restorePreservedStorage(preserved);
+  restorePreservedStorage(toRestore);
+  lastCaptured = toRestore;
+  persistPreservedStorageBackup(toRestore);
 
   try {
     window.sessionStorage.clear();

--- a/client/dashboard/src/lib/logout-storage.ts
+++ b/client/dashboard/src/lib/logout-storage.ts
@@ -13,7 +13,8 @@ const LEGACY_USER_STORAGE_KEYS = [
 // Survives Clear-Site-Data and the /login navigation that follows logout.
 // localStorage and sessionStorage are both emptied by that header; window.name
 // is not. theme-init.ts reads the same prefix before first paint — keep them
-// in lockstep. Cleared as soon as the entries are written back.
+// in lockstep. Left in place after restore so a later impersonation document
+// can still recover the admin snapshot; a safe capture overwrites it.
 export const LOGOUT_PRESERVE_WINDOW_NAME_PREFIX = "gram:logout-preserve:";
 
 function shouldPreserveLocalStorageKey(key: string) {
@@ -64,6 +65,20 @@ export type PreservedStorage = ReadonlyArray<readonly [string, string]>;
 // cannot find the per-request WeakMap entry (cloned Request identity) and
 // when logout times out after Clear-Site-Data has already emptied the store.
 let lastCaptured: PreservedStorage = [];
+
+// WorkOS impersonation and org support sessions must not refresh the
+// snapshot: that would replace the platform admin's own theme/favorites
+// with whatever the impersonated org wrote. Auth writes this before logout.
+let sessionIsImpersonating = false;
+
+export function setPreservedStorageImpersonating(value: boolean): void {
+  sessionIsImpersonating = value;
+}
+
+/** Drop the in-memory snapshot the way a full navigation would. Tests only. */
+export function resetPreservedStorageCapture(): void {
+  lastCaptured = [];
+}
 
 function persistPreservedStorageBackup(preserved: PreservedStorage): void {
   if (typeof window === "undefined") return;
@@ -117,15 +132,16 @@ function readPreservedStorageBackup(): PreservedStorage {
 }
 
 /**
- * Writes a captured snapshot back into localStorage and drops the
- * navigation-surviving backup so a later site in this tab cannot read it.
+ * Writes a captured snapshot back into localStorage. The window.name backup
+ * stays until a later *safe* capture replaces it — impersonation loads in a
+ * new document and must still be able to restore the admin's prefs on exit.
  */
 export function restorePreservedStorageBackup(): void {
   const preserved = readPreservedStorageBackup();
   if (preserved.length === 0) return;
 
   restorePreservedStorage(preserved);
-  persistPreservedStorageBackup([]);
+  lastCaptured = preserved;
 }
 
 function snapshotForRestore(preserved?: PreservedStorage): PreservedStorage {
@@ -135,6 +151,22 @@ function snapshotForRestore(preserved?: PreservedStorage): PreservedStorage {
   const backup = readPreservedStorageBackup();
   if (backup.length > 0) return backup;
 
+  // An impersonated session's current store is not the admin's prefs.
+  if (sessionIsImpersonating) return [];
+  return capturePreservedStorage();
+}
+
+/**
+ * Snapshot theme and favorites only for a normal (non-impersonation) session.
+ * While impersonating, returns the last safe snapshot without reading
+ * localStorage, so a customer org's keys cannot replace the admin's.
+ */
+export function capturePreservedStorageIfSafe(): PreservedStorage {
+  if (sessionIsImpersonating) {
+    return lastCaptured.length > 0
+      ? lastCaptured
+      : readPreservedStorageBackup();
+  }
   return capturePreservedStorage();
 }
 

--- a/client/dashboard/src/lib/logout-storage.ts
+++ b/client/dashboard/src/lib/logout-storage.ts
@@ -72,6 +72,17 @@ let lastCaptured: PreservedStorage = [];
 let sessionIsImpersonating = false;
 
 export function setPreservedStorageImpersonating(value: boolean): void {
+  // WorkOS impersonation lands in a new document with no heap snapshot and
+  // usually no window.name backup. Seal the live store on the rising edge,
+  // before children write the customer org's favorites.
+  if (
+    value &&
+    !sessionIsImpersonating &&
+    lastCaptured.length === 0 &&
+    readPreservedStorageBackup().length === 0
+  ) {
+    capturePreservedStorage();
+  }
   sessionIsImpersonating = value;
 }
 
@@ -171,6 +182,21 @@ export function capturePreservedStorageIfSafe(): PreservedStorage {
 }
 
 /**
+ * Merge one preserved key into the snapshot. Theme/favorite writes use this
+ * so a full localStorage scan cannot pick up another tab's impersonated keys.
+ */
+export function rememberPreservedStorageKey(key: string, value: string): void {
+  if (sessionIsImpersonating || !shouldPreserveLocalStorageKey(key)) return;
+
+  const current =
+    lastCaptured.length > 0 ? lastCaptured : readPreservedStorageBackup();
+  const next = new Map(current);
+  next.set(key, value);
+  lastCaptured = Array.from(next.entries());
+  persistPreservedStorageBackup(lastCaptured);
+}
+
+/**
  * Reads the localStorage entries that survive logout.
  *
  * Exported for the logout request itself: that response carries
@@ -229,8 +255,8 @@ export function restorePreservedStorage(preserved: PreservedStorage): void {
  *
  * Pass `preserved` when the store may already have been emptied — after a
  * `Clear-Site-Data` response, a snapshot taken before the request is the only
- * remaining copy of those entries. Callers clearing an intact store omit it and
- * the entries are read from storage directly.
+ * remaining copy of those entries. Callers that omit it restore lastCaptured
+ * or the window.name backup, not a live re-read of a possibly mixed store.
  */
 export function clearStorageForLogout(preserved?: PreservedStorage): void {
   if (typeof window === "undefined") return;

--- a/client/dashboard/src/lib/logout-storage.ts
+++ b/client/dashboard/src/lib/logout-storage.ts
@@ -66,29 +66,38 @@ export type PreservedStorage = ReadonlyArray<readonly [string, string]>;
 // when logout times out after Clear-Site-Data has already emptied the store.
 let lastCaptured: PreservedStorage = [];
 
+// Empty `[]` is a real snapshot (admin has no theme/favorites). Distinct
+// from "never captured", which is when a WorkOS landing may still seal
+// the live store on the rising edge of impersonation.
+let hasSnapshot = false;
+
 // WorkOS impersonation and org support sessions must not refresh the
 // snapshot: that would replace the platform admin's own theme/favorites
 // with whatever the impersonated org wrote. Auth writes this before logout.
 let sessionIsImpersonating = false;
 
+// Theme/favorite upserts stay closed until Auth classifies the session,
+// so a mount-time theme apply cannot seal customer keys while auth.info
+// is still pending on an impersonation document.
+let sessionClassified = false;
+
 export function setPreservedStorageImpersonating(value: boolean): void {
   // WorkOS impersonation lands in a new document with no heap snapshot and
   // usually no window.name backup. Seal the live store on the rising edge,
   // before children write the customer org's favorites.
-  if (
-    value &&
-    !sessionIsImpersonating &&
-    lastCaptured.length === 0 &&
-    readPreservedStorageBackup().length === 0
-  ) {
+  if (value && !sessionIsImpersonating && !hasSnapshot) {
     capturePreservedStorage();
   }
   sessionIsImpersonating = value;
+  sessionClassified = true;
 }
 
 /** Drop the in-memory snapshot the way a full navigation would. Tests only. */
 export function resetPreservedStorageCapture(): void {
   lastCaptured = [];
+  hasSnapshot = false;
+  sessionIsImpersonating = false;
+  sessionClassified = false;
 }
 
 function persistPreservedStorageBackup(preserved: PreservedStorage): void {
@@ -102,12 +111,20 @@ function persistPreservedStorageBackup(preserved: PreservedStorage): void {
     ) {
       return;
     }
-    window.name =
-      preserved.length === 0
-        ? ""
-        : `${LOGOUT_PRESERVE_WINDOW_NAME_PREFIX}${JSON.stringify(preserved)}`;
+    // Persist `[]` too — an empty sealed snapshot must survive navigation
+    // so the next document does not treat it as "never captured".
+    window.name = `${LOGOUT_PRESERVE_WINDOW_NAME_PREFIX}${JSON.stringify(preserved)}`;
   } catch {
     // window.name unavailable — same-document restore still works.
+  }
+}
+
+function hasPreservedStorageBackup(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.name.startsWith(LOGOUT_PRESERVE_WINDOW_NAME_PREFIX);
+  } catch {
+    return false;
   }
 }
 
@@ -148,19 +165,20 @@ function readPreservedStorageBackup(): PreservedStorage {
  * new document and must still be able to restore the admin's prefs on exit.
  */
 export function restorePreservedStorageBackup(): void {
-  const preserved = readPreservedStorageBackup();
-  if (preserved.length === 0) return;
+  if (!hasPreservedStorageBackup()) return;
 
+  const preserved = readPreservedStorageBackup();
   restorePreservedStorage(preserved);
   lastCaptured = preserved;
+  hasSnapshot = true;
 }
 
 function snapshotForRestore(preserved?: PreservedStorage): PreservedStorage {
   if (preserved && preserved.length > 0) return preserved;
+  if (hasSnapshot) return lastCaptured;
   if (lastCaptured.length > 0) return lastCaptured;
 
-  const backup = readPreservedStorageBackup();
-  if (backup.length > 0) return backup;
+  if (hasPreservedStorageBackup()) return readPreservedStorageBackup();
 
   // An impersonated session's current store is not the admin's prefs.
   if (sessionIsImpersonating) return [];
@@ -186,13 +204,20 @@ export function capturePreservedStorageIfSafe(): PreservedStorage {
  * so a full localStorage scan cannot pick up another tab's impersonated keys.
  */
 export function rememberPreservedStorageKey(key: string, value: string): void {
-  if (sessionIsImpersonating || !shouldPreserveLocalStorageKey(key)) return;
+  if (
+    !sessionClassified ||
+    sessionIsImpersonating ||
+    !shouldPreserveLocalStorageKey(key)
+  ) {
+    return;
+  }
 
   const current =
     lastCaptured.length > 0 ? lastCaptured : readPreservedStorageBackup();
   const next = new Map(current);
   next.set(key, value);
   lastCaptured = Array.from(next.entries());
+  hasSnapshot = true;
   persistPreservedStorageBackup(lastCaptured);
 }
 
@@ -232,6 +257,7 @@ export function capturePreservedStorage(): PreservedStorage {
   }
 
   lastCaptured = preserved;
+  hasSnapshot = true;
   persistPreservedStorageBackup(preserved);
   return preserved;
 }
@@ -271,6 +297,7 @@ export function clearStorageForLogout(preserved?: PreservedStorage): void {
 
   restorePreservedStorage(toRestore);
   lastCaptured = toRestore;
+  hasSnapshot = true;
   persistPreservedStorageBackup(toRestore);
 
   try {

--- a/client/dashboard/src/lib/logout-storage.ts
+++ b/client/dashboard/src/lib/logout-storage.ts
@@ -180,8 +180,9 @@ function snapshotForRestore(preserved?: PreservedStorage): PreservedStorage {
 
   if (hasPreservedStorageBackup()) return readPreservedStorageBackup();
 
-  // An impersonated session's current store is not the admin's prefs.
-  if (sessionIsImpersonating) return [];
+  // Impersonated or not-yet-classified: do not live-capture. Session-expiry
+  // cleanup can run on an impersonation document before auth.info returns.
+  if (sessionIsImpersonating || !sessionClassified) return [];
   return capturePreservedStorage();
 }
 
@@ -191,10 +192,8 @@ function snapshotForRestore(preserved?: PreservedStorage): PreservedStorage {
  * localStorage, so a customer org's keys cannot replace the admin's.
  */
 export function capturePreservedStorageIfSafe(): PreservedStorage {
-  if (sessionIsImpersonating) {
-    return lastCaptured.length > 0
-      ? lastCaptured
-      : readPreservedStorageBackup();
+  if (sessionIsImpersonating || !sessionClassified) {
+    return hasSnapshot ? lastCaptured : readPreservedStorageBackup();
   }
   return capturePreservedStorage();
 }

--- a/client/dashboard/src/pages/platform-admin/Overview.tsx
+++ b/client/dashboard/src/pages/platform-admin/Overview.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { Switch } from "@/components/ui/Switch";
 import { useOrganization } from "@/contexts/Auth";
+import { capturePreservedStorageIfSafe } from "@/lib/logout-storage";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { AdminRow, AdminSection } from "./AdminSection";
@@ -87,6 +88,9 @@ export function OrgOverrideSection(): JSX.Element {
         className="flex items-center gap-2 px-4 py-3"
         method="post"
         action="/rpc/auth.startSupportSession"
+        onSubmit={() => {
+          capturePreservedStorageIfSafe();
+        }}
       >
         <Input
           placeholder="organization-slug"

--- a/client/dashboard/src/theme-init.test.ts
+++ b/client/dashboard/src/theme-init.test.ts
@@ -2,8 +2,18 @@ import fs from "node:fs";
 
 import { describe, expect, it } from "vitest";
 
-import { PREFERRED_THEME_STORAGE_KEY } from "./lib/local-storage-keys";
+import {
+  PREFERRED_THEME_STORAGE_KEY,
+  PROJECT_FAVORITES_STORAGE_PREFIX,
+} from "./lib/local-storage-keys";
 import { LOGOUT_PRESERVE_WINDOW_NAME_PREFIX } from "./lib/logout-storage";
+
+function declaredStringConst(source: string, name: string): string | undefined {
+  const match = source.match(
+    new RegExp(String.raw`const ${name}\s*=\s*["']([^"']+)["']`),
+  );
+  return match?.[1];
+}
 
 const indexHtml = fs.readFileSync("index.html", "utf8");
 const scriptTagPattern = /<script\b([^>]*)>([\s\S]*?)<\/script>/g;
@@ -29,12 +39,16 @@ describe("theme bootstrap", () => {
   it("duplicates the logout-preserve constants used by the module bundle", () => {
     const source = fs.readFileSync("src/theme-init.ts", "utf8");
 
-    expect(source).toContain(
-      `const PREFERRED_THEME_STORAGE_KEY = "${PREFERRED_THEME_STORAGE_KEY}"`,
+    expect(declaredStringConst(source, "PREFERRED_THEME_STORAGE_KEY")).toBe(
+      PREFERRED_THEME_STORAGE_KEY,
     );
-    expect(source).toContain(
-      `const LOGOUT_PRESERVE_WINDOW_NAME_PREFIX = "${LOGOUT_PRESERVE_WINDOW_NAME_PREFIX}"`,
-    );
+    expect(
+      declaredStringConst(source, "PROJECT_FAVORITES_STORAGE_PREFIX"),
+    ).toBe(PROJECT_FAVORITES_STORAGE_PREFIX);
+    expect(
+      declaredStringConst(source, "LOGOUT_PRESERVE_WINDOW_NAME_PREFIX"),
+    ).toBe(LOGOUT_PRESERVE_WINDOW_NAME_PREFIX);
+    expect(source).toContain("shouldRestorePreservedKey");
   });
 
   it("does not treat data-src as an external script source", () => {

--- a/client/dashboard/src/theme-init.test.ts
+++ b/client/dashboard/src/theme-init.test.ts
@@ -2,6 +2,9 @@ import fs from "node:fs";
 
 import { describe, expect, it } from "vitest";
 
+import { PREFERRED_THEME_STORAGE_KEY } from "./lib/local-storage-keys";
+import { LOGOUT_PRESERVE_WINDOW_NAME_PREFIX } from "./lib/logout-storage";
+
 const indexHtml = fs.readFileSync("index.html", "utf8");
 const scriptTagPattern = /<script\b([^>]*)>([\s\S]*?)<\/script>/g;
 const scriptSrcAttributePattern = /(?:^|\s)src\s*=/i;
@@ -20,6 +23,17 @@ describe("theme bootstrap", () => {
     expect(getExecutableInlineBodies(indexHtml)).toEqual([]);
     expect(indexHtml).toContain(
       '<script src="/src/theme-init.ts" vite-ignore></script>',
+    );
+  });
+
+  it("duplicates the logout-preserve constants used by the module bundle", () => {
+    const source = fs.readFileSync("src/theme-init.ts", "utf8");
+
+    expect(source).toContain(
+      `const PREFERRED_THEME_STORAGE_KEY = "${PREFERRED_THEME_STORAGE_KEY}"`,
+    );
+    expect(source).toContain(
+      `const LOGOUT_PRESERVE_WINDOW_NAME_PREFIX = "${LOGOUT_PRESERVE_WINDOW_NAME_PREFIX}"`,
     );
   });
 

--- a/client/dashboard/src/theme-init.ts
+++ b/client/dashboard/src/theme-init.ts
@@ -6,11 +6,21 @@
 // that a classic script cannot execute.
 const PREFERRED_THEME_STORAGE_KEY = "preferred-theme";
 
+// MUST equal PROJECT_FAVORITES_STORAGE_PREFIX in `src/lib/local-storage-keys.ts`.
+const PROJECT_FAVORITES_STORAGE_PREFIX = "gram:org-favorites:";
+
 // MUST equal LOGOUT_PRESERVE_WINDOW_NAME_PREFIX in `src/lib/logout-storage.ts`.
 // Logout's Clear-Site-Data header empties localStorage before /login paints;
 // the snapshot lives on window.name so this script can put theme (and the
 // other preserved keys) back before first paint.
 const LOGOUT_PRESERVE_WINDOW_NAME_PREFIX = "gram:logout-preserve:";
+
+function shouldRestorePreservedKey(key: string) {
+  return (
+    key === PREFERRED_THEME_STORAGE_KEY ||
+    key.startsWith(PROJECT_FAVORITES_STORAGE_PREFIX)
+  );
+}
 
 (function () {
   try {
@@ -24,7 +34,8 @@ const LOGOUT_PRESERVE_WINDOW_NAME_PREFIX = "gram:logout-preserve:";
             Array.isArray(entry) &&
             entry.length === 2 &&
             typeof entry[0] === "string" &&
-            typeof entry[1] === "string"
+            typeof entry[1] === "string" &&
+            shouldRestorePreservedKey(entry[0])
           ) {
             localStorage.setItem(entry[0], entry[1]);
           }

--- a/client/dashboard/src/theme-init.ts
+++ b/client/dashboard/src/theme-init.ts
@@ -6,7 +6,36 @@
 // that a classic script cannot execute.
 const PREFERRED_THEME_STORAGE_KEY = "preferred-theme";
 
+// MUST equal LOGOUT_PRESERVE_WINDOW_NAME_PREFIX in `src/lib/logout-storage.ts`.
+// Logout's Clear-Site-Data header empties localStorage before /login paints;
+// the snapshot lives on window.name so this script can put theme (and the
+// other preserved keys) back before first paint.
+const LOGOUT_PRESERVE_WINDOW_NAME_PREFIX = "gram:logout-preserve:";
+
 (function () {
+  try {
+    if (window.name.startsWith(LOGOUT_PRESERVE_WINDOW_NAME_PREFIX)) {
+      const parsed = JSON.parse(
+        window.name.slice(LOGOUT_PRESERVE_WINDOW_NAME_PREFIX.length),
+      );
+      if (Array.isArray(parsed)) {
+        for (const entry of parsed) {
+          if (
+            Array.isArray(entry) &&
+            entry.length === 2 &&
+            typeof entry[0] === "string" &&
+            typeof entry[1] === "string"
+          ) {
+            localStorage.setItem(entry[0], entry[1]);
+          }
+        }
+      }
+      window.name = "";
+    }
+  } catch {
+    // Backup unreadable — continue with whatever localStorage still has.
+  }
+
   try {
     const theme =
       localStorage.getItem(PREFERRED_THEME_STORAGE_KEY) === "dark"

--- a/client/dashboard/src/theme-init.ts
+++ b/client/dashboard/src/theme-init.ts
@@ -30,7 +30,8 @@ const LOGOUT_PRESERVE_WINDOW_NAME_PREFIX = "gram:logout-preserve:";
           }
         }
       }
-      window.name = "";
+      // Leave window.name in place. Impersonation is a new document and
+      // still needs this snapshot when that session logs out.
     }
   } catch {
     // Backup unreadable — continue with whatever localStorage still has.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Leaving an impersonated / support session (or switching accounts) goes through `auth.logout`. That response sends `Clear-Site-Data: "cookies", "storage"`, which empties **all** of `localStorage` before any JS response handler runs.

The existing preserve-and-restore path kept theme and org favorites only if the per-request WeakMap snapshot was still around when the response hook ran. Impersonation exit can time out and navigate to `/login` after the browser has already wiped storage — the WeakMap does not survive that, so favorites and color mode disappeared.

A restore that re-read whatever was in localStorage at logout time would have restored the **impersonated org's** theme/favorites, not the platform admin's.

## Change

- Publish an explicit preserve list (`PRESERVED_LOCAL_STORAGE_KEYS` / `PRESERVED_LOCAL_STORAGE_PREFIXES`) for logout: `preferred-theme` and `gram:org-favorites:*`.
- Snapshot those keys **only on a normal admin session** (no WorkOS `impersonatorEmail`, no support `organizationOverride`). Theme/favorite writes upsert a single key so a full store scan cannot pick up another session's keys, and only after the session is classified.
- Seal the live store on the rising edge of impersonation when no snapshot exists (WorkOS landing). An empty snapshot (`[]`) is tracked separately from "never captured" and is persisted on `window.name`. Keep the impersonation flag if the session disappears before `/login`.
- Logout / session-expiry cleanup never live-captures while impersonating or before the session is classified; it restores only a sealed snapshot or the `window.name` backup.
- Keep a last-captured snapshot in memory, plus a `window.name` backup (not covered by Clear-Site-Data). The backup stays after boot restore so a later support-session document can still recover the admin prefs on exit. `theme-init` restores only preserve-list keys.
- Impersonation logout restores that last **non-impersonation** snapshot. If none exists, nothing from the customer org is live-captured.
- Recents, preferred project, and Pylon PII are still dropped.

## Tests

`aube run -F dashboard test src/lib/logout-storage.test.ts src/theme-init.test.ts src/lib/session-expired.test.ts`

- 38 tests passed.
- `aube run -F dashboard type-check` passed.

## Test plan

- In a normal admin session, set dark mode and favorite a project.
- Impersonate another account (or start support access). Optionally change theme / favorites in that org.
- Exit / switch. After login, dark mode and the **original admin org's** favorites should still be there — not the impersonated org's.
- Confirm recents and last-used project slug are cleared.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [GRW-80](https://linear.app/speakeasy/issue/GRW-80/fix-impersonating-an-account-and-then-switching-drops-entire-local)

<div><a href="https://cursor.com/agents/bc-237028d0-e593-4fa6-b204-124bdca38bcf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-237028d0-e593-4fa6-b204-124bdca38bcf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes theme and org favorites being dropped when impersonation logout or account switching clears localStorage, so dark mode and favorites survive the navigation to `/login`. Recents, preferred project, and Pylon PII are still cleared.

**Bug Fixes**
- Captures the snapshot only on a normal admin session and seals it when impersonation begins, so the customer org's keys never replace the admin's.
- Logout cleanup never live-captures: it restores only a sealed snapshot or `window.name` backup while impersonating or before the session is classified.
- Restores from the last-captured snapshot or `window.name` backup when the per-request WeakMap entry is missing.
- Tracks an empty snapshot separately from "never captured" so an admin with no prefs isn't recaptured during impersonation.
- Filters `theme-init.ts` restores to the preserve list and upserts theme/favorite writes only after the session is classified.

<sup>Written for commit 72b079a352fbd6e32de4887303f7849147142122. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



