### PR TITLE
fix: keep role editing available without agent management

### DIFF
--- a/client/dashboard/src/lib/featureFlags.ts
+++ b/client/dashboard/src/lib/featureFlags.ts
@@ -1,4 +1,5 @@
 export const FEATURE_FLAGS = {
+  agentManagement: "agent-management",
   agentCredentials: "agent-identity-credentials",
   assistants: "assistants",
   budgets: "gram-budgets",

--- a/client/dashboard/src/pages/access/CreateRoleDialog.test.tsx
+++ b/client/dashboard/src/pages/access/CreateRoleDialog.test.tsx
@@ -1,0 +1,143 @@
+import type { Role } from "@gram/client/models/components/role.js";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CreateRoleDialog } from "./CreateRoleDialog";
+
+const mocks = vi.hoisted(() => ({
+  status: "ready" as "ready" | "loading" | "error",
+  enabled: false as boolean | undefined,
+  agents: vi.fn(() => ({ data: [] })),
+  create: vi.fn(),
+  update: vi.fn(),
+}));
+vi.mock("@/contexts/Telemetry", () => ({
+  useTelemetryContext: () => ({
+    featureFlags: { status: mocks.status },
+    telemetry: { isFeatureEnabled: () => mocks.enabled },
+  }),
+}));
+vi.mock("@/contexts/Auth", () => ({
+  useOrganization: () => ({ projects: [] }),
+}));
+vi.mock("@/routes", () => ({ useOrgRoutes: () => ({}) }));
+vi.mock("@gram/client/react-query/agents.js", () => ({
+  useAgents: mocks.agents,
+}));
+vi.mock("@gram/client/react-query/members.js", () => ({
+  useMembers: () => ({ data: { members: [] } }),
+  invalidateAllMembers: vi.fn(),
+}));
+vi.mock("@gram/client/react-query/listScopes.js", () => ({
+  useListScopes: () => ({
+    data: {
+      scopes: [
+        {
+          slug: "org:read",
+          resourceType: "org",
+          visibility: "user_visible",
+          label: "Read organization",
+        },
+      ],
+    },
+  }),
+}));
+vi.mock("@gram/client/react-query/createRole.js", () => ({
+  useCreateRoleMutation: () => ({ mutate: mocks.create, isPending: false }),
+}));
+vi.mock("@gram/client/react-query/updateRole.js", () => ({
+  useUpdateRoleMutation: () => ({ mutate: mocks.update, isPending: false }),
+}));
+vi.mock("./RolePermissionsSection", () => ({
+  RolePermissionsSection: ({
+    onToggleScope,
+  }: {
+    onToggleScope: (scope: "org:read") => void;
+  }) => (
+    <button onClick={() => onToggleScope("org:read")}>Read organization</button>
+  ),
+}));
+vi.mock("./GrantRuleDrawerContent", () => ({
+  GrantRuleDrawerContent: () => null,
+}));
+
+const role: Role = {
+  id: "role-test",
+  name: "Test role",
+  description: "Original description",
+  agentIds: ["agent-test"],
+  grants: [],
+  isSystem: false,
+  memberCount: 0,
+  principalUrn: "test-role",
+  slug: "test-role",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+function renderEditor(editingRole?: Role) {
+  return render(
+    <QueryClientProvider client={new QueryClient()}>
+      <CreateRoleDialog
+        open
+        onOpenChange={vi.fn()}
+        editingRole={editingRole}
+        presentation="page"
+      />
+    </QueryClientProvider>,
+  );
+}
+afterEach(cleanup);
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.status = "ready";
+  mocks.enabled = false;
+});
+describe("agent management rollout", () => {
+  it.each(["false", "loading", "missing", "error"] as const)(
+    "does not enable the query or show the picker when %s",
+    (state) => {
+      if (state === "loading" || state === "error") mocks.status = state;
+      if (state === "missing") mocks.enabled = undefined;
+      renderEditor();
+      expect(mocks.agents).toHaveBeenLastCalledWith(undefined, undefined, {
+        enabled: false,
+      });
+      expect(screen.queryByText("Assign Agents")).toBeNull();
+    },
+  );
+  it("enables the query and picker when enabled", () => {
+    mocks.enabled = true;
+    renderEditor();
+    expect(mocks.agents).toHaveBeenLastCalledWith(undefined, undefined, {
+      enabled: true,
+    });
+    fireEvent.click(screen.getByText("Assign Agents"));
+    expect(
+      screen.getByText("No agents in this organization yet."),
+    ).toBeTruthy();
+  });
+  it("saves an ordinary role without replacing existing agents when unavailable", () => {
+    renderEditor(role);
+    fireEvent.change(
+      screen.getByPlaceholderText("Describe what this role can do..."),
+      { target: { value: "Updated description" } },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+    expect(mocks.update).toHaveBeenCalledOnce();
+    const form = mocks.update.mock.calls[0]![0].request.updateRoleForm;
+    expect(form.description).toBe("Updated description");
+    expect(form).not.toHaveProperty("agentIds");
+  });
+  it("creates an ordinary role without agent assignments when unavailable", () => {
+    renderEditor();
+    fireEvent.change(screen.getByPlaceholderText("e.g., Project Manager"), {
+      target: { value: "Test role" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Read organization" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create Role" }));
+    expect(mocks.create).toHaveBeenCalledOnce();
+    expect(
+      mocks.create.mock.calls[0]![0].request.createRoleForm,
+    ).not.toHaveProperty("agentIds");
+  });
+});

--- a/client/dashboard/src/pages/access/CreateRoleDialog.test.tsx
+++ b/client/dashboard/src/pages/access/CreateRoleDialog.test.tsx
@@ -79,7 +79,7 @@ function renderEditor(editingRole?: Role) {
     <QueryClientProvider client={new QueryClient()}>
       <CreateRoleDialog
         open
-        onOpenChange={vi.fn()}
+        onOpenChange={vi.fn<(open: boolean) => void>()}
         editingRole={editingRole}
         presentation="page"
       />

--- a/client/dashboard/src/pages/access/CreateRoleDialog.tsx
+++ b/client/dashboard/src/pages/access/CreateRoleDialog.tsx
@@ -12,6 +12,8 @@ import {
   SheetTitle,
 } from "@/components/ui/Sheet";
 import { Text } from "@/components/ui/Text";
+import { useFeatureFlag } from "@/hooks/useFeatureFlag";
+import { FEATURE_FLAGS } from "@/lib/featureFlags";
 import { cn } from "@/lib/utils";
 import { useOrganization } from "@/contexts/Auth";
 import type { Role } from "@gram/client/models/components/role.js";
@@ -169,7 +171,11 @@ export function CreateRoleDialog({
   const members = [...(membersData?.members ?? [])].sort((a, b) =>
     a.name.localeCompare(b.name),
   );
-  const { data: agentsData } = useAgents();
+  const agentManagementEnabled =
+    useFeatureFlag(FEATURE_FLAGS.agentManagement).status === "enabled";
+  const { data: agentsData } = useAgents(undefined, undefined, {
+    enabled: agentManagementEnabled,
+  });
   // Suspended and revoked agents keep the roles they hold but cannot be given
   // new ones, so only active agents are offered. An agent already on the role
   // stays listed so re-saving does not silently drop it.
@@ -517,8 +523,10 @@ export function CreateRoleDialog({
                 ? Array.from(selectedMembers)
                 : undefined,
             // Agent membership is declarative: an agent has no other surface
-            // to be taken off a role on, so the full set is always sent.
-            agentIds: Array.from(selectedAgents),
+            // to be taken off a role on. Preserve it when the rollout is unavailable.
+            ...(agentManagementEnabled
+              ? { agentIds: Array.from(selectedAgents) }
+              : {}),
           },
         },
       });
@@ -533,8 +541,9 @@ export function CreateRoleDialog({
               selectedMembers.size > 0
                 ? Array.from(selectedMembers)
                 : undefined,
-            agentIds:
-              selectedAgents.size > 0 ? Array.from(selectedAgents) : undefined,
+            ...(agentManagementEnabled && selectedAgents.size > 0
+              ? { agentIds: Array.from(selectedAgents) }
+              : {}),
           },
         },
       });
