### PR TITLE
fix: sort admin organizations by creation date

### DIFF
--- a/.speakeasy/out.admin.openapi.yaml
+++ b/.speakeasy/out.admin.openapi.yaml
@@ -2349,7 +2349,7 @@ paths:
       x-speakeasy-name-override: bulkUpdateAccountType
   /admin/organizations.list:
     get:
-      description: Lists organizations for admin operations with optional search and filters.
+      description: Lists organizations for platform admin operations with optional search and filters. Defaults to created_at descending, with id ascending to break ties.
       operationId: adminListOrganizations
       parameters:
         - allowEmptyValue: true
@@ -2401,11 +2401,11 @@ paths:
             description: Include organizations with disabled_at set. Defaults to false. Superseded by disabled_states, which overrides it outright when supplied.
             type: boolean
         - allowEmptyValue: true
-          description: 'Pagination cursor: id of the last item from the previous page. Ignored when sort or page is supplied.'
+          description: 'Pagination cursor: id of the last item from the previous page in created_at descending, id ascending order. The anchor is resolved regardless of filters; a deleted or unknown id returns an empty page. Ignored when sort or page is supplied.'
           in: query
           name: cursor
           schema:
-            description: 'Pagination cursor: id of the last item from the previous page. Ignored when sort or page is supplied.'
+            description: 'Pagination cursor: id of the last item from the previous page in created_at descending, id ascending order. The anchor is resolved regardless of filters; a deleted or unknown id returns an empty page. Ignored when sort or page is supplied.'
             type: string
         - allowEmptyValue: true
           description: Page size (default 50, max 100).
@@ -2416,18 +2416,18 @@ paths:
             format: int64
             type: integer
         - allowEmptyValue: true
-          description: 'Column to sort by: name, slug, account_type, member_count, created_at, disabled_at or trial_ends_at. Any other value sorts by id. Supplying it selects offset paging.'
+          description: 'Column to sort by: name, slug, account_type, member_count, created_at, disabled_at or trial_ends_at. Omitted or unknown values use created_at descending. Ties always sort by id ascending. Supplying it selects offset paging.'
           in: query
           name: sort
           schema:
-            description: 'Column to sort by: name, slug, account_type, member_count, created_at, disabled_at or trial_ends_at. Any other value sorts by id. Supplying it selects offset paging.'
+            description: 'Column to sort by: name, slug, account_type, member_count, created_at, disabled_at or trial_ends_at. Omitted or unknown values use created_at descending. Ties always sort by id ascending. Supplying it selects offset paging.'
             type: string
         - allowEmptyValue: true
-          description: 'Sort direction, asc or desc, applied to the column named by sort. Any other value sorts ascending. On its own it does nothing: without sort there is no column to reverse, so it neither reorders the results nor selects offset paging.'
+          description: Sort direction, asc or desc, applied to the column named by sort. Any other value sorts ascending. Ignored when sort is omitted or unknown, preserving the newest-first default. On its own it does not select offset paging.
           in: query
           name: direction
           schema:
-            description: 'Sort direction, asc or desc, applied to the column named by sort. Any other value sorts ascending. On its own it does nothing: without sort there is no column to reverse, so it neither reorders the results nor selects offset paging.'
+            description: Sort direction, asc or desc, applied to the column named by sort. Any other value sorts ascending. Ignored when sort is omitted or unknown, preserving the newest-first default. On its own it does not select offset paging.
             type: string
         - allowEmptyValue: true
           description: 1-based page number for offset paging (default 1). Supplying it selects offset paging.

