### PR TITLE
fix: speed up the toolset index sweep discovery query

### DIFF
--- a/.changeset/toolset-index-sweep-discovery-query.md
+++ b/.changeset/toolset-index-sweep-discovery-query.md
@@ -1,0 +1,5 @@
+---
+"server": patch
+---
+
+Speed up the scheduled toolset index sweep so its discovery query no longer times out on projects with many HTTP tools.

--- a/server/internal/background/activities/queries.sql
+++ b/server/internal/background/activities/queries.sql
@@ -1169,20 +1169,26 @@ SELECT
 FROM candidates
 WHERE candidates.indexed IS NULL
   AND (
+      -- Keep the deployment id as the leading index condition on
+      -- http_tool_definitions_deployment_tool_urn_idx. Folding the packaged
+      -- deployments into an OR turns the deployment match into a post-filter
+      -- and walks the whole index for every candidate.
       EXISTS (
           SELECT 1
           FROM http_tool_definitions definitions
-          WHERE definitions.tool_urn = ANY(candidates.tool_urns)
-            AND (
-                definitions.deployment_id = candidates.deployment_id
-                OR definitions.deployment_id IN (
-                    SELECT package_versions.deployment_id
-                    FROM deployments_packages
-                    JOIN package_versions
-                      ON package_versions.id = deployments_packages.version_id
-                    WHERE deployments_packages.deployment_id = candidates.deployment_id
-                )
-            )
+          WHERE definitions.deployment_id = candidates.deployment_id
+            AND definitions.tool_urn = ANY(candidates.tool_urns)
+            AND definitions.deleted IS FALSE
+      )
+      OR EXISTS (
+          SELECT 1
+          FROM deployments_packages
+          JOIN package_versions
+            ON package_versions.id = deployments_packages.version_id
+          JOIN http_tool_definitions definitions
+            ON definitions.deployment_id = package_versions.deployment_id
+          WHERE deployments_packages.deployment_id = candidates.deployment_id
+            AND definitions.tool_urn = ANY(candidates.tool_urns)
             AND definitions.deleted IS FALSE
       )
       OR EXISTS (

--- a/server/internal/background/activities/repo/queries.sql.go
+++ b/server/internal/background/activities/repo/queries.sql.go
@@ -2053,20 +2053,26 @@ SELECT
 FROM candidates
 WHERE candidates.indexed IS NULL
   AND (
+      -- Keep the deployment id as the leading index condition on
+      -- http_tool_definitions_deployment_tool_urn_idx. Folding the packaged
+      -- deployments into an OR turns the deployment match into a post-filter
+      -- and walks the whole index for every candidate.
       EXISTS (
           SELECT 1
           FROM http_tool_definitions definitions
-          WHERE definitions.tool_urn = ANY(candidates.tool_urns)
-            AND (
-                definitions.deployment_id = candidates.deployment_id
-                OR definitions.deployment_id IN (
-                    SELECT package_versions.deployment_id
-                    FROM deployments_packages
-                    JOIN package_versions
-                      ON package_versions.id = deployments_packages.version_id
-                    WHERE deployments_packages.deployment_id = candidates.deployment_id
-                )
-            )
+          WHERE definitions.deployment_id = candidates.deployment_id
+            AND definitions.tool_urn = ANY(candidates.tool_urns)
+            AND definitions.deleted IS FALSE
+      )
+      OR EXISTS (
+          SELECT 1
+          FROM deployments_packages
+          JOIN package_versions
+            ON package_versions.id = deployments_packages.version_id
+          JOIN http_tool_definitions definitions
+            ON definitions.deployment_id = package_versions.deployment_id
+          WHERE deployments_packages.deployment_id = candidates.deployment_id
+            AND definitions.tool_urn = ANY(candidates.tool_urns)
             AND definitions.deleted IS FALSE
       )
       OR EXISTS (


### PR DESCRIPTION
AIM-282

## Summary

- Rewrite the `http_tool_definitions` probe in `ListToolsetsForIndexing` (`server/internal/background/activities/queries.sql`) so the direct deployment match and the packaged deployment match are separate `EXISTS` clauses, each with `deployment_id` as the leading condition on `http_tool_definitions_deployment_tool_urn_idx`.
- Regenerate the sqlc output for that query. No schema or migration changes.
- Add a `server` patch changeset.

## Motivation

Since #6324 deployed, the `ListToolsetsForIndexing` activity in `IndexToolsetSweepWorkflow` has hit its 30 second `StartToCloseTimeout` on every attempt of every 5 minute sweep, which trips the Temporal activity failure monitor and, more importantly, means no dynamic toolset has been re-indexed under the new deployment marker. MCP `tools/list` and `search_tools` calls for those toolsets currently fail fast with "tool search is temporarily unavailable".

`EXPLAIN ANALYZE` on the production read replica showed the whole cost is the `http_tool_definitions` probe. With the packaged deployment lookup folded into `deployment_id = X OR deployment_id IN (...)`, the planner could only use `tool_urn = ANY(...)` as an index condition and applied the deployment match as a post-filter, so each candidate toolset walked the full `(deployment_id, tool_urn)` index (about 941k rows, 2.2 GB table). The candidates stage without the probe ran in 9 ms, 5 projects took 3.4 s, 20 projects took 13.9 s, and the full 100 project page was cancelled at 30 s. With the split `EXISTS` clauses the plan reports `Index Cond: ((deployment_id = deployments.id) AND (tool_urn = ANY (tv.tool_urns)))` and the same 100 project page completes in 66 ms.

The existing `TestListToolsetsForIndexingRequiresResolvableToolsAndMissingEmbeddings` test already covers the packaged HTTP tool path and passes with the rewrite.

This does not by itself clear the backlog of un-indexed toolsets. The sweep still starts at most 10 child index workflows per tick, so a backfill or a temporary limit increase is tracked separately in AIM-282.

Temporal actions/month ≈ unchanged from #6324 (about 27k), scales with fixed schedule ticks, completed deployments, and changed toolset revisions. This change only alters the SQL executed inside an existing activity.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `ListToolsetsForIndexing` discovery query so the scheduled toolset index sweep no longer times out. The old query folded the packaged deployment lookup into an `OR`, leaving `tool_urn` as the only index condition and walking the whole `(deployment_id, tool_urn)` index per candidate; the rewrite splits it into two `EXISTS` clauses that keep `deployment_id` as the leading index condition. A 100-project page now completes in ~66ms instead of timing out at 30s.

**Migration**
- No schema changes; only the sqlc output was regenerated and a `server` patch changeset was added.
- The backlog of un-indexed toolsets is not cleared by this PR; the backfill is tracked separately in AIM-282.

<sup>Written for commit 878f8c021268901580236777241b3a55770c9615. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