@@ -898,68 +907,73 @@ export function CreateRoleDialog({
             {/* ─── Assign Agents ─────────────────────────────────────
                 Not gated on SCIM: a directory syncs people, never agents,
                 so this is the only place an agent's roles are decided. */}
-            <div className="border-border border-t pt-4 pb-4">
-              <button
-                type="button"
-                onClick={() => setShowAgents(!showAgents)}
-                className="flex w-full items-center gap-1 text-left"
-              >
-                <ChevronRight
-                  className={cn(
-                    "h-4 w-4 transition-transform",
-                    showAgents && "rotate-90",
-                  )}
-                />
-                <Text variant="body" className="font-medium">
-                  Assign Agents
-                </Text>
-                <Text variant="body" className="text-muted-foreground ml-1">
-                  (optional, {selectedAgents.size} selected)
-                </Text>
-              </button>
+            {agentManagementEnabled && (
+              <div className="border-border border-t pt-4 pb-4">
+                <button
+                  type="button"
+                  onClick={() => setShowAgents(!showAgents)}
+                  className="flex w-full items-center gap-1 text-left"
+                >
+                  <ChevronRight
+                    className={cn(
+                      "h-4 w-4 transition-transform",
+                      showAgents && "rotate-90",
+                    )}
+                  />
+                  <Text variant="body" className="font-medium">
+                    Assign Agents
+                  </Text>
+                  <Text variant="body" className="text-muted-foreground ml-1">
+                    (optional, {selectedAgents.size} selected)
+                  </Text>
+                </button>
 
-              {showAgents && (
-                <div className="border-border divide-border mt-3 divide-y border">
-                  {agents.length === 0 ? (
-                    <div className="px-3 py-6 text-center">
-                      <Text muted small>
-                        No agents in this organization yet.
-                      </Text>
-                    </div>
-                  ) : (
-                    agents.map((agent) => (
-                      <label
-                        key={agent.id}
-                        className="hover:bg-muted/50 flex cursor-pointer items-center gap-3 px-3 py-2.5"
-                      >
-                        <Checkbox
-                          checked={selectedAgents.has(agent.id)}
-                          onCheckedChange={() => toggleAgent(agent.id)}
-                        />
-                        <Avatar className="h-7 w-7">
-                          <AvatarFallback className="text-xs">
-                            <Bot className="h-3.5 w-3.5" />
-                          </AvatarFallback>
-                        </Avatar>
-                        <div className="min-w-0 flex-1 space-y-0.5">
-                          <Text variant="body" className="text-sm font-medium">
-                            {agent.name}
-                          </Text>
-                          <Text
-                            variant="body"
-                            className="text-muted-foreground text-xs"
-                          >
-                            {agent.lifecycle === "active"
-                              ? "Agent"
-                              : `Agent \u00b7 ${agent.lifecycle}`}
-                          </Text>
-                        </div>
-                      </label>
-                    ))
-                  )}
-                </div>
-              )}
-            </div>
+                {showAgents && (
+                  <div className="border-border divide-border mt-3 divide-y border">
+                    {agents.length === 0 ? (
+                      <div className="px-3 py-6 text-center">
+                        <Text muted small>
+                          No agents in this organization yet.
+                        </Text>
+                      </div>
+                    ) : (
+                      agents.map((agent) => (
+                        <label
+                          key={agent.id}
+                          className="hover:bg-muted/50 flex cursor-pointer items-center gap-3 px-3 py-2.5"
+                        >
+                          <Checkbox
+                            checked={selectedAgents.has(agent.id)}
+                            onCheckedChange={() => toggleAgent(agent.id)}
+                          />
+                          <Avatar className="h-7 w-7">
+                            <AvatarFallback className="text-xs">
+                              <Bot className="h-3.5 w-3.5" />
+                            </AvatarFallback>
+                          </Avatar>
+                          <div className="min-w-0 flex-1 space-y-0.5">
+                            <Text
+                              variant="body"
+                              className="text-sm font-medium"
+                            >
+                              {agent.name}
+                            </Text>
+                            <Text
+                              variant="body"
+                              className="text-muted-foreground text-xs"
+                            >
+                              {agent.lifecycle === "active"
+                                ? "Agent"
+                                : `Agent \u00b7 ${agent.lifecycle}`}
+                            </Text>
+                          </div>
+                        </label>
+                      ))
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
           </div>
 
           {/* ─── Panel 2: Rule editor ─── */}


### PR DESCRIPTION
## Summary
- Only fetch agents and show the agent-assignment picker when agent management is enabled.
- Leave agent assignments unchanged when saving roles while the feature is unavailable.
- Cover enabled, disabled, and unavailable flag states with role-editor regression tests.

## Motivation
The role editor queried the rollout-gated agents endpoint unconditionally. Organizations without agent management received a 404, which reached the page error boundary and prevented ordinary role editing. Keep the optional feature from blocking existing role management; do not change global error handling or enable the feature for additional organizations.

## Testing
- 254 targeted tests pass across role-editor, feature-flag, identity inventory, agent management, API-key, session, policy, and MCP audience suites.
- `aube run -F dashboard type-check` passes.
- `git diff --check` passes.
- Independent review found no issues.
- Browser demo not captured: this isolated worktree has no configured dashboard runtime; verification above is component/unit coverage, not an end-to-end browser run.

## Demo data
No seed changes: this fixes conditional access to existing data without introducing or reshaping rendered entities.

## Related-path audit
Identity inventory already treats rollout-disabled 404s as empty agent inventory. Agent screens handle request errors inline. The MCP access picker uses the access service rather than the rollout-gated agent-management endpoint. No additional instance of this rollout crash was found.