--- a/client/admin/src/lib/adminQueries.test.ts
+++ b/client/admin/src/lib/adminQueries.test.ts
@@ -37,7 +37,7 @@ describe("organizationsListQuery", () => {
   it("invalidates every filtered page from the unfiltered key", () => {
     const qc = new QueryClient();
     const filtered = organizationsListQuery({ q: "x", cursor: "page-2" });
-    qc.setQueryData(filtered.queryKey, { organizations: [] });
+    qc.setQueryData(filtered.queryKey, { total: 0, organizations: [] });
     qc.setQueryData(["gram-admin-project", "p"], {});
 
     void qc.invalidateQueries({ queryKey: organizationsListQuery().queryKey });
@@ -135,6 +135,7 @@ describe("writeOrganizationToCache", () => {
     const qc = new QueryClient();
     const page = organizationsListQuery({ q: "x" });
     qc.setQueryData(page.queryKey, {
+      total: 3,
       organizations: [org("org-b"), LIVE],
       next_cursor: "cursor_page_two",
     });
@@ -159,6 +160,7 @@ describe("writeOrganizationToCache", () => {
     const qc = new QueryClient();
     const page = organizationsListQuery({ q: "x" });
     qc.setQueryData(page.queryKey, {
+      total: 1,
       organizations: [{ ...LIVE, slug: "placeholder-a-as-it-was" }],
     });
 
@@ -257,7 +259,10 @@ describe("writeOrganizationToCache", () => {
   it("leaves a page that never held the record exactly as it was", () => {
     const qc = new QueryClient();
     const page = organizationsListQuery({ q: "other" });
-    const before: ListOrganizationsResult = { organizations: [org("org-b")] };
+    const before: ListOrganizationsResult = {
+      total: 1,
+      organizations: [org("org-b")],
+    };
     qc.setQueryData(page.queryKey, before);
 
     writeOrganizationToCache(qc, DISABLED);
@@ -277,7 +282,7 @@ describe("writeOrganizationToCache", () => {
   it("survives a read that was already in flight when it landed", async () => {
     const qc = new QueryClient();
     const page = organizationsListQuery();
-    qc.setQueryData(page.queryKey, { organizations: [LIVE] });
+    qc.setQueryData(page.queryKey, { total: 1, organizations: [LIVE] });
 
     let land: (result: ListOrganizationsResult) => void = () => {};
     const stale = new Promise<ListOrganizationsResult>((resolve) => {
@@ -291,7 +296,7 @@ describe("writeOrganizationToCache", () => {
     writeOrganizationToCache(qc, DISABLED);
 
     // The stale answer arrives late, carrying the row in its pre-write state.
-    land({ organizations: [LIVE] });
+    land({ total: 1, organizations: [LIVE] });
     await inFlight;
 
     const after = qc.getQueryData<ListOrganizationsResult>(page.queryKey);

--- a/client/admin/src/lib/gramAdminApi.test.ts
+++ b/client/admin/src/lib/gramAdminApi.test.ts
@@ -92,6 +92,28 @@ describe("listOrganizations", () => {
     );
   });
 
+  it("sends Created direction and page to the admin API", async () => {
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ organizations: [], total: 0 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await listOrganizations({
+      sort: "created_at",
+      direction: "asc",
+      page: 2,
+      limit: 50,
+    });
+
+    expect(fetch.mock.calls.at(-1)?.[0]).toBe(
+      "/admin/organizations.list?sort=created_at&direction=asc&page=2&limit=50",
+    );
+    expect(result.total).toBe(0);
+  });
+
   it("asks for the unfiltered list with no query string at all", async () => {
     const fetch = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ organizations: [] }), {

--- a/client/admin/src/lib/gramAdminApi.ts
+++ b/client/admin/src/lib/gramAdminApi.ts
@@ -309,6 +309,7 @@ export function setStripeCustomer(
 }
 
 export type ListOrganizationsResult = {
+  total: number;
   organizations: AdminOrganization[];
   next_cursor?: string;
 };
@@ -322,6 +323,9 @@ export type ListOrganizationsResult = {
 // Nothing here sends them, and nothing should: two ways to say the same filter
 // is how the browser and the server end up disagreeing about what is on.
 export type ListOrganizationsParams = {
+  sort?: string;
+  direction?: "asc" | "desc";
+  page?: number;
   q?: string;
   account_types?: string[];
   trial_states?: string[];

--- a/client/admin/src/pages/organization/Overview.test.tsx
+++ b/client/admin/src/pages/organization/Overview.test.tsx
@@ -550,6 +550,7 @@ describe("Overview", () => {
     });
     qc.setQueryData(organizationQuery(ORG.slug).queryKey, ORG);
     qc.setQueryData(organizationsListQuery().queryKey, {
+      total: 1,
       organizations: [ORG],
     });
 
@@ -832,6 +833,7 @@ describe("Overview", () => {
       },
     });
     qc.setQueryData(organizationsListQuery().queryKey, {
+      total: 1,
       organizations: [ORG],
       next_cursor: undefined,
     });
@@ -868,6 +870,7 @@ describe("Overview", () => {
       converted,
     );
     expect(qc.getQueryData(organizationsListQuery().queryKey)).toEqual({
+      total: 1,
       organizations: [ORG],
       next_cursor: undefined,
     });
@@ -1069,6 +1072,7 @@ describe("Overview", () => {
       },
     });
     qc.setQueryData(organizationsListQuery().queryKey, {
+      total: 1,
       organizations: [ORG],
       next_cursor: undefined,
     });
@@ -1129,6 +1133,7 @@ describe("Overview", () => {
       converted,
     );
     expect(qc.getQueryData(organizationsListQuery().queryKey)).toEqual({
+      total: 1,
       organizations: [ORG],
       next_cursor: undefined,
     });

--- a/client/admin/src/pages/organization/SetStripeCustomer.test.tsx
+++ b/client/admin/src/pages/organization/SetStripeCustomer.test.tsx
@@ -103,6 +103,7 @@ async function renderEditor(org: AdminOrganization = ORG): Promise<{
   qc.setQueryData(organizationQuery(org.id).queryKey, org);
   qc.setQueryData(organizationQuery(org.slug).queryKey, org);
   qc.setQueryData(organizationsListQuery().queryKey, {
+    total: 1,
     organizations: [org],
   });
   const announce = vi.fn<(message: string) => void>();

--- a/client/admin/src/pages/organizations/CreateOrganization.test.tsx
+++ b/client/admin/src/pages/organizations/CreateOrganization.test.tsx
@@ -134,7 +134,7 @@ beforeEach(() => {
   mocks.createOrganization.mockReset();
   mocks.createOrganization.mockResolvedValue(CREATED);
   mocks.listOrganizations.mockReset();
-  mocks.listOrganizations.mockResolvedValue({ organizations: [] });
+  mocks.listOrganizations.mockResolvedValue({ total: 0, organizations: [] });
   mocks.getOrganization.mockReset();
   mocks.getOrganization.mockResolvedValue(CREATED);
   announce.mockReset();
@@ -241,7 +241,10 @@ describe("creating an organization", () => {
 
     // The new record belongs wherever the sort, the filter and the cursor put
     // it, so the page is fetched again rather than patched.
-    mocks.listOrganizations.mockResolvedValue({ organizations: [CREATED] });
+    mocks.listOrganizations.mockResolvedValue({
+      total: 1,
+      organizations: [CREATED],
+    });
     type("Placeholder New");
     submitForm();
 

--- a/client/admin/src/pages/organizations/StatStrip.test.tsx
+++ b/client/admin/src/pages/organizations/StatStrip.test.tsx
@@ -126,7 +126,10 @@ async function renderList(initialPath = "/organizations"): Promise<AnyRouter> {
 
 beforeEach(() => {
   mocks.listOrganizations.mockReset();
-  mocks.listOrganizations.mockResolvedValue({ organizations: ORGS });
+  mocks.listOrganizations.mockResolvedValue({
+    total: ORGS.length,
+    organizations: ORGS,
+  });
   mocks.getOrganizationStats.mockReset();
   mocks.getOrganizationStats.mockResolvedValue(STATS);
   mocks.getSession.mockReset();
@@ -418,7 +421,7 @@ describe("organizations stat strip navigation", () => {
   it("returns to the first page even where the filters do not change", async () => {
     mocks.listOrganizations.mockResolvedValue({
       organizations: ORGS,
-      next_cursor: "cursor_page_two",
+      total: 101,
     });
     await renderList(urlFor({ disabled: ["disabled"] }));
 
@@ -428,7 +431,7 @@ describe("organizations stat strip navigation", () => {
     });
     fireEvent.click(next);
     await waitFor(() => {
-      expect(lastListParams().cursor).toBe("cursor_page_two");
+      expect(lastListParams().page).toBe(2);
     });
 
     // The set this cell applies is the set already applied, so nothing in the
@@ -436,14 +439,14 @@ describe("organizations stat strip navigation", () => {
     fireEvent.click(cell("Disabled"));
 
     await waitFor(() => {
-      expect(lastListParams().cursor).toBeUndefined();
+      expect(lastListParams().page).toBe(1);
     });
   });
 
   it("turns Previous off with the page it sends the operator back to", async () => {
     mocks.listOrganizations.mockResolvedValue({
       organizations: ORGS,
-      next_cursor: "cursor_page_two",
+      total: 101,
     });
     await renderList(urlFor({ disabled: ["disabled"] }));
 
@@ -453,12 +456,12 @@ describe("organizations stat strip navigation", () => {
     });
     fireEvent.click(next);
     await waitFor(() => {
-      expect(lastListParams().cursor).toBe("cursor_page_two");
+      expect(lastListParams().page).toBe(2);
     });
 
     fireEvent.click(cell("Disabled"));
     await waitFor(() => {
-      expect(lastListParams().cursor).toBeUndefined();
+      expect(lastListParams().page).toBe(1);
     });
     // Enabled again, so the rows on screen are the first page rather than the
     // one before it. Previous is disabled off the pages behind, not off this.

--- a/client/admin/src/pages/organizations/applyFilters.ts
+++ b/client/admin/src/pages/organizations/applyFilters.ts
@@ -18,7 +18,7 @@ export type ApplyOptions = {
 };
 
 // What applying leaves for the page to do itself. Two things it cannot read
-// off the URL: the cursor is component state, so applying the set already
+// off the URL: the page is component state, so applying the set already
 // applied moves nothing it watches, and a search term the box has not
 // committed yet is in no URL at all.
 export const FiltersApplied = createContext<(options: ApplyOptions) => void>(
@@ -38,7 +38,7 @@ export function useApplyFilters(): (
 
   return useCallback(
     (next: FilterSelection, options: ApplyOptions = {}): void => {
-      // Page 1. The rows a page-two cursor points at were counted under the
+      // Page 1. The rows on a later page were counted under the
       // filters that minted it.
       onApplied(options);
       void navigate({

--- a/client/admin/src/pages/organizations/index.test.tsx
+++ b/client/admin/src/pages/organizations/index.test.tsx
@@ -156,7 +156,7 @@ const STATS: AdminOrganizationStats = {
   disabled_last_7_days: 1,
 };
 
-// A page the cursor leads to. Nothing it holds appears on the first page, so a
+// A second page. Nothing it holds appears on the first page, so a
 // row that survives the page change is a reused node rather than a match.
 const NEXT_PAGE_ORG: AdminOrganization = {
   id: "org_placeholder_three",
@@ -376,7 +376,10 @@ function urlFor(search: Record<string, unknown>): string {
 
 beforeEach(() => {
   mocks.listOrganizations.mockReset();
-  mocks.listOrganizations.mockResolvedValue({ organizations: ORGS });
+  mocks.listOrganizations.mockResolvedValue({
+    total: ORGS.length,
+    organizations: ORGS,
+  });
   mocks.getSession.mockReset();
   mocks.getSession.mockResolvedValue({
     email: "ops@example.test",
@@ -425,6 +428,58 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("organizations list", () => {
+  it("sorts only Created, resets paging, and restores direction on reload", async () => {
+    mocks.listOrganizations.mockResolvedValue({
+      organizations: ORGS,
+      total: 101,
+    });
+    const { router } = await renderRouteTree(routeTree, {
+      initialPath: "/organizations",
+    });
+    const created = await screen.findByRole("button", { name: "Created" });
+    await waitFor(() =>
+      expect(lastListParams()).toMatchObject({
+        sort: "created_at",
+        direction: "desc",
+        page: 1,
+      }),
+    );
+    expect(created.closest("th")?.getAttribute("aria-sort")).toBe("descending");
+    expect(created.textContent).toContain("↓");
+    for (const name of [
+      "Name",
+      "Slug",
+      "Type",
+      "Members",
+      "WorkOS",
+      "Disabled",
+      "Trial",
+    ]) {
+      expect(screen.queryByRole("button", { name })).toBeNull();
+    }
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    await waitFor(() => expect(lastListParams().page).toBe(2));
+    fireEvent.click(created);
+    await waitFor(() =>
+      expect(lastListParams()).toMatchObject({ direction: "asc", page: 1 }),
+    );
+    expect(created.closest("th")?.getAttribute("aria-sort")).toBe("ascending");
+    expect(created.textContent).toContain("↑");
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    await waitFor(() =>
+      expect(lastListParams()).toMatchObject({ direction: "asc", page: 2 }),
+    );
+    const reloadedPath = `/organizations${currentSearch(router)}`;
+    cleanup();
+    await renderRouteTree(routeTree, { initialPath: reloadedPath });
+    const restored = await screen.findByRole("button", { name: "Created" });
+    expect(restored.closest("th")?.getAttribute("aria-sort")).toBe("ascending");
+    fireEvent.click(restored);
+    await waitFor(() =>
+      expect(lastListParams()).toMatchObject({ direction: "desc", page: 1 }),
+    );
+  });
+
   it("takes the search term from the URL and sends it with the request", async () => {
     await renderRouteTree(routeTree, {
       initialPath: "/organizations?q=acme",
@@ -882,7 +937,7 @@ describe("organizations list", () => {
 
   it("keeps the sort when a filter is applied", async () => {
     const { router } = await renderRouteTree(routeTree, {
-      initialPath: urlFor({ sort: "name", dir: "asc" }),
+      initialPath: urlFor({ sort: "created_at", dir: "asc" }),
     });
 
     await openFilters("Status");
@@ -893,14 +948,18 @@ describe("organizations list", () => {
       expect(lastListParams().disabled_states).toEqual(["disabled"]);
     });
     const url = currentSearch(router);
-    expect(url).toContain("sort=name");
+    expect(url).toContain("sort=created_at");
     expect(url).toContain("dir=asc");
+    expect(lastListParams()).toMatchObject({
+      sort: "created_at",
+      direction: "asc",
+    });
   });
 
   it("returns to the first page when the sheet applies the set already on", async () => {
     mocks.listOrganizations.mockResolvedValue({
       organizations: ORGS,
-      next_cursor: "cursor_page_two",
+      total: 101,
     });
     await renderRouteTree(routeTree, {
       initialPath: urlFor({ disabled: ["disabled"] }),
@@ -912,7 +971,7 @@ describe("organizations list", () => {
     });
     fireEvent.click(next);
     await waitFor(() => {
-      expect(lastListParams().cursor).toBe("cursor_page_two");
+      expect(lastListParams().page).toBe(2);
     });
 
     // Nothing in the URL moves, so the pager cannot notice on its own. Page
@@ -921,7 +980,7 @@ describe("organizations list", () => {
     applyFilters();
 
     await waitFor(() => {
-      expect(lastListParams().cursor).toBeUndefined();
+      expect(lastListParams().page).toBe(1);
     });
   });
 
@@ -963,10 +1022,10 @@ describe("organizations list", () => {
     expect(lastListParams().q).toBe("acme");
   });
 
-  it("drops the cursor when a filter changes", async () => {
+  it("resets the page when a filter changes", async () => {
     mocks.listOrganizations.mockResolvedValue({
       organizations: ORGS,
-      next_cursor: "cursor_page_two",
+      total: 101,
     });
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
 
@@ -976,7 +1035,7 @@ describe("organizations list", () => {
     });
     fireEvent.click(next);
     await waitFor(() => {
-      expect(lastListParams().cursor).toBe("cursor_page_two");
+      expect(lastListParams().page).toBe(2);
     });
 
     await openFilters("Status");
@@ -986,15 +1045,15 @@ describe("organizations list", () => {
     await waitFor(() => {
       expect(lastListParams().disabled_states).toEqual(["disabled"]);
     });
-    // The cursor was minted by the previous filter set and points into a
+    // The page was fetched under the previous filter set and belongs to a
     // different result set.
-    expect(lastListParams().cursor).toBeUndefined();
+    expect(lastListParams().page).toBe(1);
   });
 
-  it("drops the cursor when the search box changes the term", async () => {
+  it("resets the page when the search box changes the term", async () => {
     mocks.listOrganizations.mockResolvedValue({
       organizations: ORGS,
-      next_cursor: "cursor_page_two",
+      total: 101,
     });
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
 
@@ -1004,7 +1063,7 @@ describe("organizations list", () => {
     });
     fireEvent.click(next);
     await waitFor(() => {
-      expect(lastListParams().cursor).toBe("cursor_page_two");
+      expect(lastListParams().page).toBe(2);
     });
 
     // The box writes to the URL itself, so nothing tells the pager. Only the
@@ -1019,7 +1078,7 @@ describe("organizations list", () => {
       },
       { timeout: 2000 },
     );
-    expect(lastListParams().cursor).toBeUndefined();
+    expect(lastListParams().page).toBe(1);
   });
 
   it("renders every cell of a row out of the record that produced it", async () => {
@@ -1051,7 +1110,7 @@ describe("organizations list", () => {
       "WorkOS",
       "Disabled",
       "Trial",
-      "Created",
+      "Created ↓",
       "Actions",
     ]);
     expect(
@@ -1152,9 +1211,9 @@ describe("organizations list", () => {
   it("drops focus rather than moving it to another organization on the next page", async () => {
     mocks.listOrganizations.mockImplementation((params) =>
       Promise.resolve(
-        params?.cursor
-          ? { organizations: [NEXT_PAGE_ORG] }
-          : { organizations: ORGS, next_cursor: "cursor_page_two" },
+        (params?.page ?? 1) > 1
+          ? { total: 101, organizations: [NEXT_PAGE_ORG] }
+          : { organizations: ORGS, total: 101 },
       ),
     );
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
@@ -1337,7 +1396,7 @@ describe("organizations list peek", () => {
       "WorkOS",
       "Disabled",
       "Trial",
-      "Created",
+      "Created ↓",
       "Actions",
     ]);
   });
@@ -1397,9 +1456,9 @@ describe("organizations list peek", () => {
   it("drops peek when the operator pages away from the record", async () => {
     mocks.listOrganizations.mockImplementation((params) =>
       Promise.resolve(
-        params?.cursor
-          ? { organizations: [NEXT_PAGE_ORG] }
-          : { organizations: ORGS, next_cursor: "cursor_page_two" },
+        (params?.page ?? 1) > 1
+          ? { total: 101, organizations: [NEXT_PAGE_ORG] }
+          : { organizations: ORGS, total: 101 },
       ),
     );
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
@@ -1431,7 +1490,7 @@ describe("organizations list peek", () => {
       "WorkOS",
       "Disabled",
       "Trial",
-      "Created",
+      "Created ↓",
       "Actions",
     ]);
   });
@@ -1538,6 +1597,7 @@ describe("organizations list peek", () => {
     // Three rows, because the trap only shows on the second press: the first
     // move works and leaves the keyboard behind on the row it moved off.
     mocks.listOrganizations.mockResolvedValue({
+      total: 3,
       organizations: [FIRST_ORG, SECOND_ORG, NEXT_PAGE_ORG],
     });
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
@@ -1693,7 +1753,7 @@ describe("organizations list peek", () => {
   it("ignores the arrow keys pressed on the pager", async () => {
     mocks.listOrganizations.mockResolvedValue({
       organizations: ORGS,
-      next_cursor: "cursor_page_two",
+      total: 101,
     });
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
     const first = await screen.findByRole("link", { name: FIRST_ORG.name });
@@ -1723,7 +1783,7 @@ describe("organizations list peek", () => {
   it("ignores Escape pressed on the pager", async () => {
     mocks.listOrganizations.mockResolvedValue({
       organizations: ORGS,
-      next_cursor: "cursor_page_two",
+      total: 101,
     });
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
     await peekOn(FIRST_ORG.name);
@@ -1862,6 +1922,7 @@ describe("organizations list peek", () => {
       name: FIRST_ORG.name,
     };
     mocks.listOrganizations.mockResolvedValue({
+      total: 2,
       organizations: [FIRST_ORG, TWIN],
     });
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
@@ -2262,9 +2323,9 @@ describe("organizations list peek", () => {
   it("puts the keyboard on the table, not on the body, when the peeked record leaves the list", async () => {
     mocks.listOrganizations.mockImplementation((params) =>
       Promise.resolve(
-        params?.cursor
-          ? { organizations: [NEXT_PAGE_ORG] }
-          : { organizations: ORGS, next_cursor: "cursor_page_two" },
+        (params?.page ?? 1) > 1
+          ? { total: 101, organizations: [NEXT_PAGE_ORG] }
+          : { organizations: ORGS, total: 101 },
       ),
     );
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
@@ -2312,9 +2373,9 @@ describe("organizations list peek", () => {
   it("leaves the keyboard on the pager when the operator pages the peeked record away", async () => {
     mocks.listOrganizations.mockImplementation((params) =>
       Promise.resolve(
-        params?.cursor
-          ? { organizations: [NEXT_PAGE_ORG], next_cursor: "cursor_page_three" }
-          : { organizations: ORGS, next_cursor: "cursor_page_two" },
+        (params?.page ?? 1) > 1
+          ? { organizations: [NEXT_PAGE_ORG], total: 101 }
+          : { organizations: ORGS, total: 101 },
       ),
     );
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
@@ -3164,9 +3225,9 @@ describe("organizations list bulk account type", () => {
   it("clears the selection when the operator pages", async () => {
     mocks.listOrganizations.mockImplementation((params) =>
       Promise.resolve(
-        params?.cursor
-          ? { organizations: [NEXT_PAGE_ORG] }
-          : { organizations: ORGS, next_cursor: "cursor_page_two" },
+        (params?.page ?? 1) > 1
+          ? { total: 101, organizations: [NEXT_PAGE_ORG] }
+          : { organizations: ORGS, total: 101 },
       ),
     );
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
@@ -3215,9 +3276,9 @@ describe("organizations list bulk account type", () => {
   it("does not bring the selection back when the operator pages back", async () => {
     mocks.listOrganizations.mockImplementation((params) =>
       Promise.resolve(
-        params?.cursor
-          ? { organizations: [NEXT_PAGE_ORG] }
-          : { organizations: ORGS, next_cursor: "cursor_page_two" },
+        (params?.page ?? 1) > 1
+          ? { total: 101, organizations: [NEXT_PAGE_ORG] }
+          : { organizations: ORGS, total: 101 },
       ),
     );
     await renderRouteTree(routeTree, { initialPath: "/organizations" });
@@ -3265,12 +3326,12 @@ describe("organizations list bulk account type", () => {
 
     await tick(FIRST_ORG.name);
 
-    // The sort is in the URL and not in the list request, so a page that
+    // The sort is in the URL and the list request, so a page that
     // watched only the request would keep a selection across a reorder.
     await act(async () => {
       await router.navigate({
         to: "/organizations",
-        search: { sort: "name", dir: "asc" },
+        search: { sort: "created_at", dir: "asc" },
       });
     });
 
@@ -3767,7 +3828,7 @@ describe("organizations list create organization: a refusal", () => {
 
     // The read the write cancelled is dead: React Query drops its answer, so
     // the rows can only arrive from a request made after the failure.
-    releaseList({ organizations: ORGS });
+    releaseList({ total: ORGS.length, organizations: ORGS });
     // An open Radix modal hides the rest of the page from the accessibility
     // tree, so the rows are unreachable by role until the operator is out of
     // the dialog. Closing it is their next move anyway.
@@ -4104,7 +4165,10 @@ describe("re-arming a trial from the peek panel", () => {
   const REARMED_TRIAL_END = "2026-09-04T00:00:00Z";
 
   beforeEach(() => {
-    mocks.listOrganizations.mockResolvedValue({ organizations: [DEMOTED_ORG] });
+    mocks.listOrganizations.mockResolvedValue({
+      total: 1,
+      organizations: [DEMOTED_ORG],
+    });
     mocks.rearmTrial.mockResolvedValue({
       ...DEMOTED_ORG,
       account_type: "enterprise",

--- a/client/admin/src/pages/organizations/index.tsx
+++ b/client/admin/src/pages/organizations/index.tsx
@@ -1,6 +1,7 @@
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
-import { useSearch } from "@tanstack/react-router";
+import { useNavigate, useSearch } from "@tanstack/react-router";
 import {
+  FlexRender,
   useTable,
   type ColumnVisibilityState,
   type RowSelectionState,
@@ -16,6 +17,7 @@ import {
 
 import { dataTableFeatures, DataTable as Table } from "@/components/data-table";
 import { Button } from "@/components/ui/button";
+import { TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { useAnnouncer } from "@/hooks/use-announcer";
 import { organizationsListQuery } from "@/lib/adminQueries";
 import {
@@ -69,14 +71,13 @@ function emptyStateMessage(isLoading: boolean, isError: boolean): string {
   return "No organizations found";
 }
 
-// The list API is cursor-paged, so a page cannot be addressed by number and the
-// pager stays out of the URL. `filters` records which filter set produced the
-// cursor: a cursor outlives its filters as a valid-looking string that points
-// into the wrong result set.
-type Pager = { filters: string; cursor?: string; stack: string[] };
+// Keep the page local; filter or direction changes restart the result set.
+type Pager = { filters: string; page: number };
 
 export function OrganizationsList(): JSX.Element {
   const search = useSearch({ from: ROUTE_ID });
+  const navigate = useNavigate({ from: ROUTE_ID });
+  const direction = search.dir ?? "desc";
   const openOrganization = useOpenOrganization();
 
   // Column visibility is deliberately not in the URL. It is a per-operator
@@ -121,6 +122,8 @@ export function OrganizationsList(): JSX.Element {
   //
   // Every value arrives validated, so nothing is normalised a second time here.
   const listParams: ListOrganizationsParams = {
+    sort: "created_at",
+    direction,
     q: search.q,
     account_types: search.type,
     trial_states: search.trial,
@@ -130,11 +133,11 @@ export function OrganizationsList(): JSX.Element {
   // omitUnset, not the raw object: the signature has to call a param unset
   // wherever the request does, or a no-op edit resets the pager.
   const filters = JSON.stringify(omitUnset(listParams));
-  const [pager, setPager] = useState<Pager>({ filters, stack: [] });
-  // Reset while rendering, so the query below never asks for the stale cursor.
+  const [pager, setPager] = useState<Pager>({ filters, page: 1 });
+  // Reset while rendering, so the query below never asks for the stale page.
   // An effect would run after the request had already gone out.
   if (pager.filters !== filters) {
-    setPager({ filters, stack: [] });
+    setPager({ filters, page: 1 });
   }
 
   // Cleared whenever the operator changes the view: a selection carried across
@@ -143,7 +146,7 @@ export function OrganizationsList(): JSX.Element {
   // reorders the page. A refetch that changes rows under a still view keeps the
   // selection, and the row model is what stops a dropped row being written to.
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
-  const viewKey = `${JSON.stringify(search)}|${pager.cursor ?? ""}`;
+  const viewKey = `${JSON.stringify(search)}|${pager.page}`;
   const [selectionView, setSelectionView] = useState(viewKey);
   if (selectionView !== viewKey) {
     setSelectionView(viewKey);
@@ -153,7 +156,7 @@ export function OrganizationsList(): JSX.Element {
   const { data, isLoading, isError, error, isPlaceholderData } = useQuery({
     ...organizationsListQuery({
       ...listParams,
-      cursor: pager.cursor,
+      page: pager.filters === filters ? pager.page : 1,
       limit: PAGE_SIZE,
     }),
     // Every filter and every page is a separate cache entry. Without this the
@@ -168,29 +171,28 @@ export function OrganizationsList(): JSX.Element {
   // Applying a set the list already carries leaves the signature above
   // untouched, so the control that applies says so itself.
   const onFiltersApplied = useCallback((options: ApplyOptions) => {
-    setPager((prev) => ({ ...prev, cursor: undefined, stack: [] }));
+    setPager((prev) => ({ ...prev, page: 1 }));
     // A term still inside the debounce is in no URL, so clearing `q` is a
     // no-op the box cannot see, and it would commit the term afterwards.
     if (options.clearSearch) setSearchCleared((token) => token + 1);
   }, []);
 
+  const hasNextPage = pager.page * PAGE_SIZE < (data?.total ?? 0);
   const goNext = () => {
-    if (!data?.next_cursor) return;
-    setPager({
-      filters,
-      cursor: data.next_cursor,
-      stack: [...pager.stack, pager.cursor ?? ""],
-    });
+    if (hasNextPage) setPager({ filters, page: pager.page + 1 });
   };
 
   const goPrev = () => {
-    if (pager.stack.length === 0) return;
-    // An empty string on the stack is the first page, which has no cursor.
-    const previous = pager.stack[pager.stack.length - 1];
-    setPager({
-      filters,
-      cursor: previous || undefined,
-      stack: pager.stack.slice(0, -1),
+    if (pager.page > 1) setPager({ filters, page: pager.page - 1 });
+  };
+
+  const toggleCreatedSort = () => {
+    void navigate({
+      search: (prev) => ({
+        ...prev,
+        sort: "created_at",
+        dir: direction === "desc" ? "asc" : "desc",
+      }),
     });
   };
 
@@ -492,7 +494,44 @@ export function OrganizationsList(): JSX.Element {
                     )}
                   >
                     <Table>
-                      <Table.Header table={table} />
+                      <TableHeader className="bg-muted sticky top-0 z-10">
+                        {table.getHeaderGroups().map((group) => (
+                          <TableRow key={group.id}>
+                            {group.headers.map((header) => (
+                              <TableHead
+                                key={header.id}
+                                colSpan={header.colSpan}
+                                className={
+                                  header.column.columnDef.meta?.headClassName
+                                }
+                                aria-sort={
+                                  header.column.id === "created_at"
+                                    ? direction === "asc"
+                                      ? "ascending"
+                                      : "descending"
+                                    : undefined
+                                }
+                              >
+                                {header.isPlaceholder ? null : header.column
+                                    .id === "created_at" ? (
+                                  <button
+                                    type="button"
+                                    className="inline-flex items-center gap-1 rounded-sm focus-visible:outline-2 focus-visible:outline-ring"
+                                    onClick={toggleCreatedSort}
+                                  >
+                                    Created{" "}
+                                    <span aria-hidden="true">
+                                      {direction === "asc" ? "↑" : "↓"}
+                                    </span>
+                                  </button>
+                                ) : (
+                                  <FlexRender header={header} />
+                                )}
+                              </TableHead>
+                            ))}
+                          </TableRow>
+                        ))}
+                      </TableHeader>
                       <Table.Body>
                         {rows.length === 0 ? (
                           <Table.NoResultsMessage>
@@ -535,7 +574,7 @@ export function OrganizationsList(): JSX.Element {
                   <Button
                     variant="ghost"
                     size="xs"
-                    disabled={isPlaceholderData || pager.stack.length === 0}
+                    disabled={isPlaceholderData || pager.page === 1}
                     onClick={goPrev}
                   >
                     Previous
@@ -543,7 +582,7 @@ export function OrganizationsList(): JSX.Element {
                   <Button
                     variant="ghost"
                     size="xs"
-                    disabled={isPlaceholderData || !data?.next_cursor}
+                    disabled={isPlaceholderData || !hasNextPage}
                     onClick={goNext}
                   >
                     Next

--- a/client/admin/src/pages/organizations/rowActions.test.tsx
+++ b/client/admin/src/pages/organizations/rowActions.test.tsx
@@ -182,7 +182,7 @@ describe("useRearmTrial", () => {
     // rather than refetching.
     qc.setQueryData<ListOrganizationsResult>(
       organizationsListQuery({ trial_states: ["demoted"] }).queryKey,
-      { organizations: [DEMOTED_ORG] },
+      { total: 1, organizations: [DEMOTED_ORG] },
     );
     return qc;
   }
@@ -210,6 +210,7 @@ describe("useRearmTrial", () => {
     // stale, and the refetch behind that would drop the row out of a filter it
     // no longer matches, under the operator who just pressed the control.
     expect(qc.getQueryData<ListOrganizationsResult>(listKey)).toEqual({
+      total: 1,
       organizations: [REARMED_ORG],
     });
     expect(qc.getQueryState(listKey)?.isInvalidated).toBe(false);
@@ -251,6 +252,7 @@ describe("useRearmTrial", () => {
     });
     // Nothing was repainted, so the row still says what the server still says.
     expect(qc.getQueryData<ListOrganizationsResult>(listKey)).toEqual({
+      total: 1,
       organizations: [DEMOTED_ORG],
     });
   });

--- a/client/admin/src/sdk/src/funcs/adminListOrganizations.ts
+++ b/client/admin/src/sdk/src/funcs/adminListOrganizations.ts
@@ -44,7 +44,7 @@ import {
  * listOrganizations admin
  *
  * @remarks
- * Lists organizations for admin operations with optional search and filters.
+ * Lists organizations for platform admin operations with optional search and filters. Defaults to created_at descending, with id ascending to break ties.
  */
 export function adminListOrganizations(
   client: GramCore,

--- a/client/admin/src/sdk/src/models/operations/adminlistorganizations.ts
+++ b/client/admin/src/sdk/src/models/operations/adminlistorganizations.ts
@@ -38,7 +38,7 @@ export type AdminListOrganizationsRequest = {
    */
   includeDisabled?: boolean | undefined;
   /**
-   * Pagination cursor: id of the last item from the previous page. Ignored when sort or page is supplied.
+   * Pagination cursor: id of the last item from the previous page in created_at descending, id ascending order. The anchor is resolved regardless of filters; a deleted or unknown id returns an empty page. Ignored when sort or page is supplied.
    */
   cursor?: string | undefined;
   /**
@@ -46,11 +46,11 @@ export type AdminListOrganizationsRequest = {
    */
   limit?: number | undefined;
   /**
-   * Column to sort by: name, slug, account_type, member_count, created_at, disabled_at or trial_ends_at. Any other value sorts by id. Supplying it selects offset paging.
+   * Column to sort by: name, slug, account_type, member_count, created_at, disabled_at or trial_ends_at. Omitted or unknown values use created_at descending. Ties always sort by id ascending. Supplying it selects offset paging.
    */
   sort?: string | undefined;
   /**
-   * Sort direction, asc or desc, applied to the column named by sort. Any other value sorts ascending. On its own it does nothing: without sort there is no column to reverse, so it neither reorders the results nor selects offset paging.
+   * Sort direction, asc or desc, applied to the column named by sort. Any other value sorts ascending. Ignored when sort is omitted or unknown, preserving the newest-first default. On its own it does not select offset paging.
    */
   direction?: string | undefined;
   /**

--- a/client/admin/src/sdk/src/react-query/adminListOrganizations.ts
+++ b/client/admin/src/sdk/src/react-query/adminListOrganizations.ts
@@ -74,7 +74,7 @@ export type AdminListOrganizationsQueryError =
  * listOrganizations admin
  *
  * @remarks
- * Lists organizations for admin operations with optional search and filters.
+ * Lists organizations for platform admin operations with optional search and filters. Defaults to created_at descending, with id ascending to break ties.
  */
 export function useAdminListOrganizations(
   request?: AdminListOrganizationsRequest | undefined,
@@ -101,7 +101,7 @@ export function useAdminListOrganizations(
  * listOrganizations admin
  *
  * @remarks
- * Lists organizations for admin operations with optional search and filters.
+ * Lists organizations for platform admin operations with optional search and filters. Defaults to created_at descending, with id ascending to break ties.
  */
 export function useAdminListOrganizationsSuspense(
   request?: AdminListOrganizationsRequest | undefined,
@@ -128,7 +128,7 @@ export function useAdminListOrganizationsSuspense(
  * listOrganizations admin
  *
  * @remarks
- * Lists organizations for admin operations with optional search and filters.
+ * Lists organizations for platform admin operations with optional search and filters. Defaults to created_at descending, with id ascending to break ties.
  */
 export function useAdminListOrganizationsInfinite(
   request?: AdminListOrganizationsRequest | undefined,
@@ -169,7 +169,7 @@ export function useAdminListOrganizationsInfinite(
  * listOrganizations admin
  *
  * @remarks
- * Lists organizations for admin operations with optional search and filters.
+ * Lists organizations for platform admin operations with optional search and filters. Defaults to created_at descending, with id ascending to break ties.
  */
 export function useAdminListOrganizationsInfiniteSuspense(
   request?: AdminListOrganizationsRequest | undefined,

--- a/client/admin/src/sdk/src/sdk/admin.ts
+++ b/client/admin/src/sdk/src/sdk/admin.ts
@@ -559,7 +559,7 @@ export class Admin extends ClientSDK {
    * listOrganizations admin
    *
    * @remarks
-   * Lists organizations for admin operations with optional search and filters.
+   * Lists organizations for platform admin operations with optional search and filters. Defaults to created_at descending, with id ascending to break ties.
    */
   async listOrganizations(
     request?: AdminListOrganizationsRequest | undefined,

--- a/server/design/admin/design.go
+++ b/server/design/admin/design.go
@@ -670,7 +670,7 @@ var _ = Service("admin", func() {
 	})
 
 	Method("listOrganizations", func() {
-		Description("Lists organizations for admin operations with optional search and filters.")
+		Description("Lists organizations for platform admin operations with optional search and filters. Defaults to created_at descending, with id ascending to break ties.")
 
 		Payload(func() {
 			security.AdminAuthPayload()
@@ -681,10 +681,10 @@ var _ = Service("admin", func() {
 			Attribute("trial_states", ArrayOf(String), "Match any of running, ending_soon, expired, demoted, converted or none. Empty matches every trial state. An unrecognised value matches nothing rather than failing the request.")
 			Attribute("disabled_states", ArrayOf(String), "Match any of active or disabled. Empty falls back to include_disabled. An unrecognised value matches nothing rather than failing the request.")
 			Attribute("include_disabled", Boolean, "Include organizations with disabled_at set. Defaults to false. Superseded by disabled_states, which overrides it outright when supplied.")
-			Attribute("cursor", String, "Pagination cursor: id of the last item from the previous page. Ignored when sort or page is supplied.")
+			Attribute("cursor", String, "Pagination cursor: id of the last item from the previous page in created_at descending, id ascending order. The anchor is resolved regardless of filters; a deleted or unknown id returns an empty page. Ignored when sort or page is supplied.")
 			Attribute("limit", Int, "Page size (default 50, max 100).")
-			Attribute("sort", String, "Column to sort by: name, slug, account_type, member_count, created_at, disabled_at or trial_ends_at. Any other value sorts by id. Supplying it selects offset paging.")
-			Attribute("direction", String, "Sort direction, asc or desc, applied to the column named by sort. Any other value sorts ascending. On its own it does nothing: without sort there is no column to reverse, so it neither reorders the results nor selects offset paging.")
+			Attribute("sort", String, "Column to sort by: name, slug, account_type, member_count, created_at, disabled_at or trial_ends_at. Omitted or unknown values use created_at descending. Ties always sort by id ascending. Supplying it selects offset paging.")
+			Attribute("direction", String, "Sort direction, asc or desc, applied to the column named by sort. Any other value sorts ascending. Ignored when sort is omitted or unknown, preserving the newest-first default. On its own it does not select offset paging.")
 			Attribute("page", Int, "1-based page number for offset paging (default 1). Supplying it selects offset paging.")
 		})
 

--- a/server/gen/admin/service.go
+++ b/server/gen/admin/service.go
@@ -67,7 +67,8 @@ type Service interface {
 	ListOrganizationProjects(context.Context, *ListOrganizationProjectsPayload) (res *AdminListOrganizationProjectsResult, err error)
 	// Lists activity belonging to an organization for admin operators.
 	ListOrganizationActivity(context.Context, *ListOrganizationActivityPayload) (res *AdminListOrganizationActivityResult, err error)
-	// Lists organizations for admin operations with optional search and filters.
+	// Lists organizations for platform admin operations with optional search and
+	// filters. Defaults to created_at descending, with id ascending to break ties.
 	ListOrganizations(context.Context, *ListOrganizationsPayload) (res *AdminListOrganizationsResult, err error)
 	// Extends a running enterprise trial by adding days to its current end date.
 	// Only a running trial can be extended: one that has converted, has been
@@ -968,19 +969,21 @@ type ListOrganizationsPayload struct {
 	// Include organizations with disabled_at set. Defaults to false. Superseded by
 	// disabled_states, which overrides it outright when supplied.
 	IncludeDisabled *bool
-	// Pagination cursor: id of the last item from the previous page. Ignored when
-	// sort or page is supplied.
+	// Pagination cursor: id of the last item from the previous page in created_at
+	// descending, id ascending order. The anchor is resolved regardless of
+	// filters; a deleted or unknown id returns an empty page. Ignored when sort or
+	// page is supplied.
 	Cursor *string
 	// Page size (default 50, max 100).
 	Limit *int
 	// Column to sort by: name, slug, account_type, member_count, created_at,
-	// disabled_at or trial_ends_at. Any other value sorts by id. Supplying it
-	// selects offset paging.
+	// disabled_at or trial_ends_at. Omitted or unknown values use created_at
+	// descending. Ties always sort by id ascending. Supplying it selects offset
+	// paging.
 	Sort *string
 	// Sort direction, asc or desc, applied to the column named by sort. Any other
-	// value sorts ascending. On its own it does nothing: without sort there is no
-	// column to reverse, so it neither reorders the results nor selects offset
-	// paging.
+	// value sorts ascending. Ignored when sort is omitted or unknown, preserving
+	// the newest-first default. On its own it does not select offset paging.
 	Direction *string
 	// 1-based page number for offset paging (default 1). Supplying it selects
 	// offset paging.

--- a/server/gen/http/cli/gram/cli.go
+++ b/server/gen/http/cli/gram/cli.go
@@ -21307,7 +21307,7 @@ func adminUsage() {
 	fmt.Fprintln(os.Stderr, `    list-organization-members: Lists members of an organization (admin view, no auth scoping).`)
 	fmt.Fprintln(os.Stderr, `    list-organization-projects: Lists projects belonging to an organization (admin view, no auth scoping).`)
 	fmt.Fprintln(os.Stderr, `    list-organization-activity: Lists activity belonging to an organization for admin operators.`)
-	fmt.Fprintln(os.Stderr, `    list-organizations: Lists organizations for admin operations with optional search and filters.`)
+	fmt.Fprintln(os.Stderr, `    list-organizations: Lists organizations for platform admin operations with optional search and filters. Defaults to created_at descending, with id ascending to break ties.`)
 	fmt.Fprintln(os.Stderr, `    extend-trial: Extends a running enterprise trial by adding days to its current end date. Only a running trial can be extended: one that has converted, has been demoted, or has already expired is rejected rather than re-armed.`)
 	fmt.Fprintln(os.Stderr, `    create-organization: Creates an organization in WorkOS and in Gram, so an operator does not have to leave the admin app for the WorkOS dashboard. The organization starts with no members, is not whitelisted, and gets no trial. Idempotent against the WorkOS organization webhook: the Gram ID is derived from the WorkOS ID, so both writers converge on one row.`)
 	fmt.Fprintln(os.Stderr, `    rearm-trial: Puts a demoted enterprise trial back on: restores the organization's account type and whitelist flag, revives its model provider keys, and gives the trial a fresh run of the given length counted from now. Only a demoted trial can be re-armed; one that has converted or is already running is rejected.`)
@@ -21748,7 +21748,7 @@ func adminListOrganizationsUsage() {
 
 	// Description
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, `Lists organizations for admin operations with optional search and filters.`)
+	fmt.Fprintln(os.Stderr, `Lists organizations for platform admin operations with optional search and filters. Defaults to created_at descending, with id ascending to break ties.`)
 
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -q STRING: `)

--- a/server/gen/http/openapi3.yaml
+++ b/server/gen/http/openapi3.yaml
@@ -2371,7 +2371,7 @@ paths:
                 - admin_auth_header_Authorization: []
     /admin/organizations.list:
         get:
-            description: Lists organizations for admin operations with optional search and filters.
+            description: Lists organizations for platform admin operations with optional search and filters. Defaults to created_at descending, with id ascending to break ties.
             operationId: adminListOrganizations
             parameters:
                 - allowEmptyValue: true
@@ -2423,11 +2423,11 @@ paths:
                     description: Include organizations with disabled_at set. Defaults to false. Superseded by disabled_states, which overrides it outright when supplied.
                     type: boolean
                 - allowEmptyValue: true
-                  description: 'Pagination cursor: id of the last item from the previous page. Ignored when sort or page is supplied.'
+                  description: 'Pagination cursor: id of the last item from the previous page in created_at descending, id ascending order. The anchor is resolved regardless of filters; a deleted or unknown id returns an empty page. Ignored when sort or page is supplied.'
                   in: query
                   name: cursor
                   schema:
-                    description: 'Pagination cursor: id of the last item from the previous page. Ignored when sort or page is supplied.'
+                    description: 'Pagination cursor: id of the last item from the previous page in created_at descending, id ascending order. The anchor is resolved regardless of filters; a deleted or unknown id returns an empty page. Ignored when sort or page is supplied.'
                     type: string
                 - allowEmptyValue: true
                   description: Page size (default 50, max 100).
@@ -2438,18 +2438,18 @@ paths:
                     format: int64
                     type: integer
                 - allowEmptyValue: true
-                  description: 'Column to sort by: name, slug, account_type, member_count, created_at, disabled_at or trial_ends_at. Any other value sorts by id. Supplying it selects offset paging.'
+                  description: 'Column to sort by: name, slug, account_type, member_count, created_at, disabled_at or trial_ends_at. Omitted or unknown values use created_at descending. Ties always sort by id ascending. Supplying it selects offset paging.'
                   in: query
                   name: sort
                   schema:
-                    description: 'Column to sort by: name, slug, account_type, member_count, created_at, disabled_at or trial_ends_at. Any other value sorts by id. Supplying it selects offset paging.'
+                    description: 'Column to sort by: name, slug, account_type, member_count, created_at, disabled_at or trial_ends_at. Omitted or unknown values use created_at descending. Ties always sort by id ascending. Supplying it selects offset paging.'
                     type: string
                 - allowEmptyValue: true
-                  description: 'Sort direction, asc or desc, applied to the column named by sort. Any other value sorts ascending. On its own it does nothing: without sort there is no column to reverse, so it neither reorders the results nor selects offset paging.'
+                  description: Sort direction, asc or desc, applied to the column named by sort. Any other value sorts ascending. Ignored when sort is omitted or unknown, preserving the newest-first default. On its own it does not select offset paging.
                   in: query
                   name: direction
                   schema:
-                    description: 'Sort direction, asc or desc, applied to the column named by sort. Any other value sorts ascending. On its own it does nothing: without sort there is no column to reverse, so it neither reorders the results nor selects offset paging.'
+                    description: Sort direction, asc or desc, applied to the column named by sort. Any other value sorts ascending. Ignored when sort is omitted or unknown, preserving the newest-first default. On its own it does not select offset paging.
                     type: string
                 - allowEmptyValue: true
                   description: 1-based page number for offset paging (default 1). Supplying it selects offset paging.

--- a/server/internal/admin/impl.go
+++ b/server/internal/admin/impl.go
@@ -673,8 +673,8 @@ const (
 // ids are absent on purpose: an order built from them tells an operator nothing.
 //
 // This map cannot widen what the ladder accepts. The ladder matches these seven
-// literals and nothing else, so an unrecognised sort key collapses to the
-// tiebreaker with or without the check here. It is defense in depth, and the one
+// literals and nothing else. Unknown keys use the newest-first default below.
+// This is defense in depth, and the one
 // place a reader can see the accepted set without reading the SQL.
 var listOrganizationsSortColumns = map[string]bool{
 	"name":          true,
@@ -736,15 +736,15 @@ func (s *Service) ListOrganizations(ctx context.Context, payload *gen.ListOrgani
 	// An unknown sort key falls back to the default order instead of failing: the
 	// value comes from a URL operators paste to each other, and a typo should not
 	// break the page.
-	sortBy := ""
+	sortBy, sortDir := "created_at", "desc"
 	if payload.Sort != nil {
 		if key := strings.ToLower(*payload.Sort); listOrganizationsSortColumns[key] {
 			sortBy = key
+			sortDir = "asc"
+			if payload.Direction != nil && strings.EqualFold(*payload.Direction, "desc") {
+				sortDir = "desc"
+			}
 		}
-	}
-	sortDir := "asc"
-	if payload.Direction != nil && strings.EqualFold(*payload.Direction, "desc") {
-		sortDir = "desc"
 	}
 
 	var afterID pgtype.Text

--- a/server/internal/admin/listorganizations_test.go
+++ b/server/internal/admin/listorganizations_test.go
@@ -46,6 +46,11 @@ func seedOrg(t *testing.T, ctx context.Context, conn testrepo.DBTX, f orgFixture
 		f.accountType = "free"
 	}
 
+	// Stable default timestamps make ID tiebreaker expectations deterministic.
+	if f.createdAt == nil {
+		f.createdAt = new(time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC))
+	}
+
 	params := testrepo.CreateOrganizationMetadataFixtureParams{
 		ID:                 f.id,
 		Name:               f.name,
@@ -850,6 +855,8 @@ func TestListOrganizations_SearchByIDRespectsFilters(t *testing.T) {
 
 	seedOrg(t, ctx, conn, orgFixture{id: proID, name: "Pro Holdings", slug: "pro-holdings", accountType: "pro", whitelisted: true})
 	seedOrg(t, ctx, conn, orgFixture{id: cursorID, name: "Cursor Holdings", slug: "cursor-holdings", whitelisted: true})
+	// Cursor anchors must exist so their creation timestamp can be resolved.
+	seedOrg(t, ctx, conn, orgFixture{id: "org_search_id_a", name: "Anchor Holdings", slug: "anchor-holdings", whitelisted: true})
 	seedOrg(t, ctx, conn, orgFixture{id: trialID, name: "Trial Holdings", slug: "trial-holdings", whitelisted: true})
 	seedTrial(t, ctx, conn, trialFixture{orgID: trialID, endsAt: time.Now().UTC().Add(30 * 24 * time.Hour)})
 
@@ -1143,7 +1150,7 @@ func TestListOrganizations_UnknownSortAndDirectionFallBack(t *testing.T) {
 	ctx, svc, conn := newTestAdminService(t)
 	seedSortFixtures(t, ctx, conn)
 
-	byID := []string{sortOrgA, sortOrgB, sortOrgC, sortOrgD}
+	newestFirst := []string{sortOrgA, sortOrgD, sortOrgB, sortOrgC}
 	nameAsc := []string{sortOrgB, sortOrgD, sortOrgA, sortOrgC}
 
 	cases := []struct {
@@ -1152,11 +1159,11 @@ func TestListOrganizations_UnknownSortAndDirectionFallBack(t *testing.T) {
 		direction string
 		want      []string
 	}{
-		{name: "a column that does not exist", sort: "not_a_column", direction: "asc", want: byID},
-		{name: "a real column left out of the whitelist", sort: "workos_id", direction: "asc", want: byID},
-		{name: "the default column cannot be named", sort: "id", direction: "asc", want: byID},
-		{name: "an empty sort", sort: "", direction: "asc", want: byID},
-		{name: "a SQL fragment", sort: "name; DROP TABLE organization_metadata", direction: "asc", want: byID},
+		{name: "a column that does not exist", sort: "not_a_column", direction: "asc", want: newestFirst},
+		{name: "a real column left out of the whitelist", sort: "workos_id", direction: "asc", want: newestFirst},
+		{name: "id is not a supported sort", sort: "id", direction: "asc", want: newestFirst},
+		{name: "an empty sort", sort: "", direction: "asc", want: newestFirst},
+		{name: "a SQL fragment", sort: "name; DROP TABLE organization_metadata", direction: "asc", want: newestFirst},
 		{name: "an unknown direction", sort: "name", direction: "sideways", want: nameAsc},
 		{name: "an empty direction", sort: "name", direction: "", want: nameAsc},
 		{name: "a direction spelled backwards", sort: "name", direction: "descending", want: nameAsc},
@@ -1516,4 +1523,46 @@ func TestListOrganizations_MemberCountSkipsRemovedMembers(t *testing.T) {
 	require.Equal(t, "org_gone_b", res.Organizations[0].ID, "the organization with a live member ranks first")
 	require.Equal(t, 1, res.Organizations[0].MemberCount)
 	require.Equal(t, 0, res.Organizations[1].MemberCount, "removed members are not counted")
+}
+
+// IDs intentionally disagree with creation order, including a timestamp tie
+// across the page boundary. Both APIs must walk exactly the same ordering.
+func TestListOrganizations_NewestFirstPagination(t *testing.T) {
+	t.Parallel()
+	ctx, svc, conn := newTestAdminService(t)
+	base := time.Date(2025, time.June, 1, 0, 0, 0, 0, time.UTC)
+	for _, f := range []orgFixture{
+		{id: "org_a", createdAt: new(base)},
+		{id: "org_z", createdAt: new(base.Add(2 * time.Hour))},
+		{id: "org_c", createdAt: new(base.Add(time.Hour))},
+		{id: "org_b", createdAt: new(base.Add(time.Hour))},
+	} {
+		f.name, f.slug = f.id, f.id
+		seedOrg(t, ctx, conn, f)
+	}
+	want := []string{"org_z", "org_b", "org_c", "org_a"}
+	for _, direction := range []*string{nil, new("asc"), new("desc")} {
+		first := requireOrder(t, ctx, svc, &gen.ListOrganizationsPayload{Limit: new(2), Direction: direction}, want[:2], "default cursor first page")
+		require.Equal(t, int64(4), first.Total)
+		require.Equal(t, new("org_b"), first.NextCursor)
+		last := requireOrder(t, ctx, svc, &gen.ListOrganizationsPayload{Limit: new(2), Cursor: first.NextCursor, Direction: direction}, want[2:], "default cursor last page")
+		require.Equal(t, int64(4), last.Total)
+		require.Nil(t, last.NextCursor)
+	}
+	for _, sort := range []*string{nil, new("created_at"), new("unknown")} {
+		for page := 1; page <= 3; page++ {
+			start := (page - 1) * 2
+			end := min(start+2, len(want))
+			res := requireOrder(t, ctx, svc, &gen.ListOrganizationsPayload{Limit: new(2), Page: &page, Sort: sort, Direction: new("desc")}, want[start:end], "offset newest-first")
+			require.Equal(t, int64(4), res.Total)
+			require.Nil(t, res.NextCursor)
+		}
+	}
+	// An existing ID-shaped cursor remains accepted, even if its anchor no
+	// longer matches the current filter. Its timestamp still defines the seek.
+	res := requireOrder(t, ctx, svc, &gen.ListOrganizationsPayload{Cursor: new("org_b"), Q: new("org_c")}, []string{"org_c"}, "filtered-out cursor anchor")
+	require.Equal(t, int64(1), res.Total)
+	res = requireOrder(t, ctx, svc, &gen.ListOrganizationsPayload{Cursor: new("org_missing")}, []string{}, "unknown cursor anchor")
+	require.Equal(t, int64(4), res.Total)
+	require.Nil(t, res.NextCursor)
 }

--- a/server/internal/admin/queries.sql
+++ b/server/internal/admin/queries.sql
@@ -194,7 +194,19 @@ filtered AS (
             OR lower(om.id) = lower(search.term)
             OR lower(om.workos_id) = lower(search.term)
         )
-        AND (sqlc.narg('after_id')::text IS NULL OR om.id > sqlc.narg('after_id')::text)
+        -- Keep ID-shaped cursors compatible, but seek in the default creation
+        -- order, not ID order. Resolve the anchor outside the filters so changes
+        -- to its account/disabled state do not break an existing cursor. A
+        -- deleted or unknown anchor exhausts the walk rather than restarting it.
+        AND (
+            sqlc.narg('after_id')::text IS NULL
+            OR EXISTS (
+                SELECT 1 FROM organization_metadata anchor
+                WHERE anchor.id = sqlc.narg('after_id')::text
+                  AND (om.created_at < anchor.created_at
+                       OR (om.created_at = anchor.created_at AND om.id > anchor.id))
+            )
+        )
 )
 SELECT * FROM filtered
 -- trial_state is computed in the CTE's select list, so it cannot be named in the

--- a/server/internal/admin/repo/queries.sql.go
+++ b/server/internal/admin/repo/queries.sql.go
@@ -561,7 +561,19 @@ filtered AS (
             OR lower(om.id) = lower(search.term)
             OR lower(om.workos_id) = lower(search.term)
         )
-        AND ($9::text IS NULL OR om.id > $9::text)
+        -- Keep ID-shaped cursors compatible, but seek in the default creation
+        -- order, not ID order. Resolve the anchor outside the filters so changes
+        -- to its account/disabled state do not break an existing cursor. A
+        -- deleted or unknown anchor exhausts the walk rather than restarting it.
+        AND (
+            $9::text IS NULL
+            OR EXISTS (
+                SELECT 1 FROM organization_metadata anchor
+                WHERE anchor.id = $9::text
+                  AND (om.created_at < anchor.created_at
+                       OR (om.created_at = anchor.created_at AND om.id > anchor.id))
+            )
+        )
 )
 SELECT id, name, slug, account_type, workos_id, stripe_customer_id, stripe_subscription_id, whitelisted, disabled_at, trial_state, trial_ends_at, created_at, updated_at, member_count FROM filtered
 WHERE coalesce(cardinality($1::text[]), 0) = 0 OR trial_state = ANY($1::text[])


### PR DESCRIPTION
## Summary
- Default the platform admin organizations API to creation time descending, with ID ascending as a stable tiebreaker. Keep cursor and offset pagination aligned, while retaining other API sort options.
- Make Created the only sortable UI column, with visible direction and aria-sort, URL-persisted ascending/descending selection, and page resets when sorting or filtering changes.
- Require the list response total for offset pagination, update fixtures, and regenerate API documentation and query bindings.

## Motivation
Platform administrators need newly created organizations first and a reliable way to reverse that order. Keeping ordering and pagination on the server avoids inconsistent results across pages without expanding sorting controls beyond Created.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defaults the admin organizations list to newest-first and makes Created the only sortable UI column. Previously the list had no default order and used cursor pagination; now the API sorts by `created_at` descending with `id` ascending as a tiebreaker, and the UI uses offset pagination via a `page` param.

- Server: unknown `sort` values now fall back to the newest-first default instead of sorting by ID; `direction` is ignored when `sort` is absent.
- Cursor pagination is still accepted but now seeks in creation order; a cursor anchor is resolved regardless of filters, and a deleted or unknown anchor returns an empty page. The list response always requires a `total` field for the pager.
- UI: the Created column header toggles ascending/descending with `aria-sort` and a direction indicator; the selection persists in the URL and any sort or filter change resets to page 1.
- Regenerated API docs and query bindings for the new descriptions and ordering.

Implements GRW-87.

<sup>Written for commit a8525fc52c6976c470336e6e8c718dcfd68a24cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/gram/pull/6345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



