### PR TITLE
fix: switch Stripe Checkout trial conversions to PAYG

### DIFF
--- a/.changeset/checkout-trial-conversion-payg.md
+++ b/.changeset/checkout-trial-conversion-payg.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Stripe Checkout trial conversions now switch the organization to payg instead of leaving it on enterprise.

--- a/server/internal/background/activities/reconcile_payg_openrouter_chat_key_test.go
+++ b/server/internal/background/activities/reconcile_payg_openrouter_chat_key_test.go
@@ -495,13 +495,12 @@ func TestReconcilePaygOpenRouterChatKeyExternalFailureIsRetryableAndIdempotent(t
 	provisioner.AssertExpectations(t)
 }
 
-func TestReconcilePaygOpenRouterChatKeyRejectsMixedProjection(t *testing.T) {
+func TestReconcilePaygOpenRouterChatKeyPendingPaygCheckoutIsNoop(t *testing.T) {
 	t.Parallel()
 
 	reconciler, provisioner, _, organizationID := setupPaygChatKeyReconciler(t, "payg", pgtype.Text{})
 
-	err := reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{OrganizationID: organizationID, DesiredState: openrouter.KeyDesiredStateEnabled})
-	require.ErrorContains(t, err, "inconsistent PAYG OpenRouter chat key billing projection")
+	require.NoError(t, reconciler.Do(t.Context(), activities.ReconcilePaygOpenRouterChatKeyArgs{OrganizationID: organizationID, DesiredState: openrouter.KeyDesiredStateEnabled}))
 	provisioner.AssertNotCalled(t, "RefreshAPIKeyLimit", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	provisioner.AssertNotCalled(t, "DisableAPIKey", mock.Anything, mock.Anything, mock.Anything)
 }

--- a/server/internal/risk/scanner_test.go
+++ b/server/internal/risk/scanner_test.go
@@ -745,11 +745,11 @@ func TestScanner_FanOutAcrossPoliciesIsConcurrent(t *testing.T) {
 	require.Equal(t, int32(n), pii.callCount.Load(), "all policies should call AnalyzeBatch")
 	require.GreaterOrEqual(t, pii.maxInflight.Load(), int32(2), "expected >=2 concurrent presidio calls; saw max=%d", pii.maxInflight.Load())
 
-	// Sequential floor would be n * delay (= 800ms). Allow generous slack but
-	// fail if we're anywhere near it.
-	maxAllowed := time.Duration(n) * pii.delay / 2
-	require.Less(t, elapsed, maxAllowed,
-		"wall time %v >= half-of-sequential %v — fan-out not happening", elapsed, maxAllowed)
+	// Sequential floor is n*delay. Bound against that floor rather than a
+	// half-window so scheduling noise on shared CI runners cannot fail a
+	// parallel run that already showed overlapping inflight calls.
+	require.Less(t, elapsed, time.Duration(n)*pii.delay,
+		"wall time %v >= sequential floor %v — fan-out not happening", elapsed, time.Duration(n)*pii.delay)
 }
 
 func TestScanner_ScanForEnforcement_SkipsGrantResolutionWhenNoPolicies(t *testing.T) {

--- a/server/internal/risk/scanner_test.go
+++ b/server/internal/risk/scanner_test.go
@@ -745,11 +745,11 @@ func TestScanner_FanOutAcrossPoliciesIsConcurrent(t *testing.T) {
 	require.Equal(t, int32(n), pii.callCount.Load(), "all policies should call AnalyzeBatch")
 	require.GreaterOrEqual(t, pii.maxInflight.Load(), int32(2), "expected >=2 concurrent presidio calls; saw max=%d", pii.maxInflight.Load())
 
-	// Sequential floor is n*delay. Bound against that floor rather than a
-	// half-window so scheduling noise on shared CI runners cannot fail a
-	// parallel run that already showed overlapping inflight calls.
-	require.Less(t, elapsed, time.Duration(n)*pii.delay,
-		"wall time %v >= sequential floor %v — fan-out not happening", elapsed, time.Duration(n)*pii.delay)
+	// Sequential floor would be n * delay (= 800ms). Allow generous slack but
+	// fail if we're anywhere near it.
+	maxAllowed := time.Duration(n) * pii.delay / 2
+	require.Less(t, elapsed, maxAllowed,
+		"wall time %v >= half-of-sequential %v — fan-out not happening", elapsed, maxAllowed)
 }
 
 func TestScanner_ScanForEnforcement_SkipsGrantResolutionWhenNoPolicies(t *testing.T) {

--- a/server/internal/usage/checkout_trial_conversion.go
+++ b/server/internal/usage/checkout_trial_conversion.go
@@ -103,7 +103,8 @@ func (s *Service) convertEnterpriseTrialForCheckoutTx(ctx context.Context, tx pg
 	if err != nil || rows != 1 {
 		return false, fmt.Errorf("mark enterprise trial converted: rows=%d: %w", rows, err)
 	}
-	if _, err := trialsrepo.New(tx).RestoreOrganizationFromTrial(ctx, trialsrepo.RestoreOrganizationFromTrialParams{OrganizationID: organizationID, AccountType: "enterprise"}); err != nil {
+	// Self-serve Checkout is the PAYG conversion path. Admin conversion keeps enterprise.
+	if _, err := trialsrepo.New(tx).RestoreOrganizationFromTrial(ctx, trialsrepo.RestoreOrganizationFromTrialParams{OrganizationID: organizationID, AccountType: string(billing.TierPayg)}); err != nil {
 		return false, fmt.Errorf("restore organization after checkout conversion: %w", err)
 	}
 	if err := productfeatures.SetTrialRuntimeFeaturesTx(ctx, tx, organizationID, true); err != nil {
@@ -129,7 +130,7 @@ func (s *Service) convertEnterpriseTrialForCheckoutTx(ctx context.Context, tx pg
 		Keys:         beforeKeys,
 	}
 	after := audit.OrganizationEnterpriseTrialConversionSnapshot{
-		Organization: audit.OrganizationEnterpriseTrialConversionOrganizationSnapshot{AccountType: "enterprise", Whitelisted: true, Disabled: organization.DisabledAt.Valid},
+		Organization: audit.OrganizationEnterpriseTrialConversionOrganizationSnapshot{AccountType: string(billing.TierPayg), Whitelisted: true, Disabled: organization.DisabledAt.Valid},
 		Trial:        checkoutConversionTrialSnapshot(convertedTrial.Tier, convertedTrial.EndsAt, convertedTrial.ConvertedAt, convertedTrial.DemotedAt, now),
 		Keys:         afterKeys,
 	}

--- a/server/internal/usage/create_stripe_checkout.go
+++ b/server/internal/usage/create_stripe_checkout.go
@@ -16,6 +16,7 @@ import (
 	"github.com/speakeasy-api/gram/server/internal/attr"
 	"github.com/speakeasy-api/gram/server/internal/audit"
 	"github.com/speakeasy-api/gram/server/internal/authz"
+	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/constants"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/feature"
@@ -301,6 +302,16 @@ func (s *Service) CreateStripeCheckout(ctx context.Context, _ *gen.CreateStripeC
 					s.logger.WarnContext(ctx, "failed to reconcile model provider key after Stripe Checkout conversion")
 				}
 			}
+		}
+		if updateErr := s.stripeClient.UpdateCustomer(ctx, stripeclient.UpdateCustomerInput{
+			CustomerID:       preparedIntent.customerID,
+			OrganizationID:   authCtx.ActiveOrganizationID,
+			OrganizationSlug: authCtx.OrganizationSlug,
+			OrganizationName: identity.name,
+			Email:            identity.email,
+			AccountType:      string(billing.TierPayg),
+		}); updateErr != nil {
+			s.logger.WarnContext(ctx, "failed to refresh Stripe customer identity after checkout conversion", attr.SlogError(updateErr))
 		}
 	}
 

--- a/server/internal/usage/create_stripe_checkout_test.go
+++ b/server/internal/usage/create_stripe_checkout_test.go
@@ -25,6 +25,7 @@ import (
 	audittestrepo "github.com/speakeasy-api/gram/server/internal/audit/audittest/repo"
 	"github.com/speakeasy-api/gram/server/internal/authz"
 	"github.com/speakeasy-api/gram/server/internal/authztest"
+	"github.com/speakeasy-api/gram/server/internal/billing"
 	"github.com/speakeasy-api/gram/server/internal/contextvalues"
 	"github.com/speakeasy-api/gram/server/internal/conv"
 	"github.com/speakeasy-api/gram/server/internal/feature"
@@ -1031,7 +1032,7 @@ func TestCreateStripeCheckoutFirstConversionIsAtomicAndReceiptReplayIsIdempotent
 	require.True(t, converted.ConvertedAt.Valid)
 	organization, err := orgrepo.New(ti.db).GetOrganizationMetadata(t.Context(), ti.orgID)
 	require.NoError(t, err)
-	require.Equal(t, "enterprise", organization.GramAccountType)
+	require.Equal(t, string(billing.TierPayg), organization.GramAccountType)
 	require.True(t, organization.Whitelisted)
 
 	record, err := audittest.LatestAuditLogByAction(t.Context(), ti.db, audit.ActionOrganizationEnterpriseTrialConverted)
@@ -1042,13 +1043,16 @@ func TestCreateStripeCheckoutFirstConversionIsAtomicAndReceiptReplayIsIdempotent
 	require.NoError(t, err)
 	require.Equal(t, map[string]any{"conversion_source": "stripe_checkout", "key_access_changed": false}, metadata)
 	var before, after struct {
-		Trial map[string]any   `json:"trial"`
-		Keys  []map[string]any `json:"keys"`
+		Organization map[string]any   `json:"organization"`
+		Trial        map[string]any   `json:"trial"`
+		Keys         []map[string]any `json:"keys"`
 	}
 	require.NoError(t, json.Unmarshal(record.BeforeSnapshot, &before))
 	require.NoError(t, json.Unmarshal(record.AfterSnapshot, &after))
 	require.Equal(t, "running", before.Trial["status"])
 	require.Equal(t, "converted", after.Trial["status"])
+	require.Equal(t, string(billing.TierPayg), after.Organization["account_type"])
+	require.Equal(t, true, after.Organization["whitelisted"])
 	require.Empty(t, before.Keys)
 	require.Empty(t, after.Keys)
 	require.Equal(t, []bool{true, true}, provisioner.reconciledAfterCommit)
@@ -1073,6 +1077,53 @@ func TestCreateStripeCheckoutFirstConversionIsAtomicAndReceiptReplayIsIdempotent
 	conversionCount, err := audittest.AuditLogCountByAction(t.Context(), ti.db, audit.ActionOrganizationEnterpriseTrialConverted)
 	require.NoError(t, err)
 	require.EqualValues(t, 1, conversionCount)
+}
+
+func TestCreateStripeCheckoutConversionSwitchesRunningEnterpriseTrialToPayg(t *testing.T) {
+	t.Parallel()
+
+	ti := newStripeCheckoutTestInstance(t)
+	require.NoError(t, orgrepo.New(ti.db).SetAccountType(t.Context(), orgrepo.SetAccountTypeParams{
+		GramAccountType: string(billing.TierEnterprise),
+		ID:              ti.orgID,
+	}))
+	_, err := orgrepo.New(ti.db).UpsertOrganizationMetadata(t.Context(), orgrepo.UpsertOrganizationMetadataParams{
+		ID:          ti.orgID,
+		Name:        "Billing Test Organization",
+		Slug:        ti.orgSlug,
+		WorkosID:    conv.ToPGText("workos-" + ti.orgID),
+		Whitelisted: pgtype.Bool{Bool: true, Valid: true},
+	})
+	require.NoError(t, err)
+	require.NoError(t, trialsrepo.New(ti.db).CreateTrial(t.Context(), trialsrepo.CreateTrialParams{
+		OrganizationID: ti.orgID,
+		Tier:           "enterprise",
+		EndsAt:         pgtype.Timestamptz{Time: time.Now().UTC().Add(8 * 24 * time.Hour), InfinityModifier: pgtype.Finite, Valid: true},
+	}))
+
+	_, err = ti.service.CreateStripeCheckout(ti.adminContext(t), &gen.CreateStripeCheckoutPayload{})
+	require.NoError(t, err)
+
+	trial, err := trialsrepo.New(ti.db).GetTrial(t.Context(), ti.orgID)
+	require.NoError(t, err)
+	require.True(t, trial.ConvertedAt.Valid)
+	organization, err := orgrepo.New(ti.db).GetOrganizationMetadata(t.Context(), ti.orgID)
+	require.NoError(t, err)
+	require.Equal(t, string(billing.TierPayg), organization.GramAccountType)
+	require.True(t, organization.Whitelisted)
+	metadata, err := repo.New(ti.db).GetBillingMetadata(t.Context(), ti.orgID)
+	require.NoError(t, err)
+	require.False(t, metadata.StripeSubscriptionID.Valid)
+
+	record, err := audittest.LatestAuditLogByAction(t.Context(), ti.db, audit.ActionOrganizationEnterpriseTrialConverted)
+	require.NoError(t, err)
+	var before, after struct {
+		Organization map[string]any `json:"organization"`
+	}
+	require.NoError(t, json.Unmarshal(record.BeforeSnapshot, &before))
+	require.NoError(t, json.Unmarshal(record.AfterSnapshot, &after))
+	require.Equal(t, string(billing.TierEnterprise), before.Organization["account_type"])
+	require.Equal(t, string(billing.TierPayg), after.Organization["account_type"])
 }
 
 func TestCreateStripeCheckoutConversionAuditCapturesAccessChangesPrivately(t *testing.T) {

--- a/server/internal/usage/create_stripe_checkout_test.go
+++ b/server/internal/usage/create_stripe_checkout_test.go
@@ -1124,6 +1124,14 @@ func TestCreateStripeCheckoutConversionSwitchesRunningEnterpriseTrialToPayg(t *t
 	require.NoError(t, json.Unmarshal(record.AfterSnapshot, &after))
 	require.Equal(t, string(billing.TierEnterprise), before.Organization["account_type"])
 	require.Equal(t, string(billing.TierPayg), after.Organization["account_type"])
+
+	_, customers, _ := ti.stripe.snapshot()
+	require.Len(t, customers, 1)
+	require.Equal(t, string(billing.TierEnterprise), customers[0].AccountType)
+	updates := ti.stripe.updates()
+	require.Len(t, updates, 1)
+	require.Equal(t, metadata.StripeCustomerID.String, updates[0].CustomerID)
+	require.Equal(t, string(billing.TierPayg), updates[0].AccountType)
 }
 
 func TestCreateStripeCheckoutConversionAuditCapturesAccessChangesPrivately(t *testing.T) {

--- a/server/internal/usage/payg_openrouter_chat_key_repair.go
+++ b/server/internal/usage/payg_openrouter_chat_key_repair.go
@@ -84,6 +84,9 @@ func RepairPaygOpenRouterChatKey(ctx context.Context, logger *slog.Logger, db *p
 			return nil
 		}
 		return repairPaidOpenRouterChatKey(ctx, conn, queries, provisioner, organizationID)
+	case projection.GramAccountType == string(billing.TierPayg) && !hasSubscription:
+		// Stripe Checkout conversion records PAYG before the subscription webhook commits.
+		return nil
 	case projection.GramAccountType == string(billing.TierBase) && !hasSubscription:
 		if intent != openrouter.KeyDesiredStateDisabled {
 			return nil

--- a/server/internal/usage/stripe_webhook_test.go
+++ b/server/internal/usage/stripe_webhook_test.go
@@ -1583,6 +1583,10 @@ func TestStripeCheckoutCompletionPreservesTrialFeatureChoices(t *testing.T) {
 	trial, err := trialsrepo.New(db).GetTrial(ctx, stripeWebhookOrganizationID)
 	require.NoError(t, err)
 	require.True(t, trial.ConvertedAt.Valid)
+	organization, err := orgrepo.New(db).GetOrganizationMetadata(ctx, stripeWebhookOrganizationID)
+	require.NoError(t, err)
+	require.Equal(t, "payg", organization.GramAccountType)
+	require.True(t, organization.Whitelisted)
 	ssoEnabled, err := featurerepo.New(db).IsFeatureEnabled(ctx, featurerepo.IsFeatureEnabledParams{
 		OrganizationID: stripeWebhookOrganizationID,
 		FeatureName:    string(productfeatures.FeatureSSO),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Self-serve Stripe Checkout is the PAYG conversion path, but `convertEnterpriseTrialForCheckoutTx` restored the organization as `enterprise`. That left converted trials looking like signed enterprise contracts in admin (account type stayed enterprise, often with no subscription yet).

This restores the organization as `payg` when a running enterprise trial converts through Checkout. Admin “mark as converted” is unchanged and still records an enterprise contract.

Checkout conversion still happens before the subscription webhook commits, so PAYG key repair now treats `payg` without a subscription as the pending activation window instead of an inconsistent projection.

After conversion commits, Stripe customer metadata is refreshed to `payg` so `aicp_account_type` does not stay on the pre-conversion tier.

## Test plan

- [x] `mise run test:server ./internal/usage/ -run 'TestCreateStripeCheckout|TestStripeCheckout'`
- [x] `mise run test:server ./internal/background/activities/ -run 'TestReconcilePaygOpenRouterChatKey'`
- [x] Confirm a running enterprise trial that starts Stripe Checkout shows account type `payg` in admin after conversion (subscription may still be empty until `checkout.session.completed`)

Fixes GRW-86

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [GRW-86](https://linear.app/speakeasy/issue/GRW-86/fix-when-trial-converts-with-payg-account-type-should-switch-to-payg)

<div><a href="https://cursor.com/agents/bc-4946de04-65f9-4a1b-aeaf-b0598fed7a30?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4946de04-65f9-4a1b-aeaf-b0598fed7a30&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Stripe Checkout trial conversions to restore the organization as `payg` instead of `enterprise`, so converted trials no longer look like signed enterprise contracts in admin (often with no subscription yet). Admin "mark as converted" still records an enterprise contract. PAYG key repair now treats `payg` without a subscription as the pending Checkout activation window rather than an inconsistent projection. After conversion commits, Stripe customer metadata is refreshed to `payg` so `aicp_account_type` does not stay on the pre-conversion tier.

Fixes GRW-86.

<sup>Written for commit b9bdbaec50f5eede37d05834ed0791e04dd7ba20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

