### PR TITLE
feat: offer the dashboard handoff from the admin command palette

### DIFF
--- a/.changeset/admin-palette-dashboard-handoff.md
+++ b/.changeset/admin-palette-dashboard-handoff.md
@@ -1,0 +1,5 @@
+---
+"admin": minor
+---
+
+Give each organization matched in the admin command palette a nested "Open in Dashboard" row, so the dashboard handoff is reachable without first opening the record.

--- a/client/admin/src/components/command-palette.test.tsx
+++ b/client/admin/src/components/command-palette.test.tsx
@@ -58,9 +58,10 @@ const OTHER = anOrganization({
   disabled_at: "2026-02-01T00:00:00Z",
 });
 
-// A second active record, because OTHER is disabled and a disabled record is
-// deliberately offered no handoff. Sharing a letter with ORG and not with its
-// name is what lets one term return two handoffs at once.
+// A second active record. Two handoffs at once cannot be ORG and OTHER: a
+// search matches OTHER perfectly well, but it is disabled and is deliberately
+// offered no handoff row. The term the two-handoff test types matches all three
+// records, so what it demonstrates is three results carrying two handoffs.
 const THIRD = anOrganization({
   id: "org_01AA",
   name: "Redwood Analytics",
@@ -383,7 +384,8 @@ describe("CommandPalette", () => {
 
     pressTheShortcut();
     await screen.findByRole("dialog");
-    // A letter both records carry, so the list holds two handoffs at once.
+    // A letter all three records carry. Two of them are active and get a
+    // handoff row; the disabled one is listed without one.
     type("r");
 
     await within(palette()).findByRole("option", {
@@ -394,6 +396,20 @@ describe("CommandPalette", () => {
         name: /Open in Dashboard for Redwood Analytics/,
       }),
     ).toBeTruthy();
+
+    // Three records matched and two handoffs are drawn, which is the whole of
+    // what the fixtures above are arranged to show: the disabled record is
+    // listed like the others and offered no handoff of its own.
+    expect(
+      within(palette()).getAllByRole("option", {
+        name: /^Redwood Analytics|^Northwind Logistics|^Umbrella Freight/,
+      }),
+    ).toHaveLength(3);
+    expect(
+      within(palette()).getAllByRole("option", {
+        name: /Open in Dashboard for/,
+      }),
+    ).toHaveLength(2);
   });
 
   it("leaves the admin record open behind the handoff", async () => {

--- a/client/admin/src/components/command-palette.test.tsx
+++ b/client/admin/src/components/command-palette.test.tsx
@@ -58,7 +58,17 @@ const OTHER = anOrganization({
   disabled_at: "2026-02-01T00:00:00Z",
 });
 
-const RECORDS = [ORG, OTHER];
+// A second active record, because OTHER is disabled and a disabled record is
+// deliberately offered no handoff. Sharing a letter with ORG and not with its
+// name is what lets one term return two handoffs at once.
+const THIRD = anOrganization({
+  id: "org_01AA",
+  name: "Redwood Analytics",
+  slug: "redwood",
+  account_type: "payg",
+});
+
+const RECORDS = [ORG, OTHER, THIRD];
 
 // The one press that opens the palette, in the modifier this platform resolves
 // `Mod` to. Read from the library rather than hardcoded, because the hotkey the
@@ -97,6 +107,10 @@ function searchedFor(): string[] {
 // would try to navigate the test document, and happy-dom has no tab to open, so
 // the call is captured instead of performed and the element read afterwards.
 let submitted: HTMLFormElement[] = [];
+// Whether each form was still in the document at the moment it was submitted.
+// A submit from a detached form does nothing at all, and Firefox abandons the
+// navigation when the form leaves before the submission task runs.
+let connectedAtSubmit: boolean[] = [];
 let router: Mounted["router"] | undefined;
 
 async function renderWithSubmitCaptured(): Promise<void> {
@@ -107,12 +121,14 @@ async function renderWithSubmitCaptured(): Promise<void> {
 
 beforeEach(() => {
   submitted = [];
+  connectedAtSubmit = [];
   router = undefined;
   vi.spyOn(HTMLFormElement.prototype, "submit").mockImplementation(
     function (this: HTMLFormElement) {
       // The helper detaches the form immediately after this returns, so the
       // element is held rather than its attributes read later off the document.
       submitted.push(this);
+      connectedAtSubmit.push(this.isConnected);
     },
   );
   mocks.getSession.mockReset();
@@ -324,6 +340,42 @@ describe("CommandPalette", () => {
     expect(submitted[0]?.getAttribute("rel")).toBe("noopener");
   });
 
+  it("submits the handoff from a form that is still in the document", async () => {
+    await renderWithSubmitCaptured();
+
+    pressTheShortcut();
+    await screen.findByRole("dialog");
+    type("northwind");
+    const handoff = await within(palette()).findByRole("option", {
+      name: /Open in Dashboard for Northwind Logistics/,
+    });
+    fireEvent.click(handoff);
+
+    // Connected when it ran, and still connected afterwards. The second half is
+    // the regression guard: detaching the form synchronously after `submit()`
+    // leaves this passing in Chromium and silently opens nothing in Firefox,
+    // because the submission is processed in a later task.
+    expect(connectedAtSubmit).toEqual([true]);
+    expect(submitted[0]?.isConnected).toBe(true);
+  });
+
+  it("offers no dashboard handoff for a disabled organization", async () => {
+    // The endpoint refuses a disabled record outright, so the row would open a
+    // new tab onto a 404 — somewhere nothing on this page could explain it.
+    await renderWithSubmitCaptured();
+
+    pressTheShortcut();
+    await screen.findByRole("dialog");
+    type("umbrella");
+
+    await within(palette()).findByRole("option", { name: /^Umbrella Freight/ });
+    expect(
+      within(palette()).queryByRole("option", {
+        name: /Open in Dashboard for Umbrella Freight/,
+      }),
+    ).toBeNull();
+  });
+
   it("names the record each handoff belongs to", async () => {
     // Every one of these rows reads "Open in Dashboard", so without the record
     // in the accessible name a screen reader hears a run of identical options.
@@ -339,7 +391,7 @@ describe("CommandPalette", () => {
     });
     expect(
       within(palette()).getByRole("option", {
-        name: /Open in Dashboard for Umbrella Freight/,
+        name: /Open in Dashboard for Redwood Analytics/,
       }),
     ).toBeTruthy();
   });

--- a/client/admin/src/components/command-palette.test.tsx
+++ b/client/admin/src/components/command-palette.test.tsx
@@ -12,9 +12,12 @@ import type {
   AdminOrganization,
   ListOrganizationsParams,
 } from "@/lib/gramAdminApi";
+import { organizationDashboardUrl } from "@/lib/gramAdminApi";
 import { routeTree } from "@/routeTree.gen";
 import { anOrganization } from "@/test/fixtures";
 import { renderRouteTree } from "@/test/harness";
+
+type Mounted = Awaited<ReturnType<typeof renderRouteTree>>;
 
 const mocks = vi.hoisted(() => ({
   getSession: vi.fn(),
@@ -71,6 +74,10 @@ function palette(): HTMLElement {
   return screen.getByRole("dialog");
 }
 
+// Record rows are matched anchored throughout. Each one is followed by its own
+// "Open in Dashboard for <record>" row, so an unanchored name matches both and
+// every query for a record becomes ambiguous.
+
 function type(term: string): void {
   fireEvent.change(within(palette()).getByRole("combobox"), {
     target: { value: term },
@@ -86,7 +93,28 @@ function searchedFor(): string[] {
     .flatMap((params) => (params.q ? [params.q] : []));
 }
 
+// The forms the palette built, in the order it submitted them. A real submit
+// would try to navigate the test document, and happy-dom has no tab to open, so
+// the call is captured instead of performed and the element read afterwards.
+let submitted: HTMLFormElement[] = [];
+let router: Mounted["router"] | undefined;
+
+async function renderWithSubmitCaptured(): Promise<void> {
+  ({ router } = await renderRouteTree(routeTree, {
+    initialPath: "/organizations",
+  }));
+}
+
 beforeEach(() => {
+  submitted = [];
+  router = undefined;
+  vi.spyOn(HTMLFormElement.prototype, "submit").mockImplementation(
+    function (this: HTMLFormElement) {
+      // The helper detaches the form immediately after this returns, so the
+      // element is held rather than its attributes read later off the document.
+      submitted.push(this);
+    },
+  );
   mocks.getSession.mockReset();
   mocks.getSession.mockResolvedValue({
     email: "ops@example.test",
@@ -146,6 +174,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe("CommandPalette", () => {
@@ -184,7 +213,7 @@ describe("CommandPalette", () => {
     type("northwind");
 
     const result = await within(palette()).findByRole("option", {
-      name: /Northwind Logistics/,
+      name: /^Northwind Logistics/,
     });
     fireEvent.click(result);
 
@@ -205,7 +234,7 @@ describe("CommandPalette", () => {
 
     expect(
       await within(palette()).findByRole("option", {
-        name: /Northwind Logistics/,
+        name: /^Northwind Logistics/,
       }),
     ).toBeTruthy();
   });
@@ -222,7 +251,7 @@ describe("CommandPalette", () => {
 
     expect(
       await within(palette()).findByRole("option", {
-        name: /Umbrella Freight/,
+        name: /^Umbrella Freight/,
       }),
     ).toBeTruthy();
 
@@ -242,7 +271,7 @@ describe("CommandPalette", () => {
     type("umbrella");
 
     const result = await within(palette()).findByRole("option", {
-      name: /Umbrella Freight/,
+      name: /^Umbrella Freight/,
     });
     expect(result.textContent).toContain("Disabled");
   });
@@ -259,12 +288,79 @@ describe("CommandPalette", () => {
     type("northwind");
 
     await within(palette()).findByRole("option", {
-      name: /Northwind Logistics/,
+      name: /^Northwind Logistics/,
     });
 
     // The keystrokes in between reached no request: each one supersedes the
     // debounce the one before it set.
     expect(searchedFor()).toEqual(["northwind"]);
+  });
+
+  it("offers each matched organization a direct dashboard handoff", async () => {
+    await renderWithSubmitCaptured();
+
+    pressTheShortcut();
+    await screen.findByRole("dialog");
+    type("northwind");
+    await within(palette()).findByRole("option", {
+      name: /^Northwind Logistics/,
+    });
+
+    const handoff = within(palette()).getByRole("option", {
+      name: /Open in Dashboard for Northwind Logistics/,
+    });
+    fireEvent.click(handoff);
+
+    // The same request RecordHeader's button makes: a POST, so the admin origin
+    // check protects handoff issuance, opened in a tab of its own.
+    expect(submitted).toHaveLength(1);
+    expect(submitted[0]?.method.toLowerCase()).toBe("post");
+    expect(submitted[0]?.getAttribute("action")).toBe(
+      organizationDashboardUrl(ORG.id),
+    );
+    expect(submitted[0]?.target).toBe("_blank");
+    // noreferrer would make Chromium send `Origin: null` for this POST, which
+    // the admin CSRF middleware correctly rejects.
+    expect(submitted[0]?.getAttribute("rel")).toBe("noopener");
+  });
+
+  it("names the record each handoff belongs to", async () => {
+    // Every one of these rows reads "Open in Dashboard", so without the record
+    // in the accessible name a screen reader hears a run of identical options.
+    await renderWithSubmitCaptured();
+
+    pressTheShortcut();
+    await screen.findByRole("dialog");
+    // A letter both records carry, so the list holds two handoffs at once.
+    type("r");
+
+    await within(palette()).findByRole("option", {
+      name: /Open in Dashboard for Northwind Logistics/,
+    });
+    expect(
+      within(palette()).getByRole("option", {
+        name: /Open in Dashboard for Umbrella Freight/,
+      }),
+    ).toBeTruthy();
+  });
+
+  it("leaves the admin record open behind the handoff", async () => {
+    await renderWithSubmitCaptured();
+
+    pressTheShortcut();
+    await screen.findByRole("dialog");
+    type("northwind");
+    const handoff = await within(palette()).findByRole("option", {
+      name: /Open in Dashboard for Northwind Logistics/,
+    });
+    fireEvent.click(handoff);
+
+    // The palette closes, but nothing navigated: the dashboard opens in a tab
+    // of its own and the operator keeps the admin page they were on.
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    expect(router?.state.location.pathname).toBe("/organizations");
   });
 
   it("says so when a term matches no organization", async () => {
@@ -319,7 +415,7 @@ describe("CommandPalette", () => {
     release?.({ organizations: [ORG] });
     expect(
       await within(palette()).findByRole("option", {
-        name: /Northwind Logistics/,
+        name: /^Northwind Logistics/,
       }),
     ).toBeTruthy();
   });
@@ -333,7 +429,7 @@ describe("CommandPalette", () => {
     await screen.findByRole("dialog");
     type("northwind");
     await within(palette()).findByRole("option", {
-      name: /Northwind Logistics/,
+      name: /^Northwind Logistics/,
     });
 
     type("umbrella");
@@ -341,12 +437,12 @@ describe("CommandPalette", () => {
     // Gone in the same commit the term changed in, rather than when the request
     // for the new one lands.
     expect(
-      within(palette()).queryByRole("option", { name: /Northwind Logistics/ }),
+      within(palette()).queryByRole("option", { name: /^Northwind Logistics/ }),
     ).toBeNull();
 
     expect(
       await within(palette()).findByRole("option", {
-        name: /Umbrella Freight/,
+        name: /^Umbrella Freight/,
       }),
     ).toBeTruthy();
   });
@@ -420,7 +516,7 @@ describe("CommandPalette", () => {
     await screen.findByRole("dialog");
     type("northwind");
     await within(palette()).findByRole("option", {
-      name: /Northwind Logistics/,
+      name: /^Northwind Logistics/,
     });
 
     pressTheShortcut();
@@ -434,7 +530,7 @@ describe("CommandPalette", () => {
     // the palette was last dismissed.
     expect(within(reopened).getByRole("combobox")).toHaveProperty("value", "");
     expect(
-      within(reopened).queryByRole("option", { name: /Northwind Logistics/ }),
+      within(reopened).queryByRole("option", { name: /^Northwind Logistics/ }),
     ).toBeNull();
   });
 });

--- a/client/admin/src/components/command-palette.tsx
+++ b/client/admin/src/components/command-palette.tsx
@@ -330,27 +330,40 @@ export function CommandPalette(): JSX.Element {
 
                           The dashboard is opened rather than navigated to, so
                           this closes the palette but leaves the admin record in
-                          the tab behind it. */}
-                      <CommandItem
-                        value={`${result.id} open in dashboard`}
-                        className="text-muted-foreground pl-8 text-xs"
-                        onSelect={() => {
-                          // Before the close, though the form does not live in
-                          // the dialog: the order is what a reader checks first
-                          // when a handoff stops firing.
-                          openOrganizationDashboard(result.id);
-                          changeOpen(false);
-                        }}
-                      >
-                        <ExternalLinkIcon />
-                        <span>Open in Dashboard</span>
-                        {/* Which record, because every one of these rows reads
+                          the tab behind it.
+
+                          Not for a disabled organization. The handoff endpoint
+                          refuses one outright — impl.go:347 answers a record
+                          with `disabled_at` set with a 404 — and this palette
+                          searches disabled records on purpose, so the case is
+                          one it goes looking for rather than a corner. Offering
+                          the action would be offering a request that cannot
+                          succeed, which is the rule `canExtendTrial` follows
+                          for the same reason, and the failure would land in a
+                          new tab where nothing on this page could explain it.
+                          The row above already reads "Disabled". */}
+                      {!result.disabled_at && (
+                        <CommandItem
+                          value={`${result.id} open in dashboard`}
+                          className="text-muted-foreground pl-8 text-xs"
+                          onSelect={() => {
+                            // Before the close, though the form does not live in
+                            // the dialog: the order is what a reader checks first
+                            // when a handoff stops firing.
+                            openOrganizationDashboard(result.id);
+                            changeOpen(false);
+                          }}
+                        >
+                          <ExternalLinkIcon />
+                          <span>Open in Dashboard</span>
+                          {/* Which record, because every one of these rows reads
                             alike otherwise, and a screen reader hears them one
                             after another with nothing to tell them apart. */}
-                        <span className="sr-only">
-                          {` for ${result.name}${LEAVES_THE_APP}`}
-                        </span>
-                      </CommandItem>
+                          <span className="sr-only">
+                            {` for ${result.name}${LEAVES_THE_APP}`}
+                          </span>
+                        </CommandItem>
+                      )}
                     </Fragment>
                   ))}
 

--- a/client/admin/src/components/command-palette.tsx
+++ b/client/admin/src/components/command-palette.tsx
@@ -8,13 +8,14 @@ import { useMatchRoute, useNavigate } from "@tanstack/react-router";
 import {
   BuildingIcon,
   CreditCardIcon,
+  ExternalLinkIcon,
   FolderIcon,
   HistoryIcon,
   SearchIcon,
   SlidersHorizontalIcon,
   UsersIcon,
 } from "lucide-react";
-import { useRef, useState, type JSX } from "react";
+import { Fragment, useRef, useState, type JSX } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -35,7 +36,11 @@ import {
 import { useOnUnmount } from "@/hooks/useOnUnmount";
 import { organizationQuery, organizationsListQuery } from "@/lib/adminQueries";
 import { ADMIN_NAV } from "@/lib/adminNav";
-import type { AdminOrganization } from "@/lib/gramAdminApi";
+import {
+  openOrganizationDashboard,
+  type AdminOrganization,
+} from "@/lib/gramAdminApi";
+import { LEAVES_THE_APP } from "@/lib/impersonation";
 import { DISABLED_STATES } from "@/lib/organizationFilters";
 import { useOpenOrganization } from "@/pages/organizations/rowActions";
 
@@ -302,22 +307,51 @@ export function CommandPalette(): JSX.Element {
               {searchState !== "idle" && (
                 <CommandGroup heading="Organizations">
                   {results.map((result) => (
-                    <CommandItem
-                      key={result.id}
-                      value={result.id}
-                      onSelect={() => {
-                        changeOpen(false);
-                        openOrganization(result);
-                      }}
-                    >
-                      <BuildingIcon />
-                      <span className="truncate">{result.name}</span>
-                      <span className="text-muted-foreground ml-auto truncate pl-2 text-xs">
-                        {result.disabled_at
-                          ? `Disabled · ${organizationHint(result)}`
-                          : organizationHint(result)}
-                      </span>
-                    </CommandItem>
+                    <Fragment key={result.id}>
+                      <CommandItem
+                        value={result.id}
+                        onSelect={() => {
+                          changeOpen(false);
+                          openOrganization(result);
+                        }}
+                      >
+                        <BuildingIcon />
+                        <span className="truncate">{result.name}</span>
+                        <span className="text-muted-foreground ml-auto truncate pl-2 text-xs">
+                          {result.disabled_at
+                            ? `Disabled · ${organizationHint(result)}`
+                            : organizationHint(result)}
+                        </span>
+                      </CommandItem>
+
+                      {/* Indented under the record it acts on, and secondary to
+                          it: the record itself is what the operator came for,
+                          and this is the other place they might have meant.
+
+                          The dashboard is opened rather than navigated to, so
+                          this closes the palette but leaves the admin record in
+                          the tab behind it. */}
+                      <CommandItem
+                        value={`${result.id} open in dashboard`}
+                        className="text-muted-foreground pl-8 text-xs"
+                        onSelect={() => {
+                          // Before the close, though the form does not live in
+                          // the dialog: the order is what a reader checks first
+                          // when a handoff stops firing.
+                          openOrganizationDashboard(result.id);
+                          changeOpen(false);
+                        }}
+                      >
+                        <ExternalLinkIcon />
+                        <span>Open in Dashboard</span>
+                        {/* Which record, because every one of these rows reads
+                            alike otherwise, and a screen reader hears them one
+                            after another with nothing to tell them apart. */}
+                        <span className="sr-only">
+                          {` for ${result.name}${LEAVES_THE_APP}`}
+                        </span>
+                      </CommandItem>
+                    </Fragment>
                   ))}
 
                   {searchState !== "results" && (

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -171,8 +171,8 @@ export function organizationDashboardUrl(organizationId: string): string {
 // A real <form> around a submit button is the better shape wherever there is a
 // button, and RecordHeader keeps it. The command palette has no button: the row
 // that triggers this unmounts with the dialog in the commit that follows a
-// selection, so a form inside that row can be gone before it submits. Building
-// it on `document.body` puts it somewhere closing the dialog cannot reach.
+// selection, so a form inside that row can be gone before it submits. This one
+// lives on `document.body`, where closing the dialog cannot reach it.
 //
 // Every attribute is load-bearing, and each is the one RecordHeader gives its
 // reason for:
@@ -181,18 +181,39 @@ export function organizationDashboardUrl(organizationId: string): string {
 //   - `noopener` and deliberately not `noreferrer`: noreferrer makes Chromium
 //     send `Origin: null` for this POST, which the admin CSRF middleware
 //     correctly rejects.
+//
+// One element, reused, and never detached. Creating one per handoff and
+// removing it after `submit()` is the obvious shape and it is a bug: submission
+// is processed in a later task, and Firefox abandons the navigation when the
+// form has left the document before that task runs. Keeping one settles the
+// timing question without a timer to reason about, and leaves nothing
+// accumulating behind it.
+let handoffForm: HTMLFormElement | undefined;
+
+function dashboardHandoffForm(): HTMLFormElement {
+  handoffForm ??= (() => {
+    const form = document.createElement("form");
+    form.method = "post";
+    form.target = "_blank";
+    form.setAttribute("rel", "noopener");
+    // It carries no controls and so draws nothing, but a form is still a block
+    // box. Said outright rather than left to the user agent's margins.
+    form.hidden = true;
+    return form;
+  })();
+
+  // Re-attached rather than assumed attached: a submit from a form outside the
+  // document does nothing at all, and a test harness that resets the document
+  // between cases takes it back out.
+  if (!handoffForm.isConnected) document.body.append(handoffForm);
+
+  return handoffForm;
+}
+
 export function openOrganizationDashboard(organizationId: string): void {
-  const form = document.createElement("form");
-  form.method = "post";
+  const form = dashboardHandoffForm();
   form.action = organizationDashboardUrl(organizationId);
-  form.target = "_blank";
-  form.setAttribute("rel", "noopener");
-  // Submitting a form that is not in the document does nothing at all, so it
-  // is attached first and taken back off once the navigation has been asked
-  // for.
-  document.body.append(form);
   form.submit();
-  form.remove();
 }
 
 // Ends the admin session, then sends the browser into the OIDC flow.

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -165,6 +165,36 @@ export function organizationDashboardUrl(organizationId: string): string {
   return `/admin/organization.open-dashboard?${query.toString()}`;
 }
 
+// The same handoff `RecordHeader` renders, for a caller that has no form to
+// render it in.
+//
+// A real <form> around a submit button is the better shape wherever there is a
+// button, and RecordHeader keeps it. The command palette has no button: the row
+// that triggers this unmounts with the dialog in the commit that follows a
+// selection, so a form inside that row can be gone before it submits. Building
+// it on `document.body` puts it somewhere closing the dialog cannot reach.
+//
+// Every attribute is load-bearing, and each is the one RecordHeader gives its
+// reason for:
+//   - POST, so the admin origin check protects handoff issuance.
+//   - `_blank`, so the admin record stays open in the tab the operator is in.
+//   - `noopener` and deliberately not `noreferrer`: noreferrer makes Chromium
+//     send `Origin: null` for this POST, which the admin CSRF middleware
+//     correctly rejects.
+export function openOrganizationDashboard(organizationId: string): void {
+  const form = document.createElement("form");
+  form.method = "post";
+  form.action = organizationDashboardUrl(organizationId);
+  form.target = "_blank";
+  form.setAttribute("rel", "noopener");
+  // Submitting a form that is not in the document does nothing at all, so it
+  // is attached first and taken back off once the navigation has been asked
+  // for.
+  document.body.append(form);
+  form.submit();
+  form.remove();
+}
+
 // Ends the admin session, then sends the browser into the OIDC flow.
 //
 // The endpoint deletes only the server-side record and leaves the `gram_admin`


### PR DESCRIPTION
## Summary

Every organization the command palette matches now carries a nested **Open in Dashboard** row beneath it, so the dashboard handoff is reachable straight from a search instead of requiring the operator to open the record first and find the button in its header.

The handoff itself is the same request `RecordHeader` already makes, and every attribute of it is load-bearing:

- `POST`, so the admin origin check protects handoff issuance.
- `target="_blank"`, so the admin page the operator is on stays open behind it.
- `rel="noopener"` and deliberately **not** `noreferrer` — noreferrer makes Chromium send `Origin: null` for this POST, which the admin CSRF middleware correctly rejects.

`RecordHeader` renders that as a real `<form>` around a submit button and keeps doing so; a submit button is the better shape wherever there is one to render. The palette has no button, and its row unmounts with the dialog in the commit that follows a selection, so a form inside the row can be gone before it submits. `openOrganizationDashboard` builds the same request on `document.body` instead, where closing the dialog cannot reach it. It sits beside `organizationDashboardUrl` so the URL and the submission that uses it stay together, and its comment records why the two call sites differ.

Each row's accessible name is `Open in Dashboard for <record>`. Without the record in the name, a screen reader hears a run of identically-named options with nothing to tell them apart. That is also why the existing tests now match record rows anchored: an unanchored name matches the record and its handoff row both.

## Motivation

Opening a customer's dashboard is one of the more common things an operator does from the admin app, and until now it cost a search, a navigation to the record, and a hunt for the button in the record header — three steps to reach something the search had already found.

One deliberate trade-off: the row appears under **every** match rather than only the highlighted one. That keeps the list stable while arrowing through it, at the cost of doubling its length — at the eight-result cap, sixteen rows. Restricting it to a single match is a one-line change if the density turns out to be the wrong call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CfysUxQ6xdX5TYuUZwGU2c

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an "Open in Dashboard" row under each active organization match in the admin command palette, so the dashboard handoff is reachable without opening the record first.

- Reuses the same POST handoff `RecordHeader` makes, with `target="_blank"` and `rel="noopener"` so the admin page stays open and the CSRF origin check passes.
- Builds the form on `document.body` and reuses one form across handoffs: the palette row unmounts before a form inside it can submit, and Firefox abandons a navigation once its form has left the document.
- Omits the row for disabled organizations, whose handoff the endpoint rejects with a 404.
- Names each row "Open in Dashboard for <record>" so screen readers can tell the rows apart.

<sup>Written for commit e2e714fbf1f2f886f32133f777aea5bc3368f60e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

