### PR TITLE
chore: add admin dashboard opener task

### DIFF
--- a/.mise-tasks/open/admin-dashboard.sh
+++ b/.mise-tasks/open/admin-dashboard.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+#MISE description="Open the admin dashboard app"
+
+set -e
+
+exec mise run open:_thing "${GRAM_ADMIN_SERVER_URL:?Environment variable GRAM_ADMIN_SERVER_URL must be set}"


### PR DESCRIPTION
Closes GRW-91

## Summary
Add `mise run open:admin-dashboard`, using `GRAM_ADMIN_SERVER_URL` and the existing cross-platform `open:_thing` helper.

## Motivation
Make the admin dashboard as convenient to open as the dashboard and IDP dashboard, while respecting the configured browser-facing admin origin.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `mise run open:admin-dashboard` to open the admin dashboard in the browser, matching the existing dashboard and IDP dashboard opener tasks. It targets `GRAM_ADMIN_SERVER_URL` and reuses the shared `open:_thing` helper; if that variable is missing, the task fails with a clear error.

<sup>Written for commit ba9012e8a0f5b160f08b3353fdfeb245dfd93a67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

